### PR TITLE
chore(ui): remove color dots from project-type dropdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -71,3 +71,6 @@ Thumbs.db
 .backups/
 .tmp_viz/
 
+# External / scratch model artifacts dropped at repo root
+path_c_v24c/
+

--- a/src/components/project/ProjectDialogForm.tsx
+++ b/src/components/project/ProjectDialogForm.tsx
@@ -18,14 +18,6 @@ import {
 import { useProjectForm } from '@/hooks/useProjectForm';
 import { useLanguage } from '@/contexts/useLanguage';
 import { PROJECT_TYPES, type ProjectType } from '@/types';
-import { cn } from '@/lib/utils';
-
-const PROJECT_TYPE_DOT: Record<ProjectType, string> = {
-  spheroid: 'bg-blue-500',
-  spheroid_invasive: 'bg-emerald-500',
-  wound: 'bg-amber-500',
-  sperm: 'bg-purple-500',
-};
 
 interface ProjectDialogFormProps {
   onSuccess?: (projectId: string) => void;
@@ -90,15 +82,7 @@ const ProjectDialogForm = ({ onSuccess, onClose }: ProjectDialogFormProps) => {
               <SelectContent>
                 {PROJECT_TYPES.map(pt => (
                   <SelectItem key={pt} value={pt}>
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          'inline-block w-2.5 h-2.5 rounded-full',
-                          PROJECT_TYPE_DOT[pt]
-                        )}
-                      />
-                      {t(`projects.types.${pt}`)}
-                    </span>
+                    {t(`projects.types.${pt}`)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -29,13 +29,6 @@ const PROJECT_TYPE_BADGE: Record<ProjectType, string> = {
     'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200 border-purple-300 dark:border-purple-700',
 };
 
-const PROJECT_TYPE_DOT: Record<ProjectType, string> = {
-  spheroid: 'bg-blue-500',
-  spheroid_invasive: 'bg-emerald-500',
-  wound: 'bg-amber-500',
-  sperm: 'bg-purple-500',
-};
-
 interface ProjectHeaderProps {
   projectTitle: string;
   imagesCount: number;
@@ -86,8 +79,8 @@ const ProjectHeader = ({
                 </span>
                 {onTypeChange ? (
                   // Editable: dropdown trigger styled as a coloured pill that
-                  // matches the badge palette. Disintegrated spheroids get an
-                  // emerald ring to stand out from the standard spheroid family.
+                  // matches the badge palette. The pill background carries the
+                  // type identity — no extra dot needed.
                   <Select
                     value={projectType}
                     onValueChange={(v: ProjectType) => onTypeChange(v)}
@@ -95,34 +88,18 @@ const ProjectHeader = ({
                     <SelectTrigger
                       aria-label={t('projects.changeProjectType')}
                       className={cn(
-                        'h-8 min-w-[200px] text-xs font-medium border rounded-md gap-2 pl-3 pr-2',
+                        'h-8 min-w-[200px] text-xs font-medium border rounded-md pl-3 pr-2',
                         PROJECT_TYPE_BADGE[projectType]
                       )}
                     >
-                      <span className="flex items-center gap-2">
-                        <span
-                          className={cn(
-                            'inline-block w-2.5 h-2.5 rounded-full shrink-0',
-                            PROJECT_TYPE_DOT[projectType]
-                          )}
-                        />
-                        <span className="truncate">
-                          {t(`projects.types.${projectType}`)}
-                        </span>
+                      <span className="truncate">
+                        {t(`projects.types.${projectType}`)}
                       </span>
                     </SelectTrigger>
                     <SelectContent>
                       {PROJECT_TYPES.map(pt => (
                         <SelectItem key={pt} value={pt} className="text-xs">
-                          <span className="flex items-center gap-2">
-                            <span
-                              className={cn(
-                                'inline-block w-2.5 h-2.5 rounded-full shrink-0',
-                                PROJECT_TYPE_DOT[pt]
-                              )}
-                            />
-                            {t(`projects.types.${pt}`)}
-                          </span>
+                          {t(`projects.types.${pt}`)}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -132,16 +109,10 @@ const ProjectHeader = ({
                   <Badge
                     variant="outline"
                     className={cn(
-                      'h-8 px-3 text-xs font-medium border gap-2',
+                      'h-8 px-3 text-xs font-medium border',
                       PROJECT_TYPE_BADGE[projectType]
                     )}
                   >
-                    <span
-                      className={cn(
-                        'inline-block w-2.5 h-2.5 rounded-full',
-                        PROJECT_TYPE_DOT[projectType]
-                      )}
-                    />
                     {t(`projects.types.${projectType}`)}
                   </Badge>
                 )}


### PR DESCRIPTION
## Summary
- Drop the colored dot from the project-type dropdown trigger and items in both `ProjectHeader.tsx` (read/edit on the project page) and `ProjectDialogForm.tsx` (create-project modal). The pill background already encodes type identity, so the extra dot was redundant visual noise.
- Add `path_c_v24c/` to `.prettierignore` — a stray sperm-model scratch directory that lives at repo root was breaking pre-commit prettier on unrelated commits.

## Test plan
- [ ] Open a project page → type pill shows label only on coloured background, no dot.
- [ ] Click the pill → dropdown items show plain labels, no leading dots.
- [ ] Open New Project dialog → type select shows plain labels in dropdown.
- [ ] Pre-commit: `git commit` on an unrelated change does not fail because of `path_c_v24c/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Prettier configuration to exclude external artifacts from formatting.

## Style
* Simplified project type display by removing colored dot indicators from dropdowns and headers, streamlining the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->