### PR TITLE
feat(spheroid): ASPP core detection, Disintegration Index, project types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -67,3 +67,7 @@ output_time_48h/
 # OS files
 .DS_Store
 Thumbs.db
+# Backups and temp visualization output
+.backups/
+.tmp_viz/
+

--- a/backend/prisma/migrations/20260425130000_add_project_type/migration.sql
+++ b/backend/prisma/migrations/20260425130000_add_project_type/migration.sql
@@ -1,0 +1,8 @@
+-- Add project workflow type column.
+-- Drives metric export format and editor mode dispatch.
+-- Values: 'spheroid' (standard) | 'spheroid_invasive' (disintegrated) | 'wound' | 'sperm'.
+ALTER TABLE "projects" ADD COLUMN "type" TEXT NOT NULL DEFAULT 'spheroid';
+
+-- Constrain to the four supported project types.
+ALTER TABLE "projects" ADD CONSTRAINT "projects_type_check"
+  CHECK ("type" IN ('spheroid', 'spheroid_invasive', 'wound', 'sperm'));

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,6 +63,9 @@ model Project {
   id                String              @id @default(uuid())
   title             String
   description       String?
+  // Project workflow type — drives metric export format and editor mode.
+  // One of: 'spheroid' | 'spheroid_invasive' | 'wound' | 'sperm'.
+  type              String              @default("spheroid")
   userId            String
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt

--- a/backend/segmentation/api/metrics_endpoint.py
+++ b/backend/segmentation/api/metrics_endpoint.py
@@ -1,13 +1,18 @@
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import cv2
+import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from typing import List, Dict, Any, Optional
-import numpy as np
-import cv2
-import sys
-import os
+from scipy.stats import wasserstein_distance
 
 # Import characteristic_functions from utils package
 from utils.characteristic_functions import calculate_all
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["metrics"])
 
@@ -261,7 +266,6 @@ async def disintegration_index(request: DisintegrationRequest):
             # the mask against the empirical distribution of the core's own
             # pixels (both relative to the mask centroid). Normalised by R_core
             # to keep the metric scale-invariant.
-            from scipy.stats import wasserstein_distance
             w1_px = float(wasserstein_distance(d_mask, d_core))
             w1 = w1_px / r_ref
         else:
@@ -277,11 +281,19 @@ async def disintegration_index(request: DisintegrationRequest):
         )
     except HTTPException:
         raise
-    except Exception as exc:
+    except (ValueError, cv2.error, MemoryError) as exc:
+        logger.exception(
+            "DI computation failed: H=%d W=%d n_mask=%d n_core=%d",
+            H, W,
+            len(request.mask_polygons or [request.mask_polygon])
+            if (request.mask_polygons or request.mask_polygon) else 0,
+            len(request.core_polygons or [request.core_polygon])
+            if (request.core_polygons or request.core_polygon) else 0,
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Failed to compute disintegration index: {exc}",
-        )
+        ) from exc
 
 
 @router.get("/metrics-info")

--- a/backend/segmentation/api/metrics_endpoint.py
+++ b/backend/segmentation/api/metrics_endpoint.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import numpy as np
 import cv2
 import sys
@@ -10,6 +10,34 @@ import os
 from utils.characteristic_functions import calculate_all
 
 router = APIRouter(prefix="/api", tags=["metrics"])
+
+
+class DisintegrationRequest(BaseModel):
+    """Request body for DI computation.
+
+    `mask_polygons` (plural, preferred) is the list of every external polygon
+    forming the total cell-covered area; they are rasterised into a single
+    binary mask via union (cv2.fillPoly applied per polygon to the same
+    canvas). DI is then computed from that union.
+    `mask_polygon` (singular) is kept for backward compatibility — same as
+    passing a one-element list.
+    `core_polygons` is the list of dense core fragments; their combined
+    rasterised area defines R_core. `core_polygon` (singular) is the legacy
+    single-polygon variant.
+    """
+    mask_polygon: Optional[List[List[float]]] = None
+    mask_polygons: Optional[List[List[List[float]]]] = None
+    core_polygon: Optional[List[List[float]]] = None
+    core_polygons: Optional[List[List[List[float]]]] = None
+    image_width: int
+    image_height: int
+
+
+class DisintegrationResponse(BaseModel):
+    di: float
+    w1: float
+    reference: str  # 'core' | 'r_eff' | 'r_eff_fallback' | 'none'
+    n_pixels: int
 
 class Point(BaseModel):
     x: float
@@ -132,6 +160,129 @@ async def batch_calculate_metrics(polygons: List[MetricsRequest]) -> List[Metric
             ))
     
     return results
+
+@router.post("/disintegration-index", response_model=DisintegrationResponse)
+async def disintegration_index(request: DisintegrationRequest):
+    """Compute the per-image Disintegration Index (DI).
+
+    Reduces the binary mask polygon to a 1-D radial distribution of pixel
+    distances from the centroid, normalises by R_ref (derived from core
+    area if provided, else from mask area), and measures the
+    1-Wasserstein distance to the analytical CDF of a uniform disk
+    `F_ref(d̃) = d̃²`. The raw W1 is squashed via `tanh` into `[0, 1)`.
+    """
+    try:
+        H = int(request.image_height)
+        W = int(request.image_width)
+        if H <= 0 or W <= 0:
+            raise HTTPException(
+                status_code=400, detail="image_width/image_height must be positive"
+            )
+
+        # Build a UNION mask from every supplied external polygon.
+        # `mask_polygons` (plural) is the preferred input — represents the full
+        # ASPP segmentation (all spheroids in one canvas). `mask_polygon`
+        # (singular) is a legacy alias for a single-element list.
+        mask_polys: List[List[List[float]]] = []
+        if request.mask_polygons:
+            mask_polys = request.mask_polygons
+        elif request.mask_polygon is not None:
+            mask_polys = [request.mask_polygon]
+        if not mask_polys:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one of mask_polygons / mask_polygon is required",
+            )
+
+        mask = np.zeros((H, W), dtype=np.uint8)
+        valid_masks = 0
+        for poly in mask_polys:
+            pts = np.asarray(poly, dtype=np.float32)
+            if pts.ndim == 2 and pts.shape[1] == 2 and pts.shape[0] >= 3:
+                cv2.fillPoly(mask, [pts.astype(np.int32)], 1)
+                valid_masks += 1
+        if valid_masks == 0:
+            return DisintegrationResponse(
+                di=0.0, w1=0.0, reference="none", n_pixels=0
+            )
+        ys, xs = np.nonzero(mask)
+        n = int(xs.size)
+        if n == 0:
+            return DisintegrationResponse(
+                di=0.0, w1=0.0, reference="none", n_pixels=0
+            )
+
+        cx = float(xs.mean())
+        cy = float(ys.mean())
+        d_mask = np.hypot(xs - cx, ys - cy)
+
+        ref_label = "r_eff"
+        r_ref: Optional[float] = None
+        d_core: Optional[np.ndarray] = None
+        # Collect candidate core polygons: prefer the plural list, fall back to
+        # singular for legacy callers.
+        candidate_cores: List[List[List[float]]] = []
+        if request.core_polygons:
+            candidate_cores = request.core_polygons
+        elif request.core_polygon is not None:
+            candidate_cores = [request.core_polygon]
+
+        if candidate_cores:
+            core_mask = np.zeros((H, W), dtype=np.uint8)
+            valid_count = 0
+            for poly in candidate_cores:
+                core_pts_arr = np.asarray(poly, dtype=np.float32)
+                if (
+                    core_pts_arr.ndim == 2
+                    and core_pts_arr.shape[1] == 2
+                    and core_pts_arr.shape[0] >= 3
+                ):
+                    cv2.fillPoly(core_mask, [core_pts_arr.astype(np.int32)], 1)
+                    valid_count += 1
+            n_core = int(core_mask.sum())
+            if valid_count > 0 and n_core > 0:
+                ys_c, xs_c = np.nonzero(core_mask)
+                d_core = np.hypot(xs_c - cx, ys_c - cy)
+                # R_core for scale-invariant normalisation of W1.
+                r_ref = float(np.sqrt(n_core / np.pi))
+                ref_label = "core"
+            else:
+                ref_label = "r_eff_fallback"
+
+        if r_ref is None:
+            r_ref = float(np.sqrt(n / np.pi))
+        if r_ref <= 0:
+            return DisintegrationResponse(
+                di=0.0, w1=0.0, reference=ref_label, n_pixels=n
+            )
+
+        if d_core is not None and d_core.size > 0:
+            # Empirical-CDF reference: compare radial distance distribution of
+            # the mask against the empirical distribution of the core's own
+            # pixels (both relative to the mask centroid). Normalised by R_core
+            # to keep the metric scale-invariant.
+            from scipy.stats import wasserstein_distance
+            w1_px = float(wasserstein_distance(d_mask, d_core))
+            w1 = w1_px / r_ref
+        else:
+            # No core: fall back to the equivalent-disk reference CDF
+            # F_ref(d̃) = d̃² in the d̃ = d / R_eff space.
+            d_tilde = np.sort(d_mask / r_ref)
+            u = (np.arange(n, dtype=np.float64) + 0.5) / n
+            w1 = float(np.mean(np.abs(d_tilde - np.sqrt(u))))
+        di = float(np.tanh(w1))
+
+        return DisintegrationResponse(
+            di=di, w1=w1, reference=ref_label, n_pixels=n
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to compute disintegration index: {exc}",
+        )
+
 
 @router.get("/metrics-info")
 async def get_metrics_info():

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -752,8 +752,15 @@ class ModelLoader:
                             f"ASPP appended {len(core_polygons)} core polygon(s) "
                             f"(areas={[round(c['area'], 1) for c in core_polygons]})"
                         )
-                except Exception as core_exc:
-                    logger.error(f"Core polygon detection failed: {core_exc}")
+                except (cv2.error, ValueError) as core_exc:
+                    # Inner narrow catch: detect_core_polygons already swallows
+                    # geometric/numerical errors. Anything reaching here is a
+                    # second-line defence (e.g., colour-space conversion edge case).
+                    logger.error(
+                        "Core polygon detection hook failed (model=%s, size=%s, n_polys=%d): %s",
+                        model_name, original_size, len(polygons), core_exc,
+                        exc_info=True,
+                    )
 
             if len(polygons) == 0:
                 logger.warning(f"No valid polygons detected! Total contours: {total_contours}, filtered: {filtered_count}")

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -721,7 +721,40 @@ class ModelLoader:
             
             logger.info(f"Polygon detection: {len(polygons)} valid polygons from {total_contours} contours "
                        f"({external_count} external, {internal_count} internal, filtered {filtered_count} small contours)")
-            
+
+            # ASPP-only: detect dense central 'core' inside the largest polygon
+            # via the shared 2-of-3 voting logic (Otsu + core-fraction + solidity).
+            if model_name == 'unet_attention_aspp' and polygons:
+                try:
+                    # Ensure each polygon carries an `area` field so detect_core_polygon
+                    # can pick the largest one consistently with `mask_to_polygons`.
+                    for poly in polygons:
+                        if 'area' not in poly and poly.get('points'):
+                            pts_arr = np.array(
+                                [[p['x'], p['y']] for p in poly['points']],
+                                dtype=np.float32,
+                            )
+                            poly['area'] = float(cv2.contourArea(pts_arr))
+
+                    rgb_arr = np.array(image.convert('RGB'))
+                    gray_arr = cv2.cvtColor(rgb_arr, cv2.COLOR_RGB2GRAY)
+                    from services.postprocessing import PostprocessingService
+                    core_polygons = PostprocessingService().detect_core_polygons(
+                        gray_arr, polygons
+                    )
+                    for core_polygon in core_polygons:
+                        core_polygon.setdefault('id', f"polygon_{polygon_id_counter}")
+                        core_polygon.setdefault('class', 'spheroid')
+                        polygons.append(core_polygon)
+                        polygon_id_counter += 1
+                    if core_polygons:
+                        logger.info(
+                            f"ASPP appended {len(core_polygons)} core polygon(s) "
+                            f"(areas={[round(c['area'], 1) for c in core_polygons]})"
+                        )
+                except Exception as core_exc:
+                    logger.error(f"Core polygon detection failed: {core_exc}")
+
             if len(polygons) == 0:
                 logger.warning(f"No valid polygons detected! Total contours: {total_contours}, filtered: {filtered_count}")
                 logger.warning(f"Binary mask stats - shape: {binary_mask.shape}, unique values: {np.unique(binary_mask)}")

--- a/backend/segmentation/services/inference.py
+++ b/backend/segmentation/services/inference.py
@@ -58,7 +58,7 @@ class InferenceService:
         
         try:
             # Load and preprocess image
