### PR TITLE
refactor(types): consolidate status unions into JobStatus / SegmentationStatus

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -10,6 +10,7 @@ import {
   UploadCompletedData,
 } from '../../types/websocket';
 import { ResponseHelper } from '../../utils/response';
+import { JOB_STATUSES } from '../../types';
 import { logger } from '../../utils/logger';
 import { prisma } from '../../db/index';
 import { getStorageProvider } from '../../storage/index';
@@ -334,9 +335,8 @@ export class ImageController {
         return;
       }
 
-      // Validate status
-      const allowedStatuses = ['pending', 'processing', 'completed', 'failed'];
-      if (statusRaw && !allowedStatuses.includes(statusRaw)) {
+      // Validate status — same set as `JOB_STATUSES` SSOT in types/index.ts
+      if (statusRaw && !(JOB_STATUSES as readonly string[]).includes(statusRaw)) {
         res
           .status(400)
           .json({ error: 'Invalid query parameter', field: 'status' });

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -21,6 +21,7 @@ import { WebSocketService } from './websocketService';
 import * as SharingService from './sharingService';
 import { batchProcessor } from '../utils/batchProcessor';
 import { mapWithConcurrency } from '../utils/concurrency';
+import type { CancellableJobStatus } from '../types';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -85,7 +86,7 @@ export interface ExportJob {
   id: string;
   projectId: string;
   userId: string;
-  status: 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
+  status: CancellableJobStatus;
   progress: number;
   message?: string;
   filePath?: string;

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -6,6 +6,7 @@ import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { logger } from '../utils/logger';
 import { config } from '../utils/config';
+import type { JobStatus } from '../types';
 import {
   PolygonValidator,
   type PolygonPartClass,
@@ -67,7 +68,7 @@ export interface SegmentationResponse {
 
 export interface SegmentationTaskStatus {
   taskId: string;
-  status: 'pending' | 'processing' | 'completed' | 'failed';
+  status: JobStatus;
   progress?: number;
   result?: SegmentationResponse;
   error?: string;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -25,3 +25,32 @@ export interface ApiError {
   message: string;
   details?: Record<string, unknown>;
 }
+
+/**
+ * Canonical status set for any job-like operation that progresses through
+ * pending → processing → completed | failed. Mirrors the frontend
+ * `SegmentationStatus` so cross-stack contracts stay aligned. Exported as
+ * both a const tuple (for runtime validators / Zod enums) and a derived
+ * type (for static interfaces).
+ *
+ * Note: distinct from `QueueStatus` in `./queue.ts` which uses `'queued'`
+ * (queue position) and adds `'cancelled'`. Do not merge — different
+ * semantic axes (job state vs queue state).
+ */
+export const JOB_STATUSES = [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+] as const;
+export type JobStatus = (typeof JOB_STATUSES)[number];
+
+/**
+ * Status union for cancellable jobs (e.g. exports). Superset of
+ * `JobStatus` plus `'cancelled'`.
+ */
+export const CANCELLABLE_JOB_STATUSES = [
+  ...JOB_STATUSES,
+  'cancelled',
+] as const;
+export type CancellableJobStatus = (typeof CANCELLABLE_JOB_STATUSES)[number];

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { JOB_STATUSES } from './index';
 
 // ============================================================================
 // Common validation schemas
@@ -249,10 +250,9 @@ export const imageQuerySchema = z.object({
   page: z.coerce.number().int().min(1).optional().default(1),
   limit: z.coerce.number().int().min(1).max(100).optional().default(50),
   status: z
-    .enum(['pending', 'processing', 'completed', 'failed'], {
+    .enum(JOB_STATUSES, {
       errorMap: () => ({
-        message:
-          'Neplatný status. Možné hodnoty: pending, processing, completed, failed',
+        message: `Neplatný status. Možné hodnoty: ${JOB_STATUSES.join(', ')}`,
       }),
     })
     .optional(),

--- a/src/components/ui/segmentation-progress.tsx
+++ b/src/components/ui/segmentation-progress.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Progress } from './progress';
 import { cn } from '@/lib/utils';
 import { CheckCircle, Clock, AlertCircle, Loader2 } from 'lucide-react';
+import type { SegmentationStatus } from '@/types';
 
 interface SegmentationProgressProps {
   status: 'queued' | 'processing' | 'completed' | 'failed';
@@ -116,7 +117,7 @@ interface BatchSegmentationProgressProps {
   items: Array<{
     id: string;
     name: string;
-    status: 'pending' | 'processing' | 'completed' | 'failed';
+    status: SegmentationStatus;
     progress?: number;
   }>;
   overallProgress: number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ import {
   UpdateProfile,
   isProjectType,
   type ProjectType,
+  type SegmentationStatus,
 } from '@/types';
 import { logger } from '@/lib/logger';
 import config from '@/lib/config';
@@ -126,7 +127,7 @@ export interface SegmentationResult {
   processingTime?: number;
   imageWidth: number;
   imageHeight: number;
-  status: 'pending' | 'processing' | 'completed' | 'failed';
+  status: SegmentationStatus;
   createdAt: string;
   updatedAt: string;
 }
@@ -647,9 +648,7 @@ class ApiClient {
   }
 
   // Helper method to map segmentation status values
-  private mapSegmentationStatus(
-    status: unknown
-  ): 'pending' | 'processing' | 'completed' | 'failed' {
+  private mapSegmentationStatus(status: unknown): SegmentationStatus {
     // Safely coerce to string
     const statusStr =
       typeof status === 'string' ? status : String(status || '');

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -7,6 +7,7 @@ import ExportStateManager from '@/lib/exportStateManager';
 import { useExportContext } from '@/contexts/ExportContext';
 import { useAbortController } from '@/hooks/shared/useAbortController';
 import { retryWithBackoff, RETRY_CONFIGS } from '@/lib/retryUtils';
+import type { ExportJobStatus } from '@/types';
 
 // Sanitize filename to remove/replace invalid characters
 const sanitizeFilename = (filename: string): string => {
@@ -82,7 +83,7 @@ export interface ExportOptions {
 
 interface ExportJob {
   id: string;
-  status: 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
+  status: ExportJobStatus;
   progress: number;
   message?: string;
   filePath?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -407,7 +407,7 @@ export interface Image {
   user_id: string;
   image_url: string;
   thumbnail_url?: string;
-  segmentation_status: 'pending' | 'processing' | 'completed' | 'failed';
+  segmentation_status: SegmentationStatus;
   created_at: string;
   updated_at: string;
 }
@@ -452,6 +452,29 @@ export interface NewAccessRequest {
   reason: string;
 }
 
+/**
+ * Canonical segmentation/job status union for the frontend. The four base
+ * states match what the backend returns over REST + WebSocket
+ * (`segmentationService.ts`, `mapSegmentationStatus()` in `api.ts`).
+ *
+ * For export jobs that can additionally be cancelled, use `ExportJobStatus`
+ * which is `SegmentationStatus | 'cancelled'`.
+ *
+ * Use these instead of writing the 4-variant union inline — auto-import
+ * stays consistent and a future status addition is one edit, not seven.
+ */
+export type SegmentationStatus =
+  | 'pending'
+  | 'processing'
+  | 'completed'
+  | 'failed';
+
+/**
+ * Status union for cancellable jobs (e.g. exports). Superset of
+ * `SegmentationStatus` plus `'cancelled'`.
+ */
+export type ExportJobStatus = SegmentationStatus | 'cancelled';
+
 // Segmentation types (can be extended as needed)
 export interface PolygonData {
   id: string;
@@ -467,7 +490,7 @@ export interface SegmentationData {
   id?: string;
   imageSrc?: string;
   polygons: PolygonData[];
-  status?: 'pending' | 'processing' | 'completed' | 'failed';
+  status?: SegmentationStatus;
   timestamp?: Date;
   imageWidth?: number;
   imageHeight?: number;
@@ -477,7 +500,7 @@ export interface SegmentationResult {
   id: string;
   image_id: string;
   polygons: PolygonData[];
-  status: 'pending' | 'processing' | 'completed' | 'failed';
+  status: SegmentationStatus;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
8+ inline definitions of \`'pending' | 'processing' | 'completed' | 'failed'\` across both stacks. Each was a separate truth source — adding a new status required 8 coordinated edits. This PR centralizes them.

### Frontend (\`src/types/index.ts\`)
- New \`SegmentationStatus\` (4 variants) and \`ExportJobStatus\` (\`= SegmentationStatus | 'cancelled'\`).
- Migrated:
  - \`Image.segmentation_status\` (types/index.ts)
  - \`SegmentationData.status\` (types/index.ts)
  - \`SegmentationResult.status\` (types/index.ts)
  - \`BatchSegmentationProgress.items[].status\` (segmentation-progress.tsx)
  - \`useSharedAdvancedExport ExportJob.status\` → \`ExportJobStatus\`
  - \`api.ts\` \`SegmentationResult.status\` + \`mapSegmentationStatus()\` return type.

### Backend (\`backend/src/types/index.ts\`)
- New \`JOB_STATUSES\` const tuple + derived \`JobStatus\`, plus \`CANCELLABLE_JOB_STATUSES\` + \`CancellableJobStatus\`. **Both forms exposed** so runtime validators (Zod enums, allow-lists) and static types stay in lockstep.
- Migrated:
  - \`segmentationService.ts\` \`SegmentationTaskStatus.status\` → \`JobStatus\`
  - \`exportService.ts\` \`ExportJob.status\` → \`CancellableJobStatus\`
  - \`validation.ts\` Zod enum from inline array to \`JOB_STATUSES\` tuple
  - \`imageController.ts\` \`allowedStatuses\` runtime check from inline array to \`JOB_STATUSES\`

### Why \`QueueStatus\` is NOT merged
\`backend/src/types/queue.ts\` already exports \`QueueStatus\` with semantically different vocabulary: it uses \`'queued'\` (position in queue) instead of \`'pending'\` (job state) and adds \`'cancelled'\`. Two axes of meaning — leaving them distinct is correct.

## Test plan
- [x] Frontend \`npx tsc --noEmit\` passes
- [x] Backend \`npx tsc --noEmit\` passes
- [x] Backend Jest: \`segmentationService.test.ts\` + \`exportController.test.ts\` → **33/33 tests pass** — strongest signal that runtime contract is preserved.
- [ ] (CI) Full test suites
- [ ] Manual smoke: filter image list by status (uses \`JOB_STATUSES\` runtime array now); kick off export and verify progress states render correctly.

## Risk
Low. Pure type renaming + extracting literal arrays into named tuple. Values byte-identical to before; no semantic shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)