### PR TITLE
fix(landing): remove lovable template refs from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,12 @@
     <title>SpheroSeg - Spheroid Segmentation Platform</title>
     <meta
       name="description"
-      content="AI-powered cell analysis for biomedical research"
+      content="AI-powered cell and sperm segmentation platform for biomedical research, developed at UTIA."
     />
-    <meta name="author" content="SpheroSeg" />
+    <meta name="author" content="Michal Průšek, UTIA" />
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/logo.svg" />
 
     <!-- Inter font family -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -24,26 +27,32 @@
     />
     <meta
       property="og:description"
-      content="AI-powered cell analysis for biomedical research"
+      content="AI-powered cell and sperm segmentation platform for biomedical research, developed at UTIA."
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://spherosegapp.utia.cas.cz" />
     <meta
       property="og:image"
-      content="https://lovable.dev/opengraph-image-p98pqg.png"
+      content="https://spherosegapp.utia.cas.cz/logo.svg"
     />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@spheroseg" />
+    <meta
+      name="twitter:title"
+      content="SpheroSeg - Spheroid Segmentation Platform"
+    />
+    <meta
+      name="twitter:description"
+      content="AI-powered cell and sperm segmentation platform for biomedical research."
+    />
     <meta
       name="twitter:image"
-      content="https://lovable.dev/opengraph-image-p98pqg.png"
+      content="https://spherosegapp.utia.cas.cz/logo.svg"
     />
   </head>
 
   <body>
     <div id="root"></div>
-    <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces Lovable boilerplate metadata in `index.html` with UTIA-branded values: self-hosted `/logo.svg` for `og:image`/`twitter:image`, canonical `og:url` to `spherosegapp.utia.cas.cz`, `rel=icon` + `apple-touch-icon`, author/description updated to UTIA + Průšek.
- Removes external `cdn.gpteng.co/gptengineer.js` (Lovable telemetry) and the "DO NOT REMOVE" sentinel comment that re-injected it.
- Production frontend already rebuilt + recreated and serves this HTML; this PR catches the source up.

## Test plan
- [x] `curl https://spherosegapp.utia.cas.cz | grep -i lovable` returns nothing
- [x] `curl https://spherosegapp.utia.cas.cz | grep og:url` returns the new canonical URL
- [x] Browser dev-tools: no requests to `cdn.gpteng.co` on landing
- [ ] Manual: LinkedIn/Slack URL preview shows logo + UTIA description (post-merge social-card cache invalidation may take ~24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)