### PR TITLE
refactor(backend): migrate uploadCancelController to ResponseHelper

### DIFF
--- a/backend/src/api/controllers/uploadCancelController.ts
+++ b/backend/src/api/controllers/uploadCancelController.ts
@@ -1,7 +1,13 @@
 import { Response } from 'express';
 import { AuthRequest } from '../../types/auth';
 import { logger } from '../../utils/logger';
+import { ResponseHelper } from '../../utils/response';
 import { WebSocketService } from '../../services/websocketService';
+
+const CTX = 'UploadCancelController';
+
+const toErr = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(String(e));
 
 export class UploadCancelController {
   constructor() {
@@ -20,12 +26,12 @@ export class UploadCancelController {
       const userId = req.user?.id;
 
       if (!userId) {
-        res.status(401).json({ error: 'Unauthorized' });
+        ResponseHelper.unauthorized(res, 'Unauthorized', CTX);
         return;
       }
 
       if (!uploadId) {
-        res.status(400).json({ error: 'Upload ID is required' });
+        ResponseHelper.badRequest(res, 'Upload ID is required', CTX);
         return;
       }
 
@@ -51,12 +57,12 @@ export class UploadCancelController {
         uploadId,
       });
     } catch (error) {
-      logger.error(
+      ResponseHelper.internalError(
+        res,
+        toErr(error),
         'Failed to cancel upload',
-        error instanceof Error ? error : new Error(String(error)),
-        'UploadCancelController'
+        CTX
       );
-      res.status(500).json({ error: 'Failed to cancel upload' });
     }
   }
 
@@ -70,12 +76,12 @@ export class UploadCancelController {
       const userId = req.user?.id;
 
       if (!userId) {
-        res.status(401).json({ error: 'Unauthorized' });
+        ResponseHelper.unauthorized(res, 'Unauthorized', CTX);
         return;
       }
 
       if (!projectId) {
-        res.status(400).json({ error: 'Project ID is required' });
+        ResponseHelper.badRequest(res, 'Project ID is required', CTX);
         return;
       }
 
@@ -99,12 +105,12 @@ export class UploadCancelController {
         projectId,
       });
     } catch (error) {
-      logger.error(
+      ResponseHelper.internalError(
+        res,
+        toErr(error),
         'Failed to cancel all uploads',
-        error instanceof Error ? error : new Error(String(error)),
-        'UploadCancelController'
+        CTX
       );
-      res.status(500).json({ error: 'Failed to cancel all uploads' });
     }
   }
 }


### PR DESCRIPTION
## Summary
Last controller still using inline \`res.status().json({ error })\` pattern. The other 6 controllers (auth, project, image, queue, segmentation, sharing) already adopted ResponseHelper before this session — verified by grep showing 244 ResponseHelper usages across them and 0 inline calls. This PR closes the consistency gap.

### Changes
- 6 inline calls migrated:
  - 2× \`res.status(401).json({ error: 'Unauthorized' })\` → \`ResponseHelper.unauthorized\`
  - 2× \`res.status(400).json({ error })\` → \`ResponseHelper.badRequest\`
  - 2× \`res.status(500).json({ error })\` + manual \`logger.error\` → \`ResponseHelper.internalError\` (which logs internally)
- Added \`CTX\` constant + \`toErr()\` helper matching the established \`exportController.ts\` pattern from PR #110.

### Response shape
Backwards-compatible additive change. Frontend \`errorUtils.ts:43\` reads \`responseData.error || responseData.message\`; the helper writes the message into \`error\` field so existing consumers continue to work. New fields (\`success: false\`, \`code\`, \`details?\`) are ignored by code that doesn't read them.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] ESLint: 0 errors, 0 warnings on the file
- [ ] (CI) Backend Jest suite — no controller-specific tests exist for uploadCancelController (greenfield); migration mechanically follows the exportController.ts pattern from PR #110 which has 22/22 tests passing.

## Risk
Low. Pattern proven by PR #110. Same response shape contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling consistency and response standardization in upload cancellation endpoints, ensuring more reliable and uniform error messaging across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->