### PR TITLE
feat: integrate UNet Attention-ASPP model + reorganize model UI + fix BMP thumbnails

### DIFF
--- a/backend/segmentation/api/main.py
+++ b/backend/segmentation/api/main.py
@@ -89,7 +89,7 @@ async def lifespan(app: FastAPI):
         
         # Pre-load all models for faster first response
         # Note: 'sperm' is optional - only loaded if weights file exists
-        models_to_load = ["hrnet", "cbam_resunet", "unet_spherohq", "sperm"]
+        models_to_load = ["hrnet", "cbam_resunet", "unet_spherohq", "unet_attention_aspp", "sperm"]
         loaded_count = 0
         
         for model_name in models_to_load:

--- a/backend/segmentation/api/models.py
+++ b/backend/segmentation/api/models.py
@@ -8,6 +8,7 @@ class ModelType(str, Enum):
     HRNET = "hrnet"
     CBAM_RESUNET = "cbam_resunet"
     UNET_SPHEROHQ = "unet_spherohq"
+    UNET_ATTENTION_ASPP = "unet_attention_aspp"
 
 class SegmentationRequest(BaseModel):
     model: ModelType = Field(default=ModelType.HRNET, description="Model to use for segmentation")

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -31,6 +31,7 @@ except ImportError:
 from models.hrnet import HRNetV2
 from models.cbam_resunet import ResUNetCBAM
 from models.unet import UNet
+from models.unet_attention import UNet as UNetAttention
 
 # Optional sperm model import
 _sperm_import_error = None
@@ -82,6 +83,12 @@ class BatchConfig:
                         "max_safe_batch_size": 2,
                         "expected_throughput": 2.2,
                         "memory_limit_mb": 4000
+                    },
+                    "unet_attention_aspp": {
+                        "optimal_batch_size": 1,
+                        "max_safe_batch_size": 1,
+                        "expected_throughput": 1.5,
+                        "memory_limit_mb": 5000
                     }
                 }
             }
@@ -132,6 +139,12 @@ class ModelLoader:
             'class': UNet,
             'pretrained_path': 'weights/unet_spherohq_best.pth',
             'finetuned_path': 'weights/unet_spherohq_best.pth',
+            'config_path': None
+        },
+        'unet_attention_aspp': {
+            'class': UNetAttention,
+            'pretrained_path': 'weights/unet_v4_weights.pth',
+            'finetuned_path': 'weights/unet_v4_weights.pth',
             'config_path': None
         },
         'sperm': {
@@ -221,6 +234,15 @@ class ModelLoader:
                 # UNet optimized for SpheroHQ dataset
                 model = UNet(in_channels=3, out_channels=1, features=[64, 128, 256, 512, 1024],
                            use_instance_norm=True, dropout_rate=0.0, use_deep_supervision=False)
+            elif model_name == 'unet_attention_aspp':
+                # Enhanced UNet with Attention Gates + ASPP for dissolving spheroids
+                model = UNetAttention(
+                    in_channels=3, out_channels=1,
+                    features=[64, 128, 256, 512, 1024],
+                    use_instance_norm=True, dropout_rate=0.0,
+                    use_deep_supervision=False,
+                    use_attention_gates=True, use_aspp=True
+                )
             elif model_name == 'sperm':
                 # Sperm segmentation model — uses its own pipeline (Mask2Former + graph assembly)
                 if SpermModel is None:
@@ -283,8 +305,9 @@ class ModelLoader:
                     # Recreate model with detected features - DROPOUT SET TO 0 FOR INFERENCE!
                     model = ResUNetCBAM(in_channels=3, out_channels=1, features=detected_features, use_instance_norm=True, dropout_rate=0.0)
             
-            # Load state dict
-            model.load_state_dict(state_dict, strict=False)
+            # Load state dict (strict=True for unet_attention_aspp, False for legacy models)
+            strict = (model_name == 'unet_attention_aspp')
+            model.load_state_dict(state_dict, strict=strict)
             
             model.to(self.device)
             model.eval()

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -307,8 +307,14 @@ class ModelLoader:
             
             # Load state dict (strict=True for unet_attention_aspp, False for legacy models)
             strict = (model_name == 'unet_attention_aspp')
-            model.load_state_dict(state_dict, strict=strict)
-            
+            load_result = model.load_state_dict(state_dict, strict=strict)
+            if not strict and (load_result.missing_keys or load_result.unexpected_keys):
+                logger.warning(
+                    f"State dict mismatch for {model_name}: "
+                    f"missing_keys={load_result.missing_keys}, "
+                    f"unexpected_keys={load_result.unexpected_keys}"
+                )
+
             model.to(self.device)
             model.eval()
             

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -3,6 +3,7 @@
 from .hrnet import HRNetV2
 from .cbam_resunet import ResUNetCBAM
 from .unet import UNet
+from .unet_attention import UNet as UNetAttention
 
 # Sperm model: optional import (loaded only when weights file is present)
 try:
@@ -10,4 +11,4 @@ try:
 except ImportError:
     SpermModel = None
 
-__all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'SpermModel']
+__all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'UNetAttention', 'SpermModel']

--- a/backend/segmentation/models/unet_attention.py
+++ b/backend/segmentation/models/unet_attention.py
@@ -1,6 +1,5 @@
-# unet.py
+# unet_attention.py
 # Enhanced UNet with Attention Gates + ASPP bottleneck for small cell detection
-# Base: https://github.com/michalprusek/cell-segmentation-hub
 
 import torch
 import torch.nn as nn
