### PR TITLE
feat(segmentation): dev-only FPS + rendering-stats overlay

### DIFF
--- a/src/lib/rendering/FpsMeter.tsx
+++ b/src/lib/rendering/FpsMeter.tsx
@@ -116,9 +116,13 @@ export function useFpsSampler(enabled: boolean): FpsMeterSample {
 /**
  * Overlay component. Mount near the top of the editor tree; it self-gates
  * on `isFpsOverlayEnabled()` and renders nothing in production by default.
+ *
+ * The gate is read ONCE per mount via a `useState` initializer so the
+ * editor's hot re-render path doesn't pay for a fresh `URLSearchParams`
+ * build and `localStorage.getItem` call on every render.
  */
 export function FpsMeter(): JSX.Element | null {
-  const enabled = isFpsOverlayEnabled();
+  const [enabled] = useState(isFpsOverlayEnabled);
   const sample = useFpsSampler(enabled);
   if (!enabled) return null;
 

--- a/src/lib/rendering/FpsMeter.tsx
+++ b/src/lib/rendering/FpsMeter.tsx
@@ -1,0 +1,156 @@
+/**
+ * Development-only FPS + rendering stats overlay for the segmentation editor.
+ *
+ * Opt-in via `?perf=1` query param or `localStorage.segPerfOverlay = '1'`.
+ * Designed for validating performance work on the editor's render path
+ * (viewport culling, quadtree hit test, etc.) without shipping anything
+ * user-visible by default.
+ *
+ * Uses an imperative rAF loop and a ref-only state update pattern so the
+ * overlay itself doesn't cause additional renders of its parent tree.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { polygonVisibilityManager } from './PolygonVisibilityManager';
+import { boundingBoxCache } from './BoundingBoxCache';
+
+const FPS_WINDOW_MS = 1000;
+
+export interface FpsMeterSample {
+  fps: number;
+  frameCount: number;
+  visibility: ReturnType<typeof polygonVisibilityManager.getStats>;
+  cache: ReturnType<typeof boundingBoxCache.getStats>;
+}
+
+/**
+ * Pure FPS sampler — a fixed-size ring of frame timestamps, trimmed to
+ * the trailing `windowMs`. Exposed as a helper so it can be unit-tested
+ * without a browser rAF.
+ */
+export class FpsSampler {
+  private readonly frames: number[] = [];
+
+  constructor(private readonly windowMs = FPS_WINDOW_MS) {}
+
+  record(nowMs: number): void {
+    this.frames.push(nowMs);
+    const cutoff = nowMs - this.windowMs;
+    while (this.frames.length > 0 && this.frames[0] < cutoff) {
+      this.frames.shift();
+    }
+  }
+
+  get fps(): number {
+    const n = this.frames.length;
+    if (n < 2) return 0;
+    const span = this.frames[n - 1] - this.frames[0];
+    return span > 0 ? ((n - 1) * 1000) / span : 0;
+  }
+
+  get frameCount(): number {
+    return this.frames.length;
+  }
+
+  reset(): void {
+    this.frames.length = 0;
+  }
+}
+
+export function isFpsOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('perf') === '1') return true;
+    return window.localStorage?.getItem('segPerfOverlay') === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hook: returns a live FPS + stats sample while an rAF loop is running.
+ * Only runs while the component is mounted AND the overlay is enabled,
+ * so disabling it has no runtime cost.
+ */
+export function useFpsSampler(enabled: boolean): FpsMeterSample {
+  const samplerRef = useRef<FpsSampler>();
+  if (!samplerRef.current) samplerRef.current = new FpsSampler();
+
+  const [sample, setSample] = useState<FpsMeterSample>(() => ({
+    fps: 0,
+    frameCount: 0,
+    visibility: polygonVisibilityManager.getStats(),
+    cache: boundingBoxCache.getStats(),
+  }));
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let raf = 0;
+    let lastPublish = 0;
+
+    const tick = (now: number) => {
+      samplerRef.current!.record(now);
+      // Publish at ~4 Hz — more than enough for human readability and
+      // keeps React renders out of the critical path.
+      if (now - lastPublish > 250) {
+        lastPublish = now;
+        setSample({
+          fps: samplerRef.current!.fps,
+          frameCount: samplerRef.current!.frameCount,
+          visibility: polygonVisibilityManager.getStats(),
+          cache: boundingBoxCache.getStats(),
+        });
+      }
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [enabled]);
+
+  return sample;
+}
+
+/**
+ * Overlay component. Mount near the top of the editor tree; it self-gates
+ * on `isFpsOverlayEnabled()` and renders nothing in production by default.
+ */
+export function FpsMeter(): JSX.Element | null {
+  const enabled = isFpsOverlayEnabled();
+  const sample = useFpsSampler(enabled);
+  if (!enabled) return null;
+
+  const vis = sample.visibility;
+  const cache = sample.cache;
+
+  return (
+    <div
+      data-testid="fps-meter"
+      style={{
+        position: 'fixed',
+        bottom: 8,
+        right: 8,
+        zIndex: 9999,
+        padding: '6px 10px',
+        borderRadius: 6,
+        background: 'rgba(0, 0, 0, 0.75)',
+        color: '#fff',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        fontSize: 11,
+        lineHeight: 1.35,
+        pointerEvents: 'none',
+        whiteSpace: 'pre',
+      }}
+    >
+      {`FPS ${sample.fps.toFixed(1)}
+frames ${sample.frameCount}
+level ${vis.isUsingReducedRendering ? 'reduced' : 'normal'}
+cull-thresh ${vis.cullingThreshold}
+avgFrame ${vis.averageFrameTime.toFixed(2)}ms
+cache ${cache.size} (${(cache.hitRate * 100).toFixed(0)}% hit)`}
+    </div>
+  );
+}

--- a/src/lib/rendering/__tests__/FpsMeter.test.ts
+++ b/src/lib/rendering/__tests__/FpsMeter.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FpsSampler, isFpsOverlayEnabled } from '../FpsMeter';
+
+describe('FpsSampler', () => {
+  it('reports 0 fps before any frames are recorded', () => {
+    const s = new FpsSampler();
+    expect(s.fps).toBe(0);
+    expect(s.frameCount).toBe(0);
+  });
+
+  it('reports 0 fps after a single frame (needs at least two samples)', () => {
+    const s = new FpsSampler();
+    s.record(100);
+    expect(s.fps).toBe(0);
+  });
+
+  it('computes fps across the trailing window', () => {
+    const s = new FpsSampler(1000);
+    // 61 frames spaced 16.67ms apart (≈60fps over 1 second)
+    let t = 0;
+    for (let i = 0; i < 61; i++) {
+      s.record(t);
+      t += 1000 / 60;
+    }
+    expect(s.fps).toBeGreaterThan(55);
+    expect(s.fps).toBeLessThan(65);
+  });
+
+  it('drops samples older than the window', () => {
+    const s = new FpsSampler(1000);
+    // 10 frames early
+    for (let i = 0; i < 10; i++) s.record(i * 10);
+    // 2 frames much later (outside the 1s window)
+    s.record(5000);
+    s.record(5016);
+    expect(s.frameCount).toBe(2);
+  });
+
+  it('reset clears all samples', () => {
+    const s = new FpsSampler();
+    s.record(10);
+    s.record(20);
+    s.reset();
+    expect(s.frameCount).toBe(0);
+    expect(s.fps).toBe(0);
+  });
+});
+
+describe('isFpsOverlayEnabled', () => {
+  // The global test setup (src/test/setup.ts) mocks localStorage with
+  // hardcoded return values for 'theme' and 'language' only — setItem
+  // does not persist. Tests mock getItem directly per scenario.
+
+  const stubLocation = (search: string) => {
+    vi.spyOn(window, 'location', 'get').mockImplementation(
+      () => ({ search }) as Location
+    );
+  };
+
+  const stubLocalStorageReturn = (value: string | null) => {
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation(key =>
+      key === 'segPerfOverlay' ? value : null
+    );
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false with no flag set and empty search', () => {
+    stubLocation('');
+    stubLocalStorageReturn(null);
+    expect(isFpsOverlayEnabled()).toBe(false);
+  });
+
+  it('returns true when ?perf=1 is present', () => {
+    stubLocation('?perf=1');
+    stubLocalStorageReturn(null);
+    expect(isFpsOverlayEnabled()).toBe(true);
+  });
+
+  it('returns false when ?perf=0', () => {
+    stubLocation('?perf=0');
+    stubLocalStorageReturn(null);
+    expect(isFpsOverlayEnabled()).toBe(false);
+  });
+
+  it('returns true when localStorage.segPerfOverlay = 1 (and no ?perf flag)', () => {
+    stubLocation('');
+    stubLocalStorageReturn('1');
+    expect(isFpsOverlayEnabled()).toBe(true);
+  });
+
+  it('swallows thrown storage errors and returns false', () => {
+    stubLocation('');
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('storage denied');
+    });
+    expect(isFpsOverlayEnabled()).toBe(false);
+  });
+});

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -47,6 +47,7 @@ import CanvasSvgFilters from './components/canvas/CanvasSvgFilters';
 import ModeInstructions from './components/canvas/ModeInstructions';
 import CanvasTemporaryGeometryLayer from './components/canvas/CanvasTemporaryGeometryLayer';
 import { polygonVisibilityManager } from '@/lib/rendering/PolygonVisibilityManager';
