### PR TITLE
chore: Add .active-environment to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ Desktop.ini
 # IDE and tool directories
 .claude/
 .cursor/
+.active-environment
 
 # Build artifacts
 build/


### PR DESCRIPTION
Small housekeeping change to prevent environment-specific state file from being tracked in version control.

The .active-environment file tracks which deployment environment (blue/green) is currently active and changes during deployment operations. It should remain local to each deployment.

🤖 Generated with Claude Code