@@ -113,8 +112,8 @@ class ASPPBottleneck(nn.Module):
 class UNet(nn.Module):
     """Enhanced UNet with Attention Gates on skip connections and ASPP bottleneck.
 
-    Compatible with pretrained weights from standard UNet (strict=False loading).
-    New modules (attention_gates, aspp_bottleneck) initialize with Kaiming.
+    Trained from scratch; weights loaded with strict=True in inference.
+    All modules (including attention_gates and bottleneck/ASPP) use Kaiming init.
     """
 
     def __init__(
@@ -176,8 +175,9 @@ class UNet(nn.Module):
         if use_attention_gates:
             self.attention_gates = nn.ModuleList()
             for i in range(len(reversed_features) - 1):
-                F_g = reversed_features[i + 1]  # upsampled decoder channels
-                F_l = reversed_features[i + 1]  # encoder skip channels
+                # F_g == F_l here: ConvTranspose2d output matches encoder skip at each level
+                F_g = reversed_features[i + 1]
+                F_l = reversed_features[i + 1]
                 F_int = F_l // 2
                 self.attention_gates.append(AttentionGate(F_g, F_l, F_int))
 

--- a/backend/segmentation/models/unet_attention.py
+++ b/backend/segmentation/models/unet_attention.py
@@ -1,0 +1,252 @@
+# unet.py
+# Enhanced UNet with Attention Gates + ASPP bottleneck for small cell detection
+# Base: https://github.com/michalprusek/cell-segmentation-hub
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def get_norm_layer(num_features, use_instance_norm=True):
+    if use_instance_norm:
+        return nn.InstanceNorm2d(num_features, affine=True)
+    else:
+        return nn.BatchNorm2d(num_features)
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_channels, out_channels, use_instance_norm=True, dropout=0.0):
+        super(DoubleConv, self).__init__()
+        self.double_conv = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            get_norm_layer(out_channels, use_instance_norm),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(p=dropout) if dropout > 0 else nn.Identity(),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            get_norm_layer(out_channels, use_instance_norm),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x):
+        return self.double_conv(x)
+
+
+class AttentionGate(nn.Module):
+    """Additive attention gate for skip connections (Oktay et al., 2018).
+
+    Suppresses irrelevant background activations in encoder features
+    while preserving small cell signals, using decoder context as gating signal.
+    """
+
+    def __init__(self, F_g, F_l, F_int):
+        super().__init__()
+        self.W_g = nn.Sequential(
+            nn.Conv2d(F_g, F_int, kernel_size=1, bias=True),
+            get_norm_layer(F_int),
+        )
+        self.W_x = nn.Sequential(
+            nn.Conv2d(F_l, F_int, kernel_size=1, bias=True),
+            get_norm_layer(F_int),
+        )
+        self.psi = nn.Sequential(
+            nn.Conv2d(F_int, 1, kernel_size=1, bias=True),
+            nn.Sigmoid(),
+        )
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, g, x):
+        g1 = self.W_g(g)
+        x1 = self.W_x(x)
+        if g1.shape[2:] != x1.shape[2:]:
+            g1 = F.interpolate(g1, size=x1.shape[2:], mode="bilinear", align_corners=False)
+        psi = self.relu(g1 + x1)
+        psi = self.psi(psi)
+        return x * psi
+
+
+class ASPPBottleneck(nn.Module):
+    """Atrous Spatial Pyramid Pooling bottleneck (DeepLab v3+).
+
+    Replaces standard DoubleConv bottleneck with multi-scale context
+    via parallel dilated convolutions. Helps discriminate small cells from noise
+    by capturing context at multiple receptive field sizes.
+    """
+
+    def __init__(self, in_channels, out_channels, rates=(1, 2, 4, 6),
+                 use_instance_norm=True, dropout=0.15):
+        super().__init__()
+        mid = out_channels // (len(rates) + 1)
+
+        self.branches = nn.ModuleList()
+        for r in rates:
+            self.branches.append(nn.Sequential(
+                nn.Conv2d(in_channels, mid,
+                          kernel_size=1 if r == 1 else 3,
+                          padding=0 if r == 1 else r,
+                          dilation=r, bias=False),
+                get_norm_layer(mid, use_instance_norm),
+                nn.ReLU(inplace=True),
+            ))
+
+        # GAP branch — no norm (1×1 spatial breaks both InstanceNorm and BatchNorm)
+        self.gap = nn.Sequential(
+            nn.AdaptiveAvgPool2d(1),
+            nn.Conv2d(in_channels, mid, 1, bias=True),
+            nn.ReLU(inplace=True),
+        )
+
+        total_mid = mid * (len(rates) + 1)
+        self.project = nn.Sequential(
+            nn.Conv2d(total_mid, out_channels, 1, bias=False),
+            get_norm_layer(out_channels, use_instance_norm),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(dropout),
+        )
+
+    def forward(self, x):
+        h, w = x.shape[2:]
+        feats = [b(x) for b in self.branches]
+        gap = F.interpolate(self.gap(x), size=(h, w), mode="bilinear", align_corners=False)
+        return self.project(torch.cat(feats + [gap], dim=1))
+
+
+class UNet(nn.Module):
+    """Enhanced UNet with Attention Gates on skip connections and ASPP bottleneck.
+
+    Compatible with pretrained weights from standard UNet (strict=False loading).
+    New modules (attention_gates, aspp_bottleneck) initialize with Kaiming.
+    """
+
+    def __init__(
+        self,
+        in_channels=3,
+        out_channels=1,
+        features=[64, 128, 256, 512, 1024],
+        use_instance_norm=True,
+        dropout_rate=0.1,
+        use_deep_supervision=False,
+        use_attention_gates=True,
+        use_aspp=True,
+    ):
+        super(UNet, self).__init__()
+
+        self.use_instance_norm = use_instance_norm
+        self.use_deep_supervision = use_deep_supervision
+        self.use_attention_gates = use_attention_gates
+
+        # Initial convolution
+        self.init_conv = DoubleConv(in_channels, features[0], use_instance_norm, dropout=0)
+
+        # Encoder path
+        self.downs = nn.ModuleList()
+        self.pools = nn.ModuleList()
+        for i in range(len(features) - 1):
+            self.downs.append(
+                DoubleConv(features[i], features[i + 1], use_instance_norm,
+                           dropout=dropout_rate if i > 0 else 0)
+            )
+            self.pools.append(nn.MaxPool2d(kernel_size=2, stride=2))
+
+        # Bottleneck — ASPP or standard DoubleConv
+        if use_aspp:
+            self.bottleneck = ASPPBottleneck(
+                features[-2], features[-1], use_instance_norm=use_instance_norm,
+                dropout=dropout_rate * 1.5,
+            )
+        else:
+            self.bottleneck = DoubleConv(
+                features[-2], features[-1], use_instance_norm, dropout=dropout_rate * 1.5
+            )
+
+        # Decoder path
+        reversed_features = list(reversed(features))
+        self.ups = nn.ModuleList()
+        self.decoder_blocks = nn.ModuleList()
+        for i in range(len(reversed_features) - 1):
+            self.ups.append(
+                nn.ConvTranspose2d(reversed_features[i], reversed_features[i + 1],
+                                   kernel_size=2, stride=2)
+            )
+            self.decoder_blocks.append(
+                DoubleConv(reversed_features[i], reversed_features[i + 1],
+                           use_instance_norm, dropout=dropout_rate)
+            )
+
+        # Attention gates on skip connections
+        if use_attention_gates:
+            self.attention_gates = nn.ModuleList()
+            for i in range(len(reversed_features) - 1):
+                F_g = reversed_features[i + 1]  # upsampled decoder channels
+                F_l = reversed_features[i + 1]  # encoder skip channels
+                F_int = F_l // 2
+                self.attention_gates.append(AttentionGate(F_g, F_l, F_int))
+
+        # Final output
+        self.final_conv = nn.Conv2d(features[0], out_channels, kernel_size=1)
+
+        # Deep supervision
+        if use_deep_supervision:
+            self.deep_outputs = nn.ModuleList([
+                nn.Conv2d(features[i], out_channels, kernel_size=1)
+                for i in range(len(features) - 1)
+            ])
+
+        self._init_weights()
+
+    def _init_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, (nn.BatchNorm2d, nn.InstanceNorm2d)):
+                if m.weight is not None:
+                    nn.init.constant_(m.weight, 1)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+
+    def forward(self, x):
+        input_size = x.shape[2:]
+
+        x = self.init_conv(x)
+        skip_connections = [x]
+
+        for pool, down in zip(self.pools[:-1], self.downs[:-1]):
+            x = pool(skip_connections[-1])
+            x = down(x)
+            skip_connections.append(x)
+
+        # Bottleneck
+        x = self.pools[-1](skip_connections[-1])
+        x = self.bottleneck(x)
+
+        skip_connections = skip_connections[::-1]
+
+        # Decoder with attention gates
+        deep_outputs = []
+        for i, (up, decoder_block) in enumerate(zip(self.ups, self.decoder_blocks)):
+            x = up(x)
+            skip = skip_connections[i]
+
+            if x.shape[2:] != skip.shape[2:]:
+                x = F.interpolate(x, size=skip.shape[2:], mode="bilinear", align_corners=False)
+
+            # Apply attention gate before concatenation
+            if self.use_attention_gates:
+                skip = self.attention_gates[i](g=x, x=skip)
+
+            x = torch.cat([skip, x], dim=1)
+            x = decoder_block(x)
+
+            if self.use_deep_supervision and self.training and i < len(self.deep_outputs):
+                deep_out = self.deep_outputs[len(self.deep_outputs) - 1 - i](x)
+                deep_out = F.interpolate(deep_out, size=input_size, mode="bilinear", align_corners=False)
+                deep_outputs.append(deep_out)
+
+        x = self.final_conv(x)
+        if x.shape[2:] != input_size:
+            x = F.interpolate(x, size=input_size, mode="bilinear", align_corners=False)
+
+        if self.use_deep_supervision and self.training:
+            return x, deep_outputs
+        return x