+import { FpsMeter } from '@/lib/rendering/FpsMeter';
 
 // Layout components
 import EditorHeader from './components/EditorHeader';
@@ -1419,6 +1420,10 @@ const SegmentationEditor = () => {
           />
         </div>
       </EditorLayout>
+      {/* Opt-in dev overlay: append ?perf=1 to the URL or set
+          localStorage.segPerfOverlay='1'. Renders null in production
+          by default — no bundle cost beyond the module itself. */}
+      <FpsMeter />
     </SegmentationErrorBoundary>
   );
 };


### PR DESCRIPTION
## Summary
Opt-in observability overlay for validating editor performance work. Zero impact on production users by default — self-gates on `?perf=1` URL param or `localStorage.segPerfOverlay='1'`, read once per mount so the editor's hot re-render path pays nothing when disabled.

- `FpsSampler` — pure trailing-window ring of frame timestamps, unit-tested.
- `useFpsSampler` hook — rAF loop publishing at 4 Hz to keep React churn out of the frame path.
- `FpsMeter` component — fixed overlay (bottom-right) showing FPS, polygon-visibility-manager stats, BoundingBoxCache hit rate.
- Mounted once at the end of SegmentationEditor; `pointer-events:none` so it can't interfere with canvas interactions.
- Review fix: gate read once via `useState` initializer (was running `URLSearchParams` + `localStorage.getItem` on every editor render).

## Test plan
- [ ] Load editor without flag — confirm no overlay, no console noise.
- [ ] Append `?perf=1` and reload — overlay appears bottom-right with live stats.
- [ ] `localStorage.setItem('segPerfOverlay', '1')` + reload — overlay appears without URL flag.
- [ ] Chrome DevTools Performance recording of editor with overlay enabled shows sub-ms overlay-render cost.
- [ ] 86/86 rendering + geometry unit tests pass: `npx vitest run src/lib/rendering/__tests__/ src/lib/__tests__/polygonGeometry.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)