### PR TITLE
fix(export): include project.type in Prisma select

### DIFF
--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -49,6 +49,7 @@ type ProjectWithImages = Prisma.ProjectGetPayload<{
   select: {
     id: true;
     title: true;
+    type: true;
     images: {
       select: {
         id: true;
@@ -319,6 +320,7 @@ export class ExportService {
         select: {
           id: true,
           title: true,
+          type: true, // drives metric export dispatcher
           images: {
             where: options.selectedImageIds
               ? { id: { in: options.selectedImageIds } }
@@ -481,7 +483,7 @@ export class ExportService {
             exportDir,
             options.metricsFormats,
             project.title,
-            (project as { type?: string }).type || 'spheroid',
+            project.type || 'spheroid',
             options,
             jobId
           ).then(() => {


### PR DESCRIPTION
## Summary

The narrow select in \`generateMetrics\` (exportService.ts:319) only fetched \`id\` and \`title\` from the Project model, so \`project.type\` was \`undefined\` at runtime. The \`(project as { type?: string }).type || 'spheroid'\` fallback at the call site then masked the bug — every project, regardless of the UI selection, received the standard polygon metrics export instead of the disintegrated-spheroid 4-column report.

## Fix

- Add \`type: true\` to the export-query \`select\` and to the \`ProjectWithImages\` Prisma type alias.
- Drop the unsafe runtime cast \`(project as { type?: string }).type\` at the call site — future schema additions now fail loud at compile time.

## Reproducer

1. Set project type to \`spheroid_invasive\` via the UI dropdown
2. Export the project
3. Excel \`metrics.xlsx\` previously contained 22-column polygon metrics; now contains the 4-metric one-row-per-image report

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Production deploy verified — same project re-exported, correct format
- [ ] Manual: re-export user's \`spheroids_test\` project (already flagged \`spheroid_invasive\` in DB) and confirm Image Metrics sheet appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export service reliability by ensuring project type information is properly retrieved during database queries and consistently applied when generating metrics, enhancing the stability of export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->