### PR TITLE
feat: polyline slicing, intersection-based junction trimming, editor UX

### DIFF
--- a/backend/segmentation/sperm_final/inference/postprocess.py
+++ b/backend/segmentation/sperm_final/inference/postprocess.py
@@ -251,25 +251,19 @@ def mask_to_polyline(
     mask: np.ndarray,
     cls: int,
     mask_threshold: float = 0.5,
-    simplify_eps: float = 5.0,
-    pts_per_100px: float = 32.0,
-    min_pts: int = 2,
+    simplify_eps: float = 2.0,
 ) -> List[Tuple[float, float]]:
     """Convert instance mask to a smooth polyline.
 
-    Pipeline: skeleton → prune → BFS longest path → RDP simplify →
-    uniform resampling.
-
-    The number of output points adapts to the arc length of the structure.
-    Head (cls=1) is always 3 points. Midpiece/tail use pts_per_100px density.
+    Pipeline: skeleton → prune → BFS longest path → RDP simplify.
+    Head (cls=1) is resampled to exactly 3 points; midpiece/tail return
+    the RDP-simplified path directly.
 
     Args:
         mask: Soft mask (float32).
         cls: Class ID (1=Head, 2=Midpiece, 3=Tail).
         mask_threshold: Threshold for binarization.
-        simplify_eps: RDP epsilon for initial simplification (higher = smoother).
-        pts_per_100px: Output point density (points per 100px of arc length).
-        min_pts: Minimum number of output points.
+        simplify_eps: RDP epsilon for simplification (lower = more detail).
     """
     bin_mask = (mask >= mask_threshold).astype(np.uint8)
     area = bin_mask.sum()
