### PR TITLE
test: cover ResponseHelper and gpu_monitor

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -71,3 +71,6 @@ Thumbs.db
 .backups/
 .tmp_viz/
 
+# External / scratch model artifacts dropped at repo root
+path_c_v24c/
+

--- a/backend/segmentation/tests/unit/test_gpu_monitor.py
+++ b/backend/segmentation/tests/unit/test_gpu_monitor.py
@@ -36,13 +36,16 @@ def test_summary_stats_reports_no_data_initially(cpu_monitor):
     assert stats == {"status": "no_data", "gpu_available": False}
 
 
-def test_record_batch_processing_with_no_gpu_yields_zero_memory(cpu_monitor):
-    """memory_after on CPU is 0; delta is therefore non-negative even after clamp."""
-    start = time.time() - 0.05  # 50ms ago
+def test_record_batch_processing_with_no_gpu_yields_zero_memory(cpu_monitor, monkeypatch):
+    """memory_after on CPU is 0; delta is therefore non-negative even after clamp.
+    Throughput math is unit-checked with a deterministic 1-second clock so a
+    formula regression (e.g. dropping the *1000 conversion) would be caught."""
+    # Pin time.time so inference_time_ms == 1000.0 exactly.
+    monkeypatch.setattr("monitoring.gpu_monitor.time.time", lambda: 1.0)
     result = cpu_monitor.record_batch_processing(
         model_name="hrnet",
         batch_size=4,
-        start_time=start,
+        start_time=0.0,
         memory_before=0,
         success=True,
     )
@@ -52,10 +55,21 @@ def test_record_batch_processing_with_no_gpu_yields_zero_memory(cpu_monitor):
     assert result.memory_before_mb == 0.0
     assert result.memory_after_mb == 0.0
     assert result.memory_delta_mb == 0.0
-    # Throughput is computed from inference_time_ms; should be positive.
-    assert result.throughput_imgs_sec > 0
+    # 4 imgs in 1.0s = 4 imgs/sec exactly.
+    assert result.inference_time_ms == pytest.approx(1000.0)
+    assert result.throughput_imgs_sec == pytest.approx(4.0)
     # Counter updates only on success.
     assert cpu_monitor.total_images_processed == 4
+
+
+def test_stop_monitoring_is_callable_after_init(cpu_monitor):
+    """Regression test for the Event-shadowing bug fixed in fix(gpu-monitor).
+    Before the fix, `__init__` did `self.stop_monitoring = threading.Event()`,
+    shadowing the `stop_monitoring()` method, so calling it raised
+    `TypeError: 'Event' object is not callable`."""
+    # Method must be callable. Without an active thread it just sets the
+    # internal stop event and returns.
+    cpu_monitor.stop_monitoring()  # must not raise
 
 
 def test_record_batch_processing_failure_does_not_update_totals(cpu_monitor):

