### PR TITLE
feat(wound-export): save area chart as standalone PNG in wound_healing folder

### DIFF
--- a/backend/src/services/export/__tests__/woundTimeSeries.test.ts
+++ b/backend/src/services/export/__tests__/woundTimeSeries.test.ts
@@ -241,7 +241,7 @@ describe('appendWoundTimeSeriesSheet', () => {
     workbook = new ExcelJS.Workbook();
   });
 
-  it('returns 0 and does not add sheet when no wound images', async () => {
+  it('returns count=0 and chartPng=null when no wound images', async () => {
     const img = sampleExternalSquareImage({
       segmentation: {
         polygons: '[]',
@@ -249,8 +249,10 @@ describe('appendWoundTimeSeriesSheet', () => {
         threshold: 0.5,
       },
     });
-    const count = await appendWoundTimeSeriesSheet(workbook, [img as never]);
-    expect(count).toBe(0);
+    const result = await appendWoundTimeSeriesSheet(workbook, [img as never]);
+    expect(result.count).toBe(0);
+    expect(result.chartPng).toBeNull();
+    expect(result.points).toEqual([]);
     expect(workbook.worksheets).toHaveLength(0);
   });
 
@@ -260,11 +262,27 @@ describe('appendWoundTimeSeriesSheet', () => {
       sampleExternalSquareImage({ id: 'b', displayOrder: 1 }),
       sampleExternalSquareImage({ id: 'c', displayOrder: 2 }),
     ];
-    const count = await appendWoundTimeSeriesSheet(workbook, imgs as never[]);
-    expect(count).toBe(3);
+    const result = await appendWoundTimeSeriesSheet(workbook, imgs as never[]);
+    expect(result.count).toBe(3);
     const sheet = workbook.getWorksheet('WoundTimeSeries');
     expect(sheet).toBeDefined();
     // Header row + 3 data rows
     expect(sheet!.rowCount).toBe(4);
+  });
+
+  it('returns a chartPng field so the caller can write it to disk', async () => {
+    const imgs = [
+      sampleExternalSquareImage({ id: 'a', displayOrder: 0 }),
+      sampleExternalSquareImage({ id: 'b', displayOrder: 1 }),
+    ];
+    const result = await appendWoundTimeSeriesSheet(workbook, imgs as never[]);
+    expect(result.count).toBe(2);
+    expect(result.points).toHaveLength(2);
+    // The field MUST be present in the return shape so
+    // ``maybeAppendWoundTimeSeries`` in exportService.ts can branch on it
+    // to decide whether to write ``wound_healing/wound_area_chart.png``.
+    // The VALUE depends on whether canvas rendering succeeded in the test
+    // environment; we only assert shape here.
+    expect(result).toHaveProperty('chartPng');
   });
 });

--- a/backend/src/services/export/woundTimeSeries.ts
+++ b/backend/src/services/export/woundTimeSeries.ts
@@ -174,19 +174,31 @@ export function buildWoundTimeSeries(images: WoundSeriesImage[]): WoundTimePoint
 }
 
 /**
+ * Outcome of appending the WoundTimeSeries sheet to a workbook.
+ * ``chartPng`` is the rendered area-vs-time PNG — the caller can additionally
+ * write it to a standalone file in ``wound_healing/`` so users don't have to
+ * extract the chart out of Excel.
+ */
+export interface WoundTimeSeriesResult {
+  count: number;
+  chartPng: Buffer | null;
+  points: WoundTimePoint[];
+}
+
+/**
  * Append a WoundTimeSeries worksheet (+ embedded chart PNG) to an existing
  * ExcelJS workbook. Does nothing if no wound images are present.
  */
 export async function appendWoundTimeSeriesSheet(
   workbook: ExcelJS.Workbook,
   images: WoundSeriesImage[]
-): Promise<number> {
+): Promise<WoundTimeSeriesResult> {
   if (!shouldExportWoundTimeSeries(images)) {
-    return 0;
+    return { count: 0, chartPng: null, points: [] };
   }
   const points = buildWoundTimeSeries(images);
   if (points.length === 0) {
-    return 0;
+    return { count: 0, chartPng: null, points: [] };
   }
 
   const sheet = workbook.addWorksheet('WoundTimeSeries');
@@ -213,13 +225,14 @@ export async function appendWoundTimeSeriesSheet(
     });
   }
 
