### PR TITLE
fix(wound-export): separate catch phases, propagate chart error, testable png write

### DIFF
--- a/backend/src/services/export/__tests__/woundTimeSeries.test.ts
+++ b/backend/src/services/export/__tests__/woundTimeSeries.test.ts
@@ -9,17 +9,20 @@ jest.mock('../../../utils/logger', () => ({
   },
 }));
 
-jest.mock('../woundChartRenderer', () => ({
-  renderWoundAreaChart: jest.fn(async () =>
-    Buffer.from([0x89, 0x50, 0x4e, 0x47])
-  ),
-}));
+// Using the real renderWoundAreaChart — node-canvas is a backend dependency
+// and works in the test environment. Failure-path tests use jest.spyOn to
+// override specific cases rather than jest.mock, because jest.mock of an
+// ESM module produces unreliable return values in ts-jest/ESM preset.
 
+import { promises as fsp } from 'fs';
+import os from 'os';
+import path from 'path';
 import ExcelJS from 'exceljs';
 import {
   buildWoundTimeSeries,
   shouldExportWoundTimeSeries,
   appendWoundTimeSeriesSheet,
+  writeStandaloneWoundChart,
 } from '../woundTimeSeries';
 
 // Helper: build a 100×100 image row with one external square (40×40 @ (10,10))
@@ -252,7 +255,7 @@ describe('appendWoundTimeSeriesSheet', () => {
     const result = await appendWoundTimeSeriesSheet(workbook, [img as never]);
     expect(result.count).toBe(0);
     expect(result.chartPng).toBeNull();
-    expect(result.points).toEqual([]);
+    expect(result.chartError).toBeUndefined();
     expect(workbook.worksheets).toHaveLength(0);
   });
 
@@ -270,19 +273,77 @@ describe('appendWoundTimeSeriesSheet', () => {
     expect(sheet!.rowCount).toBe(4);
   });
 