--- a/backend/segmentation/scripts/download_weights.py
+++ b/backend/segmentation/scripts/download_weights.py
@@ -55,6 +55,12 @@ WEIGHTS_CONFIG = {
         "size": 429175255,  # 410 MB
         "sha256": None,
     },
+    "unet_attention_aspp": {
+        "gdrive_id": "TODO",  # Fill after Google Drive upload
+        "filename": "unet_v4_weights.pth",
+        "size": 141903720,  # 135 MB
+        "sha256": None,
+    },
 }
 
 

--- a/backend/src/api/routes/mlRoutes.ts
+++ b/backend/src/api/routes/mlRoutes.ts
@@ -44,6 +44,14 @@ router.get(
           version: '1.0.0',
           status: 'active',
         },
+        {
+          id: 'unet_attention_aspp',
+          name: 'UNet Attention-ASPP',
+          description:
+            'Enhanced UNet with Attention Gates and ASPP for dissolving spheroids and satellite cells',
+          version: '4.0.0',
+          status: 'active',
+        },
       ];
 
       return ResponseHelper.success(

--- a/backend/src/services/queueService.ts
+++ b/backend/src/services/queueService.ts
@@ -568,6 +568,7 @@ export class QueueService {
       hrnet: 1, // Always process one at a time for reliability
       cbam_resunet: 1, // Always process one at a time for reliability
       unet_spherohq: 1, // Always process one at a time for reliability
+      unet_attention_aspp: 1, // Always process one at a time for reliability
     };
 
     // Get the highest priority item first, excluding specified image IDs
@@ -1136,6 +1137,7 @@ export class QueueService {
       hrnet: 196, // ~196ms per image
       cbam_resunet: 396, // ~396ms per image
       unet_spherohq: 1000, // ~1000ms per image
+      unet_attention_aspp: 350, // ~350ms per image
     };
 
     const timePerImage = modelTimes[model as keyof typeof modelTimes] || 500;

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -35,6 +35,7 @@ export interface SegmentationRequest {
     | 'hrnet'
     | 'cbam_resunet'
     | 'unet_spherohq'
+    | 'unet_attention_aspp'
     | 'resunet_advanced'
     | 'resunet_small'
     | 'sperm';

--- a/backend/src/storage/localStorage.ts
+++ b/backend/src/storage/localStorage.ts
@@ -409,12 +409,23 @@ export class LocalStorageProvider implements StorageProvider {
     const absHeight = Math.abs(height);
     const bottomUp = height > 0;
 
-    // Validate dimensions and compression
+    // Validate header, dimensions and compression
+    if (dibHeaderSize < 40) {
+      throw new Error(
+        `Unsupported BMP DIB header size: ${dibHeaderSize} (only BITMAPINFOHEADER >= 40 supported)`
+      );
+    }
     if (width <= 0 || absHeight <= 0) {
       throw new Error(`Invalid BMP dimensions: ${width}x${height}`);
     }
     if (width > 65535 || absHeight > 65535) {
       throw new Error(`BMP dimensions too large: ${width}x${absHeight}`);
+    }
+    const totalPixels = width * absHeight;
+    if (totalPixels > 100_000_000) {
+      throw new Error(
+        `BMP too large for thumbnail decoding: ${width}x${absHeight} = ${totalPixels} pixels`
+      );
     }
     if (compression !== 0) {
       throw new Error(
@@ -433,13 +444,25 @@ export class LocalStorageProvider implements StorageProvider {
       // Palette starts after the DIB header (14-byte BMP header + dibHeaderSize)
       const paletteOffset = 14 + dibHeaderSize;
       const biClrUsed = buffer.readUInt32LE(46);
-      const paletteSize = biClrUsed > 0 ? biClrUsed : 256;
+      const paletteSize = biClrUsed > 0 && biClrUsed <= 256 ? biClrUsed : 256;
+      const paletteEnd = paletteOffset + paletteSize * 4;
+      if (paletteEnd > buffer.length) {
+        throw new Error(
+          `BMP palette data truncated: need ${paletteEnd} bytes, file is ${buffer.length} bytes`
+        );
+      }
       const palette: [number, number, number][] = [];
       for (let i = 0; i < paletteSize; i++) {
         const off = paletteOffset + i * 4;
         palette.push([buffer[off + 2], buffer[off + 1], buffer[off]]);
       }
       const rowSize = Math.ceil(width / 4) * 4;
+      const requiredEnd = dataOffset + rowSize * absHeight;
+      if (requiredEnd > buffer.length) {
+        throw new Error(
+          `BMP pixel data truncated: need ${requiredEnd} bytes, file is ${buffer.length} bytes`
+        );
+      }
       for (let y = 0; y < absHeight; y++) {
         const srcRow = bottomUp ? absHeight - 1 - y : y;
         const srcOffset = dataOffset + srcRow * rowSize;
@@ -454,6 +477,12 @@ export class LocalStorageProvider implements StorageProvider {
       }
     } else if (bitsPerPixel === 24) {
       const rowSize = Math.ceil((width * 3) / 4) * 4;
+      const requiredEnd = dataOffset + rowSize * absHeight;
+      if (requiredEnd > buffer.length) {
+        throw new Error(
+          `BMP pixel data truncated: need ${requiredEnd} bytes, file is ${buffer.length} bytes`
+        );
+      }
       for (let y = 0; y < absHeight; y++) {
         const srcRow = bottomUp ? absHeight - 1 - y : y;
         const srcOffset = dataOffset + srcRow * rowSize;
@@ -467,6 +496,12 @@ export class LocalStorageProvider implements StorageProvider {
       }
     } else if (bitsPerPixel === 32) {
       const rowSize = width * 4;
+      const requiredEnd = dataOffset + rowSize * absHeight;
+      if (requiredEnd > buffer.length) {
+        throw new Error(
+          `BMP pixel data truncated: need ${requiredEnd} bytes, file is ${buffer.length} bytes`
+        );
+      }
       for (let y = 0; y < absHeight; y++) {
         const srcRow = bottomUp ? absHeight - 1 - y : y;
         const srcOffset = dataOffset + srcRow * rowSize;

--- a/backend/src/storage/localStorage.ts
+++ b/backend/src/storage/localStorage.ts
@@ -79,23 +79,17 @@ export class LocalStorageProvider implements StorageProvider {
 
           const thumbnailSize = options.thumbnailSize || DEFAULT_THUMBNAIL_SIZE;
 
-          // Sharp needs special handling for certain file formats
-          let sharpInstance = sharp(buffer);
+          // Sharp (libvips) doesn't support BMP input — decode manually
+          const inputBuffer = this.isBmpMimeType(mimeType)
+            ? this.decodeBmpToRawBuffer(buffer)
+            : { data: buffer };
 
-          // For BMP and other formats that might have issues, ensure proper conversion
-          if (
-            mimeType === 'image/bmp' ||
-            mimeType === 'image/x-ms-bmp' ||
-            mimeType === 'image/x-bmp' ||
-            mimeType === 'image/gif' ||
-            mimeType === 'image/tiff' ||
-            mimeType === 'image/tif'
-          ) {
-            // Convert these formats to JPEG for consistent thumbnails
-            sharpInstance = sharpInstance.toFormat('jpeg');
-          }
+          const sharpInput =
+            'raw' in inputBuffer
+              ? sharp(inputBuffer.data, { raw: inputBuffer.raw })
+              : sharp(inputBuffer.data);
 
-          await sharpInstance
+          await sharpInput
             .resize(thumbnailSize.width, thumbnailSize.height, {
               fit: 'inside',
               withoutEnlargement: true,
@@ -375,6 +369,92 @@ export class LocalStorageProvider implements StorageProvider {
    */
   private isImageMimeType(mimeType: string): boolean {
     return mimeType.startsWith('image/');
+  }
+
+  /**
+   * Check if MIME type is BMP (Sharp/libvips doesn't support BMP input)
+   */
+  private isBmpMimeType(mimeType: string): boolean {
+    return (
+      mimeType === 'image/bmp' ||
+      mimeType === 'image/x-ms-bmp' ||
+      mimeType === 'image/x-bmp'
+    );
+  }
+
+  /**
+   * Decode BMP file to raw RGB pixel buffer for Sharp.
+   * Sharp (libvips) doesn't support BMP input natively.
+   * Handles 8-bit palette-indexed and 24-bit direct BGR formats.
+   */
+  private decodeBmpToRawBuffer(buffer: Buffer): {
+    data: Buffer;
+    raw: { width: number; height: number; channels: 3 };
+  } {
+    const dataOffset = buffer.readUInt32LE(10);
+    const width = buffer.readInt32LE(18);
+    const height = buffer.readInt32LE(22);
+    const bitsPerPixel = buffer.readUInt16LE(28);
+    const absHeight = Math.abs(height);
+    const bottomUp = height > 0;
+
+    const pixelData = Buffer.alloc(width * absHeight * 3);
+
+    if (bitsPerPixel === 8) {
+      // Palette-indexed: 256 entries at offset 54, each 4 bytes (BGRA)
+      const paletteOffset = 54;
+      const palette: [number, number, number][] = [];
+      for (let i = 0; i < 256; i++) {
+        const off = paletteOffset + i * 4;
+        palette.push([buffer[off + 2], buffer[off + 1], buffer[off]]);
+      }
+      const rowSize = Math.ceil(width / 4) * 4;
+      for (let y = 0; y < absHeight; y++) {
+        const srcRow = bottomUp ? absHeight - 1 - y : y;
+        const srcOffset = dataOffset + srcRow * rowSize;
+        for (let x = 0; x < width; x++) {
+          const idx = buffer[srcOffset + x];
+          const dstIdx = (y * width + x) * 3;
+          const [r, g, b] = palette[idx];
+          pixelData[dstIdx] = r;
+          pixelData[dstIdx + 1] = g;
+          pixelData[dstIdx + 2] = b;
+        }
+      }
+    } else if (bitsPerPixel === 24) {
+      const rowSize = Math.ceil((width * 3) / 4) * 4;
+      for (let y = 0; y < absHeight; y++) {
+        const srcRow = bottomUp ? absHeight - 1 - y : y;
+        const srcOffset = dataOffset + srcRow * rowSize;
+        for (let x = 0; x < width; x++) {
+          const srcIdx = srcOffset + x * 3;
+          const dstIdx = (y * width + x) * 3;
+          pixelData[dstIdx] = buffer[srcIdx + 2];
+          pixelData[dstIdx + 1] = buffer[srcIdx + 1];
+          pixelData[dstIdx + 2] = buffer[srcIdx];
+        }
+      }
+    } else if (bitsPerPixel === 32) {
+      const rowSize = width * 4;
+      for (let y = 0; y < absHeight; y++) {
+        const srcRow = bottomUp ? absHeight - 1 - y : y;
+        const srcOffset = dataOffset + srcRow * rowSize;
+        for (let x = 0; x < width; x++) {
+          const srcIdx = srcOffset + x * 4;
+          const dstIdx = (y * width + x) * 3;
+          pixelData[dstIdx] = buffer[srcIdx + 2];
+          pixelData[dstIdx + 1] = buffer[srcIdx + 1];
+          pixelData[dstIdx + 2] = buffer[srcIdx];
+        }
+      }
+    } else {
+      throw new Error(`Unsupported BMP bit depth: ${bitsPerPixel}`);
+    }
+
+    return {
+      data: pixelData,
+      raw: { width, height: absHeight, channels: 3 },
+    };
   }
 
   /**

--- a/backend/src/storage/localStorage.ts
+++ b/backend/src/storage/localStorage.ts
@@ -385,26 +385,57 @@ export class LocalStorageProvider implements StorageProvider {
   /**
    * Decode BMP file to raw RGB pixel buffer for Sharp.
    * Sharp (libvips) doesn't support BMP input natively.
-   * Handles 8-bit palette-indexed and 24-bit direct BGR formats.
+   * Handles 8-bit palette-indexed, 24-bit BGR, and 32-bit BGRA formats.
+   * Only uncompressed BMPs (BI_RGB) are supported.
    */
   private decodeBmpToRawBuffer(buffer: Buffer): {
     data: Buffer;
     raw: { width: number; height: number; channels: 3 };
   } {
+    // Validate BMP signature and minimum header size
+    if (buffer.length < 54) {
+      throw new Error(`BMP file too small: ${buffer.length} bytes`);
+    }
+    if (buffer[0] !== 0x42 || buffer[1] !== 0x4d) {
+      throw new Error('Invalid BMP signature (expected BM)');
+    }
+
     const dataOffset = buffer.readUInt32LE(10);
+    const dibHeaderSize = buffer.readUInt32LE(14);
     const width = buffer.readInt32LE(18);
     const height = buffer.readInt32LE(22);
     const bitsPerPixel = buffer.readUInt16LE(28);
+    const compression = buffer.readUInt32LE(30);
     const absHeight = Math.abs(height);
     const bottomUp = height > 0;
+
+    // Validate dimensions and compression
+    if (width <= 0 || absHeight <= 0) {
+      throw new Error(`Invalid BMP dimensions: ${width}x${height}`);
+    }
+    if (width > 65535 || absHeight > 65535) {
+      throw new Error(`BMP dimensions too large: ${width}x${absHeight}`);
+    }
+    if (compression !== 0) {
+      throw new Error(
+        `Unsupported BMP compression: ${compression} (only BI_RGB=0 supported)`
+      );
+    }
+    if (dataOffset >= buffer.length) {
+      throw new Error(
+        `BMP data offset (${dataOffset}) past end of file (${buffer.length})`
+      );
+    }
 
     const pixelData = Buffer.alloc(width * absHeight * 3);
 
     if (bitsPerPixel === 8) {
-      // Palette-indexed: 256 entries at offset 54, each 4 bytes (BGRA)
-      const paletteOffset = 54;
+      // Palette starts after the DIB header (14-byte BMP header + dibHeaderSize)
+      const paletteOffset = 14 + dibHeaderSize;
+      const biClrUsed = buffer.readUInt32LE(46);
+      const paletteSize = biClrUsed > 0 ? biClrUsed : 256;
       const palette: [number, number, number][] = [];
-      for (let i = 0; i < 256; i++) {
+      for (let i = 0; i < paletteSize; i++) {
         const off = paletteOffset + i * 4;
         palette.push([buffer[off + 2], buffer[off + 1], buffer[off]]);
       }
@@ -415,7 +446,7 @@ export class LocalStorageProvider implements StorageProvider {
         for (let x = 0; x < width; x++) {
           const idx = buffer[srcOffset + x];
           const dstIdx = (y * width + x) * 3;
-          const [r, g, b] = palette[idx];
+          const [r, g, b] = palette[idx] || [0, 0, 0];
           pixelData[dstIdx] = r;
           pixelData[dstIdx + 1] = g;
           pixelData[dstIdx + 2] = b;

--- a/backend/src/types/queue.ts
+++ b/backend/src/types/queue.ts
@@ -19,6 +19,7 @@ export type SegmentationModel =
   | 'hrnet'
   | 'cbam_resunet'
   | 'unet_spherohq'
+  | 'unet_attention_aspp'
   | 'resunet_advanced'
   | 'resunet_small';
 
@@ -356,6 +357,7 @@ export function isSegmentationModel(
     value === 'hrnet' ||
     value === 'cbam_resunet' ||
     value === 'unet_spherohq' ||
+    value === 'unet_attention_aspp' ||
     value === 'resunet_advanced' ||
     value === 'resunet_small'
   );

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -13,10 +13,10 @@ export const uuidSchema = z.string().uuid('Musí být platné UUID');
  * Segmentation model validation
  */
 export const segmentationModelSchema = z.enum(
-  ['hrnet', 'cbam_resunet', 'unet_spherohq', 'sperm'],
+  ['hrnet', 'cbam_resunet', 'unet_spherohq', 'unet_attention_aspp', 'sperm'],
   {
     errorMap: () => ({
-      message: 'Model musí být hrnet, cbam_resunet, unet_spherohq nebo sperm',
+      message: 'Model musí být hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp nebo sperm',
     }),
   }
 );

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -41,16 +41,18 @@ const ModelSettingsSection = () => {
   const handleModelChange = (modelId: string) => {
     const model = availableModels.find(m => m.id === modelId);
     setSelectedModel(modelId as ModelType);
-    if (model && model.defaultThreshold !== 0.5) {
+    if (model) {
       setConfidenceThreshold(model.defaultThreshold);
-      toast.success(
-        t('settings.thresholdAutoAdjusted').replace(
-          '{threshold}',
-          String(Math.round(model.defaultThreshold * 100))
-        )
-      );
-    } else {
-      toast.success(t('settings.modelSelected'));
+      if (model.defaultThreshold !== 0.5) {
+        toast.success(
+          t('settings.thresholdAutoAdjusted').replace(
+            '{threshold}',
+            String(Math.round(model.defaultThreshold * 100))
+          )
+        );
+      } else {
+        toast.success(t('settings.modelSelected'));
+      }
     }
   };
 

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
@@ -14,6 +14,7 @@ import { toast } from 'sonner';
 import { ModelType } from '@/contexts/useModel';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useLocalizedModels } from '@/hooks/useLocalizedModels';
+import { ModelInfo } from '@/lib/modelUtils';
 import { Cpu, Zap, Target } from 'lucide-react';
 
 const ModelSettingsSection = () => {
@@ -28,9 +29,29 @@ const ModelSettingsSection = () => {
     availableModels,
   } = useLocalizedModels();
 
+  const spheroidModels = useMemo(
+    () => availableModels.filter(m => m.category === 'spheroid'),
+    [availableModels]
+  );
+  const spermModels = useMemo(
+    () => availableModels.filter(m => m.category === 'sperm'),
+    [availableModels]
+  );
+
   const handleModelChange = (modelId: string) => {
+    const model = availableModels.find(m => m.id === modelId);
     setSelectedModel(modelId as ModelType);
-    toast.success(t('settings.modelSelected'));
+    if (model && model.defaultThreshold !== 0.5) {
+      setConfidenceThreshold(model.defaultThreshold);
+      toast.success(
+        t('settings.thresholdAutoAdjusted').replace(
+          '{threshold}',
+          String(Math.round(model.defaultThreshold * 100))
+        )
+      );
+    } else {
+      toast.success(t('settings.modelSelected'));
+    }
   };
 
   const handleThresholdChange = (value: number[]) => {
@@ -72,6 +93,30 @@ const ModelSettingsSection = () => {
     }
   };
 
+  const renderModelCard = (model: ModelInfo) => (
+    <div key={model.id} className="flex items-center space-x-4">
+      <RadioGroupItem value={model.id} id={model.id} />
+      <Label htmlFor={model.id} className="flex-1 cursor-pointer">
+        <Card className="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50">
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base flex items-center gap-2">
+                {getSizeIcon(model.size)}
+                {model.displayName}
+              </CardTitle>
+              <Badge className={getSizeBadgeColor(model.size)}>
+                {t(`settings.modelSize.${model.size}`)}
+              </Badge>
+            </div>
+            <CardDescription className="text-sm">
+              {t(`settings.modelDescription.${model.id}`)}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </Label>
+    </div>
+  );
+
   return (
     <div className="space-y-6">
       <div>
@@ -84,29 +129,17 @@ const ModelSettingsSection = () => {
 
         <RadioGroup value={selectedModel} onValueChange={handleModelChange}>
           <div className="space-y-4">
-            {availableModels.map(model => (
-              <div key={model.id} className="flex items-center space-x-4">
-                <RadioGroupItem value={model.id} id={model.id} />
-                <Label htmlFor={model.id} className="flex-1 cursor-pointer">
-                  <Card className="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                    <CardHeader className="pb-3">
-                      <div className="flex items-center justify-between">
-                        <CardTitle className="text-base flex items-center gap-2">
-                          {getSizeIcon(model.size)}
-                          {model.displayName}
-                        </CardTitle>
-                        <Badge className={getSizeBadgeColor(model.size)}>
-                          {t(`settings.modelSize.${model.size}`)}
-                        </Badge>
-                      </div>
-                      <CardDescription className="text-sm">
-                        {t(`settings.modelDescription.${model.id}`)}
-                      </CardDescription>
-                    </CardHeader>
-                  </Card>
-                </Label>
-              </div>
-            ))}
+            <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              {t('settings.modelSelection.sections.spheroid')}
+            </h4>
+            {spheroidModels.map(renderModelCard)}
+
+            <div className="pt-2">
+              <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                {t('settings.modelSelection.sections.sperm')}
+              </h4>
+            </div>
+            {spermModels.map(renderModelCard)}
           </div>
         </RadioGroup>
       </div>

--- a/src/lib/modelUtils.ts
+++ b/src/lib/modelUtils.ts
@@ -1,5 +1,12 @@
 // Define types locally to avoid circular dependency
-export type ModelType = 'hrnet' | 'cbam_resunet' | 'unet_spherohq' | 'sperm';
+export type ModelType =
+  | 'hrnet'
+  | 'cbam_resunet'
+  | 'unet_spherohq'
+  | 'unet_attention_aspp'
+  | 'sperm';
+
+export type ModelCategory = 'spheroid' | 'sperm';
 
 export interface ModelPerformance {
   avgTimePerImage: number; // seconds
@@ -15,6 +22,7 @@ export interface ModelInfo {
   description: string;
   size: 'small' | 'medium' | 'large';
   defaultThreshold: number;
+  category: ModelCategory;
   performance?: ModelPerformance;
 }
 
@@ -33,6 +41,7 @@ export function getLocalizedModelInfo(
       id: 'hrnet',
       size: 'small',
       defaultThreshold: 0.5,
+      category: 'spheroid',
       performance: {
         avgTimePerImage: 0.204,
         throughput: 4.9,
@@ -44,6 +53,7 @@ export function getLocalizedModelInfo(
       id: 'cbam_resunet',
       size: 'medium',
       defaultThreshold: 0.5,
+      category: 'spheroid',
       performance: {
         avgTimePerImage: 0.377,
         throughput: 2.7,
@@ -55,6 +65,7 @@ export function getLocalizedModelInfo(
       id: 'unet_spherohq',
       size: 'small',
       defaultThreshold: 0.5,
+      category: 'spheroid',
       performance: {
         avgTimePerImage: 0.181,
         throughput: 5.5,
@@ -62,10 +73,23 @@ export function getLocalizedModelInfo(
         batchSize: 4,
       },
     },
+    unet_attention_aspp: {
+      id: 'unet_attention_aspp',
+      size: 'medium',
+      defaultThreshold: 0.2,
+      category: 'spheroid',
+      performance: {
+        avgTimePerImage: 0.35,
+        throughput: 2.8,
+        p95Latency: 0.5,
+        batchSize: 1,
+      },
+    },
     sperm: {
       id: 'sperm',
       size: 'medium',
       defaultThreshold: 0.5,
+      category: 'sperm',
       performance: {
         avgTimePerImage: 0.3,
         throughput: 3.3,
@@ -79,6 +103,7 @@ export function getLocalizedModelInfo(
     hrnet: 'hrnet',
     cbam_resunet: 'cbam',
     unet_spherohq: 'unet_spherohq',
+    unet_attention_aspp: 'unet_attention_aspp',
     sperm: 'sperm',
   };
 
@@ -101,6 +126,7 @@ export function getAllLocalizedModels(t: (key: string) => string): ModelInfo[] {
     'hrnet',
     'cbam_resunet',
     'unet_spherohq',
+    'unet_attention_aspp',
     'sperm',
   ];
   return modelIds.map(id => getLocalizedModelInfo(id, t));
@@ -124,6 +150,7 @@ export const BASIC_MODEL_INFO: Record<
     description: 'Balanced model with good speed and quality, E2E ~309ms',
     size: 'small',
     defaultThreshold: 0.5,
+    category: 'spheroid',
     performance: {
       avgTimePerImage: 0.204,
       throughput: 4.9,
@@ -139,6 +166,7 @@ export const BASIC_MODEL_INFO: Record<
       'Most precise segmentation with attention mechanisms, E2E ~482ms',
     size: 'medium',
     defaultThreshold: 0.5,
+    category: 'spheroid',
     performance: {
       avgTimePerImage: 0.377,
       throughput: 2.7,
@@ -154,6 +182,7 @@ export const BASIC_MODEL_INFO: Record<
       'Fastest model after optimizations, excellent for real-time processing, E2E ~286ms',
     size: 'small',
     defaultThreshold: 0.5,
+    category: 'spheroid',
     performance: {
       avgTimePerImage: 0.181,
       throughput: 5.5,
@@ -161,14 +190,31 @@ export const BASIC_MODEL_INFO: Record<
       batchSize: 4,
     },
   },
+  unet_attention_aspp: {
+    id: 'unet_attention_aspp',
+    name: 'UNet Attention-ASPP',
+    displayName: 'UNet Attention-ASPP',
+    description:
+      'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells',
+    size: 'medium',
+    defaultThreshold: 0.2,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.35,
+      throughput: 2.8,
+      p95Latency: 0.5,
+      batchSize: 1,
+    },
+  },
   sperm: {
     id: 'sperm',
-    name: 'Sperm Segmentation',
-    displayName: 'Sperm Segmentation',
+    name: 'Sperm Morphology',
+    displayName: 'Sperm Morphology',
     description:
       'Sperm morphology model with skeleton extraction for head/midpiece/tail measurement',
     size: 'medium',
     defaultThreshold: 0.5,
+    category: 'sperm',
     performance: {
       avgTimePerImage: 0.3,
       throughput: 3.3,

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -392,6 +392,10 @@ export default {
     modelSelection: {
       title: 'Výběr modelu',
       description: 'Vyberte AI model pro segmentaci buněk',
+      sections: {
+        spheroid: 'Modely sféroidů',
+        sperm: 'Modely spermií',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -406,8 +410,13 @@ export default {
           description:
             'Nejlepší výkon na datové sadě SpheroHQ - optimalizováno pro segmentaci sféroidů s vyváženou rychlostí a přesností (~0.25s/obr., 10 obr./s)',
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            'Vylepšený UNet s Attention Gates a ASPP pro detekci rozpadajících se sféroidů a malých satelitních buněk (~0.35s/snímek)',
+        },
         sperm: {
-          name: 'Segmentace spermií',
+          name: 'Morfologie spermií',
           description:
             'Model morfologie spermií s extrakcí kostry pro měření hlavy, středního dílu a bičíku',
         },
@@ -422,6 +431,8 @@ export default {
     currentThreshold: 'Současný práh',
     modelSelected: 'Model úspěšně vybrán',
     modelSettingsSaved: 'Nastavení modelu úspěšně uloženo',
+    thresholdAutoAdjusted:
+      'Model vybrán — práh automaticky nastaven na {threshold}% (optimalizováno pro tento model)',
     modelSize: {
       small: 'Malý',
       medium: 'Střední',
@@ -434,6 +445,8 @@ export default {
         'Nejpřesnější segmentace s mechanismy pozornosti (E2E ~482ms, 2.7 obr/s)',
       unet_spherohq:
         'Nejrychlejší model po optimalizacích! Výborný pro zpracování v reálném čase (E2E ~286ms, 5.5 obr/s)',
+      unet_attention_aspp:
+        'Vylepšený UNet s Attention Gates a ASPP bottleneck pro detekci rozpadajících se sféroidů a malých satelitních buněk (35.5M parametrů)',
       sperm:
         'Model morfologie spermií s extrakcí kostry pro měření hlavy, středního dílu a bičíku',
     },

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -410,6 +410,10 @@ export default {
     modelSelection: {
       title: 'Modellauswahl',
       description: 'Wählen Sie das KI-Modell für die Zellsegmentierung',
+      sections: {
+        spheroid: 'Sphäroid-Modelle',
+        sperm: 'Spermien-Modelle',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -426,8 +430,13 @@ export default {
           description:
             'Beste Leistung auf SpheroHQ-Datensatz - optimiert für Sphäroid-Segmentierung mit ausgewogener Geschwindigkeit und Genauigkeit (~0.25s/Bild, 10 Bilder/s)',
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            'Erweitertes UNet mit Attention Gates und ASPP zur Erkennung zerfallender Sphäroide und kleiner Satellitenzellen (~0.35s/Bild)',
+        },
         sperm: {
-          name: 'Spermien-Segmentierung',
+          name: 'Spermien-Morphologie',
           description:
             'Spermien-Morphologiemodell mit Skelettextraktion zur Messung von Kopf, Mittelstück und Schwanz',
         },
@@ -442,6 +451,8 @@ export default {
     currentThreshold: 'Aktuelle Schwelle',
     modelSelected: 'Modell erfolgreich ausgewählt',
     modelSettingsSaved: 'Modelleinstellungen erfolgreich gespeichert',
+    thresholdAutoAdjusted:
+      'Modell ausgewählt — Schwellenwert automatisch auf {threshold}% eingestellt (optimiert für dieses Modell)',
     modelSize: {
       small: 'Klein',
       medium: 'Mittel',
@@ -454,6 +465,8 @@ export default {
         'Präziseste Segmentierung mit Aufmerksamkeitsmechanismen (E2E ~482ms, 2.7 Bilder/s)',
       unet_spherohq:
         'Schnellstes Modell nach Optimierungen! Hervorragend für Echtzeitverarbeitung (E2E ~286ms, 5.5 Bilder/s)',
+      unet_attention_aspp:
+        'Erweitertes UNet mit Attention Gates und ASPP-Bottleneck zur Erkennung zerfallender Sphäroide und kleiner Satellitenzellen (35,5M Parameter)',
       sperm:
         'Spermienmorphologie-Modell mit Skelettextraktion zur Messung von Kopf, Mittelstück und Schwanz',
     },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -418,6 +418,10 @@ export default {
     modelSelection: {
       title: 'Model Selection',
       description: 'Choose the AI model to use for cell segmentation',
+      sections: {
+        spheroid: 'Spheroid Models',
+        sperm: 'Sperm Models',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -434,8 +438,13 @@ export default {
           description:
             'Best performance on SpheroHQ dataset - optimized for spheroid segmentation with balanced speed and accuracy (~0.25s/image, 10 img/s)',
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells (~0.35s/image)',
+        },
         sperm: {
-          name: 'Sperm Segmentation',
+          name: 'Sperm Morphology',
           description:
             'Sperm morphology model with skeleton extraction for head/midpiece/tail measurement',
         },
@@ -450,6 +459,8 @@ export default {
     currentThreshold: 'Current threshold',
     modelSelected: 'Model selected successfully',
     modelSettingsSaved: 'Model settings saved successfully',
+    thresholdAutoAdjusted:
+      'Model selected — threshold automatically set to {threshold}% (optimized for this model)',
     modelSize: {
       small: 'Small',
       medium: 'Medium',
@@ -462,6 +473,8 @@ export default {
         'Most precise segmentation with attention mechanisms (E2E ~482ms, 2.7 img/s)',
       unet_spherohq:
         'Fastest model after optimizations! Excellent for real-time processing (E2E ~286ms, 5.5 img/s)',
+      unet_attention_aspp:
+        'Enhanced UNet with Attention Gates and ASPP bottleneck for detecting dissolving spheroids and small satellite cells (35.5M params)',
       sperm:
         'Sperm morphology model with skeleton extraction for head, midpiece, and tail measurement',
     },

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -388,6 +388,10 @@ export default {
     modelSelection: {
       title: 'Selección de modelo',
       description: 'Elige el modelo de IA para usar en la segmentación celular',
+      sections: {
+        spheroid: 'Modelos de esferoides',
+        sperm: 'Modelos de espermatozoides',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -404,8 +408,13 @@ export default {
           description:
             'Mejor rendimiento en el conjunto de datos SpheroHQ - optimizado para segmentación de esferoides con velocidad y precisión equilibradas (~0.25s/imagen, 10 img/s)',
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            'UNet mejorado con Attention Gates y ASPP para detectar esferoides en disolución y pequeñas células satélite (~0.35s/imagen)',
+        },
         sperm: {
-          name: 'Segmentación de espermatozoides',
+          name: 'Morfología espermática',
           description:
             'Modelo de morfología espermática con extracción de esqueleto para medir cabeza, pieza media y cola',
         },
@@ -420,6 +429,8 @@ export default {
     currentThreshold: 'Umbral actual',
     modelSelected: 'Modelo seleccionado con éxito',
     modelSettingsSaved: 'Configuración de modelo guardada con éxito',
+    thresholdAutoAdjusted:
+      'Modelo seleccionado — umbral ajustado automáticamente a {threshold}% (optimizado para este modelo)',
     modelSize: {
       small: 'Pequeño',
       medium: 'Mediano',
@@ -432,6 +443,8 @@ export default {
         'Segmentación más precisa con mecanismos de atención (E2E ~482ms, 2.7 img/s)',
       unet_spherohq:
         '¡El modelo más rápido después de las optimizaciones! Excelente para procesamiento en tiempo real (E2E ~286ms, 5.5 img/s)',
+      unet_attention_aspp:
+        'UNet mejorado con Attention Gates y cuello de botella ASPP para detectar esferoides en disolución y pequeñas células satélite (35,5M parámetros)',
       sperm:
         'Modelo de morfología espermática con extracción de esqueleto para medir cabeza, pieza media y cola',
     },

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -401,6 +401,10 @@ export default {
       title: 'Sélection de modèle',
       description:
         'Choisissez le modèle IA à utiliser pour la segmentation cellulaire',
+      sections: {
+        spheroid: 'Modèles de sphéroïdes',
+        sperm: 'Modèles de spermatozoïdes',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -417,8 +421,13 @@ export default {
           description:
             "Meilleures performances sur l'ensemble de données SpheroHQ - optimisé pour la segmentation de sphéroïdes avec vitesse et précision équilibrées (~0.25s/image, 10 img/s)",
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            'UNet amélioré avec Attention Gates et ASPP pour la détection de sphéroïdes en dissolution et de petites cellules satellites (~0.35s/image)',
+        },
         sperm: {
-          name: 'Segmentation de spermatozoïdes',
+          name: 'Morphologie des spermatozoïdes',
           description:
             'Modèle de morphologie spermatique avec extraction de squelette pour mesurer la tête, la pièce intermédiaire et la queue',
         },
@@ -433,6 +442,8 @@ export default {
     currentThreshold: 'Seuil actuel',
     modelSelected: 'Modèle sélectionné avec succès',
     modelSettingsSaved: 'Paramètres du modèle enregistrés avec succès',
+    thresholdAutoAdjusted:
+      'Modèle sélectionné — seuil automatiquement réglé à {threshold}% (optimisé pour ce modèle)',
     modelSize: {
       small: 'Petit',
       medium: 'Moyen',
@@ -445,6 +456,8 @@ export default {
         "Segmentation la plus précise avec mécanismes d'attention (E2E ~482ms, 2.7 img/s)",
       unet_spherohq:
         'Le modèle le plus rapide après optimisations! Excellent pour le traitement en temps réel (E2E ~286ms, 5.5 img/s)',
+      unet_attention_aspp:
+        'UNet amélioré avec Attention Gates et goulot ASPP pour la détection de sphéroïdes en dissolution et de petites cellules satellites (35,5M paramètres)',
       sperm:
         'Modèle de morphologie spermatique avec extraction de squelette pour la mesure de la tête, de la pièce intermédiaire et de la queue',
     },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -359,6 +359,10 @@ export default {
     modelSelection: {
       title: '模型选择',
       description: '选择用于细胞分割的AI模型',
+      sections: {
+        spheroid: '球体模型',
+        sperm: '精子模型',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -373,8 +377,13 @@ export default {
           description:
             '在SpheroHQ数据集上表现最佳 - 专为球体分割优化，速度和精度平衡 (~0.25秒/图像, 10图像/秒)',
         },
+        unet_attention_aspp: {
+          name: 'UNet Attention-ASPP',
+          description:
+            '增强型UNet，配备注意力门控和ASPP，用于检测溶解中的球体和小型卫星细胞（约0.35秒/图像）',
+        },
         sperm: {
-          name: '精子分割',
+          name: '精子形态学',
           description:
             '精子形态学模型，含骨架提取功能，用于测量头部、中段和尾部',
         },
@@ -387,6 +396,8 @@ export default {
     currentThreshold: '当前阈值',
     modelSelected: '模型选择成功',
     modelSettingsSaved: '模型设置保存成功',
+    thresholdAutoAdjusted:
+      '模型已选择 — 阈值已自动设置为{threshold}%（针对此模型优化）',
     modelSize: {
       small: '小',
       medium: '中',
@@ -397,6 +408,8 @@ export default {
       cbam_resunet: '具有注意力机制的最精确分割 (E2E ~482ms, 2.7 图像/秒)',
       unet_spherohq:
         '优化后最快的模型！非常适合实时处理 (E2E ~286ms, 5.5 图像/秒)',
+      unet_attention_aspp:
+        '增强型UNet，配备注意力门控和ASPP瓶颈层，用于检测溶解中的球体和小型卫星细胞（3550万参数）',
       sperm: '精子形态模型，通过骨架提取测量头部、中段和尾部',
     },
     dataUsageTitle: '数据使用和隐私',


### PR DESCRIPTION
## Summary

- **New ML model:** UNet Attention-ASPP (v4) for detecting dissolving spheroids and small satellite cells — uses Attention Gates on skip connections + ASPP bottleneck (35.5M params, 135MB weights, default threshold 0.2)
- **Model selection UI:** reorganized into "Spheroid Models" / "Sperm Models" sections with headings; sperm model renamed to "Sperm Morphology"; auto-applies model-specific threshold with toast notification
- **BMP thumbnail fix:** Sharp (libvips) doesn't support BMP input — added manual BMP decoder (8/24/32 bpp, palette-indexed, BGR→RGB, bottom-up flip) that feeds raw pixel buffer to Sharp; retroactively generated 581 missing thumbnails

## Changes across the stack

### ML Service (Python/FastAPI)
- `backend/segmentation/models/unet_attention.py` — new architecture file (AttentionGate + ASPPBottleneck + enhanced UNet)
- `backend/segmentation/ml/model_loader.py` — import, AVAILABLE_MODELS, load_model elif, BatchConfig, strict=True loading
- `backend/segmentation/api/models.py` — ModelType enum
- `backend/segmentation/api/main.py` — startup preload list
- `backend/segmentation/scripts/download_weights.py` — WEIGHTS_CONFIG entry (gdrive_id=TODO)

### Backend (Express/TypeScript)
- `backend/src/types/validation.ts` — Zod schema
- `backend/src/types/queue.ts` — SegmentationModel type + isSegmentationModel guard
- `backend/src/services/segmentationService.ts` — SegmentationRequest model type
- `backend/src/services/queueService.ts` — BATCH_LIMITS + estimateProcessingTime
- `backend/src/api/routes/mlRoutes.ts` — models list endpoint
- `backend/src/storage/localStorage.ts` — BMP thumbnail fix with decodeBmpToRawBuffer()

### Frontend (React/TypeScript)
- `src/lib/modelUtils.ts` — ModelType union, ModelInfo category field, BASIC_MODEL_INFO
- `src/components/settings/ModelSettingsSection.tsx` — sectioned UI + auto-threshold
- `src/translations/{en,cs,de,es,fr,zh}.ts` — all 6 languages updated

## Test plan

- [ ] Settings > Models tab shows two sections with headings
- [ ] Selecting "UNet Attention-ASPP" auto-sets threshold to 20%
- [ ] Segmentation with unet_attention_aspp model returns polygons
- [ ] BMP image upload generates JPEG thumbnails
- [ ] Existing models (HRNet, CBAM, UNet SpheroHQ, Sperm) still work
- [ ] ML service logs show 5/5 models pre-loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced UNet Attention-ASPP segmentation model for improved image analysis.
  * Reorganized model selection UI into Spheroid and Sperm categories for better usability.
  * Added automatic threshold adjustment based on selected model for optimized performance.

* **Bug Fixes**
  * Improved BMP image thumbnail generation handling.

* **Documentation**
  * Extended multi-language support (English, German, Spanish, French, Chinese, Czech) for new model and updated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->