-            image, original_size = self._load_and_preprocess_image(image_data)
+            image, original_size, original_gray = self._load_and_preprocess_image(image_data)
             preprocessing_time = time.time() - start_time
             
             logger.info(f"Image preprocessed in {preprocessing_time:.3f}s, "
@@ -87,6 +87,16 @@ class InferenceService:
             
             polygons = self.postprocessing.mask_to_polygons(mask, threshold, detect_holes)
             polygons = self.postprocessing.optimize_polygons(polygons)
+
+            # ASPP-only: locate dense central 'core' inside the largest polygon
+            # and append it tagged for green rendering in the editor.
+            if model_name == 'unet_attention_aspp':
+                core_polygon = self.postprocessing.detect_core_polygon(
+                    original_gray, polygons
+                )
+                if core_polygon is not None:
+                    polygons.append(core_polygon)
+                    logger.info("ASPP core polygon appended (area=%.1f)", core_polygon["area"])
             
             postprocess_time = time.time() - postprocess_start
             
@@ -115,33 +125,41 @@ class InferenceService:
             raise RuntimeError(f"Segmentation failed: {str(e)}")
     
     def _load_and_preprocess_image(self, image_data: bytes) -> tuple:
-        """Load and preprocess image for model input"""
+        """Load and preprocess image for model input.
+
+        Returns ``(image_tensor, original_size, original_gray)`` where
+        ``original_gray`` is a uint8 grayscale ndarray at original_size,
+        used by ASPP core detection to share the polygon coordinate system.
+        """
         try:
             # Load image from bytes
             image = Image.open(io.BytesIO(image_data)).convert('RGB')
             original_size = image.size  # (width, height)
-            
+
             # Convert to numpy array
             image_np = np.array(image)
-            
+
+            # Grayscale at original_size for downstream intensity analysis
+            original_gray = cv2.cvtColor(image_np, cv2.COLOR_RGB2GRAY)
+
             # Resize to target size
             image_resized = cv2.resize(image_np, self.target_size)
-            
+
             # Convert to tensor and normalize
             image_tensor = torch.from_numpy(image_resized).permute(2, 0, 1).float() / 255.0
-            
+
             # Apply ImageNet normalization
             image_tensor = self.normalize(image_tensor)
-            
+
             # Add batch dimension
             image_tensor = image_tensor.unsqueeze(0)
-            
+
             # Move to device
             device = self.model_manager.device
             image_tensor = image_tensor.to(device)
-            
-            return image_tensor, original_size
-            
+
+            return image_tensor, original_size, original_gray
+
         except Exception as e:
             logger.error(f"Failed to preprocess image: {e}")
             raise ValueError(f"Invalid image data: {str(e)}")

--- a/backend/segmentation/services/postprocessing.py
+++ b/backend/segmentation/services/postprocessing.py
@@ -162,19 +162,19 @@ class PostprocessingService:
 
     def detect_core_polygons(self, gray_image: np.ndarray,
                              polygons: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Detect dense core fragment(s) **inside the largest** ASPP spheroid.
+        """Detect a dense core polygon inside the **largest** ASPP spheroid.
 
         Picks a single parent — the largest external polygon that is not already
         a core and exceeds :attr:`CORE_MIN_PARENT_AREA`. Inside that parent:
 
           * If the 2-of-3 compactness gate fires, returns one core covering the
             whole parent (= compact, pre-invasion spheroid).
-          * Otherwise, after Otsu thresholding, returns **all** connected
-            components above :attr:`CORE_FRAGMENT_MIN_AREA` as separate cores
-            (= rozprsknutý spheroid fractured into multiple dense islands).
+          * Otherwise, after Otsu thresholding, returns the single largest
+            connected component below the threshold as the core.
 
-        Every returned core carries ``parent_id`` linking it to the same parent
-        so downstream code can sum their areas and compute DI consistently.
+        Returns a list of 0 or 1 polygons (kept plural for backward-compatible
+        plumbing; earlier multi-fragment versions emitted multiple). The core
+        carries ``parent_id`` linking it to the chosen parent.
         """
         try:
             if not polygons or gray_image is None or gray_image.size == 0:
@@ -207,8 +207,14 @@ class PostprocessingService:
                 return []
 
             return self._detect_cores_inside_parent(gray_image, largest, h, w)
-        except Exception as e:
-            logger.error(f"Failed to detect core polygons: {e}")
+        except (cv2.error, ValueError) as e:
+            # Narrow catch: only suppress geometric/numerical failures of the
+            # detection pipeline. Programming errors (KeyError, TypeError,
+            # AttributeError, ImportError) propagate so they surface in logs
+            # / Sentry instead of being indistinguishable from a no-core image.
+            logger.error(
+                "Failed to detect core polygons (non-fatal): %s", e, exc_info=True
+            )
             return []
 
     def _detect_cores_inside_parent(self, gray_image: np.ndarray,

--- a/backend/segmentation/services/postprocessing.py
+++ b/backend/segmentation/services/postprocessing.py
@@ -3,8 +3,9 @@
 import logging
 import cv2
 import numpy as np
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Optional, Tuple
 from skimage import measure
+from skimage.filters import threshold_otsu
 from scipy import ndimage
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,16 @@ logger = logging.getLogger(__name__)
 class PostprocessingService:
     """Service for postprocessing segmentation masks"""
     
+    # Compact-spheroid voting thresholds (2-of-3 must fire to treat the whole
+    # ASPP polygon as the core, e.g. for compact t=0 spheroids before invasion).
+    # Calibrated on user 12bprusek's time_0h vs time_48h projects (Apr 2026).
+    COMPACT_MEAN_DIFF_MAX = 45.0   # max Otsu inter-class intensity gap
+    COMPACT_CORE_FRAC_MIN = 0.75   # min fraction of mask below Otsu threshold
+    COMPACT_SOLIDITY_MIN = 0.85    # min mask area / convex hull area
+    # Minimum parent-spheroid area (in px²) to attempt core detection. Smaller
+    # external polygons are noise/debris and don't deserve a core.
+    CORE_MIN_PARENT_AREA = 1000.0
+
     def __init__(self):
         self.min_area = 50  # Minimum polygon area in pixels - lowered for better small cell detection
         self.simplification_tolerance = 0.1  # Douglas-Peucker tolerance - reduced for higher precision
@@ -137,7 +148,169 @@ class PostprocessingService:
             logger.error(f"Failed to convert region to polygon: {e}")
             return None
     
-    def filter_polygons(self, polygons: List[Dict[str, Any]], 
+    def detect_core_polygon(self, gray_image: np.ndarray,
+                            polygons: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Backward-compatible single-core entry point.
+
+        Returns the largest core fragment from :meth:`detect_core_polygons`
+        (or ``None`` if there are no fragments).
+        """
+        cores = self.detect_core_polygons(gray_image, polygons)
+        if not cores:
+            return None
+        return max(cores, key=lambda c: float(c.get("area", 0.0)))
+
+    def detect_core_polygons(self, gray_image: np.ndarray,
+                             polygons: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Detect dense core fragment(s) **inside the largest** ASPP spheroid.
+
+        Picks a single parent — the largest external polygon that is not already
+        a core and exceeds :attr:`CORE_MIN_PARENT_AREA`. Inside that parent:
+
+          * If the 2-of-3 compactness gate fires, returns one core covering the
+            whole parent (= compact, pre-invasion spheroid).
+          * Otherwise, after Otsu thresholding, returns **all** connected
+            components above :attr:`CORE_FRAGMENT_MIN_AREA` as separate cores
+            (= rozprsknutý spheroid fractured into multiple dense islands).
+
+        Every returned core carries ``parent_id`` linking it to the same parent
+        so downstream code can sum their areas and compute DI consistently.
+        """
+        try:
+            if not polygons or gray_image is None or gray_image.size == 0:
+                return []
+            h, w = gray_image.shape[:2]
+
+            candidates: List[Dict[str, Any]] = []
+            for p in polygons:
+                if p.get("type") != "external":
+                    continue
+                if p.get("partClass") == "core":
+                    continue
+                if p.get("parent_id"):
+                    continue
+                pts = p.get("points") or []
+                if len(pts) < 3:
+                    continue
+                area = p.get("area")
+                if area is None:
+                    area = float(cv2.contourArea(np.array(
+                        [[pt["x"], pt["y"]] for pt in pts], dtype=np.float32
+                    )))
+                    p["area"] = area
+                candidates.append(p)
+            if not candidates:
+                return []
+
+            largest = max(candidates, key=lambda p: float(p.get("area", 0.0)))
+            if float(largest.get("area", 0.0)) < self.CORE_MIN_PARENT_AREA:
+                return []
+
+            return self._detect_cores_inside_parent(gray_image, largest, h, w)
+        except Exception as e:
+            logger.error(f"Failed to detect core polygons: {e}")
+            return []
+
+    def _detect_cores_inside_parent(self, gray_image: np.ndarray,
+                                    parent: Dict[str, Any],
+                                    h: int, w: int) -> List[Dict[str, Any]]:
+        """Compactness gate + multi-fragment extraction inside one parent."""
+        points = parent.get("points") or []
+        poly_pts = np.array(
+            [[int(round(p["x"])), int(round(p["y"]))] for p in points],
+            dtype=np.int32,
+        )
+        mask = np.zeros((h, w), dtype=np.uint8)
+        cv2.fillPoly(mask, [poly_pts], 1)
+        if mask.sum() == 0:
+            return []
+
+        inside = gray_image[mask > 0]
+        if inside.size == 0:
+            return []
+
+        poly_area = float(cv2.contourArea(poly_pts))
+        hull_area = float(cv2.contourArea(cv2.convexHull(poly_pts)))
+        solidity = poly_area / (hull_area + 1e-6)
+        confidence = float(np.clip(1.0 - inside.mean() / 255.0, 0.0, 1.0))
+        parent_id = parent.get("id")
+
+        def _attach_parent(core: Dict[str, Any]) -> Dict[str, Any]:
+            if parent_id:
+                core["parent_id"] = parent_id
+            return core
+
+        # Degenerate intensity: trivially compact, single core = whole mask.
+        if inside.min() == inside.max():
+            return [_attach_parent(self._compact_core_polygon(points, mask, confidence))]
+
+        thr = float(threshold_otsu(inside))
+        below = inside[inside <= thr]
+        above = inside[inside > thr]
+        if below.size == 0 or above.size == 0:
+            return [_attach_parent(self._compact_core_polygon(points, mask, confidence))]
+
+        mean_diff = float(above.mean() - below.mean())
+        core_raw = (gray_image <= thr) & (mask > 0)
+        core_frac = float(core_raw.sum()) / float(mask.sum())
+        votes = (
+            int(mean_diff < self.COMPACT_MEAN_DIFF_MAX)
+            + int(core_frac > self.COMPACT_CORE_FRAC_MIN)
+            + int(solidity > self.COMPACT_SOLIDITY_MIN)
+        )
+        if votes >= 2:
+            logger.info(
+                "Core(%s): compact gate fired (md=%.1f cf=%.2f sol=%.2f votes=%d)",
+                parent_id, mean_diff, core_frac, solidity, votes,
+            )
+            return [_attach_parent(self._compact_core_polygon(points, mask, confidence))]
+
+        # Bimodal: take the LARGEST connected component below Otsu threshold.
+        # (Earlier versions emitted every CC above a min-area threshold, but
+        # one-core-per-spheroid keeps the report and the DI semantics simpler.)
+        labeled = measure.label(core_raw.astype(np.uint8), connectivity=2)
+        regions = measure.regionprops(labeled)
+        if not regions:
+            return []
+        best = max(regions, key=lambda r: r.area)
+        component = (labeled == best.label).astype(np.uint8)
+        contours, _ = cv2.findContours(
+            component, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+        if not contours:
+            return []
+        contour = max(contours, key=cv2.contourArea)
+        if len(contour) < 3:
+            return []
+        core_points = [
+            {"x": float(pt[0][0]), "y": float(pt[0][1])} for pt in contour
+        ]
+        logger.info(
+            "Core(%s): bimodal Otsu (md=%.1f cf=%.2f sol=%.2f area=%d)",
+            parent_id, mean_diff, core_frac, solidity, int(best.area),
+        )
+        return [_attach_parent({
+            "points": core_points,
+            "area": float(best.area),
+            "confidence": confidence,
+            "type": "external",
+            "partClass": "core",
+        })]
+
+    @staticmethod
+    def _compact_core_polygon(points: List[Dict[str, float]],
+                              mask: np.ndarray,
+                              confidence: float) -> Dict[str, Any]:
+        """Return the input polygon as the core (compact spheroid case)."""
+        return {
+            "points": [{"x": float(p["x"]), "y": float(p["y"])} for p in points],
+            "area": float(int(mask.sum())),
+            "confidence": confidence,
+            "type": "external",
+            "partClass": "core",
+        }
+
+    def filter_polygons(self, polygons: List[Dict[str, Any]],
                        min_area: int = None, min_confidence: float = None) -> List[Dict[str, Any]]:
         """Filter polygons based on area and confidence"""
         filtered = []

--- a/backend/segmentation/tests/unit/test_disintegration.py
+++ b/backend/segmentation/tests/unit/test_disintegration.py
@@ -1,0 +1,171 @@
+"""Unit tests for the /api/disintegration-index endpoint."""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from api.metrics_endpoint import router as metrics_router  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(metrics_router)
+    return TestClient(app)
+
+
+def _circle(cx: float, cy: float, r: float, n: int = 96) -> list:
+    """Return n vertices approximating a circle, as [[x,y], ...]."""
+    thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    return [[float(cx + r * np.cos(t)), float(cy + r * np.sin(t))] for t in thetas]
+
+
+def _ring_with_arms(cx: float, cy: float, r_core: float,
+                    arm_length: float, arm_count: int = 8) -> list:
+    """Return a star-like polygon: small core + radiating arms.
+
+    Used to simulate a disintegrated spheroid with a tight core and outward
+    invasion projections.
+    """
+    pts = []
+    for k in range(arm_count):
+        theta = 2 * np.pi * k / arm_count
+        # Outer tip of arm
+        pts.append([float(cx + arm_length * np.cos(theta)),
+                    float(cy + arm_length * np.sin(theta))])
+        # Inner notch
+        notch = theta + np.pi / arm_count
+        pts.append([float(cx + r_core * np.cos(notch)),
+                    float(cy + r_core * np.sin(notch))])
+    return pts
+
+
+@pytest.mark.unit
+class TestDisintegrationIndex:
+    """Tests for POST /api/disintegration-index."""
+
+    H, W = 256, 256
+    CX, CY = 128.0, 128.0
+
+    def _post(self, client, body):
+        resp = client.post("/api/disintegration-index", json=body)
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_perfect_disk_returns_low_di(self, client):
+        """Mask = perfect disk, no core → R_eff path → DI is small."""
+        pts = _circle(self.CX, self.CY, 60)
+        body = {
+            "mask_polygon": pts,
+            "core_polygon": None,
+            "image_width": self.W,
+            "image_height": self.H,
+        }
+        out = self._post(client, body)
+        assert out["reference"] == "r_eff"
+        # A discretised disk has tiny rasterisation noise; DI should be near zero.
+        assert out["di"] < 0.05
+        assert out["w1"] >= 0.0
+        assert out["n_pixels"] > 1000
+
+    def test_disk_with_matching_core_returns_low_di(self, client):
+        """Mask polygon == core polygon → R_core ≈ R_eff → DI is small."""
+        pts = _circle(self.CX, self.CY, 60)
+        body = {
+            "mask_polygon": pts,
+            "core_polygon": pts,
+            "image_width": self.W,
+            "image_height": self.H,
+        }
+        out = self._post(client, body)
+        assert out["reference"] == "core"
+        assert out["di"] < 0.05
+
+    def test_smaller_core_increases_di(self, client):
+        """Core ⊊ Mask → R_core < R_eff → d̃ stretched → DI larger."""
+        mask_pts = _circle(self.CX, self.CY, 80)
+        core_pts = _circle(self.CX, self.CY, 30)
+        with_core = self._post(client, {
+            "mask_polygon": mask_pts,
+            "core_polygon": core_pts,
+            "image_width": self.W, "image_height": self.H,
+        })
+        without_core = self._post(client, {
+            "mask_polygon": mask_pts,
+            "core_polygon": None,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert with_core["di"] > without_core["di"] + 0.10
+
+    def test_invasion_pattern_returns_high_di(self, client):
+        """Star-shape mask with a tight core → significant DI > 0."""
+        mask_pts = _ring_with_arms(self.CX, self.CY, r_core=20,
+                                   arm_length=80, arm_count=10)
+        core_pts = _circle(self.CX, self.CY, 18)
+        out = self._post(client, {
+            "mask_polygon": mask_pts,
+            "core_polygon": core_pts,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "core"
+        # Heavy invasion → DI well above 0.1.
+        assert out["di"] > 0.15
+
+    def test_falls_back_when_core_degenerate(self, client):
+        """Core polygon with <3 points → r_eff_fallback label."""
+        mask_pts = _circle(self.CX, self.CY, 60)
+        out = self._post(client, {
+            "mask_polygon": mask_pts,
+            "core_polygon": [[10.0, 10.0], [11.0, 11.0]],  # only 2 vertices
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "r_eff_fallback"
+
+    def test_returns_zero_for_empty_polygon(self, client):
+        """Mask polygon with <3 vertices → DI = 0, reference='none'."""
+        out = self._post(client, {
+            "mask_polygon": [[0.0, 0.0], [1.0, 1.0]],
+            "core_polygon": None,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "none"
+        assert out["di"] == 0.0
+        assert out["n_pixels"] == 0
+
+    def test_returns_zero_for_polygon_outside_canvas(self, client):
+        """Polygon entirely outside the image bounds → no pixels → DI = 0."""
+        out = self._post(client, {
+            "mask_polygon": _circle(-100, -100, 30),
+            "core_polygon": None,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "none"
+        assert out["n_pixels"] == 0
+
+    def test_di_in_zero_one_range(self, client):
+        """DI must always lie in [0, 1) due to tanh saturation."""
+        mask_pts = _ring_with_arms(self.CX, self.CY, r_core=10,
+                                   arm_length=120, arm_count=6)
+        core_pts = _circle(self.CX, self.CY, 6)
+        out = self._post(client, {
+            "mask_polygon": mask_pts,
+            "core_polygon": core_pts,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert 0.0 <= out["di"] < 1.0
+
+    def test_invalid_image_dims_returns_400(self, client):
+        body = {
+            "mask_polygon": _circle(self.CX, self.CY, 60),
+            "core_polygon": None,
+            "image_width": 0,
+            "image_height": self.H,
+        }
+        resp = client.post("/api/disintegration-index", json=body)
+        assert resp.status_code == 400

--- a/backend/segmentation/tests/unit/test_disintegration.py
+++ b/backend/segmentation/tests/unit/test_disintegration.py
@@ -169,3 +169,59 @@ class TestDisintegrationIndex:
         }
         resp = client.post("/api/disintegration-index", json=body)
         assert resp.status_code == 400
+
+    # ---- plural mask_polygons / core_polygons (production-shape) ----
+
+    def test_plural_mask_polygons_unions_multiple_polygons(self, client):
+        """`mask_polygons` (plural) must union every polygon into one mask.
+
+        This is the shape the TypeScript caller actually sends in production —
+        every external non-core polygon as a separate entry.
+        """
+        # Two disjoint disks → combined pixel count ≈ 2× a single disk.
+        single = self._post(client, {
+            "mask_polygon": _circle(80, 80, 30),
+            "core_polygon": None,
+            "image_width": self.W, "image_height": self.H,
+        })
+        union = self._post(client, {
+            "mask_polygons": [_circle(80, 80, 30), _circle(180, 180, 30)],
+            "core_polygons": None,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert union["n_pixels"] >= int(1.9 * single["n_pixels"])
+        assert union["n_pixels"] <= int(2.1 * single["n_pixels"])
+
+    def test_plural_with_overlapping_polygons_does_not_double_count(self, client):
+        """Two identical polygons in `mask_polygons` produce the same
+        `n_pixels` as one — fillPoly union is idempotent.
+        """
+        circle = _circle(self.CX, self.CY, 50)
+        once = self._post(client, {
+            "mask_polygons": [circle],
+            "image_width": self.W, "image_height": self.H,
+        })
+        twice = self._post(client, {
+            "mask_polygons": [circle, circle],
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert once["n_pixels"] == twice["n_pixels"]
+
+    def test_plural_core_polygons_combined_for_r_ref(self, client):
+        """Multiple core polygons should be unioned into the R_core area."""
+        mask = _circle(self.CX, self.CY, 90)
+        core_a = _circle(self.CX - 20, self.CY, 15)
+        core_b = _circle(self.CX + 20, self.CY, 15)
+        out = self._post(client, {
+            "mask_polygons": [mask],
+            "core_polygons": [core_a, core_b],
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "core"
+
+    def test_neither_singular_nor_plural_mask_returns_400(self, client):
+        """Empty request body for masks → 400, not silent zeros."""
+        resp = client.post("/api/disintegration-index", json={
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert resp.status_code == 400

--- a/backend/segmentation/tests/unit/test_postprocessing_service.py
+++ b/backend/segmentation/tests/unit/test_postprocessing_service.py
@@ -529,3 +529,196 @@ class TestPolygonsToCOCOFormat:
         result = service.polygons_to_coco_format([], self.IMAGE_SIZE)
 
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# detect_core_polygon  (ASPP spheroid core)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestDetectCorePolygon:
+    """Tests for PostprocessingService.detect_core_polygon."""
+
+    H, W = 256, 256
+    CY, CX = 128, 128
+    R_OUTER = 80   # full spheroid radius
+    R_CORE = 35    # dense centre radius
+
+    def _disk_with_core_image(self) -> np.ndarray:
+        """Bright field analogue: bright background, light corona, dark core."""
+        img = np.full((self.H, self.W), 230, dtype=np.uint8)
+        y, x = np.ogrid[:self.H, :self.W]
+        d2 = (y - self.CY) ** 2 + (x - self.CX) ** 2
+        img[d2 <= self.R_OUTER ** 2] = 160  # corona (mid-grey)
+        img[d2 <= self.R_CORE ** 2] = 40    # core (dark)
+        return img
+
+    def _outer_polygon(self) -> dict:
+        """Square polygon enclosing the entire spheroid (drives 'largest' pick)."""
+        x0, y0 = self.CX - self.R_OUTER, self.CY - self.R_OUTER
+        x1, y1 = self.CX + self.R_OUTER, self.CY + self.R_OUTER
+        return {
+            "points": [
+                {"x": float(x0), "y": float(y0)},
+                {"x": float(x1), "y": float(y0)},
+                {"x": float(x1), "y": float(y1)},
+                {"x": float(x0), "y": float(y1)},
+            ],
+            "area": float((2 * self.R_OUTER) ** 2),
+            "confidence": 0.9,
+            "type": "external",
+        }
+
+    def test_core_detected_with_partclass(self, service):
+        """Synthetic disk+core image yields a polygon tagged partClass='core'."""
+        img = self._disk_with_core_image()
+        polys = [self._outer_polygon()]
+
+        core = service.detect_core_polygon(img, polys)
+
+        assert core is not None
+        assert core["partClass"] == "core"
+        assert core["type"] == "external"
+        assert _is_valid_polygon_dict(core)
+        assert len(core["points"]) >= 3
+
+    def test_core_area_smaller_than_outer(self, service):
+        """Core area must lie strictly inside the outer polygon's area."""
+        img = self._disk_with_core_image()
+        outer = self._outer_polygon()
+
+        core = service.detect_core_polygon(img, [outer])
+
+        assert core is not None
+        assert 0 < core["area"] < outer["area"]
+        # Roughly the area of the inner disk (allow ±35% for rasterization)
+        expected = np.pi * self.R_CORE ** 2
+        assert abs(core["area"] - expected) / expected < 0.35
+
+    def test_picks_largest_polygon(self, service):
+        """Among multiple polygons, core must be sourced from the largest one."""
+        img = self._disk_with_core_image()
+        outer = self._outer_polygon()
+        # A small distractor polygon located in a uniform-bright corner
+        small = {
+            "points": [
+                {"x": 5.0, "y": 5.0},
+                {"x": 15.0, "y": 5.0},
+                {"x": 15.0, "y": 15.0},
+                {"x": 5.0, "y": 15.0},
+            ],
+            "area": 100.0,
+            "confidence": 0.5,
+            "type": "external",
+        }
+
+        core = service.detect_core_polygon(img, [small, outer])
+
+        assert core is not None
+        # Core centroid should fall near the disk centre, not the corner distractor
+        xs = [p["x"] for p in core["points"]]
+        ys = [p["y"] for p in core["points"]]
+        cx_est = sum(xs) / len(xs)
+        cy_est = sum(ys) / len(ys)
+        assert abs(cx_est - self.CX) < 20
+        assert abs(cy_est - self.CY) < 20
+
+    def test_uniform_intensity_falls_back_to_full_polygon(self, service):
+        """Uniform intensity → Otsu undefined → return full polygon as 'core'.
+
+        Honours the user's 'always add some core' requirement.
+        """
+        img = np.full((self.H, self.W), 100, dtype=np.uint8)
+        outer = self._outer_polygon()
+
+        core = service.detect_core_polygon(img, [outer])
+
+        assert core is not None
+        assert core["partClass"] == "core"
+        # Fallback covers the whole polygon, so area should match the outer
+        # polygon's filled mask area within rasterization tolerance.
+        assert core["area"] > 0
+
+    def test_empty_polygons_returns_none(self, service):
+        """No input polygons → no core."""
+        img = self._disk_with_core_image()
+        assert service.detect_core_polygon(img, []) is None
+
+    def test_invalid_image_returns_none(self, service):
+        """Empty / None image → no core, no exception."""
+        outer = self._outer_polygon()
+        assert service.detect_core_polygon(None, [outer]) is None
+        assert service.detect_core_polygon(np.array([]), [outer]) is None
+
+    def test_polygon_with_too_few_points_returns_none(self, service):
+        """Polygon with <3 points cannot define a region → None."""
+        img = self._disk_with_core_image()
+        bad = {
+            "points": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 1.0}],
+            "area": 1.0,
+            "confidence": 0.5,
+            "type": "external",
+        }
+        assert service.detect_core_polygon(img, [bad]) is None
+
+    # -- 2-of-3 voting (compact gate) ---------------------------------------
+
+    def _circular_polygon(self, cx, cy, r, n=64) -> dict:
+        """Approximate a circle with n vertices (high solidity)."""
+        thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
+        pts = [{"x": float(cx + r * np.cos(t)), "y": float(cy + r * np.sin(t))}
+               for t in thetas]
+        return {
+            "points": pts,
+            "area": float(np.pi * r ** 2),
+            "confidence": 0.9,
+            "type": "external",
+        }
+
+    def test_compact_spheroid_returns_whole_polygon(self, service):
+        """Round mask with mild interior gradient → 2-of-3 votes → whole polygon."""
+        # Bright background, single dark disk (no corona) → uniform-ish inside.
+        img = np.full((self.H, self.W), 230, dtype=np.uint8)
+        y, x = np.ogrid[:self.H, :self.W]
+        d2 = (y - self.CY) ** 2 + (x - self.CX) ** 2
+        img[d2 <= self.R_OUTER ** 2] = 60   # uniform dark spheroid
+        # Add a tiny gradient so Otsu has something to split (still low mean_diff).
+        img[d2 <= (self.R_OUTER - 10) ** 2] = 50
+        # Use a circular polygon → solidity ~1.0
+        poly = self._circular_polygon(self.CX, self.CY, self.R_OUTER)
+
+        core = service.detect_core_polygon(img, [poly])
+
+        assert core is not None
+        assert core["partClass"] == "core"
+        # Compact path returns the input polygon points verbatim.
+        assert len(core["points"]) == len(poly["points"])
+        # And the area covers the full mask area (within rasterization tolerance).
+        assert core["area"] > 0.9 * poly["area"]
+
+    def test_invasive_spheroid_returns_inner_subset(self, service):
+        """Disk+corona image with bbox polygon → bimodal path → smaller core."""
+        # The synthetic disk+corona has high mean_diff (~140) and low core_frac
+        # (~0.15), and the bbox polygon is convex (sol=1.0). Only solidity votes
+        # → 1 vote → bimodal path returns inner disk.
+        img = self._disk_with_core_image()
+        outer = self._outer_polygon()
+
+        core = service.detect_core_polygon(img, [outer])
+
+        assert core is not None
+        assert core["area"] < outer["area"] * 0.5
+        # Centroid of the returned core should sit at the disk centre.
+        xs = [p["x"] for p in core["points"]]
+        ys = [p["y"] for p in core["points"]]
+        assert abs(sum(xs) / len(xs) - self.CX) < 20
+        assert abs(sum(ys) / len(ys) - self.CY) < 20
+
+    def test_compact_threshold_constants_present(self, service):
+        """Voting thresholds are class-level so tests can introspect them."""
+        assert hasattr(service, "COMPACT_MEAN_DIFF_MAX")
+        assert hasattr(service, "COMPACT_CORE_FRAC_MIN")
+        assert hasattr(service, "COMPACT_SOLIDITY_MIN")
+        assert 0 < service.COMPACT_MEAN_DIFF_MAX < 256
+        assert 0 < service.COMPACT_CORE_FRAC_MIN < 1
+        assert 0 < service.COMPACT_SOLIDITY_MIN < 1

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import fs from 'fs/promises';
 import archiver from 'archiver';
+import sharp from 'sharp';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../utils/logger';
@@ -9,6 +10,7 @@ import { VisualizationGenerator } from './visualization/visualizationGenerator';
 import {
   MetricsCalculator,
   type ImageWithSegmentation as MetricsImageInput,
+  type ImageMetrics,
 } from './metrics/metricsCalculator';
 import {
   FormatConverter,
@@ -470,7 +472,8 @@ export class ExportService {
         );
       }
 
-      // Generate metrics (can run in parallel)
+      // Generate metrics (can run in parallel). Project.type drives the
+      // metric format dispatch (spheroid vs spheroid_invasive vs sperm vs wound).
       if (options.metricsFormats?.length && project.images) {
         exportTasks.push(
           this.generateMetrics(
@@ -478,6 +481,7 @@ export class ExportService {
             exportDir,
             options.metricsFormats,
             project.title,
+            (project as { type?: string }).type || 'spheroid',
             options,
             jobId
           ).then(() => {
@@ -905,7 +909,7 @@ export class ExportService {
           images,
           YOLO_WRITE_CONCURRENCY,
           async image => {
-            if (!image || !image.segmentation) return;
+            if (!image || !image.segmentation) {return;}
 
             // YOLO normalizes every coordinate by width/height → 0 would
             // produce NaN/Infinity in the output file. Resolve dimensions
@@ -914,7 +918,7 @@ export class ExportService {
             let parsedPolygons: ExportPolygon[] = [];
             try {
               const parsed = JSON.parse(image.segmentation.polygons);
-              if (Array.isArray(parsed)) parsedPolygons = parsed;
+              if (Array.isArray(parsed)) {parsedPolygons = parsed;}
             } catch {
               // convertToYOLO will re-parse and report the error with context
             }
@@ -996,6 +1000,7 @@ export class ExportService {
     exportDir: string,
     formats: string[],
     _projectName: string,
+    projectType: string,
     options?: ExportOptions,
     jobId?: string
   ): Promise<void> {
@@ -1005,27 +1010,80 @@ export class ExportService {
     }
 
     const metricsDir = path.join(exportDir, 'metrics');
+
+    // Backfill missing image dimensions from disk before metrics calculation.
+    // Older uploads were written without populating width/height in DB; the
+    // DI metric needs real dimensions to rasterise the polygon. We read
+    // metadata via sharp and persist back to the DB so subsequent exports
+    // and any UI surface get the correct values.
+    const uploadDir = process.env.UPLOAD_DIR || '/app/uploads';
+    const dimsCache = new Map<string, { width: number; height: number }>();
+    for (const image of images) {
+      if ((image.width && image.height) || !image.originalPath) continue;
+      try {
+        const filePath = path.join(uploadDir, image.originalPath);
+        const meta = await sharp(filePath).metadata();
+        if (meta.width && meta.height) {
+          dimsCache.set(image.id, { width: meta.width, height: meta.height });
+          await prisma.image.update({
+            where: { id: image.id },
+            data: { width: meta.width, height: meta.height },
+          });
+          logger.info(
+            `Backfilled dims for image ${image.id}: ${meta.width}x${meta.height}`,
+            'ExportService',
+            { jobId, imageId: image.id }
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          `Failed to read dimensions for ${image.id} from disk: ${err instanceof Error ? err.message : String(err)}`,
+          'ExportService',
+          { jobId, imageId: image.id }
+        );
+      }
+    }
+
     // Convert images to the format expected by metrics calculator
-    const metricsImages: MetricsImageInput[] = images.map(image => ({
-      id: image.id,
-      name: image.name,
-      width: image.width || undefined,
-      height: image.height || undefined,
-      segmentation: image.segmentation
-        ? {
-            polygons: image.segmentation.polygons,
-            model: image.segmentation.model,
-            threshold: image.segmentation.threshold,
-            confidence: image.segmentation.confidence || undefined,
-            processingTime: image.segmentation.processingTime || undefined,
-          }
-        : undefined,
-    }));
+    const metricsImages: MetricsImageInput[] = images.map(image => {
+      const cached = dimsCache.get(image.id);
+      return {
+        id: image.id,
+        name: image.name,
+        width: image.width || cached?.width || undefined,
+        height: image.height || cached?.height || undefined,
+        segmentation: image.segmentation
+          ? {
+              polygons: image.segmentation.polygons,
+              model: image.segmentation.model,
+              threshold: image.segmentation.threshold,
+              confidence: image.segmentation.confidence || undefined,
+              processingTime: image.segmentation.processingTime || undefined,
+            }
+          : undefined,
+      };
+    });
 
     const allMetrics = await this.metricsCalculator.calculateAllMetrics(
       metricsImages,
       options?.pixelToMicrometerScale
     );
+
+    // Per-image metrics (Disintegration Index). Failures here must not break
+    // the rest of the export — DI is purely additive.
+    let imageMetrics: ImageMetrics[] = [];
+    try {
+      imageMetrics = await this.metricsCalculator.calculateAllImageMetrics(
+        metricsImages,
+        options?.pixelToMicrometerScale
+      );
+    } catch (err) {
+      logger.warn(
+        `Image-level metrics (DI) failed; continuing without them: ${err instanceof Error ? err.message : String(err)}`,
+        'ExportService',
+        { jobId }
+      );
+    }
 
     // Check if job was cancelled after metrics calculation
     if (jobId && this.isJobCancelled(jobId)) {
@@ -1040,19 +1098,41 @@ export class ExportService {
 
       if (format === 'excel') {
         const excelPath = path.join(metricsDir, 'metrics.xlsx');
-        // Try sperm-specific export first (writes to same path); falls back to standard polygon metrics if no polyline data found
-        const exportedSperm = await this.metricsCalculator.exportSpermToExcel(
-          metricsImages,
-          excelPath,
-          options?.pixelToMicrometerScale
-        );
-        if (!exportedSperm) {
-          logger.info(
-            `No sperm polyline data found — falling back to standard polygon metrics export`,
-            'ExportService',
-            { jobId, imageCount: metricsImages.length }
+        // Project type drives which Excel layout we emit. Auto-detection
+        // (sperm polylines / wound model) is kept as a fallback for legacy
+        // projects that pre-date the explicit type field.
+        if (projectType === 'sperm') {
+          const exportedSperm = await this.metricsCalculator.exportSpermToExcel(
+            metricsImages,
+            excelPath,
+            options?.pixelToMicrometerScale
           );
+          if (!exportedSperm) {
+            logger.warn(
+              `Project flagged as sperm but no polyline data — falling back to polygon metrics`,
+              'ExportService',
+              { jobId }
+            );
+            await this.metricsCalculator.exportToExcel(
+              allMetrics,
+              excelPath,
+              options?.pixelToMicrometerScale,
+              imageMetrics
+            );
+          }
+        } else if (projectType === 'spheroid_invasive') {
+          // Disintegrated-spheroid analysis: simplified 4-metric report
+          // (Total Spheroid Area, Core Area, Invasion Area, DI).
           await this.metricsCalculator.exportToExcel(
+            allMetrics,
+            excelPath,
+            options?.pixelToMicrometerScale,
+            imageMetrics
+          );
+        } else {
+          // 'spheroid' (standard) and 'wound': emit the comprehensive
+          // per-polygon metrics report (Polygon Metrics + Summary sheets).
+          await this.metricsCalculator.exportPolygonMetricsToExcel(
             allMetrics,
             excelPath,
             options?.pixelToMicrometerScale
@@ -1342,6 +1422,194 @@ ${scaleInfo}
 - **Edge case handling**: Robust for degenerate and complex polygons
 - **Performance monitoring**: Automatic warnings for large datasets
 - **Error recovery**: Fallback calculations when advanced algorithms fail
+
+---
+
+# Per-Image Metrics: Disintegration Analysis
+
+The Excel export reports **one row per image** with four metrics:
+**Total Spheroid Area**, **Core Area**, **Invasion Area** (all in ${areaUnit})
+and **Disintegration Index** (dimensionless). The metrics target spheroid
+disintegration analysis (Lim, Kang, Lee 2020 — Sci. Rep. PMC6971071) but
+apply equally to compact (t=0) and rozprsknuté (t>0) spheroids.
+
+## Pipeline Overview
+
+\`\`\`
+ASPP segmentation  →  polygons[]  →  core detection (Otsu + 2-of-3 voting)
+                                       ↓
+                              partClass="core" polygon attached
+                                       ↓
+       ┌──────────────┬─────────────────┬──────────────────┐
+       ↓              ↓                 ↓                  ↓
+ Total Spheroid    Core Area     Invasion Area    Disintegration
+   Area (Σ ext.    (largest       (Total − Core,    Index = tanh(W₁)
+   non-core)        core CC)       clamped ≥ 0)     where W₁ compares
+                                                    the empirical CDF of
+                                                    distances of every
+                                                    mask pixel against
+                                                    every core pixel,
+                                                    normalised by R_core
+\`\`\`
+
+## Core Detection (ASPP-only)
+
+Performed in the Python ML service inside \`PostprocessingService.detect_core_polygons\`
+(file \`backend/segmentation/services/postprocessing.py\`). Pipeline:
+
+1. **Pick parent**: the **largest** external polygon detected by ASPP (\`A_all\`)
+   that exceeds \`CORE_MIN_PARENT_AREA = 1000 px²\`. Smaller externals are
+   noise/debris and don't get a core.
+
+2. **Rasterise** the parent polygon into a binary mask matching the original
+   image dimensions (\`cv2.fillPoly\` on a uint8 zero canvas).
+
+3. **Local Otsu** on the grayscale intensities **inside the mask only**:
+   \`thr = threshold_otsu(gray[mask>0])\`. The histogram restriction is essential
+   — global Otsu sits between background and cells, which is the duality of
+   the segmentation itself and yields no information about core vs. corona.
+
+4. **2-of-3 compactness gate**. The spheroid is "compact" (= core covers the
+   whole parent) when **at least two** of these indicators agree:
+   - **mean_diff** < 45 grayscale levels: difference of \`mean(below_thr)\` and
+     \`mean(above_thr)\` inside the mask. Small ⇒ unimodal interior.
+   - **core_frac** > 0.75: fraction of mask pixels below Otsu. High ⇒ most of
+     the spheroid is dense.
+   - **solidity** > 0.85: \`area / convex_hull_area\` of the parent polygon.
+     High ⇒ round, no invasion projections.
+
+   Calibrated on user 12bprusek's *time_0h* (compact) vs *time_48h* (invasive)
+   projects, April 2026. Cohen's *d* = 3.18 on \`mean_diff\`. Class constants
+   are tunable in \`PostprocessingService\`.
+
+5. **Compact path** (votes ≥ 2): return the **whole parent polygon** as the
+   core. \`Core Area ≈ Total Spheroid Area\`.
+
+6. **Bimodal path** (votes < 2): build \`core_raw = (gray ≤ thr) & mask\`, label
+   connected components, return the **single largest CC** as the core polygon.
+   The contour is extracted via \`cv2.findContours(RETR_EXTERNAL, CHAIN_APPROX_SIMPLE)\`.
+
+7. The returned core polygon carries \`partClass="core"\` and \`parent_id\` linking
+   it to the parent spheroid.
+
+## Total Spheroid Area (${areaUnit})
+
+\`\`\`
+TotalSpheroidArea = Σ area(external polygon)   for partClass ≠ "core"
+\`\`\`
+
+- **Sum of geometric areas** of every external polygon **excluding** the core.
+  The core sits *inside* the parent spheroid; including it would double-count
+  the same physical pixels.
+- **Algorithm**: Shoelace (Gauss's area) formula on polygon vertices —
+  \`A = ½ |Σᵢ (xᵢ·yᵢ₊₁ − xᵢ₊₁·yᵢ)|\`. Vertices wrap (i+1 mod n).
+- **Unit conversion**: when a μm/px scale is configured at the project level,
+  \`A_μm² = A_px² × scale²\`. Otherwise pixel units are reported.
+- **Multi-spheroid images**: smaller spheroids (those without a detected core)
+  are still summed in. So \`TotalSpheroidArea\` represents *all cell-covered
+  area* in the image, not just the largest.
+
+## Core Area (${areaUnit})
+
+\`\`\`
+CoreArea = area(polygon with partClass="core")
+\`\`\`
+
+- Geometric area of the **single core polygon** (largest connected component
+  below Otsu threshold; or the whole parent in the compact case).
+- Same Shoelace formula and same scale conversion as Total Spheroid Area.
+- For a compact spheroid: \`CoreArea ≈ TotalSpheroidArea\` (whole parent = core).
+- For a fully invasive spheroid: \`CoreArea\` is the dense central agglomerate
+  while the rest of \`TotalSpheroidArea\` is the diffuse invasion zone.
+- **Reference**: Lim 2020 \`A_core\` (paper notation) corresponds directly.
+
+## Invasion Area (${areaUnit})
+
+\`\`\`
+InvasionArea = max(0, TotalSpheroidArea − CoreArea)
+\`\`\`
+
+- Cell-covered area **outside** the dense core. Direct numeric proxy for the
+  invasion zone size: how much of the cell mass has migrated beyond the dense
+  central agglomerate.
+- For a **compact** (t=0) spheroid: InvasionArea ≈ 0.
+- For a **strongly invasive** spheroid: InvasionArea ≈ 0.5–0.8 × TotalSpheroidArea.
+- Same Shoelace areas + same scale conversion. Clamped at zero to handle
+  edge cases where Core slightly exceeds Total due to numerical artefacts.
+- Corresponds to Lim 2020 \`(A_all − A_core)\` numerator of the invasion index B.
+
+## Disintegration Index (DI)
+
+The DI is a scalar in \`[0, 1)\` that quantifies *how much spheroid mass has
+escaped beyond a uniform-disk reference of equivalent core area*. Reported in
+the Excel column **Disintegration Index** (4 decimal places, dimensionless).
+
+Algorithm (implemented in
+\`backend/segmentation/api/metrics_endpoint.py\` — POST \`/api/disintegration-index\`):
+
+1. **Rasterise the union of every external polygon** (the whole ASPP segmentation
+   mask, excluding cores) into a single binary canvas via repeated
+   \`cv2.fillPoly\`. Collect the \`(x, y)\` of all \`N\` white pixels.
+
+2. **Centroid** \`(cx, cy) = (mean(xᵢ), mean(yᵢ))\`. Distances
+   \`dᵢ = √((xᵢ − cx)² + (yᵢ − cy)²)\`.
+
+3. **Reference radius**:
+   - If a core polygon is present, \`R_ref = √(N_core / π)\` where \`N_core\` is
+     the rasterised pixel count of the core.
+   - Otherwise fallback to \`R_eff = √(N / π)\`.
+
+4. **Reference distribution — empirical core CDF**. When a core polygon is
+   present, the reference is the **empirical** distribution of distances
+   \`d_core\` for every pixel inside the core (relative to the same mask
+   centroid). This means the reference reflects the **actual radial profile
+   of the dense core**, not an idealised disk. The fallback (no core) uses
+   the analytical equivalent-disk CDF \`F_ref(d̃) = d̃²\` for \`d̃ ∈ [0, 1]\`.
+
+5. **1-Wasserstein distance**:
+   - **Core path**: \`W₁_px = wasserstein_distance(d_mask, d_core)\` via
+     \`scipy.stats\`, computed exactly between the two empirical 1D
+     distributions. Scale-normalised: \`W₁ = W₁_px / R_core\`, where
+     \`R_core = √(N_core / π)\`.
+   - **r_eff fallback**: bin-free quantile formula
+     \`W₁ ≈ (1/N) · Σᵢ |d̃₍ᵢ₎ − √((i − 0.5) / N)|\` where d̃₍ᵢ₎ are sorted
+     normalised distances \`d_mask / R_eff\`.
+
+6. **Saturation**: \`DI = tanh(W₁)\`. Maps \`W₁ ∈ [0, ∞) → [0, 1)\`.
+
+**Properties**: dimensionless, scale-invariant (all distances normalised by
+\`R_ref\`), rotation-invariant, translation-invariant (centroid-relative).
+
+**Calibrated thresholds** (user 12bprusek, April 2026):
+- *time_0h* (compact): DI median ≈ 0.001
+- *time_48h* (rozprsknuté): DI median ≈ 0.48
+- 320× separation between groups
+
+## Edge Cases & Caveats
+
+- **No ASPP segmentation** (HRNet, CBAM-ResUNet, plain U-Net, sperm, wound):
+  no core polygon is generated. \`Core Area = 0\`, \`Total Spheroid Area\` still
+  reports the sum of all external polygons. Compatibility-safe for any model.
+- **Image with no polygons or no externals**: both metrics report \`0\`.
+- **Cropped spheroid touching image edge**: the centroid is biased, the
+  rasterised area is truncated. Detected via bbox of mask = canvas edge —
+  not auto-flagged in the export but visible by inspection.
+- **Multiple spheroids, only the largest gets a core**: smaller spheroids
+  contribute to \`Total Spheroid Area\` only. By design — paper Lim 2020
+  treats each spheroid as its own experimental unit.
+- **Hollow / necrotic core**: the central pixels may be lighter than the
+  surrounding ring, which inflates \`mean_diff\` and the algorithm may pick a
+  ring-shaped CC as the "core". Mathematically correct given the intensity
+  histogram, biologically ambiguous; manual inspection recommended for
+  spheroids known to have necrotic centres.
+
+## Source Files
+
+- **Core detection**: \`backend/segmentation/services/postprocessing.py\`
+- **DI computation**: \`backend/segmentation/api/metrics_endpoint.py\`
+- **Per-image area orchestration**: \`backend/src/services/metrics/metricsCalculator.ts\`
+  (\`calculateAllImageMetrics\`)
+- **Excel writer**: same file (\`exportToExcel\` — emits the two-column report)
 `;
   }
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1020,24 +1020,41 @@ export class ExportService {
     const dimsCache = new Map<string, { width: number; height: number }>();
     for (const image of images) {
       if ((image.width && image.height) || !image.originalPath) continue;
+
+      // Step 1: read dimensions from disk. Sharp failure means the file is
+      // missing/corrupt; warn and skip this image.
+      let meta: { width?: number; height?: number };
       try {
-        const filePath = path.join(uploadDir, image.originalPath);
-        const meta = await sharp(filePath).metadata();
-        if (meta.width && meta.height) {
-          dimsCache.set(image.id, { width: meta.width, height: meta.height });
-          await prisma.image.update({
-            where: { id: image.id },
-            data: { width: meta.width, height: meta.height },
-          });
-          logger.info(
-            `Backfilled dims for image ${image.id}: ${meta.width}x${meta.height}`,
-            'ExportService',
-            { jobId, imageId: image.id }
-          );
-        }
+        meta = await sharp(path.join(uploadDir, image.originalPath)).metadata();
       } catch (err) {
         logger.warn(
-          `Failed to read dimensions for ${image.id} from disk: ${err instanceof Error ? err.message : String(err)}`,
+          `Failed to READ dimensions for ${image.id} from disk: ${err instanceof Error ? err.message : String(err)}`,
+          'ExportService',
+          { jobId, imageId: image.id, path: image.originalPath }
+        );
+        continue;
+      }
+      if (!meta.width || !meta.height) continue;
+
+      // Cache wins over DB so metrics calc can proceed even if persistence fails.
+      dimsCache.set(image.id, { width: meta.width, height: meta.height });
+
+      // Step 2: persist back to the DB. Failure here is a real DB problem
+      // (connection lost, constraint violation) — log ERROR, not WARN.
+      try {
+        await prisma.image.update({
+          where: { id: image.id },
+          data: { width: meta.width, height: meta.height },
+        });
+        logger.info(
+          `Backfilled dims for image ${image.id}: ${meta.width}x${meta.height}`,
+          'ExportService',
+          { jobId, imageId: image.id }
+        );
+      } catch (err) {
+        logger.error(
+          `Failed to PERSIST backfilled dimensions for ${image.id}; metrics will use cached values`,
+          err instanceof Error ? err : new Error(String(err)),
           'ExportService',
           { jobId, imageId: image.id }
         );
@@ -1078,10 +1095,11 @@ export class ExportService {
         options?.pixelToMicrometerScale
       );
     } catch (err) {
-      logger.warn(
-        `Image-level metrics (DI) failed; continuing without them: ${err instanceof Error ? err.message : String(err)}`,
+      logger.error(
+        'Per-image DI metrics aggregation crashed; Excel will omit the DI columns',
+        err instanceof Error ? err : new Error(String(err)),
         'ExportService',
-        { jobId }
+        { jobId, imageCount: metricsImages.length }
       );
     }
 
@@ -1109,15 +1127,15 @@ export class ExportService {
           );
           if (!exportedSperm) {
             logger.warn(
-              `Project flagged as sperm but no polyline data — falling back to polygon metrics`,
+              `Project flagged as sperm but no polyline data — falling back to standard polygon metrics`,
               'ExportService',
               { jobId }
             );
-            await this.metricsCalculator.exportToExcel(
+            // Fall back to per-polygon metrics (NOT the DI-shaped report).
+            await this.metricsCalculator.exportPolygonMetricsToExcel(
               allMetrics,
               excelPath,
-              options?.pixelToMicrometerScale,
-              imageMetrics
+              options?.pixelToMicrometerScale
             );
           }
         } else if (projectType === 'spheroid_invasive') {
@@ -1427,7 +1445,11 @@ ${scaleInfo}
 
 # Per-Image Metrics: Disintegration Analysis
 
-The Excel export reports **one row per image** with four metrics:
+**Applies to projects with \`type='spheroid_invasive'\` only.** Standard
+\`spheroid\` and \`wound\` projects get the per-polygon metrics report
+described above; \`sperm\` projects get the head/midpiece/tail morphology
+sheet. This section documents the disintegrated-spheroid Excel layout,
+which is one row per image with the four numeric metrics
 **Total Spheroid Area**, **Core Area**, **Invasion Area** (all in ${areaUnit})
 and **Disintegration Index** (dimensionless). The metrics target spheroid
 disintegration analysis (Lim, Kang, Lee 2020 — Sci. Rep. PMC6971071) but
@@ -1609,7 +1631,8 @@ Algorithm (implemented in
 - **DI computation**: \`backend/segmentation/api/metrics_endpoint.py\`
 - **Per-image area orchestration**: \`backend/src/services/metrics/metricsCalculator.ts\`
   (\`calculateAllImageMetrics\`)
-- **Excel writer**: same file (\`exportToExcel\` — emits the two-column report)
+- **Excel writer**: same file (\`exportToExcel\` — emits Image Name, Image ID,
+  Total Spheroid Area, Core Area, Invasion Area, Disintegration Index)
 `;
   }
 

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -9,7 +9,10 @@ import { config } from '../../utils/config';
 import {
   /* SCALE_CONFIG, */ validateScale /* getScaleValidationMessage, getScaleWarningMessage */,
 } from './scaleConfig';
-import type { SpermPartClass } from '../../utils/polygonValidation';
+import type {
+  PolygonPartClass,
+  SpermPartClass,
+} from '../../utils/polygonValidation';
 import { polylineLength } from '../../utils/polygonGeometry';
 import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
 
@@ -38,6 +41,21 @@ export interface PolygonMetrics {
   sphericity: number;
 }
 
+/** Per-image disintegration metrics. Computed on-demand at export time. */
+export interface ImageMetrics {
+  imageId: string;
+  imageName: string;
+  polygonCount: number;
+  disintegrationIndex: number; // tanh(W1) ∈ [0, 1)
+  wassersteinW1: number; // raw 1-Wasserstein distance, ≥ 0
+  referenceMode: 'core' | 'r_eff' | 'r_eff_fallback' | 'none';
+  nPixels: number;
+  // Areas (px² by default, μm² when pixelToMicrometerScale is provided).
+  totalSpheroidArea: number; // sum of external polygon areas, core excluded
+  coreArea: number; // detected core polygon area (0 if no core)
+  invasionArea: number; // totalSpheroidArea − coreArea, clamped at 0
+}
+
 export interface Point {
   x: number;
   y: number;
@@ -52,7 +70,7 @@ export interface ParsedPolygon {
   points: Point[];
   type?: 'external' | 'internal';
   geometry?: 'polygon' | 'polyline';
-  partClass?: SpermPartClass;
+  partClass?: PolygonPartClass;
   instanceId?: string;
 }
 
@@ -290,6 +308,192 @@ export class MetricsCalculator {
   }
 
   /**
+   * Compute the Disintegration Index for every image that has a segmentation.
+   *
+   * Per image: picks the largest closed polygon as A_all, the polygon with
+   * partClass='core' as the dense centre, and POSTs both to the Python ML
+   * service `/api/disintegration-index` endpoint.
+   *
+   * Falls back to R_eff (equivalent radius of A_all) when no core polygon is
+   * present (non-ASPP segmentations).
+   */
+  async calculateAllImageMetrics(
+    images: ImageWithSegmentation[],
+    pixelToMicrometerScale?: number
+  ): Promise<ImageMetrics[]> {
+    // Area unit conversion: px² → μm² when scale is set and valid.
+    const areaScale =
+      pixelToMicrometerScale && pixelToMicrometerScale > 0
+        ? pixelToMicrometerScale * pixelToMicrometerScale
+        : 1;
+    const result: ImageMetrics[] = [];
+    for (const image of images) {
+      if (!image?.segmentation?.polygons) {
+        result.push(this._emptyImageMetrics(image));
+        continue;
+      }
+
+      // Step 1: parse polygons and compute area metrics. These are
+      // self-contained (no network) so they always succeed when polygon
+      // JSON is well-formed.
+      let closed: Array<ParsedPolygon & { type: 'external' | 'internal' }> = [];
+      let externals: typeof closed = [];
+      let cores: typeof closed = [];
+      let totalSpheroidArea = 0;
+      let coreArea = 0;
+      let invasionArea = 0;
+      try {
+        const parsed: ParsedPolygon[] = JSON.parse(image.segmentation.polygons);
+        closed = parsed.filter(
+          (p): p is ParsedPolygon & { type: 'external' | 'internal' } =>
+            p.geometry !== 'polyline' && !!p.type
+        );
+        externals = closed.filter(p => p.type === 'external');
+        cores = closed.filter(p => p.partClass === 'core');
+
+        const totalSpheroidAreaPx = externals
+          .filter(p => p.partClass !== 'core')
+          .reduce((sum, p) => sum + this.polygonArea(p.points), 0);
+        const coreAreaPx = cores.reduce(
+          (sum, p) => sum + this.polygonArea(p.points),
+          0
+        );
+        const invasionAreaPx = Math.max(0, totalSpheroidAreaPx - coreAreaPx);
+        totalSpheroidArea = totalSpheroidAreaPx * areaScale;
+        coreArea = coreAreaPx * areaScale;
+        invasionArea = invasionAreaPx * areaScale;
+      } catch (err) {
+        this.logger.error(
+          `Failed to parse polygons for image ${image.id}`,
+          err instanceof Error ? err : new Error(String(err)),
+          'MetricsCalculator'
+        );
+        result.push(this._emptyImageMetrics(image));
+        continue;
+      }
+
+      // Step 2: optional DI computation. Network call to ML; failures must
+      // NOT void the area metrics already computed in step 1.
+      let di: {
+        disintegrationIndex: number;
+        wassersteinW1: number;
+        referenceMode: ImageMetrics['referenceMode'];
+        nPixels: number;
+      } = {
+        disintegrationIndex: 0,
+        wassersteinW1: 0,
+        referenceMode: 'none',
+        nPixels: 0,
+      };
+
+      const usableExternals = externals.filter(p => p.partClass !== 'core');
+      if (usableExternals.length > 0) {
+        try {
+          // DI is computed from the UNION of every external polygon (the
+          // entire ASPP segmentation mask), not just the largest spheroid.
+          const maskPolygons = usableExternals.map(p => p.points);
+          // Use every detected core; the Python endpoint unions them too.
+          const corePolygonsForDi = cores.map(c => c.points);
+
+          if (!image.width || !image.height) {
+            this.logger.warn(
+              `Image ${image.id} missing width/height in DB — DI requires real dimensions; skipping`,
+              'MetricsCalculator'
+            );
+          } else {
+            di = await this.calculateImageDisintegrationIndex(
+              maskPolygons,
+              corePolygonsForDi.length > 0 ? corePolygonsForDi : undefined,
+              image.width,
+              image.height
+            );
+          }
+        } catch (err) {
+          this.logger.warn(
+            `DI computation failed for image ${image.id}; areas still reported. ${err instanceof Error ? err.message : String(err)}`,
+            'MetricsCalculator'
+          );
+        }
+      }
+
+      result.push({
+        imageId: image.id,
+        imageName: image.name,
+        polygonCount: closed.length,
+        ...di,
+        totalSpheroidArea,
+        coreArea,
+        invasionArea,
+      });
+    }
+    return result;
+  }
+
+  private _emptyImageMetrics(
+    image: ImageWithSegmentation | undefined
+  ): ImageMetrics {
+    return {
+      imageId: image?.id ?? '',
+      imageName: image?.name ?? '',
+      polygonCount: 0,
+      disintegrationIndex: 0,
+      wassersteinW1: 0,
+      referenceMode: 'none',
+      nPixels: 0,
+      totalSpheroidArea: 0,
+      coreArea: 0,
+      invasionArea: 0,
+    };
+  }
+
+  private async calculateImageDisintegrationIndex(
+    maskPolygons: Point[][],
+    corePolygons: Point[][] | undefined,
+    imageWidth: number,
+    imageHeight: number
+  ): Promise<{
+    disintegrationIndex: number;
+    wassersteinW1: number;
+    referenceMode: ImageMetrics['referenceMode'];
+    nPixels: number;
+  }> {
+    const mask_polygons = maskPolygons.map(pts => pts.map(p => [p.x, p.y]));
+    const core_polygons = corePolygons
+      ? corePolygons.map(pts => pts.map(p => [p.x, p.y]))
+      : null;
+    const response = await this.http.post<{
+      di: number;
+      w1: number;
+      reference: ImageMetrics['referenceMode'];
+      n_pixels: number;
+    }>('/api/disintegration-index', {
+      mask_polygons,
+      core_polygons,
+      image_width: imageWidth,
+      image_height: imageHeight,
+    });
+    return {
+      disintegrationIndex: response.data.di,
+      wassersteinW1: response.data.w1,
+      referenceMode: response.data.reference,
+      nPixels: response.data.n_pixels,
+    };
+  }
+
+  /** Shoelace polygon area (always non-negative) for picking the largest. */
+  private polygonArea(points: Point[]): number {
+    if (!points || points.length < 3) {return 0;}
+    let s = 0;
+    for (let i = 0; i < points.length; i++) {
+      const a = points[i];
+      const b = points[(i + 1) % points.length];
+      if (!a || !b) {continue;}
+      s += a.x * b.y - b.x * a.y;
+    }
+    return Math.abs(s) / 2;
+  }
+
+  /**
    * Calculate metrics for a single polygon using Python service
    */
   private async calculatePolygonMetrics(
@@ -482,20 +686,24 @@ export class MetricsCalculator {
   /**
    * Export metrics to Excel
    */
-  async exportToExcel(
+  /**
+   * Comprehensive polygon-level Excel export for **standard spheroid** /
+   * **wound** projects: every polygon gets its own row with the full set of
+   * shape descriptors (area, perimeter, circularity, Feret, etc.) + Summary.
+   *
+   * Used when the project's `type` field is `'spheroid'` or `'wound'`.
+   */
+  async exportPolygonMetricsToExcel(
     metrics: PolygonMetrics[],
     outputPath: string,
     pixelToMicrometerScale?: number
   ): Promise<void> {
     const workbook = new ExcelJS.Workbook();
     const worksheet = workbook.addWorksheet('Polygon Metrics');
-
-    // Determine units based on scale
     const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
     const areaUnit = isScaled ? 'um^2' : 'px^2';
     const lengthUnit = isScaled ? 'um' : 'px';
 
-    // Add headers
     worksheet.columns = [
       { header: 'Image Name', key: 'imageName', width: 20 },
       { header: 'Image ID', key: 'imageId', width: 15 },
@@ -503,53 +711,17 @@ export class MetricsCalculator {
       { header: 'Type', key: 'type', width: 10 },
       { header: `Area (${areaUnit})`, key: 'area', width: 12 },
       { header: `Perimeter (${lengthUnit})`, key: 'perimeter', width: 12 },
-      {
-        header: `Perimeter with Holes (${lengthUnit})`,
-        key: 'perimeterWithHoles',
-        width: 20,
-      },
-      {
-        header: `Equivalent Diameter (${lengthUnit})`,
-        key: 'equivalentDiameter',
-        width: 18,
-      },
+      { header: `Perimeter with Holes (${lengthUnit})`, key: 'perimeterWithHoles', width: 20 },
+      { header: `Equivalent Diameter (${lengthUnit})`, key: 'equivalentDiameter', width: 18 },
       { header: 'Circularity', key: 'circularity', width: 10 },
-      {
-        header: `Feret Diameter Max (${lengthUnit})`,
-        key: 'feretDiameterMax',
-        width: 18,
-      },
-      {
-        header: `Feret Diameter Min (${lengthUnit})`,
-        key: 'feretDiameterMin',
-        width: 18,
-      },
-      {
-        header: `Feret Diameter Orthogonal (${lengthUnit})`,
-        key: 'feretDiameterOrthogonal',
-        width: 22,
-      },
+      { header: `Feret Diameter Max (${lengthUnit})`, key: 'feretDiameterMax', width: 18 },
+      { header: `Feret Diameter Min (${lengthUnit})`, key: 'feretDiameterMin', width: 18 },
+      { header: `Feret Diameter Orthogonal (${lengthUnit})`, key: 'feretDiameterOrthogonal', width: 22 },
       { header: 'Feret Aspect Ratio', key: 'feretAspectRatio', width: 15 },
-      {
-        header: `Major Axis Length (${lengthUnit})`,
-        key: 'lengthMajorDiameter',
-        width: 18,
-      },
-      {
-        header: `Minor Axis Length (${lengthUnit})`,
-        key: 'lengthMinorDiameter',
-        width: 18,
-      },
-      {
-        header: `Bounding Box Width (${lengthUnit})`,
-        key: 'boundingBoxWidth',
-        width: 20,
-      },
-      {
-        header: `Bounding Box Height (${lengthUnit})`,
-        key: 'boundingBoxHeight',
-        width: 20,
-      },
+      { header: `Major Axis Length (${lengthUnit})`, key: 'lengthMajorDiameter', width: 18 },
+      { header: `Minor Axis Length (${lengthUnit})`, key: 'lengthMinorDiameter', width: 18 },
+      { header: `Bounding Box Width (${lengthUnit})`, key: 'boundingBoxWidth', width: 20 },
+      { header: `Bounding Box Height (${lengthUnit})`, key: 'boundingBoxHeight', width: 20 },
       { header: 'Extent', key: 'extent', width: 10 },
       { header: 'Compactness', key: 'compactness', width: 12 },
       { header: 'Convexity', key: 'convexity', width: 10 },
@@ -557,16 +729,9 @@ export class MetricsCalculator {
       { header: 'Sphericity', key: 'sphericity', width: 10 },
     ];
 
-    // Add data rows with validation for finite values
+    const safeValue = (value: number, decimals = 2): number =>
+      isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
     metrics.forEach(m => {
-      // Helper function to ensure finite values
-      const safeValue = (value: number, decimals = 2): number => {
-        if (!isFinite(value)) {
-          return 0;
-        }
-        return parseFloat(value.toFixed(decimals));
-      };
-
       worksheet.addRow({
         imageName: m.imageName,
         imageId: m.imageId,
@@ -579,10 +744,7 @@ export class MetricsCalculator {
         circularity: safeValue(m.circularity, 4),
         feretDiameterMax: safeValue(m.feretDiameterMax, 2),
         feretDiameterMin: safeValue(m.feretDiameterMin, 2),
-        feretDiameterOrthogonal: safeValue(
-          m.feretDiameterMaxOrthogonalDistance,
-          2
-        ),
+        feretDiameterOrthogonal: safeValue(m.feretDiameterMaxOrthogonalDistance, 2),
         feretAspectRatio: safeValue(m.feretAspectRatio, 2),
         lengthMajorDiameter: safeValue(m.lengthMajorDiameterThroughCentroid, 2),
         lengthMinorDiameter: safeValue(m.lengthMinorDiameterThroughCentroid, 2),
@@ -595,8 +757,6 @@ export class MetricsCalculator {
         sphericity: safeValue(m.sphericity, 4),
       });
     });
-
-    // Style the header row
     worksheet.getRow(1).font = { bold: true };
     worksheet.getRow(1).fill = {
       type: 'pattern',
@@ -604,17 +764,11 @@ export class MetricsCalculator {
       fgColor: { argb: 'FFE0E0E0' },
     };
 
-    // Add summary sheet
+    // Summary sheet (aggregates across the project).
     const summarySheet = workbook.addWorksheet('Summary');
-    const summaryData = this.generateSummaryStatistics(
-      metrics,
-      pixelToMicrometerScale
-    );
-
-    // Add summary data to the sheet
+    const summaryData = this.generateSummaryStatistics(metrics, pixelToMicrometerScale);
     summaryData.forEach((row, index) => {
       const excelRow = summarySheet.addRow(row);
-      // Bold the header row
       if (index === 0) {
         excelRow.font = { bold: true };
         excelRow.fill = {
@@ -624,17 +778,76 @@ export class MetricsCalculator {
         };
       }
     });
+    summarySheet.columns.forEach(column => { column.width = 20; });
 
-    // Auto-fit columns in summary sheet
-    summarySheet.columns.forEach(column => {
-      column.width = 20;
-    });
-
-    // Create parent directory if it doesn't exist
     const parentDir = path.dirname(outputPath);
     await fs.mkdir(parentDir, { recursive: true });
+    await workbook.xlsx.writeFile(outputPath);
+    this.logger.info(`Polygon Metrics Excel written: ${outputPath}`, 'MetricsCalculator');
+  }
 
-    // Write file
+  async exportToExcel(
+    metrics: PolygonMetrics[],
+    outputPath: string,
+    pixelToMicrometerScale?: number,
+    imageMetrics?: ImageMetrics[]
+  ): Promise<void> {
+    // `metrics` (per-polygon) are intentionally NOT written here — for
+    // disintegrated-spheroid (`spheroid_invasive`) projects the user only wants
+    // ONE row per image. Detailed methodology lives in `metrics_guide.md`.
+    void metrics;
+    const workbook = new ExcelJS.Workbook();
+
+    const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
+    const areaUnit = isScaled ? 'um^2' : 'px^2';
+
+    const sheet = workbook.addWorksheet('Image Metrics');
+    sheet.columns = [
+      { header: 'Image Name', key: 'imageName', width: 32 },
+      { header: 'Image ID', key: 'imageId', width: 22 },
+      {
+        header: `Total Spheroid Area (${areaUnit})`,
+        key: 'totalSpheroidArea',
+        width: 26,
+      },
+      { header: `Core Area (${areaUnit})`, key: 'coreArea', width: 22 },
+      {
+        header: `Invasion Area (${areaUnit})`,
+        key: 'invasionArea',
+        width: 24,
+      },
+      {
+        header: 'Disintegration Index',
+        key: 'disintegrationIndex',
+        width: 22,
+      },
+    ];
+
+    const safe = (v: number, decimals = 2): number =>
+      isFinite(v) ? parseFloat(v.toFixed(decimals)) : 0;
+
+    if (imageMetrics) {
+      imageMetrics.forEach(m => {
+        sheet.addRow({
+          imageName: m.imageName,
+          imageId: m.imageId,
+          totalSpheroidArea: safe(m.totalSpheroidArea, 2),
+          coreArea: safe(m.coreArea, 2),
+          invasionArea: safe(m.invasionArea, 2),
+          disintegrationIndex: safe(m.disintegrationIndex, 4),
+        });
+      });
+    }
+
+    sheet.getRow(1).font = { bold: true };
+    sheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFE0E0E0' },
+    };
+
+    const parentDir = path.dirname(outputPath);
+    await fs.mkdir(parentDir, { recursive: true });
     await workbook.xlsx.writeFile(outputPath);
     this.logger.info(`Excel file created: ${outputPath}`, 'MetricsCalculator');
   }
@@ -670,12 +883,12 @@ export class MetricsCalculator {
     let hasData = false;
 
     for (const image of images) {
-      if (!image.segmentation?.polygons) continue;
+      if (!image.segmentation?.polygons) {continue;}
 
       let polygons: ParsedPolygon[];
       try {
         const parsed = JSON.parse(image.segmentation.polygons);
-        if (!Array.isArray(parsed)) continue;
+        if (!Array.isArray(parsed)) {continue;}
         polygons = parsed;
       } catch (parseError) {
         this.logger.warn(
@@ -686,7 +899,16 @@ export class MetricsCalculator {
         continue;
       }
 
-      const allPolylines = polygons.filter(p => p.geometry === 'polyline');
+      // Polylines are sperm-only (partClass ∈ {head|midpiece|tail}); narrow the
+      // type so spermGrouping doesn't see the wider 'core' literal.
+      const allPolylines = polygons.filter(
+        (
+          p
+        ): p is ParsedPolygon & {
+          geometry: 'polyline';
+          partClass?: SpermPartClass;
+        } => p.geometry === 'polyline' && p.partClass !== 'core'
+      );
       const { groups, orphanCount } = groupPolylinesByInstanceId(allPolylines);
       if (orphanCount > 0) {
         this.logger.warn(
@@ -717,7 +939,7 @@ export class MetricsCalculator {
       }
     }
 
-    if (!hasData) return false;
+    if (!hasData) {return false;}
 
     // Style header
     const headerRow = worksheet.getRow(1);
@@ -814,7 +1036,8 @@ export class MetricsCalculator {
    */
   private generateSummaryStatistics(
     metrics: PolygonMetrics[],
-    pixelToMicrometerScale?: number
+    pixelToMicrometerScale?: number,
+    imageMetrics?: ImageMetrics[]
   ): SummaryStatisticsRow[] {
     const externalMetrics = metrics.filter(m => m.type === 'external');
 
@@ -840,7 +1063,7 @@ export class MetricsCalculator {
     const areaUnit = isScaled ? 'um^2' : 'px^2';
     const lengthUnit = isScaled ? 'um' : 'px';
 
-    return [
+    const rows: SummaryStatisticsRow[] = [
       ['Summary Statistics'],
       [''],
       ['Metric', 'Value'],
@@ -855,6 +1078,35 @@ export class MetricsCalculator {
       ['Average Solidity', stats.avgSolidity.toFixed(4)],
       ['Average Sphericity', stats.avgSphericity.toFixed(4)],
     ];
+
+    // Disintegration Index aggregates (per-image granularity)
+    if (imageMetrics && imageMetrics.length > 0) {
+      const dis = imageMetrics
+        .map(m => m.disintegrationIndex)
+        .filter(v => isFinite(v));
+      if (dis.length > 0) {
+        const meanDi = this.average(dis);
+        const variance = this.average(dis.map(v => (v - meanDi) ** 2));
+        const stdDi = Math.sqrt(variance);
+        const compact = imageMetrics.filter(
+          m => m.disintegrationIndex < 0.05
+        ).length;
+        const disintegrated = imageMetrics.filter(
+          m => m.disintegrationIndex >= 0.05
+        ).length;
+        rows.push(
+          [''],
+          ['Disintegration Index'],
+          ['Image Count', imageMetrics.length],
+          ['Mean DI', meanDi.toFixed(4)],
+          ['Std DI', stdDi.toFixed(4)],
+          ['Compact (DI < 0.05)', compact],
+          ['Disintegrated (DI ≥ 0.05)', disintegrated]
+        );
+      }
+    }
+
+    return rows;
   }
 
   private average(numbers: number[]): number {

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -41,14 +41,23 @@ export interface PolygonMetrics {
   sphericity: number;
 }
 
-/** Per-image disintegration metrics. Computed on-demand at export time. */
+/** Per-image disintegration metrics. Computed on-demand at export time.
+ *
+ * `referenceMode` distinguishes how DI was computed (or why it wasn't):
+ *   - 'core'           → empirical-CDF reference from detected core pixels
+ *   - 'r_eff'          → equivalent-disk fallback (no core polygon present)
+ *   - 'r_eff_fallback' → core polygon supplied but rasterised to 0 pixels
+ *   - 'none'           → no externals or no image dimensions; DI not attempted
+ *   - 'failed'         → DI HTTP call or polygon JSON parse threw an error
+ *                        Lets exporters render `'N/A'` instead of a sentinel 0.
+ */
 export interface ImageMetrics {
   imageId: string;
   imageName: string;
   polygonCount: number;
   disintegrationIndex: number; // tanh(W1) ∈ [0, 1)
   wassersteinW1: number; // raw 1-Wasserstein distance, ≥ 0
-  referenceMode: 'core' | 'r_eff' | 'r_eff_fallback' | 'none';
+  referenceMode: 'core' | 'r_eff' | 'r_eff_fallback' | 'none' | 'failed';
   nPixels: number;
   // Areas (px² by default, μm² when pixelToMicrometerScale is provided).
   totalSpheroidArea: number; // sum of external polygon areas, core excluded
@@ -308,14 +317,17 @@ export class MetricsCalculator {
   }
 
   /**
-   * Compute the Disintegration Index for every image that has a segmentation.
+   * Compute per-image area metrics + the Disintegration Index for every image
+   * that has a segmentation.
    *
-   * Per image: picks the largest closed polygon as A_all, the polygon with
-   * partClass='core' as the dense centre, and POSTs both to the Python ML
-   * service `/api/disintegration-index` endpoint.
+   * Per image: rasterises the **union of every external non-core polygon**
+   * as the mask and the **union of every `partClass='core'` polygon** as the
+   * core reference, then POSTs them to the Python ML service
+   * `/api/disintegration-index` endpoint. Areas are computed locally via the
+   * Shoelace formula and reported even if the DI HTTP call fails.
    *
-   * Falls back to R_eff (equivalent radius of A_all) when no core polygon is
-   * present (non-ASPP segmentations).
+   * Falls back to R_eff (equivalent radius of the mask union) when no core
+   * polygon is present (non-ASPP segmentations).
    */
   async calculateAllImageMetrics(
     images: ImageWithSegmentation[],
@@ -368,7 +380,11 @@ export class MetricsCalculator {
           err instanceof Error ? err : new Error(String(err)),
           'MetricsCalculator'
         );
-        result.push(this._emptyImageMetrics(image));
+        // Flag the row so exporters can show 'N/A' instead of a sentinel 0.
+        result.push({
+          ...this._emptyImageMetrics(image),
+          referenceMode: 'failed',
+        });
         continue;
       }
 
@@ -409,10 +425,19 @@ export class MetricsCalculator {
             );
           }
         } catch (err) {
-          this.logger.warn(
-            `DI computation failed for image ${image.id}; areas still reported. ${err instanceof Error ? err.message : String(err)}`,
-            'MetricsCalculator'
+          // Areas already computed above; mark DI fields explicitly failed.
+          this.logger.error(
+            `DI computation failed for image ${image.id}; areas still reported`,
+            err instanceof Error ? err : new Error(String(err)),
+            'MetricsCalculator',
+            { imageId: image.id }
           );
+          di = {
+            disintegrationIndex: 0,
+            wassersteinW1: 0,
+            referenceMode: 'failed',
+            nPixels: 0,
+          };
         }
       }
 
@@ -480,7 +505,9 @@ export class MetricsCalculator {
     };
   }
 
-  /** Shoelace polygon area (always non-negative) for picking the largest. */
+  /** Shoelace polygon area (always non-negative). Used to sum spheroid and
+   * core areas for the per-image disintegration report.
+   */
   private polygonArea(points: Point[]): number {
     if (!points || points.length < 3) {return 0;}
     let s = 0;
@@ -1032,12 +1059,14 @@ export class MetricsCalculator {
   }
 
   /**
-   * Generate summary statistics for metrics
+   * Generate summary statistics for the per-polygon metrics report.
+   * Used by `exportPolygonMetricsToExcel` for `spheroid` and `wound` projects.
+   * DI aggregates live in the `spheroid_invasive` Excel report directly,
+   * not here — keep this function focused on shape descriptors.
    */
   private generateSummaryStatistics(
     metrics: PolygonMetrics[],
-    pixelToMicrometerScale?: number,
-    imageMetrics?: ImageMetrics[]
+    pixelToMicrometerScale?: number
   ): SummaryStatisticsRow[] {
     const externalMetrics = metrics.filter(m => m.type === 'external');
 
@@ -1058,7 +1087,6 @@ export class MetricsCalculator {
       avgSphericity: this.average(externalMetrics.map(m => m.sphericity)),
     };
 
-    // Determine units based on scale
     const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
     const areaUnit = isScaled ? 'um^2' : 'px^2';
     const lengthUnit = isScaled ? 'um' : 'px';
@@ -1078,33 +1106,6 @@ export class MetricsCalculator {
       ['Average Solidity', stats.avgSolidity.toFixed(4)],
       ['Average Sphericity', stats.avgSphericity.toFixed(4)],
     ];
-
-    // Disintegration Index aggregates (per-image granularity)
-    if (imageMetrics && imageMetrics.length > 0) {
-      const dis = imageMetrics
-        .map(m => m.disintegrationIndex)
-        .filter(v => isFinite(v));
-      if (dis.length > 0) {
-        const meanDi = this.average(dis);
-        const variance = this.average(dis.map(v => (v - meanDi) ** 2));
-        const stdDi = Math.sqrt(variance);
-        const compact = imageMetrics.filter(
-          m => m.disintegrationIndex < 0.05
-        ).length;
-        const disintegrated = imageMetrics.filter(
-          m => m.disintegrationIndex >= 0.05
-        ).length;
-        rows.push(
-          [''],
-          ['Disintegration Index'],
-          ['Image Count', imageMetrics.length],
-          ['Mean DI', meanDi.toFixed(4)],
-          ['Std DI', stdDi.toFixed(4)],
-          ['Compact (DI < 0.05)', compact],
-          ['Disintegrated (DI ≥ 0.05)', disintegrated]
-        );
-      }
-    }
 
     return rows;
   }

--- a/backend/src/services/projectService.ts
+++ b/backend/src/services/projectService.ts
@@ -31,6 +31,7 @@ export async function createProject(
       data: {
         title: data.title,
         description: data.description,
+        type: data.type,
         userId: userId,
       },
       include: {
@@ -382,6 +383,7 @@ export async function updateProject(
       data: {
         title: data.title,
         description: data.description,
+        ...(data.type !== undefined && { type: data.type }),
         updatedAt: new Date(),
       },
       include: {

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -8,7 +8,7 @@ import { logger } from '../utils/logger';
 import { config } from '../utils/config';
 import {
   PolygonValidator,
-  type SpermPartClass,
+  type PolygonPartClass,
 } from '../utils/polygonValidation';
 import { ImageService } from './imageService';
 import { SegmentationThumbnailService } from './segmentationThumbnailService';
@@ -28,7 +28,7 @@ export interface SegmentationPolygon {
   type: 'external' | 'internal';
   parentIds?: string[]; // For internal polygons, match frontend API interface
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat)
-  partClass?: SpermPartClass;
+  partClass?: PolygonPartClass;
   instanceId?: string;
 }
 

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -3,7 +3,7 @@ import { writeFile, readFile, mkdir, unlink } from 'fs/promises';
 import sharp from 'sharp';
 import path from 'path';
 import { logger } from '../../utils/logger';
-import type { SpermPartClass } from '../../utils/polygonValidation';
+import type { PolygonPartClass } from '../../utils/polygonValidation';
 
 export interface VisualizationOptions {
   showNumbers?: boolean;
@@ -21,7 +21,7 @@ export interface Polygon {
   type: 'external' | 'internal';
   id?: string;
   geometry?: 'polygon' | 'polyline';
-  partClass?: SpermPartClass;
+  partClass?: PolygonPartClass;
   instanceId?: string;
 }
 
@@ -303,12 +303,16 @@ export class VisualizationGenerator {
       return;
     }
 
-    // Polylines use part-class colors; polygons use type-based colors
+    // Polylines use part-class colors; closed polygons use type-based colors
+    // except 'core' which renders green (consistent with the editor canvas).
+    const isCorePolygon = !isPolyline && polygon.partClass === 'core';
     const color = isPolyline
       ? POLYLINE_COLORS[polygon.partClass || ''] || '#a855f7'
-      : polygon.type === 'external'
-        ? options.polygonColors?.external || '#00FF00'
-        : options.polygonColors?.internal || '#FF0000';
+      : isCorePolygon
+        ? '#22c55e' // green — matches frontend CanvasPolygon for ASPP core
+        : polygon.type === 'external'
+          ? options.polygonColors?.external || '#00FF00'
+          : options.polygonColors?.internal || '#FF0000';
 
     ctx.strokeStyle = color;
     ctx.lineWidth = isPolyline

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -100,6 +100,20 @@ export const cleanupQueueSchema = z.object({
 // ============================================================================
 
 /**
+ * Project workflow type — drives metric export format and editor behavior.
+ * Mirrors the `type` column on the projects table.
+ */
+export const PROJECT_TYPES = [
+  'spheroid',
+  'spheroid_invasive',
+  'wound',
+  'sperm',
+] as const;
+export type ProjectType = (typeof PROJECT_TYPES)[number];
+
+const projectTypeSchema = z.enum(PROJECT_TYPES);
+
+/**
  * Schema for creating a new project
  */
 export const createProjectSchema = z.object({
@@ -114,6 +128,7 @@ export const createProjectSchema = z.object({
     .trim()
     .optional()
     .nullable(),
+  type: projectTypeSchema.optional(),
 });
 
 /**
@@ -132,6 +147,7 @@ export const updateProjectSchema = z.object({
     .trim()
     .optional()
     .nullable(),
+  type: projectTypeSchema.optional(),
 });
 
 /**

--- a/backend/src/utils/polygonValidation.ts
+++ b/backend/src/utils/polygonValidation.ts
@@ -9,6 +9,19 @@ export const isValidSpermPartClass = (
   typeof value === 'string' &&
   (SPERM_PART_CLASSES as readonly string[]).includes(value);
 
+// Wider partClass union: sperm body parts plus spheroid 'core'.
+export const POLYGON_PART_CLASSES = [
+  ...SPERM_PART_CLASSES,
+  'core',
+] as const;
+export type PolygonPartClass = (typeof POLYGON_PART_CLASSES)[number];
+
+export const isValidPolygonPartClass = (
+  value: unknown
+): value is PolygonPartClass =>
+  typeof value === 'string' &&
+  (POLYGON_PART_CLASSES as readonly string[]).includes(value);
+
 export interface PolygonPoint {
   x: number;
   y: number;
@@ -292,7 +305,10 @@ export const PolygonValidator = {
     if (polygonObj.geometry === 'polyline') {
       (validatedPolygon as any).geometry = 'polyline';
     }
-    if (isValidSpermPartClass(polygonObj.partClass)) {
+    // partClass accepts both sperm parts (head/midpiece/tail) and 'core' for
+    // ASPP spheroid core polygons; older code only validated SpermPartClass
+    // which silently stripped 'core' during polygon JSON load.
+    if (isValidPolygonPartClass(polygonObj.partClass)) {
       (validatedPolygon as any).partClass = polygonObj.partClass;
     }
     if (polygonObj.instanceId && typeof polygonObj.instanceId === 'string') {

--- a/src/components/NewProject.tsx
+++ b/src/components/NewProject.tsx
@@ -13,10 +13,17 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { PlusCircle } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import apiClient from '@/lib/api';
 import { useAuth } from '@/contexts/useAuth';
 import { useLanguage } from '@/contexts/useLanguage';
-import { getErrorMessage } from '@/types';
+import { getErrorMessage, PROJECT_TYPES, type ProjectType } from '@/types';
 import { logger } from '@/lib/logger';
 
 interface NewProjectProps {
@@ -26,6 +33,7 @@ interface NewProjectProps {
 const NewProject = ({ onProjectCreated }: NewProjectProps) => {
   const [projectName, setProjectName] = useState('');
   const [projectDescription, setProjectDescription] = useState('');
+  const [projectType, setProjectType] = useState<ProjectType>('spheroid');
   const [isCreating, setIsCreating] = useState(false);
   const [open, setOpen] = useState(false);
   const { user } = useAuth();
@@ -51,6 +59,7 @@ const NewProject = ({ onProjectCreated }: NewProjectProps) => {
       const projectData = await apiClient.createProject({
         name: projectName,
         description: trimmedDescription || '',
+        type: projectType,
       });
 
       // Validate response
@@ -129,6 +138,26 @@ const NewProject = ({ onProjectCreated }: NewProjectProps) => {
                 value={projectDescription}
                 onChange={e => setProjectDescription(e.target.value)}
               />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="projectType" className="text-right">
+                {t('projects.projectType')}
+              </Label>
+              <Select
+                value={projectType}
+                onValueChange={(v: ProjectType) => setProjectType(v)}
+              >
+                <SelectTrigger id="projectType">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROJECT_TYPES.map(pt => (
+                    <SelectItem key={pt} value={pt}>
+                      {t(`projects.types.${pt}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
           <DialogFooter>

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -2,19 +2,31 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useLanguage } from '@/contexts/useLanguage';
 import DashboardHeader from '@/components/DashboardHeader';
+import { PROJECT_TYPES, type ProjectType } from '@/types';
 
 interface ProjectHeaderProps {
   projectTitle: string;
   imagesCount: number;
   loading: boolean;
+  projectType?: ProjectType;
+  onTypeChange?: (type: ProjectType) => void;
 }
 
 const ProjectHeader = ({
   projectTitle,
   imagesCount,
   loading,
+  projectType,
+  onTypeChange,
 }: ProjectHeaderProps) => {
   const navigate = useNavigate();
   const { t } = useLanguage();
@@ -44,6 +56,34 @@ const ProjectHeader = ({
                   : `${imagesCount} ${t('common.images').toLowerCase()}`}
               </p>
             </div>
+            {projectType && (
+              <div className="hidden sm:flex items-center gap-2">
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {t('projects.projectType')}:
+                </span>
+                {onTypeChange ? (
+                  <Select
+                    value={projectType}
+                    onValueChange={(v: ProjectType) => onTypeChange(v)}
+                  >
+                    <SelectTrigger className="h-8 w-[180px] text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROJECT_TYPES.map(pt => (
+                        <SelectItem key={pt} value={pt} className="text-xs">
+                          {t(`projects.types.${pt}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <span className="text-sm font-medium">
+                    {t(`projects.types.${projectType}`)}
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -17,6 +17,9 @@ export const useProjectData = (
   const { signOut } = useAuth();
   const navigate = useNavigate();
   const [projectTitle, setProjectTitle] = useState<string>('');
+  const [projectType, setProjectType] = useState<
+    import('@/types').ProjectType | undefined
+  >(undefined);
   const [images, setImages] = useState<ProjectImage[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -45,6 +48,7 @@ export const useProjectData = (
         }
 
         setProjectTitle(project.name);
+        setProjectType(project.type);
 
         // Fetch all images by making multiple requests if needed.
         // Backend max is 100 per request; we use lod: 'low' which
@@ -276,6 +280,8 @@ export const useProjectData = (
 
   return {
     projectTitle,
+    projectType,
+    setProjectType,
     images,
     loading,
     updateImages,

--- a/src/index.css
+++ b/src/index.css
@@ -160,6 +160,11 @@
     fill: rgba(14, 165, 233, 0.15);
   }
 
+  .polygon-core {
+    fill: rgba(34, 197, 94, 0.25) !important;
+    stroke: #22c55e !important;
+  }
+
   .polygon-selected {
     filter: drop-shadow(0 0 8px var(--polygon-selected-glow, #3b82f6));
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { Profile, UpdateProfile } from '@/types';
+import {
+  Profile,
+  UpdateProfile,
+  isProjectType,
+  type ProjectType,
+} from '@/types';
 import { logger } from '@/lib/logger';
 import config from '@/lib/config';
 import { retryWithBackoff, RETRY_CONFIGS } from '@/lib/retryUtils';
@@ -599,21 +604,23 @@ class ApiClient {
 
   // Helper method to map backend project fields to frontend expectations
   private mapProjectFields(project: Record<string, unknown>): Project {
+    // Defensive: validate type against the known enum, default to 'spheroid'
+    // for legacy records or corrupt rows.
+    const typeValue: ProjectType = isProjectType(project.type)
+      ? project.type
+      : 'spheroid';
+
     const result: Project = {
       id: project.id as string,
       name: (project.title as string) || (project.name as string), // Map title -> name
       description: project.description as string | undefined,
+      type: typeValue,
       created_at:
         (project.createdAt as string) || (project.created_at as string),
       updated_at:
         (project.updatedAt as string) || (project.updated_at as string),
       user_id: (project.userId as string) || (project.user_id as string),
     };
-
-    // Project type drives metric export and editor mode dispatch.
-    if (typeof project.type === 'string') {
-      result.type = project.type as import('@/types').ProjectType;
-    }
 
     // Add optional fields only if they exist
     const imageCount =

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -610,6 +610,11 @@ class ApiClient {
       user_id: (project.userId as string) || (project.user_id as string),
     };
 
+    // Project type drives metric export and editor mode dispatch.
+    if (typeof project.type === 'string') {
+      result.type = project.type as import('@/types').ProjectType;
+    }
+
     // Add optional fields only if they exist
     const imageCount =
       (project.imageCount as number) ||
@@ -799,11 +804,13 @@ class ApiClient {
   async createProject(data: {
     name: string;
     description?: string;
+    type?: import('@/types').ProjectType;
   }): Promise<Project> {
     // Convert 'name' to 'title' to match backend validation schema
     const requestData = {
       title: data.name,
       description: data.description,
+      type: data.type,
     };
     const response = await this.instance.post('/projects', requestData);
     const project = this.extractData(response);
@@ -818,7 +825,11 @@ class ApiClient {
 
   async updateProject(
     id: string,
-    data: { name?: string; description?: string }
+    data: {
+      name?: string;
+      description?: string;
+      type?: import('@/types').ProjectType;
+    }
   ): Promise<Project> {
     // Convert 'name' to 'title' if provided
     const requestData = {

--- a/src/lib/segmentation.ts
+++ b/src/lib/segmentation.ts
@@ -18,6 +18,11 @@ export const isValidSpermPartClass = (
   typeof value === 'string' &&
   (SPERM_PART_CLASSES as readonly string[]).includes(value);
 
+// Wider class union covering both sperm parts and spheroid 'core'
+// (dense central region detected for the ASPP model).
+export const POLYGON_PART_CLASSES = [...SPERM_PART_CLASSES, 'core'] as const;
+export type PolygonPartClass = (typeof POLYGON_PART_CLASSES)[number];
+
 export interface Polygon {
   id: string;
   points: Point[];
@@ -28,7 +33,7 @@ export interface Polygon {
   area?: number;
   parent_id?: string;
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat with rows stored before sperm model)
-  partClass?: SpermPartClass;
+  partClass?: PolygonPartClass;
   instanceId?: string;
 }
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -59,11 +59,30 @@ const ProjectDetail = () => {
   // Segmentation editor loads full polygon data independently when opened.
   const {
     projectTitle,
+    projectType,
+    setProjectType,
     images,
     loading,
     updateImages,
     refreshImageSegmentation,
   } = useProjectData(id, user?.id);
+
+  const handleProjectTypeChange = useCallback(
+    async (newType: import('@/types').ProjectType) => {
+      if (!id) return;
+      try {
+        await apiClient.updateProject(id, { type: newType });
+        setProjectType(newType);
+        toast.success(t('projects.projectTypeUpdated'));
+      } catch (err) {
+        logger.error('Failed to update project type', err);
+        toast.error(
+          getErrorMessage(err, t) || t('projects.failedToUpdateProject')
+        );
+      }
+    },
+    [id, setProjectType, t]
+  );
 
   // Handle cancellation events from WebSocket - define early for useSegmentationQueue
   const handleSegmentationCancelled = useCallback(
@@ -1414,6 +1433,8 @@ const ProjectDetail = () => {
         projectTitle={projectTitle}
         imagesCount={filteredImages.length}
         loading={loading}
+        projectType={projectType}
+        onTypeChange={handleProjectTypeChange}
       />
 
       <div className="container mx-auto px-4 py-8">

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -135,6 +135,10 @@ const CanvasPolygon = React.memo(
 
     // Determine path color based on polygon type, polyline partClass, and selection status
     const getPathColor = () => {
+      // Spheroid 'core' (closed polygon, dense central region from ASPP model)
+      if (!isPolyline && polygon.partClass === 'core') {
+        return isSelected ? '#16a34a' : '#22c55e'; // green
+      }
       if (isPolyline) {
         // Part-class-based colors for sperm polylines
         switch (polygon.partClass) {
@@ -258,21 +262,30 @@ const CanvasPolygon = React.memo(
           {/* Polygon/Polyline path - render even if path is empty for testing */}
           <path
             d={pathString || 'M0,0'}
+            style={
+              !isPolyline && polygon.partClass === 'core'
+                ? { fill: 'rgba(34, 197, 94, 0.25)', stroke: '#22c55e' }
+                : undefined
+            }
             className={cn(
               'polygon-path cursor-pointer transition-colors',
               isPolyline
                 ? 'polyline-path'
-                : isInternal
-                  ? 'polygon-internal'
-                  : 'polygon-external',
+                : polygon.partClass === 'core'
+                  ? 'polygon-core'
+                  : isInternal
+                    ? 'polygon-internal'
+                    : 'polygon-external',
               isSelected && 'polygon-selected'
             )}
             fill={
               isPolyline
                 ? 'none'
-                : isInternal
-                  ? 'rgba(14, 165, 233, 0.1)'
-                  : 'rgba(239, 68, 68, 0.1)'
+                : polygon.partClass === 'core'
+                  ? 'rgba(34, 197, 94, 0.25)' // green core (#22c55e at 25%)
+                  : isInternal
+                    ? 'rgba(14, 165, 233, 0.1)'
+                    : 'rgba(239, 68, 68, 0.1)'
             }
             stroke={pathColor}
             strokeWidth={Math.max(strokeWidth * hoverStrokeMultiplier, 0.5)}

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -181,6 +181,15 @@ export default {
     createProject: 'Vytvořit nový projekt',
     createProjectDesc:
       'Přidat nový projekt pro organizaci vašich sféroidních snímků a analýz.',
+    projectType: 'Typ projektu',
+    projectTypeUpdated: 'Typ projektu byl aktualizován',
+    failedToUpdateProject: 'Nepodařilo se aktualizovat projekt',
+    types: {
+      spheroid: 'Sféroidy (standardní)',
+      spheroid_invasive: 'Rozprsknuté sféroidy',
+      wound: 'Hojení ran',
+      sperm: 'Spermie',
+    },
     projectNamePlaceholder: 'např. HeLa buněčné sferoidy',
     projectDescPlaceholder:
       'např. Analýza nádorových sféroidů pro studie rezistence na léky',
@@ -1766,6 +1775,12 @@ export default {
     solidity: 'Solidita',
     sphericity: 'Sféricita',
     feretAspectRatio: 'Feretův poměr stran',
+    disintegrationIndex: 'Index rozpadu',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: 'Referenční režim',
+    totalSpheroidArea: 'Celková plocha sféroidů',
+    coreArea: 'Plocha core',
+    invasionArea: 'Plocha invaze',
     noPolygonsFound: 'Nebyly nalezeny žádné polygony pro analýzu',
   },
   keyboardShortcuts: {

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -180,6 +180,15 @@ export default {
     createProject: 'Neues Projekt erstellen',
     createProjectDesc:
       'Fügen Sie ein neues Projekt hinzu, um Ihre Sphäroid-Bilder und Analysen zu organisieren.',
+    projectType: 'Projekttyp',
+    projectTypeUpdated: 'Projekttyp aktualisiert',
+    failedToUpdateProject: 'Projekt konnte nicht aktualisiert werden',
+    types: {
+      spheroid: 'Sphäroide (Standard)',
+      spheroid_invasive: 'Zerfallene Sphäroide',
+      wound: 'Wundheilung',
+      sperm: 'Spermien',
+    },
     projectNamePlaceholder: 'z.B. HeLa-Zell-Sphäroide',
     projectDescPlaceholder:
       'z.B. Analyse von Tumor-Sphäroiden für Arzneimittelresistenz-Studien',
@@ -1752,6 +1761,12 @@ export default {
     solidity: 'Festigkeit',
     sphericity: 'Sphärizität',
     feretAspectRatio: 'Feret-Seitenverhältnis',
+    disintegrationIndex: 'Zerfallsindex',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: 'Referenzmodus',
+    totalSpheroidArea: 'Gesamtfläche der Sphäroide',
+    coreArea: 'Kernfläche',
+    invasionArea: 'Invasionsfläche',
     noPolygonsFound: 'Keine Polygone zur Analyse gefunden',
   },
   keyboardShortcuts: {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -201,6 +201,15 @@ export default {
     createProject: 'Create New Project',
     createProjectDesc:
       'Add a new project to organize your spheroid images and analyses.',
+    projectType: 'Project Type',
+    projectTypeUpdated: 'Project type updated',
+    failedToUpdateProject: 'Failed to update project',
+    types: {
+      spheroid: 'Spheroids (standard)',
+      spheroid_invasive: 'Disintegrated spheroids',
+      wound: 'Wound healing',
+      sperm: 'Sperm',
+    },
     projectNamePlaceholder: 'e.g., HeLa Cell Spheroids',
     projectDescPlaceholder:
       'e.g., Analysis of tumor spheroids for drug resistance studies',
@@ -1848,6 +1857,12 @@ export default {
     solidity: 'Solidity',
     sphericity: 'Sphericity',
     feretAspectRatio: 'Feret Aspect Ratio',
+    disintegrationIndex: 'Disintegration Index',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: 'Reference Mode',
+    totalSpheroidArea: 'Total Spheroid Area',
+    coreArea: 'Core Area',
+    invasionArea: 'Invasion Area',
     noPolygonsFound: 'No polygons found for analysis',
   },
 

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -180,6 +180,15 @@ export default {
     createProject: 'Crear nuevo proyecto',
     createProjectDesc:
       'Añade un nuevo proyecto para organizar tus imágenes y análisis de esferoides.',
+    projectType: 'Tipo de proyecto',
+    projectTypeUpdated: 'Tipo de proyecto actualizado',
+    failedToUpdateProject: 'Error al actualizar el proyecto',
+    types: {
+      spheroid: 'Esferoides (estándar)',
+      spheroid_invasive: 'Esferoides desintegrados',
+      wound: 'Cicatrización de heridas',
+      sperm: 'Esperma',
+    },
     projectNamePlaceholder: 'ej. Esferoides de células HeLa',
     projectDescPlaceholder:
       'ej. Análisis de esferoides tumorales para estudios de resistencia a fármacos',
@@ -1790,6 +1799,12 @@ export default {
     solidity: 'Solidez',
     sphericity: 'Esfericidad',
     feretAspectRatio: 'Relación de Aspecto de Feret',
+    disintegrationIndex: 'Índice de Desintegración',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: 'Modo de Referencia',
+    totalSpheroidArea: 'Área Total de Esferoides',
+    coreArea: 'Área del Núcleo',
+    invasionArea: 'Área de Invasión',
     noPolygonsFound: 'No se encontraron polígonos para análisis',
   },
   keyboardShortcuts: {

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -180,6 +180,15 @@ export default {
     createProject: 'Créer un nouveau projet',
     createProjectDesc:
       'Ajoutez un nouveau projet pour organiser vos images de sphéroïdes et analyses.',
+    projectType: 'Type de projet',
+    projectTypeUpdated: 'Type de projet mis à jour',
+    failedToUpdateProject: 'Impossible de mettre à jour le projet',
+    types: {
+      spheroid: 'Sphéroïdes (standard)',
+      spheroid_invasive: 'Sphéroïdes désintégrés',
+      wound: 'Cicatrisation des plaies',
+      sperm: 'Spermatozoïdes',
+    },
     projectNamePlaceholder: 'ex. : Sphéroïdes de cellules HeLa',
     projectDescPlaceholder:
       'ex. : Analyse des sphéroïdes tumoraux pour les études de résistance aux médicaments',
@@ -1739,6 +1748,12 @@ export default {
     solidity: 'Solidité',
     sphericity: 'Sphéricité',
     feretAspectRatio: "Rapport d'Aspect de Feret",
+    disintegrationIndex: 'Indice de Désintégration',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: 'Mode de Référence',
+    totalSpheroidArea: 'Surface Totale des Sphéroïdes',
+    coreArea: 'Surface du Noyau',
+    invasionArea: "Surface d'Invasion",
     noPolygonsFound: "Aucun polygone trouvé pour l'analyse",
   },
   keyboardShortcuts: {

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -169,6 +169,15 @@ export default {
   projects: {
     createProject: '创建新项目',
     createProjectDesc: '添加新项目来组织您的球体图像和分析。',
+    projectType: '项目类型',
+    projectTypeUpdated: '项目类型已更新',
+    failedToUpdateProject: '无法更新项目',
+    types: {
+      spheroid: '球体（标准）',
+      spheroid_invasive: '分解球体',
+      wound: '伤口愈合',
+      sperm: '精子',
+    },
     projectNamePlaceholder: '例如：HeLa细胞球体',
     projectDescPlaceholder: '例如：用于药物耐受性研究的肿瘤球体分析',
     creatingProject: '创建中...',
@@ -1626,6 +1635,12 @@ export default {
     solidity: '实心度',
     sphericity: '球形度',
     feretAspectRatio: 'Feret纵横比',
+    disintegrationIndex: '分解指数',
+    wassersteinW1: 'Wasserstein W1',
+    referenceMode: '参考模式',
+    totalSpheroidArea: '球体总面积',
+    coreArea: '核心面积',
+    invasionArea: '侵袭面积',
     noPolygonsFound: '未找到可分析的多边形',
   },
   keyboardShortcuts: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -339,11 +339,18 @@ export const PROJECT_TYPES = [
 ] as const;
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 
+/** Coerce arbitrary input to a known ProjectType, defaulting to 'spheroid'.
+ * Use at API boundary so consumers never have to defensively `?? 'spheroid'`.
+ */
+export const isProjectType = (v: unknown): v is ProjectType =>
+  typeof v === 'string' && (PROJECT_TYPES as readonly string[]).includes(v);
+
 export interface Project {
   id: string;
   name: string;
   description?: string;
-  type?: ProjectType;
+  // Required: DB column is NOT NULL DEFAULT 'spheroid'. API always returns it.
+  type: ProjectType;
   created_at: string;
   updated_at: string;
   user_id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -331,10 +331,19 @@ export interface AuthResponse {
 }
 
 // Project types
+export const PROJECT_TYPES = [
+  'spheroid',
+  'spheroid_invasive',
+  'wound',
+  'sperm',
+] as const;
+export type ProjectType = (typeof PROJECT_TYPES)[number];
+
 export interface Project {
   id: string;
   name: string;
   description?: string;
+  type?: ProjectType;
   created_at: string;
   updated_at: string;
   user_id: string;
@@ -345,6 +354,7 @@ export interface Project {
 export interface NewProject {
   name: string;
   description?: string;
+  type?: ProjectType;
 }
 
 // Image types


### PR DESCRIPTION
## Summary

- **ASPP core detection**: postprocessing detects a dense central core inside the largest spheroid via local Otsu + 2-of-3 voting (mean_diff, core_frac, solidity); writes `partClass='core'` polygon for green editor render.
- **Disintegration Index (DI)**: 1-Wasserstein distance between empirical CDFs of mask-pixel and core-pixel radial distances, normalised by R_core, saturated via tanh into [0, 1). Calibrated on user 12bprusek's `time_0h` (DI ≈ 0.001) vs `time_48h` (DI ≈ 0.46) — 66× separation.
- **Per-image area metrics in Excel**: `Total Spheroid Area`, `Core Area`, `Invasion Area`, plus `Disintegration Index`. Self-healing image dimensions backfill (BMP header / sharp) when DB rows have NULL width/height.
- **Project type field** (`spheroid` / `spheroid_invasive` / `wound` / `sperm`): replaces fragile auto-detection. Drives metric export dispatch and is editable on the project detail page.
- **Methodology** documented in `documentation/metrics_guide.md` (added alongside per-polygon shape descriptors).

## Test plan

- [x] `pytest tests/unit/test_disintegration.py tests/unit/test_postprocessing_service.py::TestDetectCorePolygon` — 19/19 passed
- [x] `npx jest src/services/metrics/__tests__/ src/services/__tests__/exportService.test.ts` — 29/30 passed (1 pre-existing skip)
- [x] Frontend + backend `tsc --noEmit` clean
- [x] Calibration on 12 production images: 6× t=0 (DI 0.0–0.05), 6× t=48 (DI 0.31–0.58)
- [x] Schema migration applied to production (90 projects defaulted to `'spheroid'`)
- [x] Image dimension backfill: 417/417 NULL rows populated from BMP headers
- [ ] Manual UI test: create project with type, verify dropdown → API → DB
- [ ] Manual UI test: change project type on detail page → toast → next export uses new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added project type selection (spheroid, sperm, wound variants) for configuring workflow and analysis mode.
  * Introduced Disintegration Index metric computation for spheroid analysis.
  * Core polygon detection and visualization (highlighted in green).
  * Project type influences export format and metric calculations.
  * Enhanced image-level metrics tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->