-  it('returns a chartPng field so the caller can write it to disk', async () => {
+  it('returns a real PNG Buffer on chartPng so the caller can write it to disk', async () => {
     const imgs = [
       sampleExternalSquareImage({ id: 'a', displayOrder: 0 }),
       sampleExternalSquareImage({ id: 'b', displayOrder: 1 }),
     ];
     const result = await appendWoundTimeSeriesSheet(workbook, imgs as never[]);
     expect(result.count).toBe(2);
-    expect(result.points).toHaveLength(2);
-    // The field MUST be present in the return shape so
-    // ``maybeAppendWoundTimeSeries`` in exportService.ts can branch on it
-    // to decide whether to write ``wound_healing/wound_area_chart.png``.
-    // The VALUE depends on whether canvas rendering succeeded in the test
-    // environment; we only assert shape here.
-    expect(result).toHaveProperty('chartPng');
+    expect(result.chartError).toBeUndefined();
+    expect(Buffer.isBuffer(result.chartPng)).toBe(true);
+    // PNG magic bytes
+    expect(result.chartPng!.slice(0, 4).toString('hex')).toBe('89504e47');
   });
+
+  it('sets chartError when renderWoundAreaChart throws', async () => {
+    const mod = await import('../woundChartRenderer');
+    const spy = jest
+      .spyOn(mod, 'renderWoundAreaChart')
+      .mockRejectedValueOnce(new Error('canvas backend unavailable'));
+    try {
+      const imgs = [
+        sampleExternalSquareImage({ id: 'a', displayOrder: 0 }),
+        sampleExternalSquareImage({ id: 'b', displayOrder: 1 }),
+      ];
+      const result = await appendWoundTimeSeriesSheet(
+        workbook,
+        imgs as never[]
+      );
+      expect(result.count).toBe(2);
+      expect(result.chartPng).toBeNull();
+      expect(result.chartError).toMatch(/canvas backend unavailable/);
+      // Data rows are still written — only the chart image is missing.
+      expect(workbook.getWorksheet('WoundTimeSeries')).toBeDefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('writeStandaloneWoundChart', () => {
+  let exportDir: string;
+
+  beforeEach(async () => {
+    exportDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wound-export-test-')
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(exportDir, { recursive: true, force: true });
+  });
+
+  it('writes the PNG into wound_healing/wound_area_chart.png', async () => {
+    const buf = Buffer.from('89504e470d0a1a0a', 'hex');
+    const chartPath = await writeStandaloneWoundChart(exportDir, buf);
+    expect(chartPath).toBe(
+      path.join(exportDir, 'wound_healing', 'wound_area_chart.png')
+    );
+    const st = await fsp.stat(chartPath);
+    expect(st.size).toBe(buf.length);
+    const readBack = await fsp.readFile(chartPath);
+    expect(readBack.equals(buf)).toBe(true);
+  });
+
+  it('is idempotent across repeated calls (mkdir recursive)', async () => {
+    const buf1 = Buffer.from('89504e470d0a1a0a', 'hex');
+    const buf2 = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+    await writeStandaloneWoundChart(exportDir, buf1);
+    const p = await writeStandaloneWoundChart(exportDir, buf2);
+    const readBack = await fsp.readFile(p);
+    // Second call should overwrite, not append / fail.
+    expect(readBack.equals(buf2)).toBe(true);
+  });
+
 });

--- a/backend/src/services/export/woundTimeSeries.ts
+++ b/backend/src/services/export/woundTimeSeries.ts
@@ -18,6 +18,8 @@
  * area calculation.
  */
 
+import { promises as fsp } from 'fs';
+import path from 'path';
 import type ExcelJS from 'exceljs';
 import { logger } from '../../utils/logger';
 import type { ImageWithSegmentation } from '../metrics/metricsCalculator';
@@ -175,14 +177,15 @@ export function buildWoundTimeSeries(images: WoundSeriesImage[]): WoundTimePoint
 
 /**
  * Outcome of appending the WoundTimeSeries sheet to a workbook.
- * ``chartPng`` is the rendered area-vs-time PNG — the caller can additionally
- * write it to a standalone file in ``wound_healing/`` so users don't have to
- * extract the chart out of Excel.
+ * ``chartPng`` is null when the chart could not be rendered; in that case
+ * ``chartError`` carries the human-readable reason so the caller can surface
+ * it to the user. Callers commonly persist the PNG alongside the workbook —
+ * see ``writeStandaloneWoundChart`` for the companion helper.
  */
 export interface WoundTimeSeriesResult {
   count: number;
   chartPng: Buffer | null;
-  points: WoundTimePoint[];
+  chartError?: string;
 }
 
 /**
@@ -194,11 +197,11 @@ export async function appendWoundTimeSeriesSheet(
   images: WoundSeriesImage[]
 ): Promise<WoundTimeSeriesResult> {
   if (!shouldExportWoundTimeSeries(images)) {
-    return { count: 0, chartPng: null, points: [] };
+    return { count: 0, chartPng: null };
   }
   const points = buildWoundTimeSeries(images);
   if (points.length === 0) {
-    return { count: 0, chartPng: null, points: [] };
+    return { count: 0, chartPng: null };
   }
 
   const sheet = workbook.addWorksheet('WoundTimeSeries');
@@ -226,32 +229,69 @@ export async function appendWoundTimeSeriesSheet(
   }
 
   let chartPng: Buffer | null = null;
+  let chartError: string | undefined;
+
+  // Step 1: render the chart. On failure the sheet still gets its data rows
+  // (they're already written above) — only the chart image is lost.
   try {
     chartPng = await renderWoundAreaChart(points);
-    // ExcelJS's Buffer type lags behind recent @types/node which narrowed
-    // Buffer to Buffer<ArrayBuffer>; node-canvas returns the runtime-identical
-    // Buffer<ArrayBufferLike>. Cast keeps the types happy without copying.
-    const imageId = workbook.addImage({
-      buffer: chartPng as unknown as ExcelJS.Buffer,
-      extension: 'png',
-    });
-    // Anchor the chart to the right of the data, starting at column H row 1.
-    sheet.addImage(imageId, {
-      tl: { col: 7, row: 0 },
-      ext: { width: 960, height: 480 },
-    });
   } catch (err) {
+    chartError = err instanceof Error ? err.message : String(err);
     logger.warn(
       'Wound area chart render failed — TimeSeries sheet written without chart',
       'woundTimeSeries',
-      { error: err instanceof Error ? err.message : String(err) }
+      { error: chartError }
     );
-    chartPng = null;
   }
 
-  return {
-    count: points.length,
-    chartPng,
-    points,
-  };
+  // Step 2: best-effort embed the chart into the sheet. A failure here
+  // (e.g. ExcelJS rejects the buffer) must not invalidate ``chartPng`` —
+  // the caller still wants to write it to disk as a standalone artifact.
+  if (chartPng) {
+    try {
+      // ExcelJS's Buffer type lags behind recent @types/node which narrowed
+      // Buffer to Buffer<ArrayBuffer>; node-canvas returns the runtime-
+      // identical Buffer<ArrayBufferLike>. Cast keeps the types happy
+      // without copying.
+      const imageId = workbook.addImage({
+        buffer: chartPng as unknown as ExcelJS.Buffer,
+        extension: 'png',
+      });
+      // Anchor the chart to the right of the data, starting at column H row 1.
+      sheet.addImage(imageId, {
+        tl: { col: 7, row: 0 },
+        ext: { width: 960, height: 480 },
+      });
+    } catch (err) {
+      logger.warn(
+        'Wound chart rendered but could not be embedded in workbook — standalone PNG still usable',
+        'woundTimeSeries',
+        { error: err instanceof Error ? err.message : String(err) }
+      );
+    }
+  }
+
+  return chartError !== undefined
+    ? { count: points.length, chartPng, chartError }
+    : { count: points.length, chartPng };
+}
+
+/**
+ * Writes the rendered wound-area chart as a standalone PNG to
+ * ``<exportDir>/wound_healing/wound_area_chart.png``.
+ *
+ * Extracted as its own function so the ``mkdir`` + ``writeFile`` logic is
+ * unit-testable via ``fs.mkdtemp`` without spinning up the full export
+ * service. Returns the resulting file path on success, or throws the
+ * original filesystem error (caller wraps into a job warning).
+ */
+export async function writeStandaloneWoundChart(
+  exportDir: string,
+  chartPng: Buffer
+): Promise<string> {
+  const woundDir = path.join(exportDir, 'wound_healing');
+  await fsp.mkdir(woundDir, { recursive: true });
+  const chartPath = path.join(woundDir, 'wound_area_chart.png');
+  await fsp.writeFile(chartPath, chartPng);
+  return chartPath;
 }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1019,21 +1019,19 @@ export class ExportService {
           );
         }
 
-        // Wound-healing time-series: only triggered when at least one image
-        // was segmented with the wound model. Appends an extra worksheet +
-        // embedded area-vs-time chart to the existing metrics.xlsx AND
-        // writes the chart as a standalone PNG into ``wound_healing/``.
-        // Any failure attaches a warning to the job so the UI can surface it.
-        const tsWarning = await this.maybeAppendWoundTimeSeries(
+        // Wound time-series: no-op for non-wound projects. Failures are
+        // reported per phase so the UI can distinguish chart-render issues
+        // from filesystem issues from xlsx corruption.
+        const tsWarnings = await this.maybeAppendWoundTimeSeries(
           images,
           excelPath,
           exportDir,
           jobId
         );
-        if (tsWarning && jobId) {
+        if (tsWarnings.length > 0 && jobId) {
           const job = this.exportJobs.get(jobId);
           if (job) {
-            job.warnings = [...(job.warnings ?? []), tsWarning];
+            job.warnings = [...(job.warnings ?? []), ...tsWarnings];
           }
         }
       } else if (format === 'csv') {
@@ -1972,63 +1970,134 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
    * so users don't have to extract it out of Excel. No-op for spheroid/
    * sperm projects.
    *
-   * Returns a warning string when the wound feature was expected (project
-   * has wound segmentations) but the sheet could not be written — the
-   * caller attaches the message to the export job so the user sees it.
+   * Returns an array of warnings so the caller can attach all of them to
+   * the export job; empty array on full success or non-wound project.
+   * Each phase (xlsx-append, xlsx-write, chart-render, png-write) surfaces
+   * its own distinct warning so the user can tell which part failed —
+   * previously one failure was reported as "the whole time-series broke",
+   * which was misleading when e.g. only the standalone PNG file failed.
    */
   private async maybeAppendWoundTimeSeries(
     images: ImageWithSegmentation[],
     excelPath: string,
     exportDir: string,
     jobId?: string
-  ): Promise<string | null> {
+  ): Promise<string[]> {
     const hasWound = images.some(img => img.segmentation?.model === 'wound');
     if (!hasWound) {
-      return null;
+      return [];
     }
 
+    const warnings: string[] = [];
+
+    // Phase 1: load export deps + open the just-written metrics workbook.
+    // exceljs is a CJS module with TypeScript interop — ``.default`` works at
+    // runtime via esModuleInterop but the namespace type doesn't advertise
+    // it, hence the cast.
+    type ExcelJsDefault = typeof import('exceljs');
+    let ExcelJS: ExcelJsDefault;
+    let appendWoundTimeSeriesSheet: typeof import('./export/woundTimeSeries').appendWoundTimeSeriesSheet;
+    let writeStandaloneWoundChart: typeof import('./export/woundTimeSeries').writeStandaloneWoundChart;
     try {
-      const ExcelJS = (await import('exceljs')).default;
-      const { appendWoundTimeSeriesSheet } = await import(
+      const excelMod = (await import('exceljs')) as unknown as {
+        default: ExcelJsDefault;
+      };
+      ExcelJS = excelMod.default;
+      ({ appendWoundTimeSeriesSheet, writeStandaloneWoundChart } = await import(
         './export/woundTimeSeries'
-      );
-
-      const workbook = new ExcelJS.Workbook();
-      await workbook.xlsx.readFile(excelPath);
-      const { count, chartPng } = await appendWoundTimeSeriesSheet(
-        workbook,
-        images
-      );
-      if (count > 0) {
-        await workbook.xlsx.writeFile(excelPath);
-        logger.info(
-          `Wound TimeSeries appended: ${count} frames`,
-          'ExportService',
-          { jobId }
-        );
-
-        if (chartPng) {
-          const woundDir = path.join(exportDir, 'wound_healing');
-          await fs.mkdir(woundDir, { recursive: true });
-          const chartPath = path.join(woundDir, 'wound_area_chart.png');
-          await fs.writeFile(chartPath, chartPng);
-          logger.info(
-            `Wound area chart saved to ${chartPath}`,
-            'ExportService',
-            { jobId, frames: count }
-          );
-        }
-      }
-      return null;
+      ));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(
-        'Failed to append wound TimeSeries — metrics.xlsx left without it',
+        'Failed to load wound TimeSeries dependencies',
         err instanceof Error ? err : undefined,
         'ExportService',
         { error: message, jobId }
       );
-      return `Wound time-series sheet could not be written: ${message}`;
+      return [
+        `Wound time-series skipped — export dependency load failed: ${message}`,
+      ];
     }
+
+    const workbook = new ExcelJS.Workbook();
+    try {
+      await workbook.xlsx.readFile(excelPath);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        'Failed to open metrics.xlsx for wound TimeSeries append',
+        err instanceof Error ? err : undefined,
+        'ExportService',
+        { error: message, jobId, excelPath }
+      );
+      return [
+        `Wound time-series sheet could not be added — metrics.xlsx unreadable: ${message}`,
+      ];
+    }
+
+    // Phase 2: compute + write the TimeSeries sheet. Also captures chart
+    // render failures as a non-fatal ``chartError`` on the returned shape.
+    const { count, chartPng, chartError } = await appendWoundTimeSeriesSheet(
+      workbook,
+      images
+    );
+
+    if (count === 0) {
+      return [];
+    }
+
+    if (chartError) {
+      warnings.push(
+        `Wound area chart could not be rendered (TimeSeries sheet still written): ${chartError}`
+      );
+    }
+
+    try {
+      await workbook.xlsx.writeFile(excelPath);
+      logger.info(
+        `Wound TimeSeries appended: ${count} frames`,
+        'ExportService',
+        { jobId, hasChart: chartPng !== null }
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        'Failed to save metrics.xlsx after wound TimeSeries append',
+        err instanceof Error ? err : undefined,
+        'ExportService',
+        { error: message, jobId, excelPath }
+      );
+      return [
+        ...warnings,
+        `Wound time-series sheet could not be saved: ${message}`,
+      ];
+    }
+
+    // Phase 3: standalone PNG copy for users who don't want to extract
+    // the chart out of Excel. Independent of the sheet above — this can
+    // fail without invalidating the xlsx.
+    if (chartPng) {
+      try {
+        const chartPath = await writeStandaloneWoundChart(exportDir, chartPng);
+        logger.info(
+          `Wound area chart saved to ${chartPath}`,
+          'ExportService',
+          { jobId, frames: count }
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(
+          'Failed to save standalone wound chart PNG',
+          err instanceof Error ? err : undefined,
+          'ExportService',
+          { error: message, jobId }
+        );
+        warnings.push(
+          `Wound area chart PNG could not be saved (Excel copy is still available): ${message}`
+        );
+      }
+    }
+
+    return warnings;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #93 (wound standalone chart PNG). Addresses 5-agent review findings: narrowed catch phases with per-phase warnings, explicit chart-render error propagation, extracted ``writeStandaloneWoundChart`` helper with real integration tests, decoupled ExcelJS embed from disk write.

## Changes

- **A1** — ``maybeAppendWoundTimeSeries`` splits into phases (dep-load, xlsx-read, chart-render, xlsx-write, png-write). Returns ``string[]`` of per-phase warnings instead of single generic message. Users now see distinct warnings like "chart could not be rendered" vs. "PNG could not be saved".
- **B1** — New ``chartError?: string`` on ``WoundTimeSeriesResult`` propagates render failure to the caller → job.warnings → UI. Previously `logger.warn` only.
- **B2** — Extracted ``writeStandaloneWoundChart(exportDir, chartPng)`` helper. Unit-testable via ``fs.mkdtemp``.
- **B3** — Real ``chartPng`` Buffer assertion restored. Dropped ill-behaving ``jest.mock`` (returned undefined in ts-jest ESM), rely on real node-canvas for happy path and ``jest.spyOn`` for failure cases.
- **S2** — Dropped dead ``points`` field from return type.
- **S4** — Chart render and workbook.addImage are independent: ExcelJS rejecting a buffer no longer drops the standalone PNG.

## Test plan

- [x] Backend ``tsc --noEmit`` clean
- [x] ``npx jest src/services/export/__tests__/`` — 49/49 passed
- [x] ``woundTimeSeries.test.ts`` — 17/17 (was 14 pre-PR)
- [ ] After deploy: wound export produces ``wound_healing/wound_area_chart.png``, spheroid export does NOT
- [ ] Force chart-render failure (e.g. disk full during mkdir) → user sees distinct warning

## Deploy

Backend rebuild + recreate only. No DB migration, no ML changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to export wound area charts as standalone files.

* **Bug Fixes**
  * Improved error handling for wound chart generation—exports now succeed with partial data when chart rendering fails.
  * Enhanced warning messages for export failures.

* **Tests**
  * Expanded test coverage for wound chart generation and export scenarios, including error cases and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->