### PR TITLE
fix: prevent mid-session logout caused by token refresh race conditions

### DIFF
--- a/src/lib/__tests__/tokenRefresh.test.ts
+++ b/src/lib/__tests__/tokenRefresh.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/api', () => ({
     isAuthenticated: vi.fn(() => false),
     getAccessToken: vi.fn(() => null),
     getUserProfile: vi.fn().mockResolvedValue({ id: '1' }),
+    refreshAccessToken: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -99,7 +100,7 @@ describe('TokenRefreshManager', () => {
 
       // Timer should be at 30s minimum — advancing 29s should not trigger it
       vi.advanceTimersByTime(29_000);
-      expect(vi.mocked(apiClient.getUserProfile)).not.toHaveBeenCalled();
+      expect(vi.mocked(apiClient.refreshAccessToken)).not.toHaveBeenCalled();
     });
   });
 
@@ -115,17 +116,17 @@ describe('TokenRefreshManager', () => {
     it('returns true and reschedules when refresh succeeds', async () => {
       const { default: apiClient } = await import('@/lib/api');
       vi.mocked(apiClient.isAuthenticated).mockReturnValue(true);
-      vi.mocked(apiClient.getUserProfile).mockResolvedValue({ id: '1' });
+      vi.mocked(apiClient.refreshAccessToken).mockResolvedValue(undefined);
       vi.mocked(apiClient.getAccessToken).mockReturnValue(makeJwt());
 
       const result = await tokenRefreshManager.refreshTokenIfNeeded();
       expect(result).toBe(true);
     });
 
-    it('returns false when getUserProfile throws', async () => {
+    it('returns false when refreshAccessToken throws', async () => {
       const { default: apiClient } = await import('@/lib/api');
       vi.mocked(apiClient.isAuthenticated).mockReturnValue(true);
-      vi.mocked(apiClient.getUserProfile).mockRejectedValue(
+      vi.mocked(apiClient.refreshAccessToken).mockRejectedValue(
         new Error('Network error')
       );
 
@@ -133,28 +134,28 @@ describe('TokenRefreshManager', () => {
       expect(result).toBe(false);
     });
 
-    it('does not call getUserProfile concurrently (deduplicates in-flight refresh)', async () => {
+    it('does not refresh concurrently (deduplicates in-flight refresh)', async () => {
       const { default: apiClient } = await import('@/lib/api');
       vi.mocked(apiClient.isAuthenticated).mockReturnValue(true);
       vi.mocked(apiClient.getAccessToken).mockReturnValue(makeJwt());
 
-      let resolveProfile!: () => void;
-      vi.mocked(apiClient.getUserProfile).mockReturnValue(
-        new Promise<any>(res => {
-          resolveProfile = () => res({ id: '1' });
+      let resolveRefresh!: () => void;
+      vi.mocked(apiClient.refreshAccessToken).mockReturnValue(
+        new Promise<void>(res => {
+          resolveRefresh = () => res();
         })
       );
 
       const p1 = tokenRefreshManager.refreshTokenIfNeeded();
       const p2 = tokenRefreshManager.refreshTokenIfNeeded();
 
-      resolveProfile();
+      resolveRefresh();
       const [r1, r2] = await Promise.all([p1, p2]);
 
-      // First call succeeds, second is deduplicated and returns false
+      // First call succeeds, second is deduplicated via isRefreshing flag
       expect(r1).toBe(true);
       expect(r2).toBe(false);
-      expect(vi.mocked(apiClient.getUserProfile)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(apiClient.refreshAccessToken)).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -215,8 +215,8 @@ class ApiClient {
               // Retry the original request with new token
               originalRequest.headers.Authorization = `Bearer ${this.accessToken}`;
               return this.instance(originalRequest);
-            } catch (_refreshError) {
-              logger.debug('🔄 Token refresh failed, forcing logout');
+            } catch (refreshError) {
+              logger.error('Token refresh failed, forcing logout:', refreshError);
               // Fall through to force logout below
             }
           }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -498,7 +498,23 @@ class ApiClient {
     }
   }
 
+  private refreshPromise: Promise<void> | null = null;
+
   async refreshAccessToken(): Promise<void> {
+    // Deduplicate concurrent refresh attempts — all callers share one in-flight request
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this._doRefresh();
+    try {
+      await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+    }
+  }
+
+  private async _doRefresh(): Promise<void> {
     if (!this.refreshToken) {
       throw new Error('No refresh token available');
     }
@@ -507,8 +523,14 @@ class ApiClient {
       refreshToken: this.refreshToken,
     });
 
-    const data = this.extractData<{ accessToken: string }>(response);
+    const data = this.extractData<{
+      accessToken: string;
+      refreshToken: string;
+    }>(response);
     this.accessToken = data.accessToken;
+    if (data.refreshToken) {
+      this.refreshToken = data.refreshToken;
+    }
     this.saveTokensToStorage();
   }
 

--- a/src/lib/tokenRefresh.ts
+++ b/src/lib/tokenRefresh.ts
@@ -73,22 +73,21 @@ class TokenRefreshManager {
 
     try {
       this.isRefreshing = true;
-      logger.debug('🔄 Refreshing access token...');
+      logger.debug('Proactive token refresh...');
 
-      // The API client will handle the refresh automatically through its interceptor
-      // We just need to make a request that will trigger the refresh if needed
-      await apiClient.getUserProfile();
+      // Directly refresh the token — don't go through getUserProfile which would
+      // trigger the 401 interceptor and create a double-refresh race condition
+      await apiClient.refreshAccessToken();
 
-      // If we get here, the token was successfully refreshed
       const newAccessToken = apiClient.getAccessToken();
       if (newAccessToken) {
         this.scheduleTokenRefresh(newAccessToken);
-        logger.debug('✅ Token refreshed successfully');
+        logger.debug('Token refreshed successfully');
         return true;
       }
+      return false;
     } catch (error) {
       logger.error('Token refresh failed:', error);
-      // Clear tokens on refresh failure
       this.clearRefreshTimer();
       return false;
     } finally {

--- a/src/lib/tokenRefresh.ts
+++ b/src/lib/tokenRefresh.ts
@@ -85,6 +85,7 @@ class TokenRefreshManager {
         logger.debug('Token refreshed successfully');
         return true;
       }
+      logger.error('Token refresh completed but no access token was returned');
       return false;
     } catch (error) {
       logger.error('Token refresh failed:', error);


### PR DESCRIPTION
## Summary

Users were being unexpectedly logged out after 30-50 minutes of active use. Root cause: three interconnected bugs in the token refresh mechanism.

## Bug Analysis

**Bug 1 — Missing refresh token storage** (`api.ts:510`):
`refreshAccessToken()` extracted only `{ accessToken: string }` from the response, but backend returns `{ accessToken, refreshToken }` (rotated). After 2-3 refresh cycles, the old refresh token was invalidated by rotation, causing the next refresh to fail → logout.

**Bug 2 — No concurrency control** (`api.ts:203-222`):
When multiple requests received 401 simultaneously (common near token expiry), each independently called `refreshAccessToken()`. This caused multiple concurrent token rotation requests on the backend, creating race conditions in Redis.

**Bug 3 — Double refresh from timer** (`tokenRefresh.ts:80`):
The proactive timer called `getUserProfile()` which, if the token was already expired, triggered the 401 interceptor — creating a second refresh attempt alongside the timer's own.

## Fixes

1. Extract and store **both** `accessToken` and `refreshToken` from refresh response
2. **Promise deduplication**: `refreshPromise` field acts as a mutex — first caller creates the Promise, concurrent callers share it
3. Timer calls `refreshAccessToken()` directly instead of `getUserProfile()`

## Test plan

- [x] All 13 tokenRefresh tests pass (updated for new behavior)
- [x] All 201 auth-related tests pass
- [x] TypeScript compiles with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant concurrent token refreshes, improved refresh failure handling, and ensure refresh tokens are updated when provided.

* **Tests**
  * Updated token refresh tests to validate the new refresh flow, deduplication behavior, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->