+  let chartPng: Buffer | null = null;
   try {
-    const pngBuffer = await renderWoundAreaChart(points);
+    chartPng = await renderWoundAreaChart(points);
     // ExcelJS's Buffer type lags behind recent @types/node which narrowed
     // Buffer to Buffer<ArrayBuffer>; node-canvas returns the runtime-identical
     // Buffer<ArrayBufferLike>. Cast keeps the types happy without copying.
     const imageId = workbook.addImage({
-      buffer: pngBuffer as unknown as ExcelJS.Buffer,
+      buffer: chartPng as unknown as ExcelJS.Buffer,
       extension: 'png',
     });
     // Anchor the chart to the right of the data, starting at column H row 1.
@@ -233,7 +246,12 @@ export async function appendWoundTimeSeriesSheet(
       'woundTimeSeries',
       { error: err instanceof Error ? err.message : String(err) }
     );
+    chartPng = null;
   }
 
-  return points.length;
+  return {
+    count: points.length,
+    chartPng,
+    points,
+  };
 }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1021,11 +1021,13 @@ export class ExportService {
 
         // Wound-healing time-series: only triggered when at least one image
         // was segmented with the wound model. Appends an extra worksheet +
-        // embedded area-vs-time chart to the existing metrics.xlsx. Any
-        // failure attaches a warning to the job so the UI can surface it.
+        // embedded area-vs-time chart to the existing metrics.xlsx AND
+        // writes the chart as a standalone PNG into ``wound_healing/``.
+        // Any failure attaches a warning to the job so the UI can surface it.
         const tsWarning = await this.maybeAppendWoundTimeSeries(
           images,
           excelPath,
+          exportDir,
           jobId
         );
         if (tsWarning && jobId) {
@@ -1965,7 +1967,10 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
   /**
    * If the project contains wound-model segmentations, open the metrics
    * workbook and append a ``WoundTimeSeries`` sheet with wound-area % per
-   * frame and an embedded line chart. No-op for spheroid/sperm projects.
+   * frame and an embedded line chart. Additionally writes the chart PNG
+   * as a standalone file at ``<exportDir>/wound_healing/wound_area_chart.png``
+   * so users don't have to extract it out of Excel. No-op for spheroid/
+   * sperm projects.
    *
    * Returns a warning string when the wound feature was expected (project
    * has wound segmentations) but the sheet could not be written — the
@@ -1974,6 +1979,7 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
   private async maybeAppendWoundTimeSeries(
     images: ImageWithSegmentation[],
     excelPath: string,
+    exportDir: string,
     jobId?: string
   ): Promise<string | null> {
     const hasWound = images.some(img => img.segmentation?.model === 'wound');
@@ -1989,7 +1995,10 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
 
       const workbook = new ExcelJS.Workbook();
       await workbook.xlsx.readFile(excelPath);
-      const count = await appendWoundTimeSeriesSheet(workbook, images);
+      const { count, chartPng } = await appendWoundTimeSeriesSheet(
+        workbook,
+        images
+      );
       if (count > 0) {
         await workbook.xlsx.writeFile(excelPath);
         logger.info(
@@ -1997,6 +2006,18 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
           'ExportService',
           { jobId }
         );
+
+        if (chartPng) {
+          const woundDir = path.join(exportDir, 'wound_healing');
+          await fs.mkdir(woundDir, { recursive: true });
+          const chartPath = path.join(woundDir, 'wound_area_chart.png');
+          await fs.writeFile(chartPath, chartPng);
+          logger.info(
+            `Wound area chart saved to ${chartPath}`,
+            'ExportService',
+            { jobId, frames: count }
+          );
+        }
       }
       return null;
     } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to PR #92. The wound time-series export already embedded a line chart into the Excel ``WoundTimeSeries`` sheet. Users who only want the chart (for a slide, report, or email) had to extract it out of the workbook manually. Now the same PNG is additionally written to ``<exportDir>/wound_healing/wound_area_chart.png`` in the export zip.

## Change

- ``appendWoundTimeSeriesSheet`` now returns ``{ count, chartPng, points }`` instead of just ``count``. Callers get the rendered PNG buffer to reuse.
- ``exportService.maybeAppendWoundTimeSeries`` writes the returned PNG to ``<exportDir>/wound_healing/wound_area_chart.png``. The folder is created on demand only when the project contains wound-model segmentations — spheroid/sperm exports are unchanged.
- Chart is rendered exactly once; the same buffer is embedded in Excel AND written to the standalone file.
- Updated woundTimeSeries.test.ts to 14 cases: adds a shape guard on the new ``chartPng`` return field.

## Test plan

- [ ] Backend ``tsc --noEmit`` clean
- [ ] ``npx jest src/services/export/__tests__/woundTimeSeries.test.ts`` — 14 passed
- [ ] After deploy: segment wound project, run export → the zip contains both ``metrics/metrics.xlsx`` (with WoundTimeSeries sheet + embedded chart) and ``wound_healing/wound_area_chart.png``
- [ ] Non-wound project export: ``wound_healing/`` folder should NOT exist in the zip

## Deploy

Only ``backend`` rebuild + restart needed. No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wound area charts are now exported as standalone PNG files in addition to embedded Excel charts, with enhanced wound time series data reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->