### PR TITLE
fix: allow free canvas panning at zoom >= 1.0x

### DIFF
--- a/src/lib/__tests__/coordinateUtils.test.ts
+++ b/src/lib/__tests__/coordinateUtils.test.ts
@@ -142,20 +142,32 @@ describe('Coordinate Utilities', () => {
       expect(typeof result.translateY).toBe('number');
     });
 
-    it('should constrain translation to keep image in bounds', () => {
-      // Use zoom < 2 to test translation constraints (zoom >= 2 allows unlimited panning)
+    it('should allow free panning when zoomed in (>= 1.0)', () => {
       const extremeTransform: TransformState = {
-        zoom: 1.5, // Below 2.0 threshold where constraints apply
-        translateX: -2000, // Far out of bounds
+        zoom: 1.5,
+        translateX: -2000,
         translateY: -2000,
       };
 
       const result = constrainTransform(extremeTransform, 800, 600, 400, 300);
 
-      // Translation should be constrained to keep image visible
-      // For zoom >= 1.0, very generous constraints apply
-      expect(result.translateX).toBeGreaterThan(-2000); // Should be constrained from original
-      expect(result.translateY).toBeGreaterThan(-2000); // Should be constrained from original
+      // Zoom >= 1.0 allows unlimited panning
+      expect(result.translateX).toBe(-2000);
+      expect(result.translateY).toBe(-2000);
+    });
+
+    it('should constrain translation when zoomed out (< 1.0)', () => {
+      const extremeTransform: TransformState = {
+        zoom: 0.5,
+        translateX: -5000,
+        translateY: -5000,
+      };
+
+      const result = constrainTransform(extremeTransform, 800, 600, 400, 300);
+
+      // Zoom < 1.0 applies constraints to keep image visible
+      expect(result.translateX).toBeGreaterThan(-5000);
+      expect(result.translateY).toBeGreaterThan(-5000);
     });
   });
 

--- a/src/lib/coordinateUtils.ts
+++ b/src/lib/coordinateUtils.ts
@@ -196,9 +196,9 @@ export const constrainTransform = (
   let translateX = transform.translateX;
   let translateY = transform.translateY;
 
-  // When zoomed in significantly (>= 2x), allow unlimited panning
-  // This fixes the issue where highly zoomed images get stuck at boundaries
-  if (zoom >= 2.0) {
+  // When zoomed in (>= 1x), allow unlimited panning
+  // so the user can freely navigate to any part of the image
+  if (zoom >= 1.0) {
     return {
       zoom,
       translateX: transform.translateX,


### PR DESCRIPTION
## Summary
Users couldn't freely pan the segmentation editor canvas when zoomed to 1.0x-2.0x — the image hit invisible boundaries.

## Root Cause
`constrainTransform()` in `coordinateUtils.ts` had three zoom tiers:
- **>= 2.0x**: unlimited panning (correct)
- **1.0-2.0x**: constrained by `canvasSize * 3` margin (BUG — too small for large images)
- **< 1.0x**: gentle constraints (correct)

For a 4104px image at 1.5x zoom, `scaledWidth = 6156px` but the margin was only `~2400px`, creating a ~4800px panning window on a 6156px image.

## Fix
Lower the free-panning threshold from `zoom >= 2.0` to `zoom >= 1.0`. When zoomed in, there's no reason to restrict panning — users need to see any part of the image.

## Test plan
- [x] 15/15 coordinateUtils tests pass (1 updated, 1 added)
- [x] TypeScript compiles with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panning behavior at lower zoom levels. Users can now pan freely starting at 1x zoom, whereas previously panning constraints applied between 1x and 2x zoom levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->