### PR TITLE
fix(export): preserve polyline geometry and sperm metadata in COCO/YOLO/JSON

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -40,6 +40,10 @@ pnpm-lock.yaml
 **/*.d.ts
 **/*.generated.*
 
+# Research / study data artifacts (large untracked datasets)
+iaa_study/
+output_time_48h/
+
 # Binary files
 **/*.png
 **/*.jpg

--- a/backend/src/services/__tests__/exportService.test.ts
+++ b/backend/src/services/__tests__/exportService.test.ts
@@ -124,7 +124,10 @@ describe('ExportService', () => {
     }));
     MockFormatConverter.mockImplementation(() => ({
       convertToCOCO: (jest.fn() as any).mockResolvedValue({}),
-      convertToYOLO: (jest.fn() as any).mockResolvedValue([]),
+      convertToYOLO: (jest.fn() as any).mockResolvedValue({
+        content: '',
+        warnings: [],
+      }),
       convertToJSON: (jest.fn() as any).mockResolvedValue({}),
     }));
 

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
 jest.mock('../../../utils/logger', () => ({
   logger: {
@@ -9,10 +9,19 @@ jest.mock('../../../utils/logger', () => ({
   },
 }));
 
-import { FormatConverter, type ImageData, type Polygon } from '../formatConverter';
+import {
+  FormatConverter,
+  type ImageData,
+  type Polygon,
+} from '../formatConverter';
 import { logger } from '../../../utils/logger';
 
 const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+beforeEach(() => {
+  mockedLogger.warn.mockClear();
+  mockedLogger.error.mockClear();
+});
 
 const closedPolygon: Polygon = {
   id: 'p1',
@@ -61,7 +70,10 @@ const spermTail: Polygon = {
   ],
 };
 
-const buildImageData = (polygons: Polygon[]): ImageData => ({
+const buildImageData = (
+  polygons: Polygon[],
+  overrides: Partial<ImageData> = {}
+): ImageData => ({
   id: 'img1',
   filename: 'image1.png',
   width: 100,
@@ -73,13 +85,26 @@ const buildImageData = (polygons: Polygon[]): ImageData => ({
       timestamp: new Date('2026-04-17T00:00:00Z'),
     },
   ],
+  ...overrides,
 });
 
 describe('FormatConverter', () => {
   describe('convertToCOCO', () => {
-    it('emits a separate sperm category alongside cell', async () => {
+    it('emits only the cell category for polygon-only projects', async () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      expect(coco.categories).toEqual([
+        expect.objectContaining({ id: 1, name: 'cell' }),
+      ]);
+      expect(coco.categories.find(c => c.name === 'sperm')).toBeUndefined();
+    });
+
+    it('adds sperm category when polylines are present', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon, spermHead]);
 
       const coco = await converter.convertToCOCO([data]);
 
@@ -89,7 +114,7 @@ describe('FormatConverter', () => {
       ]);
     });
 
-    it('writes closed polygons under category 1 with geometry=polygon', async () => {
+    it('writes closed polygons under category 1 with exact area', async () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon]);
 
@@ -99,12 +124,17 @@ describe('FormatConverter', () => {
       const ann = coco.annotations[0];
       expect(ann.category_id).toBe(1);
       expect(ann.attributes?.geometry).toBe('polygon');
-      expect(ann.area).toBeGreaterThan(0);
+      expect(ann.area).toBe(100);
     });
 
-    it('writes polylines under category 2 with partClass+instanceId in attributes', async () => {
+    it('writes polylines under category 2 with exact length and partClass+instanceId', async () => {
       const converter = new FormatConverter();
-      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+      const data = buildImageData([
+        closedPolygon,
+        spermHead,
+        spermMidpiece,
+        spermTail,
+      ]);
 
       const coco = await converter.convertToCOCO([data]);
 
@@ -116,27 +146,76 @@ describe('FormatConverter', () => {
         .sort();
       expect(partClasses).toEqual(['head', 'midpiece', 'tail']);
 
+      const expectedLengths: Record<string, number> = {
+        head: 3,
+        midpiece: 4,
+        tail: 5,
+      };
       for (const ann of polylineAnns) {
         expect(ann.attributes?.geometry).toBe('polyline');
         expect(ann.attributes?.instanceId).toBe('sperm_1');
-        expect(ann.attributes?.length).toBeGreaterThan(0);
         expect(ann.area).toBe(0);
+        const part = ann.attributes?.partClass as keyof typeof expectedLengths;
+        expect(ann.attributes?.length).toBeCloseTo(expectedLengths[part]);
       }
     });
 
-    it('produces stable annotation IDs (no collision between polygons and polylines)', async () => {
+    it('skips polylines with missing partClass and warns', async () => {
       const converter = new FormatConverter();
-      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+      const orphan: Polygon = {
+        ...spermHead,
+        id: 'orphan-no-part',
+        partClass: undefined,
+      };
+      const data = buildImageData([closedPolygon, orphan]);
 
       const coco = await converter.convertToCOCO([data]);
 
+      const spermAnns = coco.annotations.filter(a => a.category_id === 2);
+      expect(spermAnns).toHaveLength(0);
+      expect(coco.categories.find(c => c.name === 'sperm')).toBeUndefined();
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or invalid partClass'),
+        'FormatConverter',
+        expect.objectContaining({ skipped: 1 })
+      );
+    });
+
+    it('rejects polylines whose partClass is outside the whitelist', async () => {
+      const converter = new FormatConverter();
+      const typo: Polygon = {
+        ...spermHead,
+        partClass: 'flagellum' as never,
+      };
+      const data = buildImageData([typo]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      expect(coco.annotations.filter(a => a.category_id === 2)).toHaveLength(0);
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('keeps annotation IDs unique across multiple images', async () => {
+      const converter = new FormatConverter();
+      const data1 = buildImageData([closedPolygon, spermHead], {
+        id: 'img1',
+        filename: 'a.png',
+      });
+      const data2 = buildImageData([closedPolygon, spermMidpiece], {
+        id: 'img2',
+        filename: 'b.png',
+      });
+
+      const coco = await converter.convertToCOCO([data1, data2]);
+
       const ids = coco.annotations.map(a => a.id);
       expect(new Set(ids).size).toBe(ids.length);
+      expect(coco.annotations.length).toBe(4);
     });
   });
 
   describe('convertToYOLO', () => {
-    it('skips polylines with a warning log', async () => {
+    it('returns { content, warnings } with warning when polylines present', async () => {
       const converter = new FormatConverter();
       const polygonsJson = JSON.stringify([
         closedPolygon,
@@ -145,26 +224,46 @@ describe('FormatConverter', () => {
         spermTail,
       ]);
 
-      const yolo = await converter.convertToYOLO(polygonsJson, 100, 100);
-      const lines = yolo.split('\n').filter(l => l && !l.startsWith('#'));
+      const result = await converter.convertToYOLO(polygonsJson, 100, 100);
+      const lines = result.content
+        .split('\n')
+        .filter(l => l && !l.startsWith('#'));
 
       expect(lines).toHaveLength(1);
       expect(lines[0]).toMatch(/^0 /);
-      expect(mockedLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('YOLO format does not support open polylines'),
-        'FormatConverter',
-        expect.objectContaining({ polylineCount: 3 })
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain(
+        'YOLO format does not support open polylines'
       );
+      expect(result.warnings[0]).toContain('skipped 3');
     });
 
-    it('does not warn when there are no polylines', async () => {
-      mockedLogger.warn.mockClear();
+    it('returns empty warnings array when no polylines present', async () => {
       const converter = new FormatConverter();
       const polygonsJson = JSON.stringify([closedPolygon]);
 
-      await converter.convertToYOLO(polygonsJson, 100, 100);
+      const result = await converter.convertToYOLO(polygonsJson, 100, 100);
 
+      expect(result.warnings).toEqual([]);
       expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('produces empty content but warns for pure-polyline input', async () => {
+      const converter = new FormatConverter();
+      const polygonsJson = JSON.stringify([spermHead, spermMidpiece]);
+
+      const result = await converter.convertToYOLO(polygonsJson, 100, 100);
+
+      expect(result.content).toBe('');
+      expect(result.warnings).toHaveLength(1);
+    });
+
+    it('throws on malformed JSON', async () => {
+      const converter = new FormatConverter();
+
+      await expect(
+        converter.convertToYOLO('not-json', 100, 100)
+      ).rejects.toThrow(/Invalid polygon data format/);
     });
   });
 
@@ -180,11 +279,17 @@ describe('FormatConverter', () => {
       expect(seg?.polylines).toBeUndefined();
       expect(seg?.spermInstances).toBeUndefined();
       expect(seg?.statistics.totalPolylines).toBeUndefined();
+      expect(seg?.statistics.orphanPolylineCount).toBeUndefined();
     });
 
-    it('emits polylines and spermInstances when polylines exist', async () => {
+    it('emits polylines and spermInstances with exact lengths', async () => {
       const converter = new FormatConverter();
-      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+      const data = buildImageData([
+        closedPolygon,
+        spermHead,
+        spermMidpiece,
+        spermTail,
+      ]);
 
       const out = await converter.convertToJSON([data]);
       const seg = out.images[0]?.segmentation;
@@ -202,9 +307,10 @@ describe('FormatConverter', () => {
 
       expect(seg?.statistics.totalPolylines).toBe(3);
       expect(seg?.statistics.totalSpermInstances).toBe(1);
+      expect(seg?.statistics.orphanPolylineCount).toBeUndefined();
     });
 
-    it('orphan polylines (no instanceId) are exported but not grouped', async () => {
+    it('logs orphan polylines and reports orphanPolylineCount in statistics', async () => {
       const converter = new FormatConverter();
       const orphan: Polygon = {
         ...spermHead,
@@ -218,6 +324,41 @@ describe('FormatConverter', () => {
 
       expect(seg?.polylines).toHaveLength(1);
       expect(seg?.spermInstances).toBeUndefined();
+      expect(seg?.statistics.orphanPolylineCount).toBe(1);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('without instanceId'),
+        'FormatConverter',
+        expect.objectContaining({ orphanCount: 1 })
+      );
+    });
+
+    it('handles a pure-polyline image with no closed polygons', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([spermHead, spermMidpiece, spermTail]);
+
+      const out = await converter.convertToJSON([data]);
+      const seg = out.images[0]?.segmentation;
+
+      expect(seg?.polygons.external).toHaveLength(0);
+      expect(seg?.polygons.internal).toHaveLength(0);
+      expect(seg?.polylines).toHaveLength(3);
+      expect(seg?.spermInstances).toHaveLength(1);
+      expect(seg?.statistics.totalArea).toBe(0);
+    });
+
+    it('skips invalid partClass in polylinesData but keeps the polyline entry', async () => {
+      const converter = new FormatConverter();
+      const typo: Polygon = {
+        ...spermHead,
+        partClass: 'midpeice' as never,
+      };
+      const data = buildImageData([typo]);
+
+      const out = await converter.convertToJSON([data]);
+      const polylines = out.images[0]?.segmentation?.polylines;
+
+      expect(polylines).toHaveLength(1);
+      expect(polylines?.[0]?.partClass).toBeUndefined();
     });
   });
 });

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { FormatConverter, type ImageData, type Polygon } from '../formatConverter';
+import { logger } from '../../../utils/logger';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+const closedPolygon: Polygon = {
+  id: 'p1',
+  type: 'external',
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ],
+};
+
+const spermHead: Polygon = {
+  id: 'pl-head',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'head',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ],
+};
+
+const spermMidpiece: Polygon = {
+  id: 'pl-mid',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'midpiece',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 3, y: 0 },
+    { x: 3, y: 4 },
+  ],
+};
+
+const spermTail: Polygon = {
+  id: 'pl-tail',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'tail',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 3, y: 4 },
+    { x: 3, y: 9 },
+  ],
+};
+
+const buildImageData = (polygons: Polygon[]): ImageData => ({
+  id: 'img1',
+  filename: 'image1.png',
+  width: 100,
+  height: 100,
+  segmentationResults: [
+    {
+      polygons: JSON.stringify(polygons),
+      cellCount: 0,
+      timestamp: new Date('2026-04-17T00:00:00Z'),
+    },
+  ],
+});
+
+describe('FormatConverter', () => {
+  describe('convertToCOCO', () => {
+    it('emits a separate sperm category alongside cell', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      expect(coco.categories).toEqual([
+        expect.objectContaining({ id: 1, name: 'cell' }),
+        expect.objectContaining({ id: 2, name: 'sperm' }),
+      ]);
+    });
+
+    it('writes closed polygons under category 1 with geometry=polygon', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      expect(coco.annotations).toHaveLength(1);
+      const ann = coco.annotations[0];
+      expect(ann.category_id).toBe(1);
+      expect(ann.attributes?.geometry).toBe('polygon');
+      expect(ann.area).toBeGreaterThan(0);
+    });
+
+    it('writes polylines under category 2 with partClass+instanceId in attributes', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      const polylineAnns = coco.annotations.filter(a => a.category_id === 2);
+      expect(polylineAnns).toHaveLength(3);
+
+      const partClasses = polylineAnns
+        .map(a => a.attributes?.partClass)
+        .sort();
+      expect(partClasses).toEqual(['head', 'midpiece', 'tail']);
+
+      for (const ann of polylineAnns) {
+        expect(ann.attributes?.geometry).toBe('polyline');
+        expect(ann.attributes?.instanceId).toBe('sperm_1');
+        expect(ann.attributes?.length).toBeGreaterThan(0);
+        expect(ann.area).toBe(0);
+      }
+    });
+
+    it('produces stable annotation IDs (no collision between polygons and polylines)', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+
+      const coco = await converter.convertToCOCO([data]);
+
+      const ids = coco.annotations.map(a => a.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  describe('convertToYOLO', () => {
+    it('skips polylines with a warning log', async () => {
+      const converter = new FormatConverter();
+      const polygonsJson = JSON.stringify([
+        closedPolygon,
+        spermHead,
+        spermMidpiece,
+        spermTail,
+      ]);
+
+      const yolo = await converter.convertToYOLO(polygonsJson, 100, 100);
+      const lines = yolo.split('\n').filter(l => l && !l.startsWith('#'));
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/^0 /);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('YOLO format does not support open polylines'),
+        'FormatConverter',
+        expect.objectContaining({ polylineCount: 3 })
+      );
+    });
+
+    it('does not warn when there are no polylines', async () => {
+      mockedLogger.warn.mockClear();
+      const converter = new FormatConverter();
+      const polygonsJson = JSON.stringify([closedPolygon]);
+
+      await converter.convertToYOLO(polygonsJson, 100, 100);
+
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('convertToJSON', () => {
+    it('keeps polygon-only output backward compatible (no polylines field)', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon]);
+
+      const out = await converter.convertToJSON([data]);
+      const seg = out.images[0]?.segmentation;
+
+      expect(seg?.polygons.external).toHaveLength(1);
+      expect(seg?.polylines).toBeUndefined();
+      expect(seg?.spermInstances).toBeUndefined();
+      expect(seg?.statistics.totalPolylines).toBeUndefined();
+    });
+
+    it('emits polylines and spermInstances when polylines exist', async () => {
+      const converter = new FormatConverter();
+      const data = buildImageData([closedPolygon, spermHead, spermMidpiece, spermTail]);
+
+      const out = await converter.convertToJSON([data]);
+      const seg = out.images[0]?.segmentation;
+
+      expect(seg?.polygons.external).toHaveLength(1);
+      expect(seg?.polylines).toHaveLength(3);
+      expect(seg?.spermInstances).toHaveLength(1);
+
+      const inst = seg?.spermInstances?.[0];
+      expect(inst?.instanceId).toBe('sperm_1');
+      expect(inst?.parts.head?.length).toBeCloseTo(3);
+      expect(inst?.parts.midpiece?.length).toBeCloseTo(4);
+      expect(inst?.parts.tail?.length).toBeCloseTo(5);
+      expect(inst?.totalLength).toBeCloseTo(12);
+
+      expect(seg?.statistics.totalPolylines).toBe(3);
+      expect(seg?.statistics.totalSpermInstances).toBe(1);
+    });
+
+    it('orphan polylines (no instanceId) are exported but not grouped', async () => {
+      const converter = new FormatConverter();
+      const orphan: Polygon = {
+        ...spermHead,
+        id: 'orphan',
+        instanceId: undefined,
+      };
+      const data = buildImageData([orphan]);
+
+      const out = await converter.convertToJSON([data]);
+      const seg = out.images[0]?.segmentation;
+
+      expect(seg?.polylines).toHaveLength(1);
+      expect(seg?.spermInstances).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -343,6 +343,37 @@ describe('FormatConverter', () => {
       );
     });
 
+    it('keeps multiple sperm instances separate within one image', async () => {
+      const converter = new FormatConverter();
+      const sperm1Head = { ...spermHead, instanceId: 'sperm_1', id: 's1h' };
+      const sperm1Tail = { ...spermTail, instanceId: 'sperm_1', id: 's1t' };
+      const sperm2Head = { ...spermHead, instanceId: 'sperm_2', id: 's2h' };
+      const sperm2Mid = {
+        ...spermMidpiece,
+        instanceId: 'sperm_2',
+        id: 's2m',
+      };
+      const data = buildImageData([
+        sperm1Head,
+        sperm2Head,
+        sperm1Tail,
+        sperm2Mid,
+      ]);
+
+      const out = await converter.convertToJSON([data]);
+      const seg = out.images[0]?.segmentation;
+
+      expect(seg?.spermInstances).toHaveLength(2);
+      const s1 = seg?.spermInstances?.find(s => s.instanceId === 'sperm_1');
+      const s2 = seg?.spermInstances?.find(s => s.instanceId === 'sperm_2');
+      expect(s1?.parts.head).toBeDefined();
+      expect(s1?.parts.tail).toBeDefined();
+      expect(s1?.parts.midpiece).toBeUndefined();
+      expect(s2?.parts.head).toBeDefined();
+      expect(s2?.parts.midpiece).toBeDefined();
+      expect(s2?.parts.tail).toBeUndefined();
+    });
+
     it('handles a pure-polyline image with no closed polygons', async () => {
       const converter = new FormatConverter();
       const data = buildImageData([spermHead, spermMidpiece, spermTail]);

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -160,7 +160,7 @@ describe('FormatConverter', () => {
       }
     });
 
-    it('skips polylines with missing partClass and warns', async () => {
+    it('skips polylines with missing partClass and warns once with sample imageIds', async () => {
       const converter = new FormatConverter();
       const orphan: Polygon = {
         ...spermHead,
@@ -177,7 +177,11 @@ describe('FormatConverter', () => {
       expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('missing or invalid partClass'),
         'FormatConverter',
-        expect.objectContaining({ skipped: 1 })
+        expect.objectContaining({
+          totalSkipped: 1,
+          sampleImageIds: ['img1'],
+          expected: ['head', 'midpiece', 'tail'],
+        })
       );
     });
 
@@ -192,7 +196,11 @@ describe('FormatConverter', () => {
       const coco = await converter.convertToCOCO([data]);
 
       expect(coco.annotations.filter(a => a.category_id === 2)).toHaveLength(0);
-      expect(mockedLogger.warn).toHaveBeenCalled();
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or invalid partClass'),
+        'FormatConverter',
+        expect.objectContaining({ totalSkipped: 1 })
+      );
     });
 
     it('keeps annotation IDs unique across multiple images', async () => {
@@ -328,7 +336,10 @@ describe('FormatConverter', () => {
       expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('without instanceId'),
         'FormatConverter',
-        expect.objectContaining({ orphanCount: 1 })
+        expect.objectContaining({
+          totalOrphans: 1,
+          sampleImageIds: ['img1'],
+        })
       );
     });
 
@@ -359,6 +370,23 @@ describe('FormatConverter', () => {
 
       expect(polylines).toHaveLength(1);
       expect(polylines?.[0]?.partClass).toBeUndefined();
+    });
+
+  });
+
+  describe('annotation ID stability', () => {
+    it('keeps IDs unique within a single image with mixed polygons and polylines', async () => {
+      const data = buildImageData([
+        closedPolygon,
+        spermHead,
+        spermMidpiece,
+        spermTail,
+      ]);
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+      const ids = coco.annotations.map(a => a.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids).toEqual([1, 2, 3, 4]);
     });
   });
 });

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -1,4 +1,12 @@
 import { logger } from '../../utils/logger';
+import {
+  SPERM_PART_CLASSES,
+  type SpermPartClass,
+  isValidSpermPartClass,
+} from '../../utils/polygonValidation';
+
+export type { SpermPartClass };
+export { SPERM_PART_CLASSES, isValidSpermPartClass };
 
 export interface Point {
   x: number;
@@ -10,9 +18,11 @@ export interface Polygon {
   type: 'external' | 'internal';
   id?: string;
   geometry?: 'polygon' | 'polyline';
-  partClass?: 'head' | 'midpiece' | 'tail';
+  partClass?: SpermPartClass;
   instanceId?: string;
 }
+
+export const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
 
 export interface SegmentationResult {
   polygons: string; // JSON string of Polygon[]
@@ -49,7 +59,7 @@ export interface COCOAnnotation {
     type: string;
     geometry?: 'polygon' | 'polyline';
     has_holes?: boolean;
-    partClass?: 'head' | 'midpiece' | 'tail';
+    partClass?: SpermPartClass;
     instanceId?: string;
     length?: number;
   };
@@ -96,7 +106,7 @@ export interface JSONPolylineData {
   id: number;
   points: Point[];
   geometry: 'polyline';
-  partClass?: 'head' | 'midpiece' | 'tail';
+  partClass?: SpermPartClass;
   instanceId?: string;
   length: number;
   boundingBox?: [number, number, number, number];
@@ -127,7 +137,13 @@ export interface JSONSegmentationData {
     totalArea: number;
     totalPolylines?: number;
     totalSpermInstances?: number;
+    orphanPolylineCount?: number;
   };
+}
+
+export interface YOLOConversionResult {
+  content: string;
+  warnings: string[];
 }
 
 export interface JSONImageData {
@@ -165,6 +181,7 @@ export class FormatConverter {
     const annotations: COCOAnnotation[] = [];
     const imagesList: COCOImage[] = [];
     let annotationId = 1;
+    let totalValidPolylines = 0;
 
     for (let imageIdx = 0; imageIdx < images.length; imageIdx++) {
       const image = images[imageIdx];
@@ -210,9 +227,28 @@ export class FormatConverter {
           const internalPolygons = polygons.filter(
             (p: Polygon) => p.type === 'internal'
           );
-          const polylines = polygons.filter(
-            (p: Polygon) => p.geometry === 'polyline'
-          );
+          const allPolylines = polygons.filter((p: Polygon) => isPolyline(p));
+          const validPolylines: Polygon[] = [];
+          let invalidPartClassCount = 0;
+          for (const pl of allPolylines) {
+            if (isValidSpermPartClass(pl.partClass)) {
+              validPolylines.push(pl);
+            } else {
+              invalidPartClassCount += 1;
+            }
+          }
+          if (invalidPartClassCount > 0) {
+            logger.warn(
+              `Skipping ${invalidPartClassCount} polyline(s) with missing or invalid partClass in COCO export`,
+              'FormatConverter',
+              {
+                imageId: image.id,
+                expected: SPERM_PART_CLASSES,
+                skipped: invalidPartClassCount,
+              }
+            );
+          }
+          totalValidPolylines += validPolylines.length;
 
           for (const polygon of closedExternalPolygons) {
             // Find internal polygons that belong to this external polygon
@@ -278,7 +314,7 @@ export class FormatConverter {
             });
           }
 
-          for (const polyline of polylines) {
+          for (const polyline of validPolylines) {
             const flat = polyline.points.reduce(
               (acc: number[], point: Point) => {
                 acc.push(point.x, point.y);
@@ -289,7 +325,7 @@ export class FormatConverter {
             annotations.push({
               id: annotationId++,
               image_id: imageIdx + 1,
-              category_id: 2, // Sperm category
+              category_id: 2,
               segmentation: [flat],
               bbox: this.calculateBoundingBox(polyline.points),
               area: 0,
@@ -297,7 +333,7 @@ export class FormatConverter {
               attributes: {
                 type: 'external',
                 geometry: 'polyline',
-                ...(polyline.partClass && { partClass: polyline.partClass }),
+                partClass: polyline.partClass,
                 ...(polyline.instanceId && { instanceId: polyline.instanceId }),
                 length: this.calculatePolylineLength(polyline.points),
               },
@@ -318,20 +354,30 @@ export class FormatConverter {
       },
       images: imagesList,
       annotations,
-      categories: [
-        {
-          id: 1,
-          name: 'cell',
-          supercategory: 'biological',
-          color: [0, 255, 0] as [number, number, number],
-        },
-        {
-          id: 2,
-          name: 'sperm',
-          supercategory: 'biological',
-          color: [255, 128, 0] as [number, number, number],
-        },
-      ],
+      categories:
+        totalValidPolylines > 0
+          ? [
+              {
+                id: 1,
+                name: 'cell',
+                supercategory: 'biological',
+                color: [0, 255, 0] as [number, number, number],
+              },
+              {
+                id: 2,
+                name: 'sperm',
+                supercategory: 'biological',
+                color: [255, 128, 0] as [number, number, number],
+              },
+            ]
+          : [
+              {
+                id: 1,
+                name: 'cell',
+                supercategory: 'biological',
+                color: [0, 255, 0] as [number, number, number],
+              },
+            ],
       licenses: [
         {
           id: 1,
@@ -344,14 +390,11 @@ export class FormatConverter {
     return cocoData;
   }
 
-  /**
-   * Convert to YOLO format (returns string content for text file)
-   */
   async convertToYOLO(
     polygonsJson: string,
     imageWidth: number,
     imageHeight: number
-  ): Promise<string> {
+  ): Promise<YOLOConversionResult> {
     let polygons;
     try {
       polygons = JSON.parse(polygonsJson);
@@ -374,19 +417,16 @@ export class FormatConverter {
       );
     }
     const lines: string[] = [];
+    const warnings: string[] = [];
 
-    // Polylines (e.g. sperm head/midpiece/tail) are open curves — YOLO has no
-    // representation for them. Skip them and surface a warning so the user
-    // exports COCO/JSON when they need polyline data preserved.
-    const polylines = polygons.filter(
-      (p: Polygon) => p.geometry === 'polyline'
-    );
+    // YOLO has no open-curve representation; polylines are skipped (warning emitted).
+    const polylines = polygons.filter((p: Polygon) => isPolyline(p));
     if (polylines.length > 0) {
-      logger.warn(
-        `YOLO format does not support open polylines — skipping ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`,
-        'FormatConverter',
-        { polylineCount: polylines.length }
-      );
+      const msg = `YOLO format does not support open polylines — skipped ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`;
+      warnings.push(msg);
+      logger.warn(msg, 'FormatConverter', {
+        polylineCount: polylines.length,
+      });
     }
 
     const externalPolygons = polygons.filter(
@@ -422,7 +462,7 @@ export class FormatConverter {
       lines.push(`# Segmentation: 0 ${segmentationPoints}`);
     }
 
-    return lines.join('\n');
+    return { content: lines.join('\n'), warnings };
   }
 
   /**
@@ -484,23 +524,24 @@ export class FormatConverter {
           const internalPolygons = polygons.filter(
             (p: Polygon) => p.type === 'internal'
           );
-          const polylines = polygons.filter(
-            (p: Polygon) => p.geometry === 'polyline'
-          );
+          const polylines = polygons.filter((p: Polygon) => isPolyline(p));
 
           const polylinesData: JSONPolylineData[] = polylines.map(
             (p: Polygon, idx: number) => ({
               id: idx + 1,
               points: p.points,
               geometry: 'polyline',
-              ...(p.partClass && { partClass: p.partClass }),
+              ...(isValidSpermPartClass(p.partClass) && {
+                partClass: p.partClass,
+              }),
               ...(p.instanceId && { instanceId: p.instanceId }),
               length: this.calculatePolylineLength(p.points),
               boundingBox: this.calculateBoundingBox(p.points),
             })
           );
 
-          const spermInstances = this.groupPolylinesByInstanceId(polylines);
+          const { instances: spermInstances, orphanCount } =
+            this.groupPolylinesByInstanceId(polylines, image.id);
 
           imageData.segmentation = {
             cellCount: result.cellCount || externalPolygons.length,
@@ -543,6 +584,7 @@ export class FormatConverter {
               ...(spermInstances.length > 0 && {
                 totalSpermInstances: spermInstances.length,
               }),
+              ...(orphanCount > 0 && { orphanPolylineCount: orphanCount }),
             },
           };
         }
@@ -630,11 +672,14 @@ export class FormatConverter {
   }
 
   private groupPolylinesByInstanceId(
-    polylines: Polygon[]
-  ): JSONSpermInstance[] {
+    polylines: Polygon[],
+    imageId?: string
+  ): { instances: JSONSpermInstance[]; orphanCount: number } {
     const groups = new Map<string, Polygon[]>();
+    let orphanCount = 0;
     for (const p of polylines) {
       if (!p.instanceId) {
+        orphanCount += 1;
         continue;
       }
       const list = groups.get(p.instanceId);
@@ -643,6 +688,14 @@ export class FormatConverter {
       } else {
         groups.set(p.instanceId, [p]);
       }
+    }
+
+    if (orphanCount > 0) {
+      logger.warn(
+        `${orphanCount} polyline(s) without instanceId — excluded from spermInstances grouping`,
+        'FormatConverter',
+        { imageId, orphanCount }
+      );
     }
 
     const instances: JSONSpermInstance[] = [];
@@ -669,7 +722,7 @@ export class FormatConverter {
         totalLength: headLen + midLen + tailLen,
       });
     }
-    return instances;
+    return { instances, orphanCount };
   }
 
   /**

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -4,6 +4,8 @@ import {
   type SpermPartClass,
   isValidSpermPartClass,
 } from '../../utils/polygonValidation';
+import { polylineLength } from '../../utils/polygonGeometry';
+import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
 
 export interface Point {
   x: number;
@@ -343,7 +345,7 @@ export class FormatConverter {
                 geometry: 'polyline',
                 partClass: polyline.partClass,
                 ...(polyline.instanceId && { instanceId: polyline.instanceId }),
-                length: this.calculatePolylineLength(polyline.points),
+                length: polylineLength(polyline.points),
               },
             });
           }
@@ -537,13 +539,13 @@ export class FormatConverter {
                 partClass: p.partClass,
               }),
               ...(p.instanceId && { instanceId: p.instanceId }),
-              length: this.calculatePolylineLength(p.points),
+              length: polylineLength(p.points),
               boundingBox: this.calculateBoundingBox(p.points),
             })
           );
 
           const { instances: spermInstances, orphanCount } =
-            this.groupPolylinesByInstanceId(polylines);
+            this.buildSpermInstances(polylines);
           if (orphanCount > 0) {
             totalOrphans += orphanCount;
             if (orphanSampleImages.length < 10) {
@@ -673,52 +675,22 @@ export class FormatConverter {
     return perimeter;
   }
 
-  private calculatePolylineLength(points: Point[]): number {
-    let length = 0;
-    for (let i = 1; i < points.length; i++) {
-      const prev = points[i - 1];
-      const curr = points[i];
-      if (prev && curr) {
-        const dx = curr.x - prev.x;
-        const dy = curr.y - prev.y;
-        length += Math.sqrt(dx * dx + dy * dy);
-      }
-    }
-    return length;
-  }
-
-  private groupPolylinesByInstanceId(polylines: Polygon[]): {
+  private buildSpermInstances(polylines: Polygon[]): {
     instances: JSONSpermInstance[];
     orphanCount: number;
   } {
-    const groups = new Map<string, Polygon[]>();
-    let orphanCount = 0;
-    for (const p of polylines) {
-      if (!p.instanceId) {
-        orphanCount += 1;
-        continue;
-      }
-      const list = groups.get(p.instanceId);
-      if (list) {
-        list.push(p);
-      } else {
-        groups.set(p.instanceId, [p]);
-      }
-    }
+    const { groups, orphanCount } = groupPolylinesByInstanceId(polylines);
 
-    const instances: JSONSpermInstance[] = [];
-    for (const [instanceId, parts] of groups) {
-      const head = parts.find(p => p.partClass === 'head');
-      const midpiece = parts.find(p => p.partClass === 'midpiece');
-      const tail = parts.find(p => p.partClass === 'tail');
+    const instances: JSONSpermInstance[] = groups.map(({ instanceId, parts }) => {
+      const head = findPart(parts, 'head');
+      const midpiece = findPart(parts, 'midpiece');
+      const tail = findPart(parts, 'tail');
 
-      const headLen = head ? this.calculatePolylineLength(head.points) : 0;
-      const midLen = midpiece
-        ? this.calculatePolylineLength(midpiece.points)
-        : 0;
-      const tailLen = tail ? this.calculatePolylineLength(tail.points) : 0;
+      const headLen = head ? polylineLength(head.points) : 0;
+      const midLen = midpiece ? polylineLength(midpiece.points) : 0;
+      const tailLen = tail ? polylineLength(tail.points) : 0;
 
-      instances.push({
+      return {
         instanceId,
         parts: {
           ...(head && { head: { points: head.points, length: headLen } }),
@@ -728,8 +700,9 @@ export class FormatConverter {
           ...(tail && { tail: { points: tail.points, length: tailLen } }),
         },
         totalLength: headLen + midLen + tailLen,
-      });
-    }
+      };
+    });
+
     return { instances, orphanCount };
   }
 

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -9,6 +9,9 @@ export interface Polygon {
   points: Point[];
   type: 'external' | 'internal';
   id?: string;
+  geometry?: 'polygon' | 'polyline';
+  partClass?: 'head' | 'midpiece' | 'tail';
+  instanceId?: string;
 }
 
 export interface SegmentationResult {
@@ -44,7 +47,11 @@ export interface COCOAnnotation {
   iscrowd: number;
   attributes?: {
     type: string;
-    has_holes: boolean;
+    geometry?: 'polygon' | 'polyline';
+    has_holes?: boolean;
+    partClass?: 'head' | 'midpiece' | 'tail';
+    instanceId?: string;
+    length?: number;
   };
 }
 
@@ -85,6 +92,26 @@ export interface JSONPolygonData {
   centroid?: Point;
 }
 
+export interface JSONPolylineData {
+  id: number;
+  points: Point[];
+  geometry: 'polyline';
+  partClass?: 'head' | 'midpiece' | 'tail';
+  instanceId?: string;
+  length: number;
+  boundingBox?: [number, number, number, number];
+}
+
+export interface JSONSpermInstance {
+  instanceId: string;
+  parts: {
+    head?: { points: Point[]; length: number };
+    midpiece?: { points: Point[]; length: number };
+    tail?: { points: Point[]; length: number };
+  };
+  totalLength: number;
+}
+
 export interface JSONSegmentationData {
   cellCount: number;
   timestamp?: Date;
@@ -92,10 +119,14 @@ export interface JSONSegmentationData {
     external: JSONPolygonData[];
     internal: JSONPolygonData[];
   };
+  polylines?: JSONPolylineData[];
+  spermInstances?: JSONSpermInstance[];
   statistics: {
     totalExternalPolygons: number;
     totalInternalPolygons: number;
     totalArea: number;
+    totalPolylines?: number;
+    totalSpermInstances?: number;
   };
 }
 
@@ -172,15 +203,18 @@ export class FormatConverter {
             polygons = [];
           }
 
-          // Process external polygons
-          const externalPolygons = polygons.filter(
-            (p: Polygon) => p.type === 'external'
+          const closedExternalPolygons = polygons.filter(
+            (p: Polygon) =>
+              p.type === 'external' && p.geometry !== 'polyline'
           );
           const internalPolygons = polygons.filter(
             (p: Polygon) => p.type === 'internal'
           );
+          const polylines = polygons.filter(
+            (p: Polygon) => p.geometry === 'polyline'
+          );
 
-          for (const polygon of externalPolygons) {
+          for (const polygon of closedExternalPolygons) {
             // Find internal polygons that belong to this external polygon
             // (simplified - in real scenario, you'd check spatial containment)
             const associatedInternalPolygons = internalPolygons.filter(
@@ -238,7 +272,34 @@ export class FormatConverter {
               iscrowd: associatedInternalPolygons.length > 0 ? 1 : 0, // iscrowd=1 for RLE format
               attributes: {
                 type: 'external',
+                geometry: 'polygon',
                 has_holes: associatedInternalPolygons.length > 0,
+              },
+            });
+          }
+
+          for (const polyline of polylines) {
+            const flat = polyline.points.reduce(
+              (acc: number[], point: Point) => {
+                acc.push(point.x, point.y);
+                return acc;
+              },
+              []
+            );
+            annotations.push({
+              id: annotationId++,
+              image_id: imageIdx + 1,
+              category_id: 2, // Sperm category
+              segmentation: [flat],
+              bbox: this.calculateBoundingBox(polyline.points),
+              area: 0,
+              iscrowd: 0,
+              attributes: {
+                type: 'external',
+                geometry: 'polyline',
+                ...(polyline.partClass && { partClass: polyline.partClass }),
+                ...(polyline.instanceId && { instanceId: polyline.instanceId }),
+                length: this.calculatePolylineLength(polyline.points),
               },
             });
           }
@@ -263,6 +324,12 @@ export class FormatConverter {
           name: 'cell',
           supercategory: 'biological',
           color: [0, 255, 0] as [number, number, number],
+        },
+        {
+          id: 2,
+          name: 'sperm',
+          supercategory: 'biological',
+          color: [255, 128, 0] as [number, number, number],
         },
       ],
       licenses: [
@@ -308,9 +375,23 @@ export class FormatConverter {
     }
     const lines: string[] = [];
 
-    // Filter external polygons only for YOLO
+    // Polylines (e.g. sperm head/midpiece/tail) are open curves — YOLO has no
+    // representation for them. Skip them and surface a warning so the user
+    // exports COCO/JSON when they need polyline data preserved.
+    const polylines = polygons.filter(
+      (p: Polygon) => p.geometry === 'polyline'
+    );
+    if (polylines.length > 0) {
+      logger.warn(
+        `YOLO format does not support open polylines — skipping ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`,
+        'FormatConverter',
+        { polylineCount: polylines.length }
+      );
+    }
+
     const externalPolygons = polygons.filter(
-      (p: Polygon) => p.type === 'external'
+      (p: Polygon) =>
+        p.type === 'external' && p.geometry !== 'polyline'
     );
 
     for (const polygon of externalPolygons) {
@@ -397,11 +478,29 @@ export class FormatConverter {
           }
 
           const externalPolygons = polygons.filter(
-            (p: Polygon) => p.type === 'external'
+            (p: Polygon) =>
+              p.type === 'external' && p.geometry !== 'polyline'
           );
           const internalPolygons = polygons.filter(
             (p: Polygon) => p.type === 'internal'
           );
+          const polylines = polygons.filter(
+            (p: Polygon) => p.geometry === 'polyline'
+          );
+
+          const polylinesData: JSONPolylineData[] = polylines.map(
+            (p: Polygon, idx: number) => ({
+              id: idx + 1,
+              points: p.points,
+              geometry: 'polyline',
+              ...(p.partClass && { partClass: p.partClass }),
+              ...(p.instanceId && { instanceId: p.instanceId }),
+              length: this.calculatePolylineLength(p.points),
+              boundingBox: this.calculateBoundingBox(p.points),
+            })
+          );
+
+          const spermInstances = this.groupPolylinesByInstanceId(polylines);
 
           imageData.segmentation = {
             cellCount: result.cellCount || externalPolygons.length,
@@ -422,6 +521,8 @@ export class FormatConverter {
                 perimeter: this.calculatePerimeter(p.points),
               })),
             },
+            ...(polylinesData.length > 0 && { polylines: polylinesData }),
+            ...(spermInstances.length > 0 && { spermInstances }),
             statistics: {
               totalExternalPolygons: externalPolygons.length,
               totalInternalPolygons: internalPolygons.length,
@@ -436,6 +537,12 @@ export class FormatConverter {
                     sum + this.calculatePolygonArea(p.points),
                   0
                 ),
+              ...(polylinesData.length > 0 && {
+                totalPolylines: polylinesData.length,
+              }),
+              ...(spermInstances.length > 0 && {
+                totalSpermInstances: spermInstances.length,
+              }),
             },
           };
         }
@@ -506,6 +613,63 @@ export class FormatConverter {
     }
 
     return perimeter;
+  }
+
+  private calculatePolylineLength(points: Point[]): number {
+    let length = 0;
+    for (let i = 1; i < points.length; i++) {
+      const prev = points[i - 1];
+      const curr = points[i];
+      if (prev && curr) {
+        const dx = curr.x - prev.x;
+        const dy = curr.y - prev.y;
+        length += Math.sqrt(dx * dx + dy * dy);
+      }
+    }
+    return length;
+  }
+
+  private groupPolylinesByInstanceId(
+    polylines: Polygon[]
+  ): JSONSpermInstance[] {
+    const groups = new Map<string, Polygon[]>();
+    for (const p of polylines) {
+      if (!p.instanceId) {
+        continue;
+      }
+      const list = groups.get(p.instanceId);
+      if (list) {
+        list.push(p);
+      } else {
+        groups.set(p.instanceId, [p]);
+      }
+    }
+
+    const instances: JSONSpermInstance[] = [];
+    for (const [instanceId, parts] of groups) {
+      const head = parts.find(p => p.partClass === 'head');
+      const midpiece = parts.find(p => p.partClass === 'midpiece');
+      const tail = parts.find(p => p.partClass === 'tail');
+
+      const headLen = head ? this.calculatePolylineLength(head.points) : 0;
+      const midLen = midpiece
+        ? this.calculatePolylineLength(midpiece.points)
+        : 0;
+      const tailLen = tail ? this.calculatePolylineLength(tail.points) : 0;
+
+      instances.push({
+        instanceId,
+        parts: {
+          ...(head && { head: { points: head.points, length: headLen } }),
+          ...(midpiece && {
+            midpiece: { points: midpiece.points, length: midLen },
+          }),
+          ...(tail && { tail: { points: tail.points, length: tailLen } }),
+        },
+        totalLength: headLen + midLen + tailLen,
+      });
+    }
+    return instances;
   }
 
   /**

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -420,11 +420,9 @@ export class FormatConverter {
     // YOLO has no open-curve representation; polylines are skipped (warning emitted).
     const polylines = polygons.filter((p: Polygon) => isPolyline(p));
     if (polylines.length > 0) {
-      const msg = `YOLO format does not support open polylines — skipped ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`;
-      warnings.push(msg);
-      logger.warn(msg, 'FormatConverter', {
-        polylineCount: polylines.length,
-      });
+      warnings.push(
+        `YOLO format does not support open polylines — skipped ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`
+      );
     }
 
     const externalPolygons = polygons.filter(

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -5,9 +5,6 @@ import {
   isValidSpermPartClass,
 } from '../../utils/polygonValidation';
 
-export type { SpermPartClass };
-export { SPERM_PART_CLASSES, isValidSpermPartClass };
-
 export interface Point {
   x: number;
   y: number;
@@ -22,7 +19,32 @@ export interface Polygon {
   instanceId?: string;
 }
 
-export const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
+const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
+
+const flattenPoints = (points: Point[]): number[] => {
+  const out: number[] = [];
+  for (const p of points) {
+    out.push(p.x, p.y);
+  }
+  return out;
+};
+
+const CELL_CATEGORY: COCOCategory = {
+  id: 1,
+  name: 'cell',
+  supercategory: 'biological',
+  color: [0, 255, 0],
+};
+
+const SPERM_CATEGORY: COCOCategory = {
+  id: 2,
+  name: 'sperm',
+  supercategory: 'biological',
+  color: [255, 128, 0],
+};
+
+const buildCocoCategories = (hasSperm: boolean): COCOCategory[] =>
+  hasSperm ? [CELL_CATEGORY, SPERM_CATEGORY] : [CELL_CATEGORY];
 
 export interface SegmentationResult {
   polygons: string; // JSON string of Polygon[]
@@ -181,7 +203,9 @@ export class FormatConverter {
     const annotations: COCOAnnotation[] = [];
     const imagesList: COCOImage[] = [];
     let annotationId = 1;
-    let totalValidPolylines = 0;
+    let hasSperm = false;
+    let totalInvalidPartClass = 0;
+    const sampleAffectedImages: string[] = [];
 
     for (let imageIdx = 0; imageIdx < images.length; imageIdx++) {
       const image = images[imageIdx];
@@ -220,35 +244,32 @@ export class FormatConverter {
             polygons = [];
           }
 
-          const closedExternalPolygons = polygons.filter(
-            (p: Polygon) =>
-              p.type === 'external' && p.geometry !== 'polyline'
-          );
-          const internalPolygons = polygons.filter(
-            (p: Polygon) => p.type === 'internal'
-          );
-          const allPolylines = polygons.filter((p: Polygon) => isPolyline(p));
+          const closedExternalPolygons: Polygon[] = [];
+          const internalPolygons: Polygon[] = [];
           const validPolylines: Polygon[] = [];
           let invalidPartClassCount = 0;
-          for (const pl of allPolylines) {
-            if (isValidSpermPartClass(pl.partClass)) {
-              validPolylines.push(pl);
-            } else {
-              invalidPartClassCount += 1;
+          for (const p of polygons as Polygon[]) {
+            if (isPolyline(p)) {
+              if (isValidSpermPartClass(p.partClass)) {
+                validPolylines.push(p);
+              } else {
+                invalidPartClassCount += 1;
+              }
+            } else if (p.type === 'internal') {
+              internalPolygons.push(p);
+            } else if (p.type === 'external') {
+              closedExternalPolygons.push(p);
             }
           }
           if (invalidPartClassCount > 0) {
-            logger.warn(
-              `Skipping ${invalidPartClassCount} polyline(s) with missing or invalid partClass in COCO export`,
-              'FormatConverter',
-              {
-                imageId: image.id,
-                expected: SPERM_PART_CLASSES,
-                skipped: invalidPartClassCount,
-              }
-            );
+            totalInvalidPartClass += invalidPartClassCount;
+            if (sampleAffectedImages.length < 10) {
+              sampleAffectedImages.push(image.id);
+            }
           }
-          totalValidPolylines += validPolylines.length;
+          if (validPolylines.length > 0) {
+            hasSperm = true;
+          }
 
           for (const polygon of closedExternalPolygons) {
             // Find internal polygons that belong to this external polygon
@@ -289,13 +310,7 @@ export class FormatConverter {
               );
               segmentation = rle;
             } else {
-              // Simple polygon without holes - use polygon format
-              segmentation = [
-                polygon.points.reduce((acc: number[], point: Point) => {
-                  acc.push(point.x, point.y);
-                  return acc;
-                }, []),
-              ];
+              segmentation = [flattenPoints(polygon.points)];
             }
 
             annotations.push({
@@ -315,18 +330,11 @@ export class FormatConverter {
           }
 
           for (const polyline of validPolylines) {
-            const flat = polyline.points.reduce(
-              (acc: number[], point: Point) => {
-                acc.push(point.x, point.y);
-                return acc;
-              },
-              []
-            );
             annotations.push({
               id: annotationId++,
               image_id: imageIdx + 1,
               category_id: 2,
-              segmentation: [flat],
+              segmentation: [flattenPoints(polyline.points)],
               bbox: this.calculateBoundingBox(polyline.points),
               area: 0,
               iscrowd: 0,
@@ -343,7 +351,18 @@ export class FormatConverter {
       }
     }
 
-    // Create COCO format object
+    if (totalInvalidPartClass > 0) {
+      logger.warn(
+        `COCO export skipped ${totalInvalidPartClass} polyline(s) with missing or invalid partClass across ${sampleAffectedImages.length}+ image(s)`,
+        'FormatConverter',
+        {
+          expected: SPERM_PART_CLASSES,
+          totalSkipped: totalInvalidPartClass,
+          sampleImageIds: sampleAffectedImages,
+        }
+      );
+    }
+
     const cocoData = {
       info: {
         description: 'Cell Segmentation Dataset',
@@ -354,30 +373,7 @@ export class FormatConverter {
       },
       images: imagesList,
       annotations,
-      categories:
-        totalValidPolylines > 0
-          ? [
-              {
-                id: 1,
-                name: 'cell',
-                supercategory: 'biological',
-                color: [0, 255, 0] as [number, number, number],
-              },
-              {
-                id: 2,
-                name: 'sperm',
-                supercategory: 'biological',
-                color: [255, 128, 0] as [number, number, number],
-              },
-            ]
-          : [
-              {
-                id: 1,
-                name: 'cell',
-                supercategory: 'biological',
-                color: [0, 255, 0] as [number, number, number],
-              },
-            ],
+      categories: buildCocoCategories(hasSperm),
       licenses: [
         {
           id: 1,
@@ -478,6 +474,8 @@ export class FormatConverter {
       },
       images: [],
     };
+    let totalOrphans = 0;
+    const orphanSampleImages: string[] = [];
 
     for (let imageIdx = 0; imageIdx < images.length; imageIdx++) {
       const image = images[imageIdx];
@@ -517,14 +515,18 @@ export class FormatConverter {
             polygons = [];
           }
 
-          const externalPolygons = polygons.filter(
-            (p: Polygon) =>
-              p.type === 'external' && p.geometry !== 'polyline'
-          );
-          const internalPolygons = polygons.filter(
-            (p: Polygon) => p.type === 'internal'
-          );
-          const polylines = polygons.filter((p: Polygon) => isPolyline(p));
+          const externalPolygons: Polygon[] = [];
+          const internalPolygons: Polygon[] = [];
+          const polylines: Polygon[] = [];
+          for (const p of polygons as Polygon[]) {
+            if (isPolyline(p)) {
+              polylines.push(p);
+            } else if (p.type === 'internal') {
+              internalPolygons.push(p);
+            } else if (p.type === 'external') {
+              externalPolygons.push(p);
+            }
+          }
 
           const polylinesData: JSONPolylineData[] = polylines.map(
             (p: Polygon, idx: number) => ({
@@ -541,7 +543,13 @@ export class FormatConverter {
           );
 
           const { instances: spermInstances, orphanCount } =
-            this.groupPolylinesByInstanceId(polylines, image.id);
+            this.groupPolylinesByInstanceId(polylines);
+          if (orphanCount > 0) {
+            totalOrphans += orphanCount;
+            if (orphanSampleImages.length < 10) {
+              orphanSampleImages.push(image.id);
+            }
+          }
 
           imageData.segmentation = {
             cellCount: result.cellCount || externalPolygons.length,
@@ -591,6 +599,14 @@ export class FormatConverter {
       }
 
       exportData.images.push(imageData);
+    }
+
+    if (totalOrphans > 0) {
+      logger.warn(
+        `JSON export found ${totalOrphans} polyline(s) without instanceId across ${orphanSampleImages.length}+ image(s) — excluded from spermInstances grouping`,
+        'FormatConverter',
+        { totalOrphans, sampleImageIds: orphanSampleImages }
+      );
     }
 
     return exportData;
@@ -671,10 +687,10 @@ export class FormatConverter {
     return length;
   }
 
-  private groupPolylinesByInstanceId(
-    polylines: Polygon[],
-    imageId?: string
-  ): { instances: JSONSpermInstance[]; orphanCount: number } {
+  private groupPolylinesByInstanceId(polylines: Polygon[]): {
+    instances: JSONSpermInstance[];
+    orphanCount: number;
+  } {
     const groups = new Map<string, Polygon[]>();
     let orphanCount = 0;
     for (const p of polylines) {
@@ -688,14 +704,6 @@ export class FormatConverter {
       } else {
         groups.set(p.instanceId, [p]);
       }
-    }
-
-    if (orphanCount > 0) {
-      logger.warn(
-        `${orphanCount} polyline(s) without instanceId — excluded from spermInstances grouping`,
-        'FormatConverter',
-        { imageId, orphanCount }
-      );
     }
 
     const instances: JSONSpermInstance[] = [];

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -11,6 +11,9 @@ import { FormatConverter } from './export/formatConverter';
 import { WebSocketService } from './websocketService';
 import * as SharingService from './sharingService';
 import { batchProcessor } from '../utils/batchProcessor';
+import { mapWithConcurrency } from '../utils/concurrency';
+
+const YOLO_WRITE_CONCURRENCY = 16;
 
 export interface ExportOptions {
   includeOriginalImages?: boolean;
@@ -884,14 +887,11 @@ export class ExportService {
           JSON.stringify(cocoData, null, 2)
         );
       } else if (format === 'yolo') {
-        for (let i = 0; i < images.length; i++) {
-          // Check if job was cancelled inside YOLO loop (most time-consuming)
-          if (jobId && this.isJobCancelled(jobId)) {
-            throw new Error('Export cancelled by user');
-          }
-
-          const image = images[i];
-          if (image && image.segmentation) {
+        await mapWithConcurrency(
+          images,
+          YOLO_WRITE_CONCURRENCY,
+          async image => {
+            if (!image || !image.segmentation) return;
             const yoloResult = await this.formatConverter.convertToYOLO(
               image.segmentation.polygons,
               image.width || 0,
@@ -909,13 +909,13 @@ export class ExportService {
                 { jobId, imageId: image.id, warnings: yoloResult.warnings }
               );
             }
+          },
+          {
+            shouldAbort: () => !!jobId && this.isJobCancelled(jobId),
+            onProgress,
+            abortMessage: 'Export cancelled by user',
           }
-
-          // Report progress for YOLO generation
-          if (onProgress) {
-            onProgress(i + 1, images.length);
-          }
-        }
+        );
       } else if (format === 'json') {
         // Convert ImageWithSegmentation[] to ImageData[]
         const imageDataArray = images.map(image => ({

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -892,7 +892,7 @@ export class ExportService {
 
           const image = images[i];
           if (image && image.segmentation) {
-            const yoloData = await this.formatConverter.convertToYOLO(
+            const yoloResult = await this.formatConverter.convertToYOLO(
               image.segmentation.polygons,
               image.width || 0,
               image.height || 0
@@ -900,8 +900,15 @@ export class ExportService {
             const imageNameWithoutExt = path.parse(image.name).name;
             await fs.writeFile(
               path.join(formatDir, `${imageNameWithoutExt}.txt`),
-              yoloData
+              yoloResult.content
             );
+            if (yoloResult.warnings.length > 0) {
+              logger.warn(
+                `YOLO export for ${image.name} produced ${yoloResult.warnings.length} warning(s)`,
+                'ExportService',
+                { jobId, imageId: image.id, warnings: yoloResult.warnings }
+              );
+            }
           }
 
           // Report progress for YOLO generation

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -9,6 +9,9 @@ import { config } from '../../utils/config';
 import {
   /* SCALE_CONFIG, */ validateScale /* getScaleValidationMessage, getScaleWarningMessage */,
 } from './scaleConfig';
+import type { SpermPartClass } from '../../utils/polygonValidation';
+import { polylineLength } from '../../utils/polygonGeometry';
+import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
 
 export interface PolygonMetrics {
   imageId: string;
@@ -49,7 +52,7 @@ export interface ParsedPolygon {
   points: Point[];
   type?: 'external' | 'internal';
   geometry?: 'polygon' | 'polyline';
-  partClass?: 'head' | 'midpiece' | 'tail';
+  partClass?: SpermPartClass;
   instanceId?: string;
 }
 
@@ -75,16 +78,6 @@ export class MetricsCalculator {
   private pythonApiUrl: string;
   private http: AxiosInstance;
   private logger = logger;
-
-  private polylineLength(points: Point[]): number {
-    let len = 0;
-    for (let i = 1; i < points.length; i++) {
-      const dx = points[i].x - points[i - 1].x;
-      const dy = points[i].y - points[i - 1].y;
-      len += Math.sqrt(dx * dx + dy * dy);
-    }
-    return len;
-  }
 
   constructor() {
     // Validate ML service URL
@@ -693,37 +686,25 @@ export class MetricsCalculator {
         continue;
       }
 
-      // Get polylines grouped by instanceId
-      const orphanedCount = polygons.filter(
-        p => p.geometry === 'polyline' && !p.instanceId
-      ).length;
-      if (orphanedCount > 0) {
+      const allPolylines = polygons.filter(p => p.geometry === 'polyline');
+      const { groups, orphanCount } = groupPolylinesByInstanceId(allPolylines);
+      if (orphanCount > 0) {
         this.logger.warn(
-          `Image "${image.name}" has ${orphanedCount} polyline(s) without instanceId — excluded from sperm metrics`,
+          `Image "${image.name}" has ${orphanCount} polyline(s) without instanceId — excluded from sperm metrics`,
           'MetricsCalculator',
           { imageId: image.id }
         );
       }
 
-      const polylines = polygons.filter(
-        (p): p is ParsedPolygon & { instanceId: string } =>
-          p.geometry === 'polyline' && !!p.instanceId
-      );
-      const groups = new Map<string, ParsedPolygon[]>();
-      for (const pl of polylines) {
-        if (!groups.has(pl.instanceId)) groups.set(pl.instanceId, []);
-        groups.get(pl.instanceId)!.push(pl);
-      }
-
-      for (const [instanceId, parts] of groups) {
+      for (const { instanceId, parts } of groups) {
         hasData = true;
-        const head = parts.find(p => p.partClass === 'head');
-        const mid = parts.find(p => p.partClass === 'midpiece');
-        const tail = parts.find(p => p.partClass === 'tail');
+        const head = findPart(parts, 'head');
+        const mid = findPart(parts, 'midpiece');
+        const tail = findPart(parts, 'tail');
 
-        const headLen = head ? this.polylineLength(head.points) * scale : 0;
-        const midLen = mid ? this.polylineLength(mid.points) * scale : 0;
-        const tailLen = tail ? this.polylineLength(tail.points) * scale : 0;
+        const headLen = head ? polylineLength(head.points) * scale : 0;
+        const midLen = mid ? polylineLength(mid.points) * scale : 0;
+        const tailLen = tail ? polylineLength(tail.points) * scale : 0;
 
         worksheet.addRow({
           imageName: image.name,

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -6,7 +6,10 @@ import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { logger } from '../utils/logger';
 import { config } from '../utils/config';
-import { PolygonValidator } from '../utils/polygonValidation';
+import {
+  PolygonValidator,
+  type SpermPartClass,
+} from '../utils/polygonValidation';
 import { ImageService } from './imageService';
 import { SegmentationThumbnailService } from './segmentationThumbnailService';
 import { ThumbnailManager } from './thumbnailManager';
@@ -25,8 +28,8 @@ export interface SegmentationPolygon {
   type: 'external' | 'internal';
   parentIds?: string[]; // For internal polygons, match frontend API interface
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat)
-  partClass?: 'head' | 'midpiece' | 'tail'; // For sperm polyline parts
-  instanceId?: string; // Groups polylines into instances, e.g. 'sperm_1'
+  partClass?: SpermPartClass;
+  instanceId?: string;
 }
 
 export interface SegmentationRequest {

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -3,6 +3,7 @@ import { writeFile, readFile, mkdir, unlink } from 'fs/promises';
 import sharp from 'sharp';
 import path from 'path';
 import { logger } from '../../utils/logger';
+import type { SpermPartClass } from '../../utils/polygonValidation';
 
 export interface VisualizationOptions {
   showNumbers?: boolean;
@@ -20,7 +21,7 @@ export interface Polygon {
   type: 'external' | 'internal';
   id?: string;
   geometry?: 'polygon' | 'polyline';
-  partClass?: 'head' | 'midpiece' | 'tail';
+  partClass?: SpermPartClass;
   instanceId?: string;
 }
 

--- a/backend/src/utils/__tests__/concurrency.test.ts
+++ b/backend/src/utils/__tests__/concurrency.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { mapWithConcurrency } from '../concurrency';
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+describe('mapWithConcurrency', () => {
+  it('processes all items in correct count and reports progress', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    const processed: number[] = [];
+    const onProgress = jest.fn();
+
+    await mapWithConcurrency(
+      items,
+      4,
+      async i => {
+        await sleep(1);
+        processed.push(i);
+      },
+      { onProgress }
+    );
+
+    expect(processed.sort((a, b) => a - b)).toEqual(items);
+    expect(onProgress).toHaveBeenCalledTimes(20);
+    expect(onProgress).toHaveBeenLastCalledWith(20, 20);
+  });
+
+  it('respects concurrency limit (never exceeds it)', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+
+    await mapWithConcurrency(items, 5, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(2);
+      inFlight -= 1;
+    });
+
+    expect(peak).toBe(5);
+  });
+
+  it('aborts when shouldAbort returns true and reports abortMessage', async () => {
+    let count = 0;
+    const items = Array.from({ length: 50 }, (_, i) => i);
+
+    await expect(
+      mapWithConcurrency(
+        items,
+        4,
+        async () => {
+          count += 1;
+          await sleep(1);
+        },
+        {
+          shouldAbort: () => count >= 8,
+          abortMessage: 'Cancelled by user',
+        }
+      )
+    ).rejects.toThrow('Cancelled by user');
+
+    expect(count).toBeLessThan(items.length);
+  });
+
+  it('rethrows the first task error after in-flight tasks settle', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await expect(
+      mapWithConcurrency(items, 3, async i => {
+        if (i === 2) throw new Error('boom');
+        await sleep(1);
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  it('handles empty input as no-op', async () => {
+    const onProgress = jest.fn();
+    await expect(
+      mapWithConcurrency([], 4, async () => {}, { onProgress })
+    ).resolves.toBeUndefined();
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('caps concurrency at item count when items < limit', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapWithConcurrency([1, 2, 3], 16, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(1);
+      inFlight -= 1;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+});

--- a/backend/src/utils/__tests__/polygonGeometry.test.ts
+++ b/backend/src/utils/__tests__/polygonGeometry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals';
+import { polylineLength } from '../polygonGeometry';
+
+describe('polylineLength', () => {
+  it('returns 0 for empty input', () => {
+    expect(polylineLength([])).toBe(0);
+  });
+
+  it('returns 0 for a single point (no segments)', () => {
+    expect(polylineLength([{ x: 5, y: 5 }])).toBe(0);
+  });
+
+  it('computes Euclidean length for a 3-4-5 right triangle hypotenuse', () => {
+    expect(
+      polylineLength([
+        { x: 0, y: 0 },
+        { x: 3, y: 4 },
+      ])
+    ).toBeCloseTo(5);
+  });
+
+  it('sums segments along an open polyline (no closing segment)', () => {
+    expect(
+      polylineLength([
+        { x: 0, y: 0 },
+        { x: 3, y: 0 },
+        { x: 3, y: 4 },
+      ])
+    ).toBeCloseTo(7);
+  });
+
+  it('returns NaN if any coordinate is NaN (does not silently coerce to 0)', () => {
+    const result = polylineLength([
+      { x: 0, y: 0 },
+      { x: Number.NaN, y: 1 },
+    ]);
+    expect(Number.isNaN(result)).toBe(true);
+  });
+});

--- a/backend/src/utils/__tests__/spermGrouping.test.ts
+++ b/backend/src/utils/__tests__/spermGrouping.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  groupPolylinesByInstanceId,
+  findPart,
+  type SpermPolylinePart,
+} from '../spermGrouping';
+
+const makePart = (
+  instanceId: string | undefined,
+  partClass: SpermPolylinePart['partClass']
+): SpermPolylinePart => ({
+  instanceId,
+  partClass,
+  points: [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ],
+});
+
+describe('groupPolylinesByInstanceId', () => {
+  it('returns empty result for empty input', () => {
+    expect(groupPolylinesByInstanceId([])).toEqual({
+      groups: [],
+      orphanCount: 0,
+    });
+  });
+
+  it('groups multiple parts under one instanceId', () => {
+    const result = groupPolylinesByInstanceId([
+      makePart('s1', 'head'),
+      makePart('s1', 'midpiece'),
+      makePart('s1', 'tail'),
+    ]);
+
+    expect(result.orphanCount).toBe(0);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.instanceId).toBe('s1');
+    expect(result.groups[0]?.parts).toHaveLength(3);
+  });
+
+  it('keeps multiple instances separate (no collapse-by-partClass)', () => {
+    const result = groupPolylinesByInstanceId([
+      makePart('s1', 'head'),
+      makePart('s2', 'head'),
+      makePart('s1', 'tail'),
+      makePart('s2', 'midpiece'),
+    ]);
+
+    expect(result.groups).toHaveLength(2);
+    const s1 = result.groups.find(g => g.instanceId === 's1');
+    const s2 = result.groups.find(g => g.instanceId === 's2');
+    expect(s1?.parts.map(p => p.partClass).sort()).toEqual(['head', 'tail']);
+    expect(s2?.parts.map(p => p.partClass).sort()).toEqual([
+      'head',
+      'midpiece',
+    ]);
+  });
+
+  it('counts polylines without instanceId as orphans', () => {
+    const result = groupPolylinesByInstanceId([
+      makePart(undefined, 'head'),
+      makePart('s1', 'midpiece'),
+      makePart(undefined, 'tail'),
+    ]);
+
+    expect(result.orphanCount).toBe(2);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.instanceId).toBe('s1');
+  });
+
+  it('preserves grouped parts in insertion order', () => {
+    const head = makePart('s1', 'head');
+    const tail = makePart('s1', 'tail');
+    const mid = makePart('s1', 'midpiece');
+
+    const { groups } = groupPolylinesByInstanceId([head, tail, mid]);
+
+    expect(groups[0]?.parts).toEqual([head, tail, mid]);
+  });
+});
+
+describe('findPart', () => {
+  it('returns the matching part by partClass', () => {
+    const head = makePart('s1', 'head');
+    const tail = makePart('s1', 'tail');
+    expect(findPart([head, tail], 'tail')).toBe(tail);
+  });
+
+  it('returns undefined when no part matches', () => {
+    const head = makePart('s1', 'head');
+    expect(findPart([head], 'midpiece')).toBeUndefined();
+  });
+
+  it('returns the first match when duplicates exist', () => {
+    const a = makePart('s1', 'head');
+    const b = makePart('s1', 'head');
+    expect(findPart([a, b], 'head')).toBe(a);
+  });
+});

--- a/backend/src/utils/concurrency.ts
+++ b/backend/src/utils/concurrency.ts
@@ -1,0 +1,57 @@
+/**
+ * Process items with bounded concurrency. Workers pull from a shared
+ * cursor; the first thrown error short-circuits remaining work.
+ *
+ * - `shouldAbort()` is checked before each item — used for user-initiated
+ *   cancellation. Throws are surfaced after all in-flight tasks settle.
+ * - `onProgress(completed, total)` fires after each successful completion.
+ *   Order is non-deterministic; counts are accurate.
+ */
+export const mapWithConcurrency = async <T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<void>,
+  options: {
+    shouldAbort?: () => boolean;
+    onProgress?: (completed: number, total: number) => void;
+    abortMessage?: string;
+  } = {}
+): Promise<void> => {
+  const total = items.length;
+  if (total === 0) return;
+
+  const limit = Math.max(1, Math.min(concurrency, total));
+  let nextIndex = 0;
+  let completed = 0;
+  let firstError: unknown = undefined;
+  let aborted = false;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      if (firstError !== undefined || aborted) return;
+      if (options.shouldAbort?.()) {
+        aborted = true;
+        return;
+      }
+      const i = nextIndex++;
+      if (i >= total) return;
+      try {
+        await task(items[i] as T, i);
+      } catch (err) {
+        if (firstError === undefined) firstError = err;
+        return;
+      }
+      completed += 1;
+      options.onProgress?.(completed, total);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: limit }, () => worker())
+  );
+
+  if (firstError !== undefined) throw firstError;
+  if (aborted) {
+    throw new Error(options.abortMessage ?? 'Operation aborted');
+  }
+};

--- a/backend/src/utils/concurrency.ts
+++ b/backend/src/utils/concurrency.ts
@@ -1,9 +1,11 @@
+import { logger } from './logger';
+
 /**
- * Process items with bounded concurrency. Workers pull from a shared
- * cursor; the first thrown error short-circuits remaining work.
+ * Bounded-concurrency map. Workers share a cursor; the first thrown error
+ * short-circuits remaining work and is rethrown after in-flight tasks
+ * settle. Subsequent concurrent errors are logged so they aren't lost.
  *
- * - `shouldAbort()` is checked before each item — used for user-initiated
- *   cancellation. Throws are surfaced after all in-flight tasks settle.
+ * - `shouldAbort()` is polled before each item for user-initiated cancellation.
  * - `onProgress(completed, total)` fires after each successful completion.
  *   Order is non-deterministic; counts are accurate.
  */
@@ -38,7 +40,15 @@ export const mapWithConcurrency = async <T>(
       try {
         await task(items[i] as T, i);
       } catch (err) {
-        if (firstError === undefined) firstError = err;
+        if (firstError === undefined) {
+          firstError = err;
+        } else {
+          logger.error(
+            'mapWithConcurrency: secondary task error suppressed by first-error short-circuit',
+            err instanceof Error ? err : new Error(String(err)),
+            'concurrency'
+          );
+        }
         return;
       }
       completed += 1;
@@ -46,9 +56,7 @@ export const mapWithConcurrency = async <T>(
     }
   };
 
-  await Promise.all(
-    Array.from({ length: limit }, () => worker())
-  );
+  await Promise.all(Array.from({ length: limit }, () => worker()));
 
   if (firstError !== undefined) throw firstError;
   if (aborted) {

--- a/backend/src/utils/polygonGeometry.ts
+++ b/backend/src/utils/polygonGeometry.ts
@@ -1,0 +1,18 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export const polylineLength = (points: Point[]): number => {
+  let length = 0;
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (prev && curr) {
+      const dx = curr.x - prev.x;
+      const dy = curr.y - prev.y;
+      length += Math.sqrt(dx * dx + dy * dy);
+    }
+  }
+  return length;
+};

--- a/backend/src/utils/polygonValidation.ts
+++ b/backend/src/utils/polygonValidation.ts
@@ -1,5 +1,14 @@
 import { logger } from '../utils/logger';
 
+export const SPERM_PART_CLASSES = ['head', 'midpiece', 'tail'] as const;
+export type SpermPartClass = (typeof SPERM_PART_CLASSES)[number];
+
+export const isValidSpermPartClass = (
+  value: unknown
+): value is SpermPartClass =>
+  typeof value === 'string' &&
+  (SPERM_PART_CLASSES as readonly string[]).includes(value);
+
 export interface PolygonPoint {
   x: number;
   y: number;
@@ -283,12 +292,7 @@ export const PolygonValidator = {
     if (polygonObj.geometry === 'polyline') {
       (validatedPolygon as any).geometry = 'polyline';
     }
-    const validPartClasses = ['head', 'midpiece', 'tail'];
-    if (
-      polygonObj.partClass &&
-      typeof polygonObj.partClass === 'string' &&
-      validPartClasses.includes(polygonObj.partClass)
-    ) {
+    if (isValidSpermPartClass(polygonObj.partClass)) {
       (validatedPolygon as any).partClass = polygonObj.partClass;
     }
     if (polygonObj.instanceId && typeof polygonObj.instanceId === 'string') {

--- a/backend/src/utils/spermGrouping.ts
+++ b/backend/src/utils/spermGrouping.ts
@@ -6,9 +6,16 @@ export interface SpermPolylinePart {
   points: { x: number; y: number }[];
 }
 
+// After grouping, every part has both fields by construction (orphans are
+// excluded). Narrowing the result type removes false confidence at call sites.
+export type GroupedPart<P extends SpermPolylinePart> = P & {
+  instanceId: string;
+};
+
 export interface SpermInstanceGroup<P extends SpermPolylinePart> {
   instanceId: string;
-  parts: P[];
+  // Non-empty by construction: a bucket is created on first push.
+  parts: readonly [GroupedPart<P>, ...GroupedPart<P>[]];
 }
 
 export interface SpermGroupingResult<P extends SpermPolylinePart> {
@@ -16,42 +23,38 @@ export interface SpermGroupingResult<P extends SpermPolylinePart> {
   orphanCount: number;
 }
 
-/**
- * Groups polylines by `instanceId` for sperm-morphology aggregation.
- * Polylines without `instanceId` are counted as orphans (not grouped).
- * Pure function — caller decides whether/where to log the orphan count.
- */
+// Polylines missing instanceId are returned as `orphanCount`, not grouped.
 export const groupPolylinesByInstanceId = <P extends SpermPolylinePart>(
   polylines: P[]
 ): SpermGroupingResult<P> => {
-  const buckets = new Map<string, P[]>();
+  const buckets = new Map<string, GroupedPart<P>[]>();
   let orphanCount = 0;
   for (const p of polylines) {
     if (!p.instanceId) {
       orphanCount += 1;
       continue;
     }
+    const grouped = p as GroupedPart<P>;
     const list = buckets.get(p.instanceId);
     if (list) {
-      list.push(p);
+      list.push(grouped);
     } else {
-      buckets.set(p.instanceId, [p]);
+      buckets.set(p.instanceId, [grouped]);
     }
   }
 
   const groups: SpermInstanceGroup<P>[] = [];
   for (const [instanceId, parts] of buckets) {
-    groups.push({ instanceId, parts });
+    groups.push({
+      instanceId,
+      parts: parts as [GroupedPart<P>, ...GroupedPart<P>[]],
+    });
   }
 
   return { groups, orphanCount };
 };
 
-/**
- * Locate the polyline for a given partClass within a group's parts.
- * Returns the first match (callers should ensure unique parts per group).
- */
 export const findPart = <P extends SpermPolylinePart>(
-  parts: P[],
+  parts: readonly P[],
   partClass: SpermPartClass
 ): P | undefined => parts.find(p => p.partClass === partClass);

--- a/backend/src/utils/spermGrouping.ts
+++ b/backend/src/utils/spermGrouping.ts
@@ -1,0 +1,57 @@
+import type { SpermPartClass } from './polygonValidation';
+
+export interface SpermPolylinePart {
+  partClass?: SpermPartClass;
+  instanceId?: string;
+  points: { x: number; y: number }[];
+}
+
+export interface SpermInstanceGroup<P extends SpermPolylinePart> {
+  instanceId: string;
+  parts: P[];
+}
+
+export interface SpermGroupingResult<P extends SpermPolylinePart> {
+  groups: SpermInstanceGroup<P>[];
+  orphanCount: number;
+}
+
+/**
+ * Groups polylines by `instanceId` for sperm-morphology aggregation.
+ * Polylines without `instanceId` are counted as orphans (not grouped).
+ * Pure function — caller decides whether/where to log the orphan count.
+ */
+export const groupPolylinesByInstanceId = <P extends SpermPolylinePart>(
+  polylines: P[]
+): SpermGroupingResult<P> => {
+  const buckets = new Map<string, P[]>();
+  let orphanCount = 0;
+  for (const p of polylines) {
+    if (!p.instanceId) {
+      orphanCount += 1;
+      continue;
+    }
+    const list = buckets.get(p.instanceId);
+    if (list) {
+      list.push(p);
+    } else {
+      buckets.set(p.instanceId, [p]);
+    }
+  }
+
+  const groups: SpermInstanceGroup<P>[] = [];
+  for (const [instanceId, parts] of buckets) {
+    groups.push({ instanceId, parts });
+  }
+
+  return { groups, orphanCount };
+};
+
+/**
+ * Locate the polyline for a given partClass within a group's parts.
+ * Returns the first match (callers should ensure unique parts per group).
+ */
+export const findPart = <P extends SpermPolylinePart>(
+  parts: P[],
+  partClass: SpermPartClass
+): P | undefined => parts.find(p => p.partClass === partClass);

--- a/src/lib/segmentation.ts
+++ b/src/lib/segmentation.ts
@@ -26,10 +26,10 @@ export interface Polygon {
   name?: string;
   confidence?: number;
   area?: number;
-  parent_id?: string; // For internal polygons, references the parent external polygon
-  geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat)
-  partClass?: SpermPartClass; // For sperm polyline parts
-  instanceId?: string; // Groups polylines into instances, e.g. 'sperm_1'
+  parent_id?: string;
+  geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat with rows stored before sperm model)
+  partClass?: SpermPartClass;
+  instanceId?: string;
 }
 
 export const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';

--- a/src/lib/segmentation.ts
+++ b/src/lib/segmentation.ts
@@ -9,6 +9,15 @@ export interface Point {
   y: number;
 }
 
+export const SPERM_PART_CLASSES = ['head', 'midpiece', 'tail'] as const;
+export type SpermPartClass = (typeof SPERM_PART_CLASSES)[number];
+
+export const isValidSpermPartClass = (
+  value: unknown
+): value is SpermPartClass =>
+  typeof value === 'string' &&
+  (SPERM_PART_CLASSES as readonly string[]).includes(value);
+
 export interface Polygon {
   id: string;
   points: Point[];
@@ -19,9 +28,11 @@ export interface Polygon {
   area?: number;
   parent_id?: string; // For internal polygons, references the parent external polygon
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat)
-  partClass?: 'head' | 'midpiece' | 'tail'; // For sperm polyline parts
+  partClass?: SpermPartClass; // For sperm polyline parts
   instanceId?: string; // Groups polylines into instances, e.g. 'sperm_1'
 }
+
+export const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
 
 // SegmentationResult type removed - use Polygon[] directly
 

--- a/src/pages/segmentation/utils/cocoConverter.ts
+++ b/src/pages/segmentation/utils/cocoConverter.ts
@@ -4,66 +4,61 @@ import {
   isPolyline,
   isValidSpermPartClass,
 } from '@/lib/segmentation';
-import { calculateMetrics } from './metricCalculations';
-import { isPolygonInsidePolygon } from '@/lib/polygonGeometry';
+import {
+  calculateMetrics,
+  calculatePolylineLength,
+} from './metricCalculations';
+import {
+  isPolygonInsidePolygon,
+  calculateBoundingBox,
+} from '@/lib/polygonGeometry';
 
-const polylineLength = (points: { x: number; y: number }[]): number => {
-  let length = 0;
-  for (let i = 1; i < points.length; i++) {
-    const dx = points[i].x - points[i - 1].x;
-    const dy = points[i].y - points[i - 1].y;
-    length += Math.sqrt(dx * dx + dy * dy);
+const flattenPoints = (points: { x: number; y: number }[]): number[] => {
+  const out: number[] = [];
+  for (const p of points) {
+    out.push(p.x, p.y);
   }
-  return length;
+  return out;
 };
 
-const flattenPoints = (points: { x: number; y: number }[]): number[] =>
-  points.reduce<number[]>((acc, p) => [...acc, p.x, p.y], []);
-
-const boundingBox = (
+const bboxTuple = (
   points: { x: number; y: number }[]
 ): [number, number, number, number] => {
-  if (points.length === 0) return [0, 0, 0, 0];
-  const xs = points.map(p => p.x);
-  const ys = points.map(p => p.y);
-  const x = Math.min(...xs);
-  const y = Math.min(...ys);
-  return [x, y, Math.max(...xs) - x, Math.max(...ys) - y];
+  const bb = calculateBoundingBox(points);
+  return [bb.minX, bb.minY, bb.width, bb.height];
 };
 
 export const convertToCOCO = (segmentation: SegmentationResult): string => {
-  const closedExternal = segmentation.polygons.filter(
-    p => p.type === 'external' && p.geometry !== 'polyline'
-  );
-  const allInternalPolygons = segmentation.polygons.filter(
-    p => p.type === 'internal'
-  );
-  const allPolylines = segmentation.polygons.filter(p => isPolyline(p));
-  const validPolylines = allPolylines.filter((p: Polygon) =>
-    isValidSpermPartClass(p.partClass)
-  );
+  const closedExternal: Polygon[] = [];
+  const internal: Polygon[] = [];
+  const validPolylines: Polygon[] = [];
+  for (const p of segmentation.polygons) {
+    if (isPolyline(p)) {
+      if (isValidSpermPartClass(p.partClass)) validPolylines.push(p);
+    } else if (p.type === 'internal') {
+      internal.push(p);
+    } else if (p.type === 'external') {
+      closedExternal.push(p);
+    }
+  }
 
   let annotationId = 1;
   const annotations: Array<Record<string, unknown>> = [];
 
   for (const polygon of closedExternal) {
-    const holes = allInternalPolygons.filter(internal =>
-      isPolygonInsidePolygon(internal.points, polygon.points)
+    const holes = internal.filter(h =>
+      isPolygonInsidePolygon(h.points, polygon.points)
     );
-    const segmentationPoints = [
-      flattenPoints(polygon.points),
-      ...holes.map(h => flattenPoints(h.points)),
-    ];
-    const [x, y, width, height] = boundingBox(polygon.points);
-    const area = calculateMetrics(polygon, holes).Area;
-
     annotations.push({
       id: annotationId++,
       image_id: 1,
       category_id: 1,
-      segmentation: segmentationPoints,
-      bbox: [x, y, width, height],
-      area,
+      segmentation: [
+        flattenPoints(polygon.points),
+        ...holes.map(h => flattenPoints(h.points)),
+      ],
+      bbox: bboxTuple(polygon.points),
+      area: calculateMetrics(polygon, holes).Area,
       iscrowd: 0,
       attributes: {
         type: 'external',
@@ -79,7 +74,7 @@ export const convertToCOCO = (segmentation: SegmentationResult): string => {
       image_id: 1,
       category_id: 2,
       segmentation: [flattenPoints(polyline.points)],
-      bbox: boundingBox(polyline.points),
+      bbox: bboxTuple(polyline.points),
       area: 0,
       iscrowd: 0,
       attributes: {
@@ -87,18 +82,17 @@ export const convertToCOCO = (segmentation: SegmentationResult): string => {
         geometry: 'polyline',
         partClass: polyline.partClass,
         ...(polyline.instanceId && { instanceId: polyline.instanceId }),
-        length: polylineLength(polyline.points),
+        length: calculatePolylineLength(polyline.points),
       },
     });
   }
 
-  const categories =
-    validPolylines.length > 0
-      ? [
-          { id: 1, name: 'spheroid', supercategory: 'cell' },
-          { id: 2, name: 'sperm', supercategory: 'biological' },
-        ]
-      : [{ id: 1, name: 'spheroid', supercategory: 'cell' }];
+  const categories: Array<Record<string, unknown>> = [
+    { id: 1, name: 'spheroid', supercategory: 'cell' },
+  ];
+  if (validPolylines.length > 0) {
+    categories.push({ id: 2, name: 'sperm', supercategory: 'biological' });
+  }
 
   const coco = {
     info: {

--- a/src/pages/segmentation/utils/cocoConverter.ts
+++ b/src/pages/segmentation/utils/cocoConverter.ts
@@ -1,65 +1,105 @@
-import { SegmentationResult } from '@/lib/segmentation';
+import {
+  type Polygon,
+  type SegmentationResult,
+  isPolyline,
+  isValidSpermPartClass,
+} from '@/lib/segmentation';
 import { calculateMetrics } from './metricCalculations';
 import { isPolygonInsidePolygon } from '@/lib/polygonGeometry';
 
-// Convert segmentation to COCO format
-export const convertToCOCO = (segmentation: SegmentationResult): string => {
-  const externalPolygons = segmentation.polygons.filter(
-    p => p.type === 'external'
-  );
+const polylineLength = (points: { x: number; y: number }[]): number => {
+  let length = 0;
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x;
+    const dy = points[i].y - points[i - 1].y;
+    length += Math.sqrt(dx * dx + dy * dy);
+  }
+  return length;
+};
 
-  // Get all internal polygons
+const flattenPoints = (points: { x: number; y: number }[]): number[] =>
+  points.reduce<number[]>((acc, p) => [...acc, p.x, p.y], []);
+
+const boundingBox = (
+  points: { x: number; y: number }[]
+): [number, number, number, number] => {
+  if (points.length === 0) return [0, 0, 0, 0];
+  const xs = points.map(p => p.x);
+  const ys = points.map(p => p.y);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  return [x, y, Math.max(...xs) - x, Math.max(...ys) - y];
+};
+
+export const convertToCOCO = (segmentation: SegmentationResult): string => {
+  const closedExternal = segmentation.polygons.filter(
+    p => p.type === 'external' && p.geometry !== 'polyline'
+  );
   const allInternalPolygons = segmentation.polygons.filter(
     p => p.type === 'internal'
   );
+  const allPolylines = segmentation.polygons.filter(p => isPolyline(p));
+  const validPolylines = allPolylines.filter((p: Polygon) =>
+    isValidSpermPartClass(p.partClass)
+  );
 
-  const annotations = externalPolygons.map((polygon, index) => {
-    // Find internal polygons (holes) that are actually inside this external polygon
+  let annotationId = 1;
+  const annotations: Array<Record<string, unknown>> = [];
+
+  for (const polygon of closedExternal) {
     const holes = allInternalPolygons.filter(internal =>
       isPolygonInsidePolygon(internal.points, polygon.points)
     );
-
-    // Convert points to COCO format (all x coordinates, then all y coordinates)
     const segmentationPoints = [
-      polygon.points.reduce<number[]>(
-        (acc, point) => [...acc, point.x, point.y],
-        []
-      ),
+      flattenPoints(polygon.points),
+      ...holes.map(h => flattenPoints(h.points)),
     ];
-
-    // Add only the holes that are inside this polygon to segmentation
-    holes.forEach(hole => {
-      segmentationPoints.push(
-        hole.points.reduce<number[]>(
-          (acc, point) => [...acc, point.x, point.y],
-          []
-        )
-      );
-    });
-
-    // Calculate bounding box
-    const xs = polygon.points.map(p => p.x);
-    const ys = polygon.points.map(p => p.y);
-    const x = Math.min(...xs);
-    const y = Math.min(...ys);
-    const width = Math.max(...xs) - x;
-    const height = Math.max(...ys) - y;
-
-    // Calculate area with only the contained holes subtracted
+    const [x, y, width, height] = boundingBox(polygon.points);
     const area = calculateMetrics(polygon, holes).Area;
 
-    return {
-      id: index + 1,
-      image_id: 1, // Assume one image
-      category_id: 1, // Spheroid category
+    annotations.push({
+      id: annotationId++,
+      image_id: 1,
+      category_id: 1,
       segmentation: segmentationPoints,
       bbox: [x, y, width, height],
-      area: area, // Area with holes subtracted
+      area,
       iscrowd: 0,
-    };
-  });
+      attributes: {
+        type: 'external',
+        geometry: 'polygon',
+        has_holes: holes.length > 0,
+      },
+    });
+  }
 
-  // Create COCO format
+  for (const polyline of validPolylines) {
+    annotations.push({
+      id: annotationId++,
+      image_id: 1,
+      category_id: 2,
+      segmentation: [flattenPoints(polyline.points)],
+      bbox: boundingBox(polyline.points),
+      area: 0,
+      iscrowd: 0,
+      attributes: {
+        type: 'external',
+        geometry: 'polyline',
+        partClass: polyline.partClass,
+        ...(polyline.instanceId && { instanceId: polyline.instanceId }),
+        length: polylineLength(polyline.points),
+      },
+    });
+  }
+
+  const categories =
+    validPolylines.length > 0
+      ? [
+          { id: 1, name: 'spheroid', supercategory: 'cell' },
+          { id: 2, name: 'sperm', supercategory: 'biological' },
+        ]
+      : [{ id: 1, name: 'spheroid', supercategory: 'cell' }];
+
   const coco = {
     info: {
       description: 'Spheroid segmentation dataset',
@@ -71,19 +111,13 @@ export const convertToCOCO = (segmentation: SegmentationResult): string => {
       {
         id: 1,
         file_name: segmentation.imageSrc?.split('/').pop() || 'image.png',
-        width: 800, // Assume fixed size
+        width: 800,
         height: 600,
         date_captured: new Date().toISOString(),
       },
     ],
     annotations,
-    categories: [
-      {
-        id: 1,
-        name: 'spheroid',
-        supercategory: 'cell',
-      },
-    ],
+    categories,
   };
 
   return JSON.stringify(coco, null, 2);


### PR DESCRIPTION
## Summary
- COCO/YOLO/JSON exporters ignored `geometry`, `partClass`, `instanceId` — polylines (sperm head/midpiece/tail) were exported as closed polygons with bogus area and sperm grouping was lost. Excel sperm export was already correct; only the annotation formats were broken.
- **COCO**: new `sperm` category (id=2). Polyline annotations carry `partClass`, `instanceId`, `length`, `geometry` in `attributes` and report `area: 0`. Closed polygons get `geometry: 'polygon'` for symmetry.
- **YOLO**: polylines are skipped with a `logger.warn` (YOLO has no open-curve representation). Use COCO/JSON for sperm data.
- **JSON**: adds `polylines[]` (with length + bbox) and `spermInstances[]` grouped by `instanceId` (head/midpiece/tail + totalLength). Polygon-only output stays byte-compatible — new fields are omitted when no polylines exist.
- Includes a small `chore:` commit to add `iaa_study/` and `output_time_48h/` to `.prettierignore` so the pre-commit hook stops OOM-ing on local research artifacts.

## Test plan
- [x] `npx jest src/services/export src/api/routes/__tests__/exportRoutes.test.ts` — 47/47 pass (9 new + 38 existing, no regressions)
- [x] `npx tsc --noEmit --skipLibCheck` (backend) — clean
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `npx eslint src/services/export/formatConverter.ts` — clean
- [ ] Manual E2E: run sperm-model project export with all formats; verify `coco/annotations.json` carries `attributes.partClass` + `attributes.instanceId`, `json/segmentation_data.json` exposes `spermInstances[]`, and `yolo/*.txt` skips polylines with warning in backend logs
- [ ] Regression: export polygon-only (spheroid) project — output must be unchanged except for the new `geometry: 'polygon'` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polyline data export support across COCO and JSON formats with automatic sperm instance grouping and part classification.
  * Enhanced YOLO export format to properly handle polyline data with user notifications.

* **Tests**
  * Added comprehensive test coverage for polyline export functionality across all formats.

* **Chores**
  * Updated export configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->