### PR TITLE
fix(create-project): add project type selector to the actually-used modal

### DIFF
--- a/src/components/project/ProjectDialogForm.tsx
+++ b/src/components/project/ProjectDialogForm.tsx
@@ -8,8 +8,24 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useProjectForm } from '@/hooks/useProjectForm';
 import { useLanguage } from '@/contexts/useLanguage';
+import { PROJECT_TYPES, type ProjectType } from '@/types';
+import { cn } from '@/lib/utils';
+
+const PROJECT_TYPE_DOT: Record<ProjectType, string> = {
+  spheroid: 'bg-blue-500',
+  spheroid_invasive: 'bg-emerald-500',
+  wound: 'bg-amber-500',
+  sperm: 'bg-purple-500',
+};
 
 interface ProjectDialogFormProps {
   onSuccess?: (projectId: string) => void;
@@ -23,6 +39,8 @@ const ProjectDialogForm = ({ onSuccess, onClose }: ProjectDialogFormProps) => {
     setProjectName,
     projectDescription,
     setProjectDescription,
+    projectType,
+    setProjectType,
     isCreating,
     handleCreateProject,
   } = useProjectForm({ onSuccess, onClose });
@@ -57,6 +75,34 @@ const ProjectDialogForm = ({ onSuccess, onClose }: ProjectDialogFormProps) => {
               value={projectDescription}
               onChange={e => setProjectDescription(e.target.value)}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="projectType" className="text-right">
+              {t('projects.projectType')}
+            </Label>
+            <Select
+              value={projectType}
+              onValueChange={(v: ProjectType) => setProjectType(v)}
+            >
+              <SelectTrigger id="projectType">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROJECT_TYPES.map(pt => (
+                  <SelectItem key={pt} value={pt}>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          'inline-block w-2.5 h-2.5 rounded-full',
+                          PROJECT_TYPE_DOT[pt]
+                        )}
+                      />
+                      {t(`projects.types.${pt}`)}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
         <DialogFooter>

--- a/src/hooks/useProjectForm.tsx
+++ b/src/hooks/useProjectForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import apiClient from '@/lib/api';
 import { useAuth } from '@/contexts/useAuth';
-import { getErrorMessage as _getErrorMessage } from '@/types';
+import { getErrorMessage as _getErrorMessage, type ProjectType } from '@/types';
 import { getLocalizedErrorMessage } from '@/lib/errorUtils';
 import { logger } from '@/lib/logger';
 import { useLanguage } from '@/contexts/useLanguage';
@@ -16,6 +16,7 @@ export const useProjectForm = ({ onSuccess, onClose }: UseProjectFormProps) => {
   const { t } = useLanguage();
   const [projectName, setProjectName] = useState('');
   const [projectDescription, setProjectDescription] = useState('');
+  const [projectType, setProjectType] = useState<ProjectType>('spheroid');
   const [isCreating, setIsCreating] = useState(false);
   const { user } = useAuth();
 
@@ -38,6 +39,7 @@ export const useProjectForm = ({ onSuccess, onClose }: UseProjectFormProps) => {
       const projectData = await apiClient.createProject({
         name: projectName,
         description: projectDescription || t('projects.noDescriptionProvided'),
+        type: projectType,
       });
 
       // Validate response
@@ -56,6 +58,7 @@ export const useProjectForm = ({ onSuccess, onClose }: UseProjectFormProps) => {
       onClose();
       setProjectName('');
       setProjectDescription('');
+      setProjectType('spheroid');
 
       // Trigger refresh or callback
       if (onSuccess && projectData.id) {
@@ -85,6 +88,8 @@ export const useProjectForm = ({ onSuccess, onClose }: UseProjectFormProps) => {
     setProjectName,
     projectDescription,
     setProjectDescription,
+    projectType,
+    setProjectType,
     isCreating,
     handleCreateProject,
   };


### PR DESCRIPTION
## Summary

The "Create New Project" UI uses the chain \`NewProjectCard\` -> \`ProjectDialogForm\` -> \`useProjectForm\`. PR #100 added the type field into a parallel legacy \`NewProject.tsx\` component which is dead code in production, so the dropdown was never visible to users.

This PR wires \`projectType\` state through \`useProjectForm\` and adds a colour-dot \`Select\` in \`ProjectDialogForm\` matching the project header's design.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Production deploy verified
- [ ] Manual: open Create New Project dialog, dropdown for type appears with 4 options + colour dots; new project gets persisted with the chosen type

🤖 Generated with [Claude Code](https://claude.com/claude-code)