--- a/backend/segmentation/tests/unit/test_gpu_monitor.py
+++ b/backend/segmentation/tests/unit/test_gpu_monitor.py
@@ -1,0 +1,105 @@
+"""Unit tests for GPUMonitor — focused on the CPU-only path that runs in CI.
+
+We verify behaviour when no GPU is available (`torch.cuda.is_available()`
+returns False), since the GH Actions test runner is CPU-only. GPU-only paths
+require an actual CUDA device and live in the integration suite.
+"""
+
+import os
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+)
+
+
+@pytest.fixture
+def cpu_monitor():
+    """Build a GPUMonitor with CUDA forced off — exercises the no-GPU code paths."""
+    with patch("torch.cuda.is_available", return_value=False):
+        from monitoring.gpu_monitor import GPUMonitor
+        return GPUMonitor(sampling_interval=0.1, history_size=5)
+
+
+def test_get_current_metrics_returns_none_without_gpu(cpu_monitor):
+    """When CUDA is not available, snapshots are skipped (returns None)."""
+    assert cpu_monitor.get_current_metrics() is None
+
+
+def test_summary_stats_reports_no_data_initially(cpu_monitor):
+    """Empty history → 'no_data' status, with the gpu_available flag echoed."""
+    stats = cpu_monitor.get_summary_stats()
+    assert stats == {"status": "no_data", "gpu_available": False}
+
+
+def test_record_batch_processing_with_no_gpu_yields_zero_memory(cpu_monitor):
+    """memory_after on CPU is 0; delta is therefore non-negative even after clamp."""
+    start = time.time() - 0.05  # 50ms ago
+    result = cpu_monitor.record_batch_processing(
+        model_name="hrnet",
+        batch_size=4,
+        start_time=start,
+        memory_before=0,
+        success=True,
+    )
+    assert result.model_name == "hrnet"
+    assert result.batch_size == 4
+    assert result.success is True
+    assert result.memory_before_mb == 0.0
+    assert result.memory_after_mb == 0.0
+    assert result.memory_delta_mb == 0.0
+    # Throughput is computed from inference_time_ms; should be positive.
+    assert result.throughput_imgs_sec > 0
+    # Counter updates only on success.
+    assert cpu_monitor.total_images_processed == 4
+
+
+def test_record_batch_processing_failure_does_not_update_totals(cpu_monitor):
+    """A failed batch is recorded but doesn't bump cumulative totals."""
+    start = time.time()
+    result = cpu_monitor.record_batch_processing(
+        model_name="hrnet",
+        batch_size=8,
+        start_time=start,
+        memory_before=0,
+        success=False,
+        error_message="OOM",
+    )
+    assert result.success is False
+    assert result.error_message == "OOM"
+    assert cpu_monitor.total_images_processed == 0
+    assert cpu_monitor.total_inference_time_ms == 0.0
+
+
+def test_summary_stats_with_populated_history(cpu_monitor):
+    """With metrics in history, summary returns 'monitoring' status, the
+    documented field names, and a CPU device label."""
+    from monitoring.gpu_monitor import GPUMetrics
+
+    sample = GPUMetrics(
+        timestamp="2026-04-26T00:00:00",
+        device_id=0,
+        device_name="mock",
+        memory_allocated_mb=100.0,
+        memory_reserved_mb=120.0,
+        memory_free_mb=900.0,
+        memory_total_mb=1000.0,
+        memory_usage_percent=10.0,
+        utilization_percent=50.0,
+    )
+    for _ in range(3):
+        cpu_monitor.metrics_history.append(sample)
+
+    stats = cpu_monitor.get_summary_stats()
+    assert stats["status"] == "monitoring"
+    assert stats["gpu_available"] is False
+    assert stats["device_name"] == "CPU"
+    assert stats["total_memory_mb"] == 0
+    assert stats["avg_memory_mb"] == pytest.approx(100.0)
+    assert stats["avg_utilization_percent"] == pytest.approx(50.0)
+    # No batches recorded → success rate defaults to 100.
+    assert stats["batch_success_rate"] == 100

--- a/backend/src/utils/__tests__/response.test.ts
+++ b/backend/src/utils/__tests__/response.test.ts
@@ -187,6 +187,56 @@ describe('ResponseHelper.error: contract for downstream consumers', () => {
     >;
     expect(body.error).toBe('X');
   });
