### PR TITLE
fix(export): prefer ML dims in COCO/YOLO/JSON, drop 800x600 fallback

### DIFF
--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -141,9 +141,7 @@ describe('FormatConverter', () => {
       const polylineAnns = coco.annotations.filter(a => a.category_id === 2);
       expect(polylineAnns).toHaveLength(3);
 
-      const partClasses = polylineAnns
-        .map(a => a.attributes?.partClass)
-        .sort();
+      const partClasses = polylineAnns.map(a => a.attributes?.partClass).sort();
       expect(partClasses).toEqual(['head', 'midpiece', 'tail']);
 
       const expectedLengths: Record<string, number> = {
@@ -402,7 +400,6 @@ describe('FormatConverter', () => {
       expect(polylines).toHaveLength(1);
       expect(polylines?.[0]?.partClass).toBeUndefined();
     });
-
   });
 
   describe('annotation ID stability', () => {
@@ -418,6 +415,63 @@ describe('FormatConverter', () => {
       const ids = coco.annotations.map(a => a.id);
       expect(new Set(ids).size).toBe(ids.length);
       expect(ids).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('missing image dimensions', () => {
+    // Regression: Sharp can fail to extract metadata on upload (BMP, unusual
+    // variants), leaving Image.width/height NULL. The export used to silently
+    // emit COCO/JSON headers of 800x600 while polygons were already in the
+    // real PIL coordinate space — producing annotations that lie about the
+    // canvas size and extend outside the declared bounding box.
+    const largePolygon: Polygon = {
+      id: 'p-big',
+      type: 'external',
+      points: [
+        { x: 0, y: 0 },
+        { x: 1286, y: 0 },
+        { x: 1286, y: 1293 },
+        { x: 0, y: 1293 },
+      ],
+    };
+
+    it('COCO infers header dimensions from polygon extents when width/height are 0', async () => {
+      const data = buildImageData([largePolygon], { width: 0, height: 0 });
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+
+      expect(coco.images).toHaveLength(1);
+      expect(coco.images[0].width).toBeGreaterThanOrEqual(1286);
+      expect(coco.images[0].height).toBeGreaterThanOrEqual(1293);
+      expect(coco.images[0].width).not.toBe(800);
+      expect(coco.images[0].height).not.toBe(600);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing dimensions'),
+        'FormatConverter'
+      );
+    });
+
+    it('JSON infers header dimensions from polygon extents when width/height are 0', async () => {
+      const data = buildImageData([largePolygon], { width: 0, height: 0 });
+
+      const json = await new FormatConverter().convertToJSON([data]);
+
+      expect(json.images[0].dimensions.width).toBeGreaterThanOrEqual(1286);
+      expect(json.images[0].dimensions.height).toBeGreaterThanOrEqual(1293);
+      expect(json.images[0].dimensions.width).not.toBe(800);
+      expect(json.images[0].dimensions.height).not.toBe(600);
+    });
+
+    it('uses provided width/height verbatim when present', async () => {
+      const data = buildImageData([closedPolygon], {
+        width: 2048,
+        height: 1536,
+      });
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+
+      expect(coco.images[0].width).toBe(2048);
+      expect(coco.images[0].height).toBe(1536);
     });
   });
 });

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -446,7 +446,7 @@ describe('FormatConverter', () => {
       expect(coco.images[0].width).not.toBe(800);
       expect(coco.images[0].height).not.toBe(600);
       expect(mockedLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('missing dimensions'),
+        expect.stringContaining('missing width/height'),
         'FormatConverter'
       );
     });
@@ -472,6 +472,72 @@ describe('FormatConverter', () => {
 
       expect(coco.images[0].width).toBe(2048);
       expect(coco.images[0].height).toBe(1536);
+    });
+
+    it('preserves a known axis when only the other is missing', async () => {
+      const data = buildImageData([largePolygon], { width: 1286, height: 0 });
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+
+      // Known width is kept verbatim; only height is inferred from extents.
+      expect(coco.images[0].width).toBe(1286);
+      expect(coco.images[0].height).toBeGreaterThanOrEqual(1293);
+    });
+
+    it('logs error (not warn) when no polygons and dims are missing', async () => {
+      const data = buildImageData([], { width: 0, height: 0 });
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+
+      expect(coco.images[0].width).toBe(0);
+      expect(coco.images[0].height).toBe(0);
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('no usable'),
+        expect.any(Error),
+        'FormatConverter'
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('inferred'),
+        'FormatConverter'
+      );
+    });
+
+    it('RLE mask path uses inferred dimensions when dims are missing', async () => {
+      // External square 0..100 with an internal hole 20..40 → triggers the
+      // createBinaryMask/encodeMaskToRLE path which previously received the
+      // hardcoded 800x600 mask buffer.
+      const external: Polygon = {
+        id: 'ext',
+        type: 'external',
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+          { x: 0, y: 100 },
+        ],
+      };
+      const hole: Polygon = {
+        id: 'hole',
+        type: 'internal',
+        points: [
+          { x: 20, y: 20 },
+          { x: 40, y: 20 },
+          { x: 40, y: 40 },
+          { x: 20, y: 40 },
+        ],
+      };
+      const data = buildImageData([external, hole], { width: 0, height: 0 });
+
+      const coco = await new FormatConverter().convertToCOCO([data]);
+
+      const ann = coco.annotations[0];
+      expect(ann.iscrowd).toBe(1);
+      const rle = ann.segmentation as { size: [number, number] };
+      // RLE size = [height, width]; inferred from extents ~ 101x101.
+      expect(rle.size[0]).toBe(coco.images[0].height);
+      expect(rle.size[1]).toBe(coco.images[0].width);
+      expect(rle.size[0]).toBeGreaterThanOrEqual(101);
+      expect(rle.size[1]).toBeGreaterThanOrEqual(101);
     });
   });
 });

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -5,7 +5,10 @@ import {
   isValidSpermPartClass,
 } from '../../utils/polygonValidation';
 import { polylineLength } from '../../utils/polygonGeometry';
