### PR TITLE
fix(i18n): wire ResetPassword + autosave toast to existing translation keys

### DIFF
--- a/scripts/check-i18n.cjs
+++ b/scripts/check-i18n.cjs
@@ -163,10 +163,17 @@ function extractUsedKeys() {
       if (
         stat.isDirectory() &&
         !file.startsWith('.') &&
-        file !== 'node_modules'
+        file !== 'node_modules' &&
+        file !== '__tests__' &&
+        file !== '__mocks__'
       ) {
         scanDirectory(filePath);
-      } else if (file.match(/\.(tsx?|jsx?)$/)) {
+      } else if (
+        file.match(/\.(tsx?|jsx?)$/) &&
+        !file.match(/\.(test|spec)\.(tsx?|jsx?)$/)
+      ) {
+        // Skip test files — they intentionally reference non-existent keys
+        // (e.g. LanguageContext.test.tsx tests fallback behavior).
         scanFile(filePath);
       }
     }

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -61,12 +61,12 @@ const ResetPassword = () => {
     }
 
     if (!validatePassword(password)) {
-      toast.error(t('errors.validationErrors.passwordMinLength'));
+      toast.error(t('errors.validationErrors.passwordTooShort'));
       return;
     }
 
     if (password !== confirmPassword) {
-      toast.error(t('errors.validationErrors.passwordMismatch'));
+      toast.error(t('errors.validationErrors.passwordsDoNotMatch'));
       return;
     }
 

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -272,7 +272,7 @@ export const useEnhancedSegmentationEditor = ({
         }
 
         logger.error('Autosave failed when switching images:', error);
-        toast.error(t('toast.autosaveFailed'));
+        toast.error(t('toast.segmentation.autosaveFailed'));
       }
     }
 


### PR DESCRIPTION
## Summary
\`npm run i18n:check\` flagged 4 missing translation keys. Root cause: code calls \`t()\` with keys that don't exist in any of the 6 translation files. User saw the literal key string instead of the localized message.

### Three real UI bugs (all toast messages)
| Caller | Was typed as | Existing correct key |
|---|---|---|
| \`ResetPassword.tsx:64\` | \`errors.validationErrors.passwordMinLength\` | \`errors.validationErrors.passwordTooShort\` |
| \`ResetPassword.tsx:69\` | \`errors.validationErrors.passwordMismatch\` | \`errors.validationErrors.passwordsDoNotMatch\` |
| \`useEnhancedSegmentationEditor.tsx:275\` | \`toast.autosaveFailed\` | \`toast.segmentation.autosaveFailed\` (nested path) |

The fourth flagged key — \`nonexistent.deeply.nested.key\` — is **intentional** test data in \`LanguageContext.test.tsx:179\` that verifies the \`t()\` fallback behavior. The validator was scanning test files; now it doesn't.

### Validator hardening
\`scripts/check-i18n.cjs\` now skips:
- \`__tests__/\` and \`__mocks__/\` directories
- \`*.test.{ts,tsx,js,jsx}\` and \`*.spec.{ts,tsx,js,jsx}\` files

Result: **Missing from code: 0** (down from 4). Three real-world toast messages now show localized text instead of raw key paths.

### Out of scope
Pre-existing translation gaps in CS (43 keys missing) and ZH (45 keys missing) — separate translation completeness work.

## Test plan
- [x] \`npm run i18n:check\` reports zero missing keys
- [x] \`npx tsc --noEmit\` passes
- [x] Pre-commit hooks all pass
- [ ] Manual smoke: trigger password validation on /reset-password, trigger autosave failure (e.g. while offline) → verify localized message appears, not the key string.

## Risk
Very low. Three single-line key path corrections + validator scoping change. No runtime behavior change beyond the user finally seeing localized strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)