### PR TITLE
fix: disable broken segmentation culling, extract nginx headers

### DIFF
--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -74,11 +74,8 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    include /etc/nginx/snippets/security-headers.conf;
     add_header X-Environment "production" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # Client body size for uploads
     client_max_body_size 500M;
@@ -107,6 +104,7 @@ server {
         proxy_set_header X-Environment "production";
 
         # Prevent caching of HTML pages (fixes stale Vite asset references after deploy)
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
@@ -115,6 +113,7 @@ server {
         location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://frontend;
             expires 1y;
+            include /etc/nginx/snippets/security-headers.conf;
             add_header Cache-Control "public, immutable";
             add_header X-Environment "production" always;
         }
@@ -216,6 +215,7 @@ server {
 
         # Disable cache for downloads
         proxy_cache off;
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
@@ -247,6 +247,7 @@ server {
     # Health check endpoint
     location /health {
         access_log off;
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Content-Type text/plain;
         add_header X-Environment "production" always;
         return 200 "production-healthy\n";
@@ -268,11 +269,9 @@ server {
     location /uploads/ {
         alias /app/uploads/blue/;
         expires 30d;
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Cache-Control "public";
         add_header X-Environment "production" always;
-
-        # Security for uploaded files
-        add_header X-Content-Type-Options "nosniff" always;
         location ~ \\.(php|jsp|asp|aspx|cgi|pl|py|rb|sh)$ {
             deny all;
         }
@@ -280,6 +279,7 @@ server {
 
     # Robots.txt
     location = /robots.txt {
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Content-Type text/plain;
         add_header X-Environment "production" always;
         return 200 "User-agent: *\nDisallow: /api/\nDisallow: /uploads/\nDisallow: /metrics/\n";
@@ -347,10 +347,7 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    include /etc/nginx/snippets/security-headers.conf;
 
     # Client body size for image uploads
     client_max_body_size 200M;
@@ -384,6 +381,7 @@ server {
         proxy_set_header Connection $connection_upgrade;
 
         # Prevent caching of HTML pages (fixes stale Next.js Server Action IDs after deploy)
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
@@ -412,13 +410,14 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         expires 30d;
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Cache-Control "public";
-        add_header X-Content-Type-Options "nosniff" always;
     }
 
     # Health check
     location /health {
         access_log off;
+        include /etc/nginx/snippets/security-headers.conf;
         add_header Content-Type text/plain;
         return 200 "maptimize-healthy\n";
     }

--- a/docker/nginx/snippets/security-headers.conf
+++ b/docker/nginx/snippets/security-headers.conf
@@ -1,0 +1,11 @@
+# Security response headers - shared across all scopes.
+# Included from both server blocks and any location that adds its own headers
+# (nginx's add_header inheritance is "all-or-nothing": any add_header in a
+# child scope drops all inherited add_headers, so overriding locations must
+# re-declare these).
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/docker/nginx/snippets/security-headers.conf
+++ b/docker/nginx/snippets/security-headers.conf
@@ -7,5 +7,3 @@ add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" alway
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
-add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/docs/polygon-rendering-optimization.md
+++ b/docs/polygon-rendering-optimization.md
@@ -54,12 +54,9 @@ Still exported, still correct, still used by non-interactive callers (slicing, e
 
 ### Editor render — `src/pages/segmentation/SegmentationEditor.tsx`
 
-`visiblePolygons` is a single `useMemo` that:
+`visiblePolygons` is a single `useMemo` that filters out hidden polygons and polygons below `minPoints`. Every remaining polygon is rendered regardless of zoom or translation.
 
-1. Filters out hidden polygons and polygons below `minPoints`.
-2. Calls `polygonVisibilityManager.getVisiblePolygons(filtered, { zoom, offset, containerWidth, containerHeight, selectedPolygonId, forceRenderSelected: true })`.
-
-Dependencies cover transform, hidden-id set, selection, and canvas dimensions — so pan/zoom re-triggers culling but a pure hover does not.
+> **Note:** frustum culling via `polygonVisibilityManager.getVisiblePolygons` is currently **disabled**. The earlier viewport-bounds calculation misculled visible polygons at low zoom and after pan. The manager module and its tests are retained so the culling path can be re-enabled once the viewport math is proven correct on a large dataset.
 
 ### Hover / drag — `src/pages/segmentation/hooks/useAdvancedInteractions.tsx`
 

--- a/src/lib/rendering/FpsMeter.tsx
+++ b/src/lib/rendering/FpsMeter.tsx
@@ -3,8 +3,14 @@
  *
  * Opt-in via `?perf=1` query param or `localStorage.segPerfOverlay = '1'`.
  * Designed for validating performance work on the editor's render path
- * (viewport culling, quadtree hit test, etc.) without shipping anything
- * user-visible by default.
+ * without shipping anything user-visible by default.
+ *
+ * Frustum culling is currently bypassed in the editor (see
+ * `SegmentationEditor.tsx visiblePolygons`), so the visibility-manager
+ * counters below will read their defaults (zero frames sampled, no
+ * reduced-mode trigger). The overlay flags this explicitly with a
+ * `culling: DISABLED` line so the zero values aren't misread as
+ * indicators that culling is "working well".
  *
  * Uses an imperative rAF loop and a ref-only state update pattern so the
  * overlay itself doesn't cause additional renders of its parent tree.
@@ -151,6 +157,7 @@ export function FpsMeter(): JSX.Element | null {
     >
       {`FPS ${sample.fps.toFixed(1)}
 frames ${sample.frameCount}
+culling DISABLED
 level ${vis.isUsingReducedRendering ? 'reduced' : 'normal'}
 cull-thresh ${vis.cullingThreshold}
 avgFrame ${vis.averageFrameTime.toFixed(2)}ms

--- a/src/lib/rendering/__tests__/PolygonVisibilityManager.test.ts
+++ b/src/lib/rendering/__tests__/PolygonVisibilityManager.test.ts
@@ -1,3 +1,7 @@
+// NOTE: PolygonVisibilityManager is currently bypassed by the segmentation
+// editor (see SegmentationEditor.tsx visiblePolygons). These tests still
+// exercise the manager directly so the module is covered in case the
+// culling path is re-enabled once its viewport math is proven correct.
 import { describe, expect, it } from 'vitest';
 import type { Polygon } from '@/lib/segmentation';
 import {

--- a/src/pages/segmentation/README.md
+++ b/src/pages/segmentation/README.md
@@ -238,7 +238,6 @@ interface TransformState {
 
 ## Performance Considerations
 
-- **Viewport Culling**: Only renders visible polygons
 - **Level of Detail**: Reduces vertex count at low zoom levels
 - **Batch Rendering**: Groups polygon operations
 - **Debounced Updates**: Smooth interaction during dragging

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -138,6 +138,7 @@ const SegmentationEditor = () => {
     width: 800,
     height: 600,
   });
+
   // Use custom hook for segmentation reload logic
   const { isReloading, reloadSegmentation, cleanupReloadOperations } =
     useSegmentationReload({
@@ -1122,11 +1123,11 @@ const SegmentationEditor = () => {
   // doesn't reallocate + re-filter the whole array each frame.
   // Must live above any early return to satisfy the rules of hooks.
   //
-  // Frustum culling via polygonVisibilityManager is intentionally DISABLED
-  // here — prior viewport-bounds calculation misculled visible polygons at
-  // low zoom and after pan. The manager code is retained for a possible
-  // future re-enable once the viewport math is proven correct on a large
-  // dataset; in the meantime every non-hidden, well-formed polygon renders
+  // Frustum culling is intentionally DISABLED here — prior viewport-bounds
+  // calculation misculled visible polygons at low zoom and after pan. The
+  // culling helper in src/lib/rendering/PolygonVisibilityManager.ts is
+  // retained but unused; delete both together if culling isn't revisited.
+  // In the meantime every non-hidden, well-formed polygon renders
   // regardless of zoom and translation.
   const visiblePolygons = useMemo(() => {
     return editor.polygons

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -46,7 +46,6 @@ import CanvasPolygon from './components/canvas/CanvasPolygon';
 import CanvasSvgFilters from './components/canvas/CanvasSvgFilters';
 import ModeInstructions from './components/canvas/ModeInstructions';
 import CanvasTemporaryGeometryLayer from './components/canvas/CanvasTemporaryGeometryLayer';
-import { polygonVisibilityManager } from '@/lib/rendering/PolygonVisibilityManager';
 import { FpsMeter } from '@/lib/rendering/FpsMeter';
 
 // Layout components
@@ -139,7 +138,6 @@ const SegmentationEditor = () => {
     width: 800,
     height: 600,
   });
-
   // Use custom hook for segmentation reload logic
   const { isReloading, reloadSegmentation, cleanupReloadOperations } =
     useSegmentationReload({
@@ -1124,58 +1122,21 @@ const SegmentationEditor = () => {
   // doesn't reallocate + re-filter the whole array each frame.
   // Must live above any early return to satisfy the rules of hooks.
   //
-  // Also runs frustum culling through polygonVisibilityManager: polygons
-  // whose bounding box doesn't intersect the visible viewport are skipped
-  // entirely. Below its internal threshold (~50–100 polygons) the manager
-  // renders the full set unchanged, so small projects see no behavior
-  // change; large projects (300+) see only the ~50 polygons actually
-  // visible on screen.
+  // Frustum culling via polygonVisibilityManager is intentionally DISABLED
+  // here — prior viewport-bounds calculation misculled visible polygons at
+  // low zoom and after pan. The manager code is retained for a possible
+  // future re-enable once the viewport math is proven correct on a large
+  // dataset; in the meantime every non-hidden, well-formed polygon renders
+  // regardless of zoom and translation.
   const visiblePolygons = useMemo(() => {
-    const filtered = editor.polygons
+    return editor.polygons
       .filter(polygon => !hiddenPolygonIds.has(polygon.id))
       .filter(polygon => {
         if (!polygon.points) return false;
         const minPoints = polygon.geometry === 'polyline' ? 2 : 3;
         return polygon.points.length >= minPoints;
       });
-
-    const containerWidth = canvasWidth || imageDimensions?.width || 0;
-    const containerHeight = canvasHeight || imageDimensions?.height || 0;
-
-    // Graceful fallback for the first render (before image dimensions
-    // are measured) or for a transient 0-sized layout: render the full
-    // filtered set instead of culling against a degenerate viewport.
-    // Returning [] here would be "safer" on paper but hides real
-    // polygons from the user during normal editor startup.
-    // `filtered` already includes the selected polygon (it's only
-    // excluded when hidden or malformed), so nothing load-bearing is
-    // skipped by bypassing ensureSelectedVisible/sortForRendering here.
-    if (containerWidth <= 0 || containerHeight <= 0) {
-      return filtered;
-    }
-
-    return polygonVisibilityManager.getVisiblePolygons(filtered, {
-      zoom: editor.transform.zoom,
-      offset: {
-        x: editor.transform.translateX,
-        y: editor.transform.translateY,
-      },
-      containerWidth,
-      containerHeight,
-      selectedPolygonId: editor.selectedPolygonId,
-      forceRenderSelected: true,
-    }).visiblePolygons;
-  }, [
-    editor.polygons,
-    hiddenPolygonIds,
-    editor.transform.zoom,
-    editor.transform.translateX,
-    editor.transform.translateY,
-    editor.selectedPolygonId,
-    canvasWidth,
-    canvasHeight,
-    imageDimensions,
-  ]);
+  }, [editor.polygons, hiddenPolygonIds]);
 
   // Show loading state only during initial load
   // Once we have basic image metadata, show the UI even if segmentation is still loading

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -4,7 +4,6 @@ import { Polygon, Point } from '@/lib/segmentation';
 import PolygonVertices from './PolygonVertices';
 import PolygonContextMenu from '../context-menu/PolygonContextMenu';
 import { VertexDragState, EditMode } from '@/pages/segmentation/types';
-import { calculateBoundingBox } from '@/lib/polygonGeometry';
 
 interface CanvasPolygonProps {
   polygon: Polygon;
@@ -56,9 +55,6 @@ const CanvasPolygon = React.memo(
     editMode,
   }: CanvasPolygonProps) => {
     const { id, points, type = 'external', parent_id } = polygon;
-
-    // Calculate bounding box for viewport culling (cached)
-    const boundingBox = useMemo(() => calculateBoundingBox(points), [points]);
 
     // Determine if this is a polyline (open path)
     const isPolyline = polygon.geometry === 'polyline';


### PR DESCRIPTION
## Summary
- Disable frustum culling in the segmentation editor — the viewport math in `polygonVisibilityManager` misculled visible polygons at low zoom and after pan. Manager code is retained for a future re-enable once the math is proven on a large dataset.
- Consolidate repeated nginx security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, HSTS) into `docker/nginx/snippets/security-headers.conf` and include it from every location block that previously duplicated them (both the spheroseg and maptimize server blocks).

## Test plan
- [ ] Open the segmentation editor on a large project (300+ polygons) and confirm every visible polygon renders at all zoom levels and after panning.
- [ ] Verify editor FPS for small/medium projects is unchanged from main.
- [ ] Reload nginx in a staging environment and confirm `curl -I https://spherosegapp.utia.cas.cz/` still returns the full security-header set (frame, nosniff, XSS, HSTS).
- [ ] Confirm `/uploads/`, `/health`, `robots.txt`, and the maptimize server block still carry the expected headers after the snippet refactor.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP security headers into a centralized configuration file for consistent application across all server endpoints.
  * Simplified polygon visibility filtering logic in the segmentation editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->