-import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
+import {
+  groupPolylinesByInstanceId,
+  findPart,
+} from '../../utils/spermGrouping';
 
 export interface Point {
   x: number;
@@ -22,6 +25,46 @@ export interface Polygon {
 }
 
 const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
+
+// When image dimensions are missing (e.g. nullable Image.width/height from
+// formats Sharp couldn't parse on upload), derive a safe lower bound from the
+// polygon extents. This keeps COCO/JSON self-consistent — a header that lies
+// about the canvas size is worse than one that may be slightly too large —
+// and we log it so the upstream data gap is visible.
+const inferDimensionsFromPolygons = (
+  polygons: Polygon[]
+): { width: number; height: number } => {
+  let maxX = 0;
+  let maxY = 0;
+  for (const polygon of polygons) {
+    for (const point of polygon.points) {
+      if (point.x > maxX) maxX = point.x;
+      if (point.y > maxY) maxY = point.y;
+    }
+  }
+  return {
+    width: Math.ceil(maxX) + 1,
+    height: Math.ceil(maxY) + 1,
+  };
+};
+
+const resolveImageDimensions = (
+  image: ImageData,
+  polygons: Polygon[],
+  context: 'COCO' | 'JSON'
+): { width: number; height: number } => {
+  if (image.width > 0 && image.height > 0) {
+    return { width: image.width, height: image.height };
+  }
+  const inferred = inferDimensionsFromPolygons(polygons);
+  logger.warn(
+    `${context} export: image "${image.filename}" (${image.id}) is missing dimensions; ` +
+      `inferred ${inferred.width}x${inferred.height} from polygon extents. ` +
+      'Upstream Image.width/height and Segmentation.imageWidth/imageHeight are both unset.',
+    'FormatConverter'
+  );
+  return inferred;
+};
 
 const flattenPoints = (points: Point[]): number[] => {
   const out: number[] = [];
@@ -215,140 +258,145 @@ export class FormatConverter {
         continue;
       }
 
-      // Add image to COCO images list
+      let parsedPolygons: Polygon[] = [];
+      const result = image.segmentationResults?.[0];
+      if (result?.polygons) {
+        try {
+          parsedPolygons = JSON.parse(result.polygons);
+          if (!Array.isArray(parsedPolygons)) {
+            parsedPolygons = [];
+          }
+        } catch (error) {
+          logger.error(
+            'Failed to parse polygons JSON for COCO format',
+            error instanceof Error ? error : new Error('Unknown error'),
+            'FormatConverter',
+            {
+              imageId: image.id,
+              polygonsData: result.polygons
+                ? result.polygons.substring(0, 100) + '...'
+                : 'undefined',
+            }
+          );
+          parsedPolygons = [];
+        }
+      }
+
+      const { width: imageWidth, height: imageHeight } = resolveImageDimensions(
+        image,
+        parsedPolygons,
+        'COCO'
+      );
+
       imagesList.push({
         id: imageIdx + 1,
         file_name: image.filename,
-        width: image.width || 800,
-        height: image.height || 600,
+        width: imageWidth,
+        height: imageHeight,
         date_captured: new Date().toISOString(),
       });
 
-      // Process segmentation results
-      if (image.segmentationResults && image.segmentationResults.length > 0) {
-        const result = image.segmentationResults[0];
-        if (result?.polygons) {
-          let polygons;
-          try {
-            polygons = JSON.parse(result.polygons);
-          } catch (error) {
-            logger.error(
-              'Failed to parse polygons JSON for COCO format',
-              error instanceof Error ? error : new Error('Unknown error'),
-              'FormatConverter',
-              {
-                imageId: image.id,
-                polygonsData: result.polygons
-                  ? result.polygons.substring(0, 100) + '...'
-                  : 'undefined',
-              }
-            );
-            polygons = [];
-          }
+      if (parsedPolygons.length > 0) {
+        const polygons = parsedPolygons;
 
-          const closedExternalPolygons: Polygon[] = [];
-          const internalPolygons: Polygon[] = [];
-          const validPolylines: Polygon[] = [];
-          let invalidPartClassCount = 0;
-          for (const p of polygons as Polygon[]) {
-            if (isPolyline(p)) {
-              if (isValidSpermPartClass(p.partClass)) {
-                validPolylines.push(p);
-              } else {
-                invalidPartClassCount += 1;
-              }
-            } else if (p.type === 'internal') {
-              internalPolygons.push(p);
-            } else if (p.type === 'external') {
-              closedExternalPolygons.push(p);
-            }
-          }
-          if (invalidPartClassCount > 0) {
-            totalInvalidPartClass += invalidPartClassCount;
-            if (sampleAffectedImages.length < 10) {
-              sampleAffectedImages.push(image.id);
-            }
-          }
-          if (validPolylines.length > 0) {
-            hasSperm = true;
-          }
-
-          for (const polygon of closedExternalPolygons) {
-            // Find internal polygons that belong to this external polygon
-            // (simplified - in real scenario, you'd check spatial containment)
-            const associatedInternalPolygons = internalPolygons.filter(
-              (internal: Polygon) =>
-                this.isPolygonInsidePolygon(internal.points, polygon.points)
-            );
-
-            // Calculate bounding box
-            const bbox = this.calculateBoundingBox(polygon.points);
-
-            // Calculate area (accounting for holes)
-            const area =
-              this.calculatePolygonArea(polygon.points) -
-              associatedInternalPolygons.reduce(
-                (sum: number, internal: Polygon) =>
-                  sum + this.calculatePolygonArea(internal.points),
-                0
-              );
-
-            let segmentation: number[][] | RLEFormat;
-
-            if (associatedInternalPolygons.length > 0) {
-              // Create binary mask for polygon with holes
-              const mask = this.createBinaryMask(
-                polygon.points,
-                associatedInternalPolygons.map((p: Polygon) => p.points),
-                image.width || 800,
-                image.height || 600
-              );
-
-              // Encode mask to COCO RLE format
-              const rle = this.encodeMaskToRLE(
-                mask,
-                image.width || 800,
-                image.height || 600
-              );
-              segmentation = rle;
+        const closedExternalPolygons: Polygon[] = [];
+        const internalPolygons: Polygon[] = [];
+        const validPolylines: Polygon[] = [];
+        let invalidPartClassCount = 0;
+        for (const p of polygons as Polygon[]) {
+          if (isPolyline(p)) {
+            if (isValidSpermPartClass(p.partClass)) {
+              validPolylines.push(p);
             } else {
-              segmentation = [flattenPoints(polygon.points)];
+              invalidPartClassCount += 1;
             }
+          } else if (p.type === 'internal') {
+            internalPolygons.push(p);
+          } else if (p.type === 'external') {
+            closedExternalPolygons.push(p);
+          }
+        }
+        if (invalidPartClassCount > 0) {
+          totalInvalidPartClass += invalidPartClassCount;
+          if (sampleAffectedImages.length < 10) {
+            sampleAffectedImages.push(image.id);
+          }
+        }
+        if (validPolylines.length > 0) {
+          hasSperm = true;
+        }
 
-            annotations.push({
-              id: annotationId++,
-              image_id: imageIdx + 1,
-              category_id: 1, // Cell/spheroid category
-              segmentation,
-              bbox,
-              area,
-              iscrowd: associatedInternalPolygons.length > 0 ? 1 : 0, // iscrowd=1 for RLE format
-              attributes: {
-                type: 'external',
-                geometry: 'polygon',
-                has_holes: associatedInternalPolygons.length > 0,
-              },
-            });
+        for (const polygon of closedExternalPolygons) {
+          // Find internal polygons that belong to this external polygon
+          // (simplified - in real scenario, you'd check spatial containment)
+          const associatedInternalPolygons = internalPolygons.filter(
+            (internal: Polygon) =>
+              this.isPolygonInsidePolygon(internal.points, polygon.points)
+          );
+
+          // Calculate bounding box
+          const bbox = this.calculateBoundingBox(polygon.points);
+
+          // Calculate area (accounting for holes)
+          const area =
+            this.calculatePolygonArea(polygon.points) -
+            associatedInternalPolygons.reduce(
+              (sum: number, internal: Polygon) =>
+                sum + this.calculatePolygonArea(internal.points),
+              0
+            );
+
+          let segmentation: number[][] | RLEFormat;
+
+          if (associatedInternalPolygons.length > 0) {
+            // Create binary mask for polygon with holes
+            const mask = this.createBinaryMask(
+              polygon.points,
+              associatedInternalPolygons.map((p: Polygon) => p.points),
+              imageWidth,
+              imageHeight
+            );
+
+            // Encode mask to COCO RLE format
+            const rle = this.encodeMaskToRLE(mask, imageWidth, imageHeight);
+            segmentation = rle;
+          } else {
+            segmentation = [flattenPoints(polygon.points)];
           }
 
-          for (const polyline of validPolylines) {
-            annotations.push({
-              id: annotationId++,
-              image_id: imageIdx + 1,
-              category_id: 2,
-              segmentation: [flattenPoints(polyline.points)],
-              bbox: this.calculateBoundingBox(polyline.points),
-              area: 0,
-              iscrowd: 0,
-              attributes: {
-                type: 'external',
-                geometry: 'polyline',
-                partClass: polyline.partClass,
-                ...(polyline.instanceId && { instanceId: polyline.instanceId }),
-                length: polylineLength(polyline.points),
-              },
-            });
-          }
+          annotations.push({
+            id: annotationId++,
+            image_id: imageIdx + 1,
+            category_id: 1, // Cell/spheroid category
+            segmentation,
+            bbox,
+            area,
+            iscrowd: associatedInternalPolygons.length > 0 ? 1 : 0, // iscrowd=1 for RLE format
+            attributes: {
+              type: 'external',
+              geometry: 'polygon',
+              has_holes: associatedInternalPolygons.length > 0,
+            },
+          });
+        }
+
+        for (const polyline of validPolylines) {
+          annotations.push({
+            id: annotationId++,
+            image_id: imageIdx + 1,
+            category_id: 2,
+            segmentation: [flattenPoints(polyline.points)],
+            bbox: this.calculateBoundingBox(polyline.points),
+            area: 0,
+            iscrowd: 0,
+            attributes: {
+              type: 'external',
+              geometry: 'polyline',
+              partClass: polyline.partClass,
+              ...(polyline.instanceId && { instanceId: polyline.instanceId }),
+              length: polylineLength(polyline.points),
+            },
+          });
         }
       }
     }
@@ -426,8 +474,7 @@ export class FormatConverter {
     }
 
     const externalPolygons = polygons.filter(
-      (p: Polygon) =>
-        p.type === 'external' && p.geometry !== 'polyline'
+      (p: Polygon) => p.type === 'external' && p.geometry !== 'polyline'
     );
 
     for (const polygon of externalPolygons) {
@@ -483,119 +530,126 @@ export class FormatConverter {
         continue;
       }
 
+      let parsedPolygons: Polygon[] = [];
+      const result = image.segmentationResults?.[0];
+      if (result?.polygons) {
+        try {
+          parsedPolygons = JSON.parse(result.polygons);
+          if (!Array.isArray(parsedPolygons)) {
+            parsedPolygons = [];
+          }
+        } catch (error) {
+          logger.error(
+            'Failed to parse polygons JSON for custom JSON format',
+            error instanceof Error ? error : new Error('Unknown error'),
+            'FormatConverter',
+            {
+              polygonsData: result?.polygons
+                ? result.polygons.substring(0, 100) + '...'
+                : 'undefined',
+            }
+          );
+          parsedPolygons = [];
+        }
+      }
+
+      const { width: jsonImageWidth, height: jsonImageHeight } =
+        resolveImageDimensions(image, parsedPolygons, 'JSON');
+
       const imageData: JSONImageData = {
         id: image.id,
         index: imageIdx + 1,
         filename: image.filename,
         dimensions: {
-          width: image.width || 800,
-          height: image.height || 600,
+          width: jsonImageWidth,
+          height: jsonImageHeight,
         },
         segmentation: null,
       };
 
-      // Process segmentation results
-      if (image.segmentationResults && image.segmentationResults.length > 0) {
-        const result = image.segmentationResults[0];
-        if (result?.polygons) {
-          let polygons;
-          try {
-            polygons = JSON.parse(result.polygons);
-          } catch (error) {
-            logger.error(
-              'Failed to parse polygons JSON for custom JSON format',
-              error instanceof Error ? error : new Error('Unknown error'),
-              'FormatConverter',
-              {
-                polygonsData: result?.polygons
-                  ? result.polygons.substring(0, 100) + '...'
-                  : 'undefined',
-              }
-            );
-            polygons = [];
-          }
+      if (parsedPolygons.length > 0) {
+        const polygons = parsedPolygons;
 
-          const externalPolygons: Polygon[] = [];
-          const internalPolygons: Polygon[] = [];
-          const polylines: Polygon[] = [];
-          for (const p of polygons as Polygon[]) {
-            if (isPolyline(p)) {
-              polylines.push(p);
-            } else if (p.type === 'internal') {
-              internalPolygons.push(p);
-            } else if (p.type === 'external') {
-              externalPolygons.push(p);
-            }
+        const externalPolygons: Polygon[] = [];
+        const internalPolygons: Polygon[] = [];
+        const polylines: Polygon[] = [];
+        for (const p of polygons as Polygon[]) {
+          if (isPolyline(p)) {
+            polylines.push(p);
+          } else if (p.type === 'internal') {
+            internalPolygons.push(p);
+          } else if (p.type === 'external') {
+            externalPolygons.push(p);
           }
+        }
 
-          const polylinesData: JSONPolylineData[] = polylines.map(
-            (p: Polygon, idx: number) => ({
+        const polylinesData: JSONPolylineData[] = polylines.map(
+          (p: Polygon, idx: number) => ({
+            id: idx + 1,
+            points: p.points,
+            geometry: 'polyline',
+            ...(isValidSpermPartClass(p.partClass) && {
+              partClass: p.partClass,
+            }),
+            ...(p.instanceId && { instanceId: p.instanceId }),
+            length: polylineLength(p.points),
+            boundingBox: this.calculateBoundingBox(p.points),
+          })
+        );
+
+        const { instances: spermInstances, orphanCount } =
+          this.buildSpermInstances(polylines);
+        if (orphanCount > 0) {
+          totalOrphans += orphanCount;
+          if (orphanSampleImages.length < 10) {
+            orphanSampleImages.push(image.id);
+          }
+        }
+
+        imageData.segmentation = {
+          cellCount: result.cellCount || externalPolygons.length,
+          timestamp: result.timestamp,
+          polygons: {
+            external: externalPolygons.map((p: Polygon, idx: number) => ({
               id: idx + 1,
               points: p.points,
-              geometry: 'polyline',
-              ...(isValidSpermPartClass(p.partClass) && {
-                partClass: p.partClass,
-              }),
-              ...(p.instanceId && { instanceId: p.instanceId }),
-              length: polylineLength(p.points),
+              area: this.calculatePolygonArea(p.points),
+              perimeter: this.calculatePerimeter(p.points),
               boundingBox: this.calculateBoundingBox(p.points),
-            })
-          );
-
-          const { instances: spermInstances, orphanCount } =
-            this.buildSpermInstances(polylines);
-          if (orphanCount > 0) {
-            totalOrphans += orphanCount;
-            if (orphanSampleImages.length < 10) {
-              orphanSampleImages.push(image.id);
-            }
-          }
-
-          imageData.segmentation = {
-            cellCount: result.cellCount || externalPolygons.length,
-            timestamp: result.timestamp,
-            polygons: {
-              external: externalPolygons.map((p: Polygon, idx: number) => ({
-                id: idx + 1,
-                points: p.points,
-                area: this.calculatePolygonArea(p.points),
-                perimeter: this.calculatePerimeter(p.points),
-                boundingBox: this.calculateBoundingBox(p.points),
-                centroid: this.calculateCentroid(p.points),
-              })),
-              internal: internalPolygons.map((p: Polygon, idx: number) => ({
-                id: idx + 1,
-                points: p.points,
-                area: this.calculatePolygonArea(p.points),
-                perimeter: this.calculatePerimeter(p.points),
-              })),
-            },
-            ...(polylinesData.length > 0 && { polylines: polylinesData }),
-            ...(spermInstances.length > 0 && { spermInstances }),
-            statistics: {
-              totalExternalPolygons: externalPolygons.length,
-              totalInternalPolygons: internalPolygons.length,
-              totalArea:
-                externalPolygons.reduce(
-                  (sum: number, p: Polygon) =>
-                    sum + this.calculatePolygonArea(p.points),
-                  0
-                ) -
-                internalPolygons.reduce(
-                  (sum: number, p: Polygon) =>
-                    sum + this.calculatePolygonArea(p.points),
-                  0
-                ),
-              ...(polylinesData.length > 0 && {
-                totalPolylines: polylinesData.length,
-              }),
-              ...(spermInstances.length > 0 && {
-                totalSpermInstances: spermInstances.length,
-              }),
-              ...(orphanCount > 0 && { orphanPolylineCount: orphanCount }),
-            },
-          };
-        }
+              centroid: this.calculateCentroid(p.points),
+            })),
+            internal: internalPolygons.map((p: Polygon, idx: number) => ({
+              id: idx + 1,
+              points: p.points,
+              area: this.calculatePolygonArea(p.points),
+              perimeter: this.calculatePerimeter(p.points),
+            })),
+          },
+          ...(polylinesData.length > 0 && { polylines: polylinesData }),
+          ...(spermInstances.length > 0 && { spermInstances }),
+          statistics: {
+            totalExternalPolygons: externalPolygons.length,
+            totalInternalPolygons: internalPolygons.length,
+            totalArea:
+              externalPolygons.reduce(
+                (sum: number, p: Polygon) =>
+                  sum + this.calculatePolygonArea(p.points),
+                0
+              ) -
+              internalPolygons.reduce(
+                (sum: number, p: Polygon) =>
+                  sum + this.calculatePolygonArea(p.points),
+                0
+              ),
+            ...(polylinesData.length > 0 && {
+              totalPolylines: polylinesData.length,
+            }),
+            ...(spermInstances.length > 0 && {
+              totalSpermInstances: spermInstances.length,
+            }),
+            ...(orphanCount > 0 && { orphanPolylineCount: orphanCount }),
+          },
+        };
       }
 
       exportData.images.push(imageData);
@@ -679,27 +733,29 @@ export class FormatConverter {
   } {
     const { groups, orphanCount } = groupPolylinesByInstanceId(polylines);
 
-    const instances: JSONSpermInstance[] = groups.map(({ instanceId, parts }) => {
-      const head = findPart(parts, 'head');
-      const midpiece = findPart(parts, 'midpiece');
-      const tail = findPart(parts, 'tail');
+    const instances: JSONSpermInstance[] = groups.map(
+      ({ instanceId, parts }) => {
+        const head = findPart(parts, 'head');
+        const midpiece = findPart(parts, 'midpiece');
+        const tail = findPart(parts, 'tail');
 
-      const headLen = head ? polylineLength(head.points) : 0;
-      const midLen = midpiece ? polylineLength(midpiece.points) : 0;
-      const tailLen = tail ? polylineLength(tail.points) : 0;
+        const headLen = head ? polylineLength(head.points) : 0;
+        const midLen = midpiece ? polylineLength(midpiece.points) : 0;
+        const tailLen = tail ? polylineLength(tail.points) : 0;
 
-      return {
-        instanceId,
-        parts: {
-          ...(head && { head: { points: head.points, length: headLen } }),
-          ...(midpiece && {
-            midpiece: { points: midpiece.points, length: midLen },
-          }),
-          ...(tail && { tail: { points: tail.points, length: tailLen } }),
-        },
-        totalLength: headLen + midLen + tailLen,
-      };
-    });
+        return {
+          instanceId,
+          parts: {
+            ...(head && { head: { points: head.points, length: headLen } }),
+            ...(midpiece && {
+              midpiece: { points: midpiece.points, length: midLen },
+            }),
+            ...(tail && { tail: { points: tail.points, length: tailLen } }),
+          },
+          totalLength: headLen + midLen + tailLen,
+        };
+      }
+    );
 
     return { instances, orphanCount };
   }

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -26,44 +26,65 @@ export interface Polygon {
 
 const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';
 
-// When image dimensions are missing (e.g. nullable Image.width/height from
-// formats Sharp couldn't parse on upload), derive a safe lower bound from the
-// polygon extents. This keeps COCO/JSON self-consistent — a header that lies
-// about the canvas size is worse than one that may be slightly too large —
-// and we log it so the upstream data gap is visible.
-const inferDimensionsFromPolygons = (
+// Lower bound on canvas size derived from polygon extents. Used as a fallback
+// only when Image.width/height and Segmentation.imageWidth/Height are both
+// unset (e.g. BMPs that Sharp couldn't parse). Empty input yields 0x0 — the
+// caller must treat that as "no usable dimensions" and escalate.
+export const inferDimensionsFromPolygons = (
   polygons: Polygon[]
 ): { width: number; height: number } => {
   let maxX = 0;
   let maxY = 0;
+  let hasPoints = false;
   for (const polygon of polygons) {
     for (const point of polygon.points) {
+      hasPoints = true;
       if (point.x > maxX) maxX = point.x;
       if (point.y > maxY) maxY = point.y;
     }
   }
+  if (!hasPoints) return { width: 0, height: 0 };
   return {
     width: Math.ceil(maxX) + 1,
     height: Math.ceil(maxY) + 1,
   };
 };
 
-const resolveImageDimensions = (
+export const resolveImageDimensions = (
   image: ImageData,
   polygons: Polygon[],
-  context: 'COCO' | 'JSON'
+  context: 'COCO' | 'YOLO' | 'JSON'
 ): { width: number; height: number } => {
-  if (image.width > 0 && image.height > 0) {
+  const hasWidth = image.width > 0;
+  const hasHeight = image.height > 0;
+  if (hasWidth && hasHeight) {
     return { width: image.width, height: image.height };
   }
+
   const inferred = inferDimensionsFromPolygons(polygons);
-  logger.warn(
-    `${context} export: image "${image.filename}" (${image.id}) is missing dimensions; ` +
-      `inferred ${inferred.width}x${inferred.height} from polygon extents. ` +
-      'Upstream Image.width/height and Segmentation.imageWidth/imageHeight are both unset.',
-    'FormatConverter'
-  );
-  return inferred;
+  const resolvedWidth = hasWidth ? image.width : inferred.width;
+  const resolvedHeight = hasHeight ? image.height : inferred.height;
+
+  const missing = [!hasWidth && 'width', !hasHeight && 'height']
+    .filter(Boolean)
+    .join('/');
+
+  if (resolvedWidth <= 0 || resolvedHeight <= 0) {
+    logger.error(
+      `${context} export: image "${image.filename}" (${image.id}) has no usable ${missing}; ` +
+        `no polygons available to infer from. Output header will be ${resolvedWidth}x${resolvedHeight} (invalid).`,
+      new Error('Missing image dimensions with no inferable polygons'),
+      'FormatConverter'
+    );
+  } else {
+    logger.warn(
+      `${context} export: image "${image.filename}" (${image.id}) is missing ${missing}; ` +
+        `inferred ${resolvedWidth}x${resolvedHeight} from polygon extents.`,
+      'FormatConverter'
+    );
+  }
+
+  return { width: resolvedWidth, height: resolvedHeight };
 };
 
 const flattenPoints = (points: Point[]): number[] => {

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -10,7 +10,11 @@ import {
   MetricsCalculator,
   type ImageWithSegmentation as MetricsImageInput,
 } from './metrics/metricsCalculator';
-import { FormatConverter } from './export/formatConverter';
+import {
+  FormatConverter,
+  resolveImageDimensions,
+  type Polygon as ExportPolygon,
+} from './export/formatConverter';
 import { WebSocketService } from './websocketService';
 import * as SharingService from './sharingService';
 import { batchProcessor } from '../utils/batchProcessor';
@@ -902,10 +906,44 @@ export class ExportService {
           YOLO_WRITE_CONCURRENCY,
           async image => {
             if (!image || !image.segmentation) return;
+
+            // YOLO normalizes every coordinate by width/height → 0 would
+            // produce NaN/Infinity in the output file. Resolve dimensions
+            // with the same fallback chain used by COCO/JSON: ML-PIL dims
+            // first, then Sharp upload metadata, then polygon extents.
+            let parsedPolygons: ExportPolygon[] = [];
+            try {
+              const parsed = JSON.parse(image.segmentation.polygons);
+              if (Array.isArray(parsed)) parsedPolygons = parsed;
+            } catch {
+              // convertToYOLO will re-parse and report the error with context
+            }
+            const { width: yoloWidth, height: yoloHeight } =
+              resolveImageDimensions(
+                {
+                  id: image.id,
+                  filename: image.name,
+                  width: image.segmentation.imageWidth || image.width || 0,
+                  height: image.segmentation.imageHeight || image.height || 0,
+                },
+                parsedPolygons,
+                'YOLO'
+              );
+
+            if (yoloWidth <= 0 || yoloHeight <= 0) {
+              logger.error(
+                `YOLO export skipped for image ${image.name} (${image.id}): no usable dimensions`,
+                new Error('No usable image dimensions'),
+                'ExportService',
+                { jobId, imageId: image.id }
+              );
+              return;
+            }
+
             const yoloResult = await this.formatConverter.convertToYOLO(
               image.segmentation.polygons,
-              image.segmentation.imageWidth || image.width || 0,
-              image.segmentation.imageHeight || image.height || 0
+              yoloWidth,
+              yoloHeight
             );
             const imageNameWithoutExt = path.parse(image.name).name;
             await fs.writeFile(

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -6,7 +6,10 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../utils/logger';
 import { VisualizationGenerator } from './visualization/visualizationGenerator';
-import { MetricsCalculator, type ImageWithSegmentation as MetricsImageInput } from './metrics/metricsCalculator';
+import {
+  MetricsCalculator,
+  type ImageWithSegmentation as MetricsImageInput,
+} from './metrics/metricsCalculator';
 import { FormatConverter } from './export/formatConverter';
 import { WebSocketService } from './websocketService';
 import * as SharingService from './sharingService';
@@ -868,12 +871,14 @@ export class ExportService {
       const formatDir = path.join(exportDir, 'annotations', format);
 
       if (format === 'coco') {
-        // Convert ImageWithSegmentation[] to ImageData[]
+        // Polygon coordinates come from the ML service in PIL's original-image
+        // space, recorded on Segmentation.imageWidth/Height. Prefer those over
+        // Image.width/height (Sharp upload metadata, nullable for BMP).
         const imageDataArray = images.map(image => ({
           id: image.id,
           filename: image.name,
-          width: image.width || 0,
-          height: image.height || 0,
+          width: image.segmentation?.imageWidth || image.width || 0,
+          height: image.segmentation?.imageHeight || image.height || 0,
           segmentationResults: image.segmentation
             ? [
                 {
@@ -899,8 +904,8 @@ export class ExportService {
             if (!image || !image.segmentation) return;
             const yoloResult = await this.formatConverter.convertToYOLO(
               image.segmentation.polygons,
-              image.width || 0,
-              image.height || 0
+              image.segmentation.imageWidth || image.width || 0,
+              image.segmentation.imageHeight || image.height || 0
             );
             const imageNameWithoutExt = path.parse(image.name).name;
             await fs.writeFile(
@@ -922,12 +927,11 @@ export class ExportService {
           }
         );
       } else if (format === 'json') {
-        // Convert ImageWithSegmentation[] to ImageData[]
         const imageDataArray = images.map(image => ({
           id: image.id,
           filename: image.name,
-          width: image.width || 0,
-          height: image.height || 0,
+          width: image.segmentation?.imageWidth || image.width || 0,
+          height: image.segmentation?.imageHeight || image.height || 0,
           segmentationResults: image.segmentation
             ? [
                 {
@@ -2077,11 +2081,10 @@ ${exportedFormats.map(format => `- ${format}/README.md`).join('\n')}
     if (chartPng) {
       try {
         const chartPath = await writeStandaloneWoundChart(exportDir, chartPng);
-        logger.info(
-          `Wound area chart saved to ${chartPath}`,
-          'ExportService',
-          { jobId, frames: count }
-        );
+        logger.info(`Wound area chart saved to ${chartPath}`, 'ExportService', {
+          jobId,
+          frames: count,
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.error(


### PR DESCRIPTION
## Summary
- COCO/YOLO/JSON exporters used `Image.width/height` (nullable — Sharp fails to read metadata for some formats like BMP) and silently fell back to hardcoded **800x600** in `formatConverter`. Polygon coordinates meanwhile came from the ML service in PIL original-image space, so annotation headers declared 800x600 while polygons extended to the real resolution (e.g. 1286x1293).
- `exportService.ts` now prefers `Segmentation.imageWidth/Height` (authoritative, set by ML/PIL) before falling back to `Image.width/height`.
- `formatConverter.ts` removes the `|| 800` / `|| 600` defaults. If both sources are missing, dimensions are inferred from polygon extents and a `logger.warn` is emitted so the upstream data gap is discoverable.
- Originals export (non-visualization) was verified to already use `fs.copyFile` byte-for-byte — unchanged, always matches upload resolution.

## Test plan
- [x] `npx jest src/services/export` — 52 tests pass, including 3 new regression tests for missing/zero dims in COCO + JSON, plus verbatim pass-through
- [x] `npx tsc --noEmit` clean
- [ ] Manual verification on a real BMP project: exported `annotations.json` width/height should match actual image size, not 800x600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exports now infer missing image width/height from polygon extents (preserving any provided dimensions) and emit warnings or errors when inference is impossible; COCO/JSON masks/RLE and YOLO normalization use these resolved dimensions. YOLO export now skips writing and logs an error if resolved dimensions are non-positive.

* **Tests**
  * Added tests covering missing, partial, and present image-dimension scenarios across COCO, JSON and YOLO exports, including logging expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->