@@ -301,18 +295,65 @@ def mask_to_polyline(
 
     simplified = rdp_simplify(path, simplify_eps)
 
-    # Estimate arc length from simplified path to determine output point count
-    pts_arr = np.array(simplified, dtype=float)
-    arc_len = float(np.linalg.norm(pts_arr[1:] - pts_arr[:-1], axis=1).sum())
-    # Head (cls=1): always 3 points (start, midpoint, end) for a clean arc
+    # Head: always exactly 3 points (start, midpoint, end)
     if cls == 1:
-        n_output = 3
-    else:
-        n_output = max(min_pts, round(arc_len * pts_per_100px / 100.0))
+        return resample_polyline(simplified, 3)
 
-    # Uniform resampling along the simplified polyline — stable and follows
-    # the RDP-simplified path exactly without B-spline overshoot
-    return resample_polyline(simplified, n_output)
+    return [(float(x), float(y)) for x, y in simplified]
+
+
+def _segment_intersection(
+    p1: np.ndarray, p2: np.ndarray, p3: np.ndarray, p4: np.ndarray,
+) -> "np.ndarray | None":
+    """Find intersection point of segments p1-p2 and p3-p4.
+
+    Returns the intersection (x, y) array if the segments cross, else None.
+    Uses the parametric cross-product method.
+    """
+    d1 = p2 - p1
+    d2 = p4 - p3
+    cross = d1[0] * d2[1] - d1[1] * d2[0]
+    if abs(cross) < 1e-10:
+        return None  # parallel / collinear
+    dp = p3 - p1
+    t = (dp[0] * d2[1] - dp[1] * d2[0]) / cross
+    u = (dp[0] * d1[1] - dp[1] * d1[0]) / cross
+    if 0.0 <= t <= 1.0 and 0.0 <= u <= 1.0:
+        return p1 + t * d1
+    return None
+
+
+def _find_junction_intersection(
+    poly_a: List[Tuple[float, float]],
+    poly_b: List[Tuple[float, float]],
+) -> "tuple | None":
+    """Find the intersection closest to the junction of two polylines.
+
+    poly_a is traversed from its END (last segment first) and poly_b from its
+    START (first segment first). Returns (intersection_point, seg_idx_a,
+    seg_idx_b) for the closest hit, or None if the polylines do not cross.
+    """
+    if len(poly_a) < 2 or len(poly_b) < 2:
+        return None
+    pts_a = [np.array(p) for p in poly_a]
+    pts_b = [np.array(p) for p in poly_b]
+    # Search from the junction end: a-segments from last to first, b from first
+    # to last.  Return the first hit — closest to the junction.
+    best = None
+    best_rank = None  # (i_from_end, j_from_start) — lower is closer to junction
+    for i in range(len(pts_a) - 2, -1, -1):
+        for j in range(len(pts_b) - 1):
+            pt = _segment_intersection(pts_a[i], pts_a[i + 1],
+                                       pts_b[j], pts_b[j + 1])
+            if pt is not None:
+                rank = (len(pts_a) - 2 - i, j)
+                if best_rank is None or rank < best_rank:
+                    best = (tuple(pt.tolist()), i, j)
+                    best_rank = rank
+        # Once we found an intersection at this a-segment, no need to go further
+        if best is not None:
+            break
+    return best
 
 
 def _orient_polyline_toward(
@@ -349,18 +390,19 @@ def _orient_polyline_toward(
 def connect_sperm_polylines(
     sperm: dict,
     mask_threshold: float = 0.3,
-    simplify_eps: float = 5.0,
-    pts_per_100px: float = 32.0,
+    simplify_eps: float = 2.0,
 ) -> dict:
     """Generate connected polylines for a complete sperm (H+M+T).
 
     For each part, generates a polyline via mask_to_polyline(). Then orients
-    them so they flow Head → Midpiece → Tail, and at each junction replaces
-    the meeting endpoints with their average so the polylines connect seamlessly.
+    them so they flow Head → Midpiece → Tail. At each junction, trims both
+    polylines to their closest intersection point. Falls back to endpoint
+    averaging when the polylines do not cross.
 
     Args:
         sperm: Dict with "head", "midpiece", "tail" instance dicts.
         mask_threshold: Threshold for binary masks.
+        simplify_eps: RDP epsilon for polyline simplification.
 
     Returns:
         Dict with "head", "midpiece", "tail" polylines (list of (x,y) tuples).
@@ -380,7 +422,6 @@ def connect_sperm_polylines(
             part["mask"], cls_map[part_key],
             mask_threshold=mask_threshold,
             simplify_eps=simplify_eps,
-            pts_per_100px=pts_per_100px,
         )
         polylines[part_key] = poly
         # Compute centroid for orientation reference
@@ -410,20 +451,33 @@ def connect_sperm_polylines(
     if len(t_poly) >= 2 and len(m_poly) >= 1:
         t_poly = _orient_polyline_toward(t_poly, m_poly[-1], use_start=True)
 
-    # Connect Head↔Midpiece junction: average meeting endpoints
+    # Connect Head↔Midpiece junction: use first intersection point,
+    # falling back to endpoint average when polylines don't cross.
     if len(h_poly) >= 1 and len(m_poly) >= 1:
-        h_end = np.array(h_poly[-1])
-        m_start = np.array(m_poly[0])
-        junction = tuple(((h_end + m_start) / 2.0).tolist())
-        h_poly[-1] = junction
-        m_poly[0] = junction
+        hit = _find_junction_intersection(h_poly, m_poly)
+        if hit is not None:
+            junction, seg_a, seg_b = hit
+            h_poly = h_poly[: seg_a + 1] + [junction]
+            m_poly = [junction] + m_poly[seg_b + 1 :]
+        else:
+            h_end = np.array(h_poly[-1])
+            m_start = np.array(m_poly[0])
+            junction = tuple(((h_end + m_start) / 2.0).tolist())
+            h_poly[-1] = junction
+            m_poly[0] = junction
 
-    # Connect Midpiece↔Tail junction: average meeting endpoints
+    # Connect Midpiece↔Tail junction: same strategy.
     if len(m_poly) >= 1 and len(t_poly) >= 1:
-        m_end = np.array(m_poly[-1])
-        t_start = np.array(t_poly[0])
-        junction = tuple(((m_end + t_start) / 2.0).tolist())
-        m_poly[-1] = junction
-        t_poly[0] = junction
+        hit = _find_junction_intersection(m_poly, t_poly)
+        if hit is not None:
+            junction, seg_a, seg_b = hit
+            m_poly = m_poly[: seg_a + 1] + [junction]
+            t_poly = [junction] + t_poly[seg_b + 1 :]
+        else:
+            m_end = np.array(m_poly[-1])
+            t_start = np.array(t_poly[0])
+            junction = tuple(((m_end + t_start) / 2.0).tolist())
+            m_poly[-1] = junction
+            t_poly[0] = junction
 
     return {"head": h_poly, "midpiece": m_poly, "tail": t_poly}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -506,7 +506,7 @@ class ApiClient {
       throw new Error('No refresh token available');
     }
 
-    const response = await this.instance.post('/auth/refresh', {
+    const response = await this.instance.post('/auth/refresh-token', {
       refreshToken: this.refreshToken,
     });
 

--- a/src/lib/polygonSlicing.ts
+++ b/src/lib/polygonSlicing.ts
@@ -336,6 +336,103 @@ export function slicePolygon(
 }
 
 /**
+ * Slices a polyline (open path) at the intersection closest to the slice
+ * midpoint, producing two new polylines that share the intersection point.
+ */
+export function slicePolyline(
+  polygon: Polygon,
+  sliceStart: Point,
+  sliceEnd: Point
+): [Polygon, Polygon] | null {
+  const points = polygon.points;
+  if (!points || points.length < 2) {
+    return null;
+  }
+
+  // Find intersections — iterate open edges (no wrapping)
+  const intersections: Array<{ point: Point; edgeIndex: number; t: number }> =
+    [];
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const intersection = lineIntersection(
+      sliceStart,
+      sliceEnd,
+      points[i],
+      points[i + 1]
+    );
+    if (intersection) {
+      const edgeLength = Math.sqrt(
+        Math.pow(points[i + 1].x - points[i].x, 2) +
+          Math.pow(points[i + 1].y - points[i].y, 2)
+      );
+      const dist = Math.sqrt(
+        Math.pow(intersection.x - points[i].x, 2) +
+          Math.pow(intersection.y - points[i].y, 2)
+      );
+      const t = edgeLength > 0 ? dist / edgeLength : 0;
+      intersections.push({ point: intersection, edgeIndex: i, t });
+    }
+  }
+
+  if (intersections.length === 0) {
+    return null;
+  }
+
+  // Pick the intersection closest to the slice midpoint (most "central" cut)
+  const sliceMidX = (sliceStart.x + sliceEnd.x) / 2;
+  const sliceMidY = (sliceStart.y + sliceEnd.y) / 2;
+  intersections.sort((a, b) => {
+    const da =
+      Math.pow(a.point.x - sliceMidX, 2) +
+      Math.pow(a.point.y - sliceMidY, 2);
+    const db =
+      Math.pow(b.point.x - sliceMidX, 2) +
+      Math.pow(b.point.y - sliceMidY, 2);
+    return da - db;
+  });
+  const hit = intersections[0];
+
+  // Split: polyline1 = points[0..edgeIdx] + intersection
+  //        polyline2 = intersection + points[edgeIdx+1..end]
+  const poly1Points: Point[] = [];
+  for (let i = 0; i <= hit.edgeIndex; i++) {
+    poly1Points.push(points[i]);
+  }
+  poly1Points.push(hit.point);
+
+  const poly2Points: Point[] = [hit.point];
+  for (let i = hit.edgeIndex + 1; i < points.length; i++) {
+    poly2Points.push(points[i]);
+  }
+
+  // Both halves need at least 2 points
+  if (poly1Points.length < 2 || poly2Points.length < 2) {
+    return null;
+  }
+
+  const newPolyline1 = createPolygon(poly1Points, polygon.color);
+  const newPolyline2 = createPolygon(poly2Points, polygon.color);
+
+  // Preserve polyline-specific properties
+  newPolyline1.geometry = 'polyline';
+  newPolyline2.geometry = 'polyline';
+  if (polygon.confidence !== undefined) {
+    newPolyline1.confidence = polygon.confidence;
+    newPolyline2.confidence = polygon.confidence;
+  }
+  if (polygon.partClass) {
+    newPolyline1.partClass = polygon.partClass;
+    newPolyline2.partClass = polygon.partClass;
+  }
+  if (polygon.instanceId) {
+    newPolyline1.instanceId = polygon.instanceId;
+    newPolyline2.instanceId = polygon.instanceId;
+  }
+
+  return [newPolyline1, newPolyline2];
+}
+
+/**
  * Validate if a slice line is valid for a given polygon
  * If the line segment doesn't intersect properly, try extending it to an infinite line
  */

--- a/src/pages/segmentation/components/EnhancedEditorToolbar.tsx
+++ b/src/pages/segmentation/components/EnhancedEditorToolbar.tsx
@@ -5,7 +5,7 @@ import {
   MousePointer,
   Edit3,
   Plus,
-  PenTool,
+  Pentagon,
   Spline,
   Scissors,
   Trash2,
@@ -73,7 +73,7 @@ const EnhancedEditorToolbar: React.FC<EnhancedEditorToolbarProps> = ({
       case EditMode.AddPoints:
         return Plus;
       case EditMode.CreatePolygon:
-        return PenTool;
+        return Pentagon;
       case EditMode.CreatePolyline:
         return Spline;
       case EditMode.Slice:

--- a/src/pages/segmentation/components/StatusBar.tsx
+++ b/src/pages/segmentation/components/StatusBar.tsx
@@ -12,7 +12,7 @@ import {
   Plus,
   Hash,
   MousePointer,
-  PenTool,
+  Pentagon,
   Trash2,
   Eye,
   EyeOff,
@@ -53,7 +53,7 @@ const StatusBar = ({
       case EditMode.AddPoints:
         return <Plus className="h-3 w-3" />;
       case EditMode.CreatePolygon:
-        return <PenTool className="h-3 w-3" />;
+        return <Pentagon className="h-3 w-3" />;
       case EditMode.Slice:
         return <Scissors className="h-3 w-3" />;
       case EditMode.DeletePolygon:

--- a/src/pages/segmentation/components/VerticalToolbar.tsx
+++ b/src/pages/segmentation/components/VerticalToolbar.tsx
@@ -4,7 +4,7 @@ import {
   MousePointer,
   Edit3,
   Plus,
-  PenTool,
+  Pentagon,
   Spline,
   Scissors,
   Trash2,
@@ -48,7 +48,7 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
       case EditMode.AddPoints:
         return Plus;
       case EditMode.CreatePolygon:
-        return PenTool;
+        return Pentagon;
       case EditMode.CreatePolyline:
         return Spline;
       case EditMode.Slice:

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -212,6 +212,14 @@ const CanvasPolygon = React.memo(
       (instanceId: string) => onChangeInstanceId?.(id, instanceId),
       [onChangeInstanceId, id]
     );
+    // Suppress hover/click on non-selected polylines during editing to
+    // prevent accidental selection while working on the active polyline.
+    const suppressInteraction =
+      isPolyline &&
+      !isSelected &&
+      editMode !== EditMode.View &&
+      editMode !== EditMode.DeletePolygon;
+
     const handleMouseEnter = useCallback(() => onHover?.(id), [onHover, id]);
     const handleMouseLeave = useCallback(() => onHover?.(null), [onHover]);
 
@@ -254,10 +262,25 @@ const CanvasPolygon = React.memo(
           role="button"
           aria-label={`${isPolyline ? 'Polyline' : 'Polygon'} ${id} - ${type} ${isPolyline ? 'polyline' : 'polygon'} with ${points.length} vertices`}
           onKeyDown={handleKeyDown}
-          onMouseEnter={isPolyline ? handleMouseEnter : undefined}
-          onMouseLeave={isPolyline ? handleMouseLeave : undefined}
+          onMouseEnter={isPolyline && !suppressInteraction ? handleMouseEnter : undefined}
+          onMouseLeave={isPolyline && !suppressInteraction ? handleMouseLeave : undefined}
           style={{ outline: 'none' }}
         >
+          {/* Invisible wide hit-area path for polylines (easier clicking) */}
+          {isPolyline && pathString && !suppressInteraction && (
+            <path
+              d={pathString}
+              fill="none"
+              stroke="transparent"
+              strokeWidth={Math.max(12 / zoom, 6)}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              onClick={handleClick}
+              onDoubleClick={handleDoubleClick}
+              pointerEvents="stroke"
+            />
+          )}
+
           {/* Polygon/Polyline path - render even if path is empty for testing */}
           <path
             d={pathString || 'M0,0'}
@@ -290,8 +313,9 @@ const CanvasPolygon = React.memo(
             pointerEvents={isPolyline ? 'stroke' : 'all'}
           />
 
-          {/* Polyline endpoint markers (small circles at start and end) */}
-          {isPolyline && validPoints.length >= 2 && (
+          {/* Polyline endpoint markers (small circles at start and end) — hidden when
+              selected because vertices are shown and dragging updates only on mouseup */}
+          {isPolyline && !isSelected && validPoints.length >= 2 && (
             <>
               <circle
                 cx={validPoints[0].x}
@@ -372,6 +396,7 @@ const CanvasPolygon = React.memo(
       prevProps.polygon.instanceId === nextProps.polygon.instanceId &&
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isHovered === nextProps.isHovered &&
+      prevProps.editMode === nextProps.editMode &&
       prevProps.isUndoRedoInProgress === nextProps.isUndoRedoInProgress &&
       prevProps.zoom === nextProps.zoom &&
       prevProps.hideVertices === nextProps.hideVertices &&

--- a/src/pages/segmentation/components/canvas/ModeInstructions.tsx
+++ b/src/pages/segmentation/components/canvas/ModeInstructions.tsx
@@ -116,7 +116,7 @@ const ModeInstructions: React.FC<ModeInstructionsProps> = ({
             color: '#10b981', // emerald-500 to match border
             instructions: [
               t('segmentation.instructions.addPoints.addPoints'),
-              `${t('segmentation.instructions.addPoints.holdShift')} • ${t('segmentation.instructions.addPoints.cancel')}`,
+              `${t('segmentation.instructions.addPoints.holdShift')} • ${t('segmentation.instructions.addPoints.enterFinalize')} • ${t('segmentation.instructions.addPoints.cancel')}`,
             ],
           };
         }

--- a/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
+++ b/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
@@ -141,7 +141,7 @@ export const useAdvancedInteractions = ({
       }
 
       // Add point to temporary points
-      setTempPoints([...tempPoints, imagePoint]);
+      setTempPoints(prev => [...prev, imagePoint]);
     },
     [
       tempPoints,
@@ -260,11 +260,13 @@ export const useAdvancedInteractions = ({
             interactionState.addPointStartVertex.vertexIndex
           ) {
             // Complete the sequence - implement CVAT-like point insertion
+            const isPolyline = selectedPolygon.geometry === 'polyline';
             const newPoints = insertPointsBetweenVertices(
               selectedPolygon.points,
               interactionState.addPointStartVertex.vertexIndex,
               closestVertex.index,
-              tempPoints
+              tempPoints,
+              isPolyline
             );
 
             if (newPoints) {
@@ -291,7 +293,7 @@ export const useAdvancedInteractions = ({
           }
         } else {
           // Add intermediate point to sequence (not on a vertex)
-          setTempPoints([...tempPoints, imagePoint]);
+          setTempPoints(prev => [...prev, imagePoint]);
         }
       }
     },
@@ -357,9 +359,9 @@ export const useAdvancedInteractions = ({
   const handleCreatePolylineClick = useCallback(
     (imagePoint: Point) => {
       // Add point to temporary points
-      setTempPoints([...tempPoints, imagePoint]);
+      setTempPoints(prev => [...prev, imagePoint]);
     },
-    [tempPoints, setTempPoints]
+    [setTempPoints]
   );
 
   /**
@@ -475,6 +477,13 @@ export const useAdvancedInteractions = ({
             // Nothing selected - exit slice mode to View mode
             setEditMode(EditMode.View);
           }
+        } else if (editMode === EditMode.AddPoints) {
+          // AddPoints mode: right-click starts panning (don't cancel)
+          setInteractionState({
+            ...interactionState,
+            isPanning: true,
+            panStart: { x: e.clientX, y: e.clientY },
+          });
         } else {
           // For other modes - always cancel current operation
           if (editMode !== EditMode.View) {
@@ -743,7 +752,7 @@ export const useAdvancedInteractions = ({
             EDITING_CONSTANTS.MIN_AUTO_ADD_DISTANCE / transform.zoom;
 
           if (distance >= MIN_DISTANCE) {
-            setTempPoints([...tempPoints, imagePoint]);
+            setTempPoints(prev => [...prev, imagePoint]);
             lastAutoAddedPoint.current = imagePoint;
           }
         }
@@ -890,15 +899,12 @@ function insertPointsBetweenVertices(
   originalPoints: Point[],
   startVertexIndex: number,
   endVertexIndex: number,
-  newPoints: Point[]
+  newPoints: Point[],
+  isPolyline = false
 ): Point[] | null {
-  // Inserts new points between two vertices, creating two candidate polygons
-  // and selecting the one with the smaller perimeter (preserves original boundary).
-
   const numPoints = originalPoints.length;
 
   // Normalize vertices to ensure consistent behavior
-  // Always work with the smaller index as vertex1 and larger as vertex2
   const vertex1 = Math.min(startVertexIndex, endVertexIndex);
   const vertex2 = Math.max(startVertexIndex, endVertexIndex);
 
@@ -917,12 +923,25 @@ function insertPointsBetweenVertices(
     ? [...newPoints].reverse()
     : newPoints;
 
-  // Create two candidate polygons
-  const candidate1Points: Point[] = []; // Replace direct path
-  const candidate2Points: Point[] = []; // Replace wrapped path
+  // Polyline: path between two vertices is unambiguous (always direct order),
+  // so just replace points[vertex1..vertex2] with the new sequence.
+  if (isPolyline) {
+    const result: Point[] = [];
+    for (let i = 0; i <= vertex1; i++) {
+      result.push(originalPoints[i]);
+    }
+    result.push(...finalNewPoints);
+    for (let i = vertex2; i < numPoints; i++) {
+      result.push(originalPoints[i]);
+    }
+    return result;
+  }
+
+  // Polygon: create two candidate polygons, pick the one with smaller perimeter.
+  const candidate1Points: Point[] = [];
+  const candidate2Points: Point[] = [];
 
   // Candidate 1: Replace direct path (vertex1 to vertex2)
-  // Keep: [0...vertex1] + newPoints + [vertex2...numPoints-1]
   for (let i = 0; i <= vertex1; i++) {
     candidate1Points.push(originalPoints[i]);
   }
@@ -932,21 +951,16 @@ function insertPointsBetweenVertices(
   }
 
   // Candidate 2: Replace wrapped path (vertex2 to vertex1 going around)
-  // Keep only the direct path vertices and replace wrapped path with newPoints
   candidate2Points.push(originalPoints[vertex1]);
   candidate2Points.push(...finalNewPoints);
   candidate2Points.push(originalPoints[vertex2]);
 
-  // Add the remaining points (wrapped path) by going from vertex2 to vertex1
   let idx = (vertex2 + 1) % numPoints;
   while (idx !== vertex1) {
     candidate2Points.push(originalPoints[idx]);
     idx = (idx + 1) % numPoints;
   }
 
-  // Calculate perimeters and choose the one with smaller perimeter.
-  // The candidate closer to the original polygon shape is the correct one,
-  // as adding points refines the boundary rather than replacing it.
   const perimeter1 = calculatePolygonPerimeter(candidate1Points);
   const perimeter2 = calculatePolygonPerimeter(candidate2Points);
 

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -79,6 +79,8 @@ export const useEnhancedSegmentationEditor = ({
   const [selectedPolygonId, setSelectedPolygonIdInternal] = useState<
     string | null
   >(null);
+  const selectedPolygonIdRef = useRef<string | null>(null);
+  selectedPolygonIdRef.current = selectedPolygonId;
 
   // Wrapped setSelectedPolygonId - fixed to not depend on selectedPolygonId
   const setSelectedPolygonId = useCallback((id: string | null) => {
@@ -106,6 +108,8 @@ export const useEnhancedSegmentationEditor = ({
     []
   ); // CRITICAL: No dependencies to prevent stale closures!
   const [tempPoints, setTempPoints] = useState<Point[]>([]);
+  const tempPointsRef = useRef<Point[]>([]);
+  tempPointsRef.current = tempPoints;
   const [hoveredVertex, setHoveredVertex] = useState<{
     polygonId: string;
     vertexIndex: number;
@@ -177,6 +181,8 @@ export const useEnhancedSegmentationEditor = ({
     addPointEndVertex: null,
     isAddingPoints: false,
   });
+  const interactionStateRef = useRef(interactionState);
+  interactionStateRef.current = interactionState;
 
   // History management
   const [history, setHistory] = useState<Polygon[][]>([initialPolygons]);
@@ -716,11 +722,74 @@ export const useEnhancedSegmentationEditor = ({
     [polygons, updatePolygons, t]
   );
 
-  // Ref to hold the polyline finalization callback (set after interactions hook)
+  // Ref to hold the polyline creation finalization callback
   const polylineDoubleClickRef = useRef<(() => void) | null>(null);
+
+  // Stable Enter handler — reads ALL state from refs, never stale.
   const handleEnterPolyline = useCallback(() => {
+    const iState = interactionStateRef.current;
+    const currentTempPoints = tempPointsRef.current;
+    const selId = selectedPolygonIdRef.current;
+
+    // AddPoints mode: truncate/extend polyline
+    if (
+      iState.isAddingPoints &&
+      iState.addPointStartVertex &&
+      selId &&
+      currentTempPoints.length > 0
+    ) {
+      const allPolygons = getPolygons();
+      const selectedPolygon = allPolygons.find(p => p.id === selId);
+      if (!selectedPolygon || selectedPolygon.geometry !== 'polyline') return;
+
+      const pts = selectedPolygon.points;
+      const startIdx = iState.addPointStartVertex.vertexIndex;
+      const firstNew = currentTempPoints[0];
+      const startPt = pts[startIdx];
+
+      // Endpoints always extend; middle vertices use dot product
+      let towardEnd: boolean;
+      const hasPrev = startIdx > 0;
+      const hasNext = startIdx < pts.length - 1;
+
+      if (!hasNext) {
+        towardEnd = true;
+      } else if (!hasPrev) {
+        towardEnd = false;
+      } else {
+        const dxNew = firstNew.x - startPt.x;
+        const dyNew = firstNew.y - startPt.y;
+        const dotNext =
+          dxNew * (pts[startIdx + 1].x - startPt.x) +
+          dyNew * (pts[startIdx + 1].y - startPt.y);
+        const dotPrev =
+          dxNew * (pts[startIdx - 1].x - startPt.x) +
+          dyNew * (pts[startIdx - 1].y - startPt.y);
+        towardEnd = dotNext >= dotPrev;
+      }
+
+      const newPoints = towardEnd
+        ? [...pts.slice(0, startIdx + 1), ...currentTempPoints]
+        : [...[...currentTempPoints].reverse(), ...pts.slice(startIdx)];
+
+      const updatedPolygons = allPolygons.map(p =>
+        p.id === selId ? { ...p, points: newPoints } : p
+      );
+      updatePolygons(updatedPolygons);
+      setTempPoints([]);
+      setInteractionState({
+        ...iState,
+        isAddingPoints: false,
+        addPointStartVertex: null,
+        addPointEndVertex: null,
+      });
+      setEditMode(EditMode.EditVertices);
+      return;
+    }
+
+    // CreatePolyline mode: finalize
     polylineDoubleClickRef.current?.();
-  }, []);
+  }, [getPolygons, updatePolygons, setTempPoints, setInteractionState, setEditMode]);
 
   // Escape handler - always return to View mode
   const handleEscape = useCallback(() => {

--- a/src/pages/segmentation/hooks/useKeyboardShortcuts.tsx
+++ b/src/pages/segmentation/hooks/useKeyboardShortcuts.tsx
@@ -215,9 +215,9 @@ export const useKeyboardShortcuts = ({
           }
           break;
 
-        // Enter - finalize polyline creation
+        // Enter - finalize polyline creation or AddPoints on polylines
         case 'enter':
-          if (editMode === EditMode.CreatePolyline && onEnter) {
+          if ((editMode === EditMode.CreatePolyline || editMode === EditMode.AddPoints) && onEnter) {
             event.preventDefault();
             onEnter();
           }

--- a/src/pages/segmentation/hooks/usePolygonSlicing.tsx
+++ b/src/pages/segmentation/hooks/usePolygonSlicing.tsx
@@ -3,7 +3,11 @@ import { toast } from 'sonner';
 import { useLanguage } from '@/contexts/useLanguage';
 // import { getLocalizedErrorMessage } from '@/lib/errorUtils';
 import { Point, Polygon } from '@/lib/segmentation';
-import { slicePolygon, validateSliceLine } from '@/lib/polygonSlicing';
+import {
+  slicePolygon,
+  slicePolyline,
+  validateSliceLine,
+} from '@/lib/polygonSlicing';
 import { EditMode, InteractionState } from '../types';
 
 interface UsePolygonSlicingProps {
@@ -59,29 +63,26 @@ export const usePolygonSlicing = ({
       }
 
       const [sliceStart, sliceEnd] = pointsToUse;
+      const isPolyline = polygon.geometry === 'polyline';
 
-      // Attempting slice with points
+      // For closed polygons, validate first (needs exactly 2 intersections)
+      if (!isPolyline) {
+        const validation = validateSliceLine(polygon, sliceStart, sliceEnd);
 
-      // Validate slice line
-      const validation = validateSliceLine(polygon, sliceStart, sliceEnd);
+        if (!validation.isValid) {
+          const errorMessage = validation.reason
+            ? `${t('segmentation.invalidSlice') || 'Invalid slice operation'}: ${validation.reason}`
+            : t('segmentation.invalidSlice') || 'Invalid slice operation';
 
-      // Validation result obtained
-
-      if (!validation.isValid) {
-        // Show detailed error message to user
-        const errorMessage = validation.reason
-          ? `${t('segmentation.invalidSlice') || 'Invalid slice operation'}: ${validation.reason}`
-          : t('segmentation.invalidSlice') || 'Invalid slice operation';
-
-        // Validation failed
-        toast.error(errorMessage);
-        return false;
+          toast.error(errorMessage);
+          return false;
+        }
       }
 
-      // Validation passed, performing slice
-
-      // Perform the slice
-      const result = slicePolygon(polygon, sliceStart, sliceEnd);
+      // Perform the slice — dispatch to polyline or polygon variant
+      const result = isPolyline
+        ? slicePolyline(polygon, sliceStart, sliceEnd)
+        : slicePolygon(polygon, sliceStart, sliceEnd);
 
       if (result) {
         const [newPolygon1, newPolygon2] = result;
@@ -231,6 +232,11 @@ export const usePolygonSlicing = ({
       return false;
     }
 
+    // Polylines only need a segment intersection — skip closed-polygon validation
+    if (polygon.geometry === 'polyline') {
+      return true;
+    }
+
     const [sliceStart, sliceEnd] = tempPoints;
     const validation = validateSliceLine(polygon, sliceStart, sliceEnd);
 
@@ -252,6 +258,11 @@ export const usePolygonSlicing = ({
     const polygon = polygons.find(p => p.id === selectedPolygonId);
     if (!polygon) {
       return null;
+    }
+
+    // Polylines: always valid if we have 2 slice points
+    if (polygon.geometry === 'polyline') {
+      return { isValid: true, intersectionCount: 1 };
     }
 
     const [sliceStart, sliceEnd] = tempPoints;

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -677,6 +677,7 @@ export default {
         addPoints:
           'Klikněte pro přidání bodů, poté klikněte na jiný vrchol pro dokončení. Klikněte přímo na jiný vrchol bez přidávání bodů pro odstranění všech bodů mezi nimi.',
         holdShift: 'Držte SHIFT pro automatické přidávání bodů',
+        enterFinalize: 'Stiskněte ENTER pro dokončení (polylines: ořízne ve směru přidávání)',
         cancel: 'Stiskněte ESC pro zrušení',
       },
       editVertices: {

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -827,6 +827,7 @@ export default {
         addPoints:
           'Klicken Sie, um Punkte hinzuzufügen, dann klicken Sie auf einen anderen Eckpunkt zum Abschließen. Klicken Sie direkt auf einen anderen Eckpunkt ohne Punkte hinzuzufügen, um alle Punkte dazwischen zu entfernen.',
         holdShift: 'SHIFT halten für automatisches Hinzufügen von Punkten',
+        enterFinalize: 'ENTER drücken zum Abschließen (Polylinien: schneidet in Richtung ab)',
         cancel: 'Drücken Sie ESC zum Abbrechen',
       },
       editVertices: {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -682,6 +682,7 @@ export default {
         addPoints:
           'Click to add points, then click on another vertex to complete. Click directly on another vertex without adding points to remove all points between them.',
         holdShift: 'Hold SHIFT to automatically add points',
+        enterFinalize: 'Press ENTER to finalize (polylines: truncates in direction)',
         cancel: 'Press ESC to cancel',
       },
       editVertices: {

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -818,6 +818,7 @@ export default {
         addPoints:
           'Haz clic para agregar puntos, luego haz clic en otro vértice para completar. Haz clic directamente en otro vértice sin agregar puntos para eliminar todos los puntos entre ellos.',
         holdShift: 'Mantén SHIFT para agregar puntos automáticamente',
+        enterFinalize: 'Presione ENTER para finalizar (polilíneas: trunca en la dirección)',
         cancel: 'Presiona ESC para cancelar',
       },
       editVertices: {

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -819,6 +819,7 @@ export default {
         addPoints:
           'Cliquez pour ajouter des points, puis cliquez sur un autre sommet pour terminer. Cliquez directement sur un autre sommet sans ajouter de points pour supprimer tous les points entre eux.',
         holdShift: 'Maintenez SHIFT pour ajouter automatiquement des points',
+        enterFinalize: 'Appuyez sur ENTRÉE pour finaliser (polylignes : tronque dans la direction)',
         cancel: 'Appuyez sur ESC pour annuler',
       },
       editVertices: {

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -749,6 +749,7 @@ export default {
         addPoints:
           '点击添加点，然后点击另一个顶点完成。直接点击另一个顶点而不添加点，可删除它们之间的所有点。',
         holdShift: '按住SHIFT自动添加点',
+        enterFinalize: '按 ENTER 完成（折线：沿方向截断）',
         cancel: '按ESC取消',
       },
       editVertices: {


### PR DESCRIPTION
## Summary
- **ML postprocessing**: Replace uniform resampling with RDP-simplified output for midpiece/tail. Add intersection-based junction trimming (trims H↔M and M↔T at first crossing instead of endpoint averaging). Head stays at 3 points.
- **Frontend editor**: Add polyline slicing support, toolbar/shortcut integration, mode instructions, status bar updates, translations (6 languages).
- **Auth fix**: Correct refresh token endpoint path (`/auth/refresh` → `/auth/refresh-token`).

## Test plan
- [ ] Segment sperm image — verify polyline junctions are trimmed at intersection
- [ ] Use polyline slice tool in editor — verify it splits polylines correctly
- [ ] Check all 6 language translations render properly
- [ ] Verify auth token refresh works after session expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polyline slicing added to cut open paths at intersections
  * Enter now finalizes polyline editing (trims in the add direction)

* **UI Improvements**
  * Polygon creation mode icon updated for clarity
  * Right-click now enables panning during point-adding
  * Added localized instruction text for Enter finalization

* **Improvements**
  * More precise polyline simplification and junction connectivity
  * Reduced hover/interaction noise for unselected polylines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->