+
+  it('error(res, msg, 500) without an Error param still logs at error level', () => {
+    // Locks the `if (logError || statusCode >= 500)` branch in response.ts:71.
+    // Even without a passed-in Error, a 500 response must take the error-log
+    // path (not the warn path). A future refactor swapping `||` for `&&`
+    // would break this — this test catches it.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { logger } = require('../logger');
+    (logger.error as jest.Mock).mockClear();
+    (logger.warn as jest.Mock).mockClear();
+
+    const res = mockRes();
+    ResponseHelper.error(res, 'Service down', 500);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe('ResponseHelper.paginated', () => {
+  it('writes 200 + body shape that list endpoints depend on', () => {
+    // Frontend list views read `response.pagination.totalPages` — locking
+    // the body shape here protects every paginated endpoint from a refactor
+    // that renames `pagination` to `meta` or similar.
+    const res = mockRes();
+    const data = [{ id: 'a' }, { id: 'b' }];
+    const pagination = { page: 1, limit: 10, total: 2, totalPages: 1 };
+    ResponseHelper.paginated(res, data, pagination, 'OK');
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data,
+      pagination,
+      message: 'OK',
+    });
+  });
+
+  it('honours an explicit status code (e.g. 206 Partial Content)', () => {
+    const res = mockRes();
+    ResponseHelper.paginated(
+      res,
+      [],
+      { page: 1, limit: 10, total: 0, totalPages: 0 },
+      undefined,
+      206
+    );
+    expect(res.status).toHaveBeenCalledWith(206);
+  });
 });
 
 describe('calculatePagination', () => {

--- a/backend/src/utils/__tests__/response.test.ts
+++ b/backend/src/utils/__tests__/response.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { Response } from 'express';
+import { ResponseHelper, calculatePagination } from '../response';
+
+// The helper internally calls `logger.warn` / `logger.error`. The logger
+// module reads runtime config at import; for these tests we stub out only
+// the methods we care about so the assertions don't get noisy.
+jest.mock('../logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res) as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as Response['json'];
+  return res as Response;
+};
+
+describe('ResponseHelper.success', () => {
+  it('writes 200 by default with success=true and data field', () => {
+    const res = mockRes();
+    ResponseHelper.success(res, { id: 'abc' }, 'OK');
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: { id: 'abc' },
+      message: 'OK',
+    });
+  });
+
+  it('honours an explicit status code (e.g. 201 Created)', () => {
+    const res = mockRes();
+    ResponseHelper.success(res, { id: 'x' }, 'Created', 201);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});
+
+describe('ResponseHelper error variants', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('badRequest writes 400 with code BAD_REQUEST and the message in `error`', () => {
+    const res = mockRes();
+    ResponseHelper.badRequest(res, 'Project ID is required');
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Project ID is required',
+      code: 'BAD_REQUEST',
+      details: undefined,
+    });
+  });
+
+  it('unauthorized writes 401 with code UNAUTHORIZED', () => {
+    const res = mockRes();
+    ResponseHelper.unauthorized(res, 'No token');
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'No token',
+      code: 'UNAUTHORIZED',
+      details: undefined,
+    });
+  });
+
+  it('forbidden writes 403 with code FORBIDDEN', () => {
+    const res = mockRes();
+    ResponseHelper.forbidden(res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = (res.json as jest.Mock).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.code).toBe('FORBIDDEN');
+    expect(body.success).toBe(false);
+  });
+
+  it('notFound writes 404 with code NOT_FOUND', () => {
+    const res = mockRes();
+    ResponseHelper.notFound(res, 'Export file not found');
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Export file not found',
+      code: 'NOT_FOUND',
+      details: undefined,
+    });
+  });
+
+  it('conflict writes 409 with code CONFLICT', () => {
+    const res = mockRes();
+    ResponseHelper.conflict(res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    const body = (res.json as jest.Mock).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.code).toBe('CONFLICT');
+  });
+
+  it('rateLimit writes 429 with code RATE_LIMIT_EXCEEDED', () => {
+    const res = mockRes();
+    ResponseHelper.rateLimit(res);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    const body = (res.json as jest.Mock).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.code).toBe('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('internalError writes 500 with code INTERNAL_ERROR and logs the cause', () => {
+    const res = mockRes();
+    const cause = new Error('boom');
+    ResponseHelper.internalError(res, cause, 'Failed to start export');
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Failed to start export',
+      code: 'INTERNAL_ERROR',
+      details: undefined,
+    });
+  });
+
+  it('serviceUnavailable writes 503 with code SERVICE_UNAVAILABLE', () => {
+    const res = mockRes();
+    ResponseHelper.serviceUnavailable(res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    const body = (res.json as jest.Mock).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('validationError accepts a string message', () => {
+    const res = mockRes();
+    ResponseHelper.validationError(res, 'Invalid email');
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Invalid email',
+      code: 'VALIDATION_ERROR',
+      details: undefined,
+    });
+  });
+
+  it('validationError accepts a structured field-error map', () => {
+    const res = mockRes();
+    const fieldErrors = { email: ['required'], password: ['too short'] };
+    ResponseHelper.validationError(res, fieldErrors);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Validation error',
+      code: 'VALIDATION_ERROR',
+      details: fieldErrors,
+    });
+  });
+});
+
+describe('ResponseHelper.error: contract for downstream consumers', () => {
+  it('always writes the message in `error` field — frontend errorUtils reads this', () => {
+    // Frontend `src/lib/errorUtils.ts:43` does
+    //   responseData.error || responseData.message
+    // so the migrated controller responses must keep `error` populated.
+    const res = mockRes();
+    ResponseHelper.badRequest(res, 'X');
+    const body = (res.json as jest.Mock).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.error).toBe('X');
+  });
+});
+
+describe('calculatePagination', () => {
+  it('computes offset and totalPages correctly for first page', () => {
+    expect(calculatePagination(1, 10, 25)).toEqual({
+      page: 1,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      offset: 0,
+      hasNext: true,
+      hasPrev: false,
+    });
+  });
+
+  it('marks last page hasNext=false', () => {
+    const p = calculatePagination(3, 10, 25);
+    expect(p.hasNext).toBe(false);
+    expect(p.hasPrev).toBe(true);
+    expect(p.offset).toBe(20);
+  });
+
+  it('handles zero total cleanly (no division-by-zero)', () => {
+    expect(calculatePagination(1, 10, 0)).toEqual({
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+      offset: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
PR 5 of the repo cleanup plan. Adds unit tests for two previously untested modules. Scoped narrowly: both files are small (~358 + 277 LoC), both have high leverage on the rest of the system (\`response.ts\` is exercised by every controller migration in PR #110), and both have testable contracts that don't require deep mocking.

### What's tested
**\`backend/src/utils/__tests__/response.test.ts\`** (NEW, 16 tests, all pass locally)
- \`success()\` — default 200 + custom status code path
- All 9 error variants — verified status code + full body shape \`{ success: false, error, code, details? }\`
- **Contract test**: the human-readable string lands in \`error\` field. This is load-bearing — frontend \`errorUtils.ts:43\` reads \`responseData.error || responseData.message\`. PR #110 (and any future controller migration) relies on this contract being preserved.
- \`validationError\` covers both string and field-error-map inputs
- \`calculatePagination\` — first/last/zero edge cases

**\`backend/segmentation/tests/unit/test_gpu_monitor.py\`** (NEW, 5 tests, syntax-verified)
- \`get_current_metrics\` returns \`None\` on CPU-only build (no CUDA dependency)
- \`get_summary_stats\` returns \`{status: 'no_data', gpu_available: False}\` on empty history
- \`record_batch_processing\` on CPU: zero-memory metrics, throughput math, success-only counter updates
- Failed batches recorded but don't bump totals
- Populated history → \`monitoring\` status with documented field names

### What's deliberately deferred
The plan listed 6 test targets (useSharedAdvancedExport, ShareDialog, thumbnail services, emailRetryService, gpu_monitor). I shipped 2 because writing tests for code I haven't deeply read produces flaky/wrong tests. The remaining 4 are large surfaces best tackled in dedicated PRs after the test author reads the implementation.

## Verification
- [x] \`backend && npx jest src/utils/__tests__/response.test.ts\` — **16/16 pass**
- [x] \`python3 -c "import ast; ast.parse(...)"\` — gpu_monitor test file parses
- [ ] (CI) \`pytest backend/segmentation/tests/unit/test_gpu_monitor.py\` — needs ML container with pytest available; runs alongside existing \`test_disintegration.py\`
- [ ] (CI) full backend Jest suite

## Risk
None. New tests don't modify production code; they only verify existing behaviour. If a test fails in CI, that surfaces a real bug — desired outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)