### PR TITLE
feat(project-types): block incompatible segmentation with modal, redesign type dropdown

### DIFF
--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -29,6 +29,13 @@ const PROJECT_TYPE_BADGE: Record<ProjectType, string> = {
     'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200 border-purple-300 dark:border-purple-700',
 };
 
+const PROJECT_TYPE_DOT: Record<ProjectType, string> = {
+  spheroid: 'bg-blue-500',
+  spheroid_invasive: 'bg-emerald-500',
+  wound: 'bg-amber-500',
+  sperm: 'bg-purple-500',
+};
+
 interface ProjectHeaderProps {
   projectTitle: string;
   imagesCount: number;
@@ -74,49 +81,69 @@ const ProjectHeader = ({
             </div>
             {projectType && (
               <div className="hidden sm:flex items-center gap-2">
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
                   {t('projects.projectType')}:
                 </span>
-                {/* Color badge visually segregates project types — disintegrated
-                    spheroids get an emerald ring to stand out from the standard
-                    spheroid family (blue), wound (amber), sperm (purple). */}
-                <Badge
-                  variant="outline"
-                  className={cn(
-                    'text-xs font-medium border',
-                    PROJECT_TYPE_BADGE[projectType]
-                  )}
-                >
-                  {t(`projects.types.${projectType}`)}
-                </Badge>
-                {onTypeChange && (
+                {onTypeChange ? (
+                  // Editable: dropdown trigger styled as a coloured pill that
+                  // matches the badge palette. Disintegrated spheroids get an
+                  // emerald ring to stand out from the standard spheroid family.
                   <Select
                     value={projectType}
                     onValueChange={(v: ProjectType) => onTypeChange(v)}
                   >
                     <SelectTrigger
-                      className="h-8 w-[40px] text-xs"
                       aria-label={t('projects.changeProjectType')}
+                      className={cn(
+                        'h-8 min-w-[200px] text-xs font-medium border rounded-md gap-2 pl-3 pr-2',
+                        PROJECT_TYPE_BADGE[projectType]
+                      )}
                     >
-                      <SelectValue />
+                      <span className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            'inline-block w-2.5 h-2.5 rounded-full shrink-0',
+                            PROJECT_TYPE_DOT[projectType]
+                          )}
+                        />
+                        <span className="truncate">
+                          {t(`projects.types.${projectType}`)}
+                        </span>
+                      </span>
                     </SelectTrigger>
                     <SelectContent>
                       {PROJECT_TYPES.map(pt => (
                         <SelectItem key={pt} value={pt} className="text-xs">
-                          <span
-                            className={cn(
-                              'inline-block w-2 h-2 rounded-full mr-2 align-middle',
-                              pt === 'spheroid' && 'bg-blue-500',
-                              pt === 'spheroid_invasive' && 'bg-emerald-500',
-                              pt === 'wound' && 'bg-amber-500',
-                              pt === 'sperm' && 'bg-purple-500'
-                            )}
-                          />
-                          {t(`projects.types.${pt}`)}
+                          <span className="flex items-center gap-2">
+                            <span
+                              className={cn(
+                                'inline-block w-2.5 h-2.5 rounded-full shrink-0',
+                                PROJECT_TYPE_DOT[pt]
+                              )}
+                            />
+                            {t(`projects.types.${pt}`)}
+                          </span>
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
+                ) : (
+                  // Read-only: same pill shape, no chevron.
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      'h-8 px-3 text-xs font-medium border gap-2',
+                      PROJECT_TYPE_BADGE[projectType]
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'inline-block w-2.5 h-2.5 rounded-full',
+                        PROJECT_TYPE_DOT[projectType]
+                      )}
+                    />
+                    {t(`projects.types.${projectType}`)}
+                  </Badge>
                 )}
               </div>
             )}

--- a/src/hooks/useProjectImageActions.tsx
+++ b/src/hooks/useProjectImageActions.tsx
@@ -20,6 +20,10 @@ interface UseProjectImageActionsProps {
   projectType?: ProjectType;
   onImagesChange: (images: ProjectImage[]) => void;
   images: ProjectImage[];
+  /** Called when an action is blocked because the selected model is not
+   * compatible with the project type. Lets the parent component open a
+   * blocking modal instead of relying on a toast. */
+  onIncompatibleModel?: () => void;
 }
 
 export const useProjectImageActions = ({
@@ -27,6 +31,7 @@ export const useProjectImageActions = ({
   projectType,
   onImagesChange,
   images,
+  onIncompatibleModel,
 }: UseProjectImageActionsProps) => {
   const navigate = useNavigate();
   const [processingImages, setProcessingImages] = useState<string[]>([]);
@@ -85,16 +90,22 @@ export const useProjectImageActions = ({
   const handleProcessImage = async (imageId: string): Promise<boolean> => {
     // Pre-flight: ensure the globally selected model is compatible with this
     // project's type. Backend enforces the same rule (defense in depth), but
-    // we abort here so the user gets immediate feedback instead of a 400.
+    // we abort here so the user gets immediate feedback. Prefer opening the
+    // parent's modal so the user sees a blocking explanation rather than a
+    // fading toast; fall back to toast if no modal handler is wired.
     if (projectType && !isModelCompatibleWithType(selectedModel, projectType)) {
-      const allowed = MODEL_TYPE_COMPATIBILITY[projectType].join(', ');
-      toast.error(
-        t('segmentation.modelNotCompatible', {
-          model: selectedModel,
-          type: projectType,
-          allowed,
-        })
-      );
+      if (onIncompatibleModel) {
+        onIncompatibleModel();
+      } else {
+        const allowed = MODEL_TYPE_COMPATIBILITY[projectType].join(', ');
+        toast.error(
+          t('segmentation.modelNotCompatible', {
+            model: selectedModel,
+            type: projectType,
+            allowed,
+          })
+        );
+      }
       return false;
     }
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -36,6 +36,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {
+  isModelCompatibleWithType,
+  MODEL_TYPE_COMPATIBILITY,
+  getErrorMessage,
+} from '@/types';
 
 const ProjectDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -47,6 +52,8 @@ const ProjectDetail = () => {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [batchSubmitted, setBatchSubmitted] = useState<boolean>(false);
   const [isCancelling, setIsCancelling] = useState<boolean>(false);
+  const [incompatibleModelOpen, setIncompatibleModelOpen] =
+    useState<boolean>(false);
   const [selectedImageIds, setSelectedImageIds] = useState<Set<string>>(
     new Set()
   );
@@ -418,6 +425,7 @@ const ProjectDetail = () => {
       projectType,
       onImagesChange: updateImages,
       images,
+      onIncompatibleModel: () => setIncompatibleModelOpen(true),
     });
 
   // Status reconciliation for keeping UI in sync with backend
@@ -1237,6 +1245,15 @@ const ProjectDetail = () => {
       return;
     }
 
+    // Block segmentation when the globally selected model isn't compatible
+    // with this project's type. Open the modal instead of a toast — the user
+    // tried an action that fundamentally can't proceed and needs a clear
+    // explanation, not a quickly-fading notification.
+    if (projectType && !isModelCompatibleWithType(selectedModel, projectType)) {
+      setIncompatibleModelOpen(true);
+      return;
+    }
+
     // Prevent double submission
     if (batchSubmitted) {
       return;
@@ -1595,6 +1612,36 @@ const ProjectDetail = () => {
               className="bg-red-600 hover:bg-red-700"
             >
               {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Incompatible model dialog — blocks the user from running a model
+          that doesn't fit the current project type, with a clear list of
+          allowed models for that type. */}
+      <AlertDialog
+        open={incompatibleModelOpen}
+        onOpenChange={setIncompatibleModelOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('segmentation.incompatibleModelTitle')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('segmentation.incompatibleModelDesc', {
+                model: selectedModel,
+                type: projectType ? t(`projects.types.${projectType}`) : '',
+                allowed: projectType
+                  ? MODEL_TYPE_COMPATIBILITY[projectType].join(', ')
+                  : '',
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setIncompatibleModelOpen(false)}>
+              {t('common.close')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -548,6 +548,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       'Model "{{model}}" není kompatibilní s typem projektu "{{type}}". Povolené: {{allowed}}.',
+    incompatibleModelTitle: 'Tímto modelem nelze segmentovat',
+    incompatibleModelDesc:
+      'Aktuálně vybraný model "{{model}}" není kompatibilní s typem tohoto projektu ({{type}}). Povolené modely pro tento typ: {{allowed}}. Změňte prosím model v Nastavení nebo změňte typ projektu.',
     mode: {
       view: 'Zobrazit a navigovat',
       edit: 'Upravit',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -694,6 +694,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       'Modell "{{model}}" ist nicht mit dem Projekttyp "{{type}}" kompatibel. Erlaubt: {{allowed}}.',
+    incompatibleModelTitle: 'Mit diesem Modell kann nicht segmentiert werden',
+    incompatibleModelDesc:
+      'Das ausgewählte Modell "{{model}}" ist nicht mit dem Projekttyp ({{type}}) kompatibel. Erlaubte Modelle: {{allowed}}. Bitte ändern Sie das Modell in den Einstellungen oder den Projekttyp.',
     mode: {
       view: 'Anzeigen und navigieren',
       edit: 'Bearbeiten',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -563,6 +563,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       'Model "{{model}}" is not compatible with project type "{{type}}". Allowed: {{allowed}}.',
+    incompatibleModelTitle: 'Cannot segment with this model',
+    incompatibleModelDesc:
+      'The currently selected model "{{model}}" is not compatible with this project\'s type ({{type}}). Allowed models for this type: {{allowed}}. Please change the model in Settings or change the project type.',
     mode: {
       view: 'View and navigate',
       edit: 'Edit',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -686,6 +686,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       'El modelo "{{model}}" no es compatible con el tipo de proyecto "{{type}}". Permitidos: {{allowed}}.',
+    incompatibleModelTitle: 'No se puede segmentar con este modelo',
+    incompatibleModelDesc:
+      'El modelo seleccionado "{{model}}" no es compatible con el tipo de este proyecto ({{type}}). Modelos permitidos: {{allowed}}. Cambie el modelo en Configuración o cambie el tipo de proyecto.',
     mode: {
       view: 'Ver y navegar',
       edit: 'Editar',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -687,6 +687,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       'Le modèle "{{model}}" n\'est pas compatible avec le type de projet "{{type}}". Autorisés : {{allowed}}.',
+    incompatibleModelTitle: 'Impossible de segmenter avec ce modèle',
+    incompatibleModelDesc:
+      'Le modèle sélectionné "{{model}}" n\'est pas compatible avec le type de ce projet ({{type}}). Modèles autorisés : {{allowed}}. Veuillez changer le modèle dans les Paramètres ou modifier le type de projet.',
     mode: {
       view: 'Voir et naviguer',
       edit: 'Modifier',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -627,6 +627,9 @@ export default {
   segmentation: {
     modelNotCompatible:
       '模型 "{{model}}" 与项目类型 "{{type}}" 不兼容。允许的: {{allowed}}。',
+    incompatibleModelTitle: '无法使用此模型进行分割',
+    incompatibleModelDesc:
+      '当前选择的模型 "{{model}}" 与此项目类型 ({{type}}) 不兼容。允许的模型: {{allowed}}。请在设置中更改模型或更改项目类型。',
     mode: {
       view: '查看和导航',
       edit: '编辑',


### PR DESCRIPTION
## Summary

- **Block Segment All / per-image segmentation with a modal** when the globally selected model is incompatible with the project type. Replaces the toast that was easy to miss.
- **Redesign project type dropdown**: single coloured pill showing dot + name (was 40 px chevron-only beside a static badge). Read-only mode renders the same pill as a Badge.
- **Optional `onIncompatibleModel` callback** in \`useProjectImageActions\` so callers can choose modal vs toast.
- 6 locales: \`incompatibleModelTitle\` + \`incompatibleModelDesc\` keys.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Production deploy verified
- [ ] Manual: switch model to e.g. \`hrnet\` then click Segment All on a \`spheroid_invasive\` project — modal opens
- [ ] Manual: switch to \`unet_attention_aspp\`, modal closes path, segmentation proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)