### PR TITLE
refactor(metrics): extract geometric primitives to dedicated module

### DIFF
--- a/backend/src/services/metrics/__tests__/geometricPrimitives.test.ts
+++ b/backend/src/services/metrics/__tests__/geometricPrimitives.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  calculatePolygonArea,
+  calculatePerimeter,
+  calculateBoundingBox,
+  calculateConvexHull,
+  cross,
+  distance,
+  pointToLineDistance,
+  rotatingCalipers,
+  isPointInPolygon,
+  isPolygonInside,
+  calculateCentroid,
+  type Point,
+} from '../geometricPrimitives';
+
+const square = (size: number, offset = 0): Point[] => [
+  { x: offset, y: offset },
+  { x: offset + size, y: offset },
+  { x: offset + size, y: offset + size },
+  { x: offset, y: offset + size },
+];
+
+describe('calculatePolygonArea', () => {
+  it('returns 0 for empty / fewer than 3 points', () => {
+    expect(calculatePolygonArea([])).toBe(0);
+    expect(calculatePolygonArea([{ x: 0, y: 0 }])).toBe(0);
+    expect(
+      calculatePolygonArea([
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ])
+    ).toBe(0);
+  });
+
+  it('computes area of a unit square = 1', () => {
+    expect(calculatePolygonArea(square(1))).toBe(1);
+  });
+
+  it('returns absolute value (orientation independent)', () => {
+    const ccw = square(10);
+    const cw = [...ccw].reverse();
+    expect(calculatePolygonArea(ccw)).toBe(100);
+    expect(calculatePolygonArea(cw)).toBe(100);
+  });
+
+  it('handles arrays containing entries that fail typeof check at runtime', () => {
+    // The runtime guard `typeof x !== 'number'` skips malformed entries;
+    // assert tolerance via a cast to bypass static type-checking.
+    const points = [
+      { x: 0, y: 0 },
+      { x: 'bad', y: 0 } as unknown as Point,
+      { x: 5, y: 5 },
+      { x: 0, y: 5 },
+    ];
+    expect(() => calculatePolygonArea(points)).not.toThrow();
+  });
+});
+
+describe('calculatePerimeter', () => {
+  it('returns 0 for fewer than 2 points', () => {
+    expect(calculatePerimeter([])).toBe(0);
+    expect(calculatePerimeter([{ x: 0, y: 0 }])).toBe(0);
+  });
+
+  it('computes perimeter of a unit square = 4', () => {
+    expect(calculatePerimeter(square(1))).toBe(4);
+  });
+
+  it('uses Pythagorean distance — diagonal triangle 3-4-5', () => {
+    // Triangle with sides 3, 4, 5 → perimeter 12
+    const triangle = [
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+      { x: 3, y: 4 },
+    ];
+    expect(calculatePerimeter(triangle)).toBe(12);
+  });
+});
+
+describe('calculateBoundingBox', () => {
+  it('returns zero dims for empty input', () => {
+    expect(calculateBoundingBox([])).toEqual({ width: 0, height: 0 });
+  });
+
+  it('returns extents for an axis-aligned square', () => {
+    expect(calculateBoundingBox(square(7, 3))).toEqual({
+      width: 7,
+      height: 7,
+    });
+  });
+});
+
+describe('cross', () => {
+  it('positive for CCW turn, negative for CW, zero for collinear', () => {
+    const o = { x: 0, y: 0 };
+    const a = { x: 1, y: 0 };
+    const ccw = { x: 1, y: 1 };
+    const cw = { x: 1, y: -1 };
+    const collinear = { x: 2, y: 0 };
+
+    expect(cross(o, a, ccw)).toBeGreaterThan(0);
+    expect(cross(o, a, cw)).toBeLessThan(0);
+    expect(cross(o, a, collinear)).toBe(0);
+  });
+});
+
+describe('distance', () => {
+  it('Euclidean — 3-4-5', () => {
+    expect(distance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+});
+
+describe('calculateConvexHull', () => {
+  it('returns input unchanged for fewer than 3 points', () => {
+    const two = [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ];
+    expect(calculateConvexHull(two)).toEqual(two);
+  });
+
+  it('strips interior points from a square + interior', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+      { x: 5, y: 5 }, // interior
+    ];
+    const hull = calculateConvexHull(points);
+    expect(hull.length).toBe(4);
+    // Interior point is gone
+    expect(hull).not.toContainEqual({ x: 5, y: 5 });
+  });
+});
+
+describe('pointToLineDistance', () => {
+  it('clamps to endpoint when projection is outside segment (param < 0)', () => {
+    const point = { x: -5, y: 0 };
+    const lineStart = { x: 0, y: 0 };
+    const lineEnd = { x: 10, y: 0 };
+    // Projection lands at -5 (left of start) → distance to start = 5
+    expect(pointToLineDistance(point, lineStart, lineEnd)).toBe(5);
+  });
+
+  it('clamps to endpoint when projection is outside segment (param > 1)', () => {
+    const point = { x: 15, y: 0 };
+    const lineStart = { x: 0, y: 0 };
+    const lineEnd = { x: 10, y: 0 };
+    expect(pointToLineDistance(point, lineStart, lineEnd)).toBe(5);
+  });
+
+  it('handles zero-length segment (lenSq === 0) gracefully', () => {
+    expect(
+      pointToLineDistance({ x: 3, y: 4 }, { x: 0, y: 0 }, { x: 0, y: 0 })
+    ).toBe(5);
+  });
+
+  it('perpendicular distance for point above midpoint', () => {
+    expect(
+      pointToLineDistance({ x: 5, y: 7 }, { x: 0, y: 0 }, { x: 10, y: 0 })
+    ).toBe(7);
+  });
+});
+
+describe('rotatingCalipers', () => {
+  it('returns zero for hull with fewer than 3 points', () => {
+    expect(
+      rotatingCalipers([
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+      ])
+    ).toEqual({ max: 0, min: 0, orthogonal: 0 });
+  });
+
+  it('square hull max Feret = diagonal length √2 * side', () => {
+    const hull = square(10);
+    const result = rotatingCalipers(hull);
+    expect(result.max).toBeCloseTo(Math.sqrt(200), 5); // ≈ 14.142
+  });
+});
+
+describe('isPointInPolygon', () => {
+  it('returns false for polygons with fewer than 3 points', () => {
+    expect(isPointInPolygon({ x: 0, y: 0 }, { points: [] })).toBe(false);
+  });
+
+  it('detects point inside a square', () => {
+    expect(isPointInPolygon({ x: 5, y: 5 }, { points: square(10) })).toBe(true);
+  });
+
+  it('detects point outside a square', () => {
+    expect(isPointInPolygon({ x: 15, y: 5 }, { points: square(10) })).toBe(false);
+  });
+});
+
+describe('calculateCentroid', () => {
+  it('returns origin for empty input', () => {
+    expect(calculateCentroid([])).toEqual({ x: 0, y: 0 });
+  });
+
+  it('finds the geometric center of a unit square', () => {
+    const c = calculateCentroid(square(10));
+    expect(c.x).toBeCloseTo(5, 5);
+    expect(c.y).toBeCloseTo(5, 5);
+  });
+
+  it('falls back to vertex average for degenerate (zero-area) input', () => {
+    // Three collinear points — area === 0 triggers fallback
+    const collinear = [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 10, y: 0 },
+    ];
+    const c = calculateCentroid(collinear);
+    expect(c.x).toBeCloseTo(5, 5);
+    expect(c.y).toBe(0);
+  });
+});
+
+describe('isPolygonInside', () => {
+  it('returns true when inner centroid lies inside outer polygon', () => {
+    const inner = { points: square(2, 4) }; // small square at (4,4)-(6,6)
+    const outer = { points: square(10) };
+    expect(isPolygonInside(inner, outer)).toBe(true);
+  });
+
+  it('returns false when inner centroid lies outside outer polygon', () => {
+    const inner = { points: square(2, 20) }; // small square far away
+    const outer = { points: square(10) };
+    expect(isPolygonInside(inner, outer)).toBe(false);
+  });
+
+  it('returns false for empty inputs', () => {
+    expect(isPolygonInside({ points: [] }, { points: square(10) })).toBe(
+      false
+    );
+    expect(isPolygonInside({ points: square(10) }, { points: [] })).toBe(
+      false
+    );
+  });
+});

--- a/backend/src/services/metrics/geometricPrimitives.ts
+++ b/backend/src/services/metrics/geometricPrimitives.ts
@@ -1,0 +1,406 @@
+/**
+ * Pure geometric primitive functions extracted from `MetricsCalculator`.
+ *
+ * Each function is stateless and side-effect-free — no class instance, no
+ * logger calls, no file IO. Domain-specific metric orchestration stays in
+ * `metricsCalculator.ts`; only the building blocks live here.
+ *
+ * Polygon vertices are represented as `Point[]` (open or closed — a closed
+ * polygon's first and last point may coincide; algorithms below handle
+ * either form via wraparound `(i + 1) % n` indexing).
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface PolygonShape {
+  points: Point[];
+}
+
+/**
+ * Shoelace formula. Returns absolute area; sign of orientation discarded.
+ */
+export function calculatePolygonArea(points: Point[]): number {
+  if (!points || points.length < 3) {
+    return 0;
+  }
+
+  let area = 0;
+  const n = points.length;
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const currentPoint = points[i];
+    const nextPoint = points[j];
+
+    if (
+      !currentPoint ||
+      !nextPoint ||
+      typeof currentPoint.x !== 'number' ||
+      typeof currentPoint.y !== 'number' ||
+      typeof nextPoint.x !== 'number' ||
+      typeof nextPoint.y !== 'number'
+    ) {
+      continue;
+    }
+
+    area += currentPoint.x * nextPoint.y;
+    area -= nextPoint.x * currentPoint.y;
+  }
+
+  return Math.abs(area / 2);
+}
+
+/**
+ * Sum of edge lengths around the polygon (closed perimeter).
+ */
+export function calculatePerimeter(points: Point[]): number {
+  if (!points || points.length < 2) {
+    return 0;
+  }
+
+  let perimeter = 0;
+  const n = points.length;
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const currentPoint = points[i];
+    const nextPoint = points[j];
+
+    if (
+      !currentPoint ||
+      !nextPoint ||
+      typeof currentPoint.x !== 'number' ||
+      typeof currentPoint.y !== 'number' ||
+      typeof nextPoint.x !== 'number' ||
+      typeof nextPoint.y !== 'number'
+    ) {
+      continue;
+    }
+
+    const dx = nextPoint.x - currentPoint.x;
+    const dy = nextPoint.y - currentPoint.y;
+    perimeter += Math.sqrt(dx * dx + dy * dy);
+  }
+
+  return perimeter;
+}
+
+/**
+ * Axis-aligned bounding box. Returns zero dimensions for empty input.
+ */
+export function calculateBoundingBox(points: Point[]): {
+  width: number;
+  height: number;
+} {
+  if (!points || points.length === 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const xs = points.filter(p => p && typeof p.x === 'number').map(p => p.x);
+  const ys = points.filter(p => p && typeof p.y === 'number').map(p => p.y);
+
+  if (xs.length === 0 || ys.length === 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+
+  return {
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}
+
+/**
+ * Cross product `(a - o) × (b - o)`. Used by convex hull and centroid.
+ * Positive = counter-clockwise turn, zero = collinear, negative = clockwise.
+ */
+export function cross(o: Point, a: Point, b: Point): number {
+  return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+}
+
+/**
+ * Euclidean distance between two points.
+ */
+export function distance(p1: Point, p2: Point): number {
+  const dx = p2.x - p1.x;
+  const dy = p2.y - p1.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Convex hull using Andrew's monotone chain algorithm.
+ * Returns hull vertices in counter-clockwise order. Input < 3 points
+ * is returned unchanged.
+ */
+export function calculateConvexHull(points: Point[]): Point[] {
+  if (points.length < 3) {
+    return points;
+  }
+
+  // Sort points by x-coordinate, then by y-coordinate
+  const sortedPoints = [...points].sort((a, b) => {
+    if (a.x === b.x) {
+      return a.y - b.y;
+    }
+    return a.x - b.x;
+  });
+
+  // Build lower hull
+  const lower: Point[] = [];
+  for (const point of sortedPoints) {
+    while (
+      lower.length >= 2 &&
+      cross(lower[lower.length - 2], lower[lower.length - 1], point) <= 0
+    ) {
+      lower.pop();
+    }
+    lower.push(point);
+  }
+
+  // Build upper hull
+  const upper: Point[] = [];
+  for (let i = sortedPoints.length - 1; i >= 0; i--) {
+    const point = sortedPoints[i];
+    while (
+      upper.length >= 2 &&
+      cross(upper[upper.length - 2], upper[upper.length - 1], point) <= 0
+    ) {
+      upper.pop();
+    }
+    upper.push(point);
+  }
+
+  // Remove last point of each half because it's repeated
+  lower.pop();
+  upper.pop();
+
+  return lower.concat(upper);
+}
+
+/**
+ * Distance from a point to a line segment (clamped to endpoints — not the
+ * infinite line).
+ */
+export function pointToLineDistance(
+  point: Point,
+  lineStart: Point,
+  lineEnd: Point
+): number {
+  const A = point.x - lineStart.x;
+  const B = point.y - lineStart.y;
+  const C = lineEnd.x - lineStart.x;
+  const D = lineEnd.y - lineStart.y;
+
+  const dot = A * C + B * D;
+  const lenSq = C * C + D * D;
+
+  if (lenSq === 0) {
+    return distance(point, lineStart);
+  }
+
+  const param = dot / lenSq;
+
+  let xx: number, yy: number;
+
+  if (param < 0) {
+    xx = lineStart.x;
+    yy = lineStart.y;
+  } else if (param > 1) {
+    xx = lineEnd.x;
+    yy = lineEnd.y;
+  } else {
+    xx = lineStart.x + param * C;
+    yy = lineStart.y + param * D;
+  }
+
+  const dx = point.x - xx;
+  const dy = point.y - yy;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Find Feret diameters via brute-force pairwise distance on the convex hull.
+ * Returns max, min, and orthogonal Feret diameters.
+ *
+ * NOTE on `orthogonal`: this doubles the max one-sided perpendicular
+ * distance from the Feret axis. A true orthogonal caliper width would
+ * measure between two parallel supporting lines (not double the one-sided
+ * distance) — this is an approximation acknowledged by the original
+ * implementation.
+ */
+export function rotatingCalipers(hull: Point[]): {
+  max: number;
+  min: number;
+  orthogonal: number;
+} {
+  if (hull.length < 3) {
+    return { max: 0, min: 0, orthogonal: 0 };
+  }
+
+  let maxDist = 0;
+  let minDist = Infinity;
+  let orthogonalDist = 0;
+  let maxPair: [Point, Point] | null = null;
+
+  // Find maximum Feret diameter (max distance between any two hull points)
+  for (let i = 0; i < hull.length; i++) {
+    for (let j = i + 1; j < hull.length; j++) {
+      const dist = distance(hull[i], hull[j]);
+      if (dist > maxDist) {
+        maxDist = dist;
+        maxPair = [hull[i], hull[j]];
+      }
+    }
+  }
+
+  // Find minimum Feret diameter (min caliper width)
+  // For each edge of the hull, find the furthest point from that edge
+  for (let i = 0; i < hull.length; i++) {
+    const j = (i + 1) % hull.length;
+    let maxDistFromEdge = 0;
+
+    for (let k = 0; k < hull.length; k++) {
+      if (k === i || k === j) {
+        continue;
+      }
+      const dist = pointToLineDistance(hull[k], hull[i], hull[j]);
+      maxDistFromEdge = Math.max(maxDistFromEdge, dist);
+    }
+
+    if (maxDistFromEdge > 0 && maxDistFromEdge < minDist) {
+      minDist = maxDistFromEdge;
+    }
+  }
+
+  // Find orthogonal Feret diameter (perpendicular to max Feret line)
+  if (maxPair) {
+    const [p1, p2] = maxPair;
+    let maxOrthDist = 0;
+
+    for (const point of hull) {
+      const dist = pointToLineDistance(point, p1, p2);
+      maxOrthDist = Math.max(maxOrthDist, dist);
+    }
+
+    orthogonalDist = maxOrthDist * 2;
+  }
+
+  if (minDist === Infinity) {
+    minDist = maxDist;
+  }
+
+  return {
+    max: maxDist,
+    min: minDist,
+    orthogonal: orthogonalDist,
+  };
+}
+
+/**
+ * Ray-casting test for point-in-polygon.
+ */
+export function isPointInPolygon(point: Point, polygon: PolygonShape): boolean {
+  if (!polygon?.points || polygon.points.length < 3) {
+    return false;
+  }
+
+  const { x, y } = point;
+  const points = polygon.points;
+  let inside = false;
+
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const xi = points[i]?.x || 0;
+    const yi = points[i]?.y || 0;
+    const xj = points[j]?.x || 0;
+    const yj = points[j]?.y || 0;
+
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}
+
+/**
+ * Centroid via shoelace-weighted formula. Falls back to vertex average
+ * when the polygon is degenerate (zero or near-zero signed area).
+ */
+export function calculateCentroid(points: Point[]): Point {
+  if (!points || points.length === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  let cx = 0;
+  let cy = 0;
+  let area = 0;
+  const n = points.length;
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const currentPoint = points[i];
+    const nextPoint = points[j];
+
+    if (
+      !currentPoint ||
+      !nextPoint ||
+      typeof currentPoint.x !== 'number' ||
+      typeof currentPoint.y !== 'number' ||
+      typeof nextPoint.x !== 'number' ||
+      typeof nextPoint.y !== 'number'
+    ) {
+      continue;
+    }
+
+    const crossVal =
+      currentPoint.x * nextPoint.y - nextPoint.x * currentPoint.y;
+    area += crossVal;
+    cx += (currentPoint.x + nextPoint.x) * crossVal;
+    cy += (currentPoint.y + nextPoint.y) * crossVal;
+  }
+
+  area *= 0.5;
+  if (Math.abs(area) < Number.EPSILON) {
+    // Fallback to simple average for degenerate cases
+    const avgX =
+      points.reduce((sum, p) => sum + (p?.x || 0), 0) / points.length;
+    const avgY =
+      points.reduce((sum, p) => sum + (p?.y || 0), 0) / points.length;
+    return { x: avgX, y: avgY };
+  }
+
+  cx /= 6 * area;
+  cy /= 6 * area;
+
+  return { x: cx, y: cy };
+}
+
+/**
+ * Check if inner polygon's centroid lies inside the outer polygon.
+ * NB: this is a centroid test, not a strict containment test —
+ * concave outer polygons can still pass even when inner has vertices
+ * outside the outer hull.
+ */
+export function isPolygonInside(
+  inner: PolygonShape,
+  outer: PolygonShape
+): boolean {
+  if (
+    !inner?.points ||
+    !outer?.points ||
+    inner.points.length === 0 ||
+    outer.points.length === 0
+  ) {
+    return false;
+  }
+
+  const centroid = calculateCentroid(inner.points);
+  return isPointInPolygon(centroid, outer);
+}

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -15,6 +15,17 @@ import type {
 } from '../../utils/polygonValidation';
 import { polylineLength } from '../../utils/polygonGeometry';
 import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
+import {
+  calculatePolygonArea,
+  calculatePerimeter,
+  calculateBoundingBox,
+  calculateConvexHull,
+  pointToLineDistance,
+  rotatingCalipers,
+  isPointInPolygon,
+  isPolygonInside,
+  calculateCentroid,
+} from './geometricPrimitives';
 
 export interface PolygonMetrics {
   imageId: string;
@@ -275,7 +286,7 @@ export class MetricsCalculator {
       try {
         // Find holes that are inside this specific polygon
         const holesForPolygon = internalPolygons.filter(inner =>
-          this.isPolygonInside(inner, polygon)
+          isPolygonInside(inner, polygon)
         );
 
         // Calculate metrics using Python service
@@ -300,7 +311,7 @@ export class MetricsCalculator {
 
         // Fallback to basic calculations with proper hole mapping
         const holesForPolygon = internalPolygons.filter(inner =>
-          this.isPolygonInside(inner, polygon)
+          isPolygonInside(inner, polygon)
         );
 
         metrics.push({
@@ -623,26 +634,26 @@ export class MetricsCalculator {
     }
 
     // Calculate main polygon area using Shoelace formula
-    const mainArea = this.calculatePolygonArea(polygon.points);
+    const mainArea = calculatePolygonArea(polygon.points);
 
     // Subtract hole areas
     const holesArea = holes.reduce((sum, hole) => {
       if (!hole?.points || hole.points.length === 0) {
         return sum; // Skip invalid holes
       }
-      return sum + this.calculatePolygonArea(hole.points);
+      return sum + calculatePolygonArea(hole.points);
     }, 0);
     let area = Math.max(0, mainArea - holesArea);
 
     // Calculate perimeter of external boundary only
-    const externalPerimeter = this.calculatePerimeter(polygon.points);
+    const externalPerimeter = calculatePerimeter(polygon.points);
 
     // Calculate perimeter with holes (external + all hole perimeters)
     const holesPerimeter = holes.reduce((sum, hole) => {
       if (!hole?.points || hole.points.length === 0) {
         return sum; // Skip invalid holes
       }
-      return sum + this.calculatePerimeter(hole.points);
+      return sum + calculatePerimeter(hole.points);
     }, 0);
     const perimeterWithHoles = externalPerimeter + holesPerimeter;
 
@@ -651,7 +662,7 @@ export class MetricsCalculator {
     const perimeter = Math.max(externalPerimeter, Number.EPSILON);
 
     // Calculate bounding box for extent calculation
-    const boundingBox = this.calculateBoundingBox(polygon.points);
+    const boundingBox = calculateBoundingBox(polygon.points);
     const boundingBoxArea = boundingBox.width * boundingBox.height;
 
     // Calculate circularity: 4*pi * area / perimeter^2 (clamped to [0,1])
@@ -671,9 +682,9 @@ export class MetricsCalculator {
     const equivalentDiameter = Math.sqrt((4 * area) / Math.PI);
 
     // Calculate convex hull for convexity, solidity, and proper Feret diameters
-    const convexHull = this.calculateConvexHull(polygon.points);
-    const convexArea = this.calculatePolygonArea(convexHull);
-    const convexPerimeter = this.calculatePerimeter(convexHull);
+    const convexHull = calculateConvexHull(polygon.points);
+    const convexArea = calculatePolygonArea(convexHull);
+    const convexPerimeter = calculatePerimeter(convexHull);
 
     // Convexity: perimeter of convex hull / perimeter of polygon
     const convexity = perimeter > 0 ? convexPerimeter / perimeter : 0;
@@ -682,7 +693,7 @@ export class MetricsCalculator {
     const solidity = convexArea > 0 ? area / convexArea : 0;
 
     // Calculate proper Feret diameters using rotating calipers
-    const feretDiameters = this.rotatingCalipers(convexHull);
+    const feretDiameters = rotatingCalipers(convexHull);
 
     // Ensure safe division for aspect ratio
     const feretAspectRatio =
@@ -1117,376 +1128,6 @@ export class MetricsCalculator {
     return numbers.reduce((a, b) => a + b, 0) / numbers.length;
   }
 
-  private calculatePolygonArea(points: Point[]): number {
-    if (!points || points.length < 3) {
-      return 0;
-    }
-
-    let area = 0;
-    const n = points.length;
-
-    for (let i = 0; i < n; i++) {
-      const j = (i + 1) % n;
-      const currentPoint = points[i];
-      const nextPoint = points[j];
-
-      if (
-        !currentPoint ||
-        !nextPoint ||
-        typeof currentPoint.x !== 'number' ||
-        typeof currentPoint.y !== 'number' ||
-        typeof nextPoint.x !== 'number' ||
-        typeof nextPoint.y !== 'number'
-      ) {
-        continue;
-      }
-
-      area += currentPoint.x * nextPoint.y;
-      area -= nextPoint.x * currentPoint.y;
-    }
-
-    return Math.abs(area / 2);
-  }
-
-  private calculatePerimeter(points: Point[]): number {
-    if (!points || points.length < 2) {
-      return 0;
-    }
-
-    let perimeter = 0;
-    const n = points.length;
-
-    for (let i = 0; i < n; i++) {
-      const j = (i + 1) % n;
-      const currentPoint = points[i];
-      const nextPoint = points[j];
-
-      if (
-        !currentPoint ||
-        !nextPoint ||
-        typeof currentPoint.x !== 'number' ||
-        typeof currentPoint.y !== 'number' ||
-        typeof nextPoint.x !== 'number' ||
-        typeof nextPoint.y !== 'number'
-      ) {
-        continue;
-      }
-
-      const dx = nextPoint.x - currentPoint.x;
-      const dy = nextPoint.y - currentPoint.y;
-      perimeter += Math.sqrt(dx * dx + dy * dy);
-    }
-
-    return perimeter;
-  }
-
-  private calculateBoundingBox(points: Point[]): {
-    width: number;
-    height: number;
-  } {
-    if (!points || points.length === 0) {
-      return { width: 0, height: 0 };
-    }
-
-    const xs = points.filter(p => p && typeof p.x === 'number').map(p => p.x);
-    const ys = points.filter(p => p && typeof p.y === 'number').map(p => p.y);
-
-    if (xs.length === 0 || ys.length === 0) {
-      return { width: 0, height: 0 };
-    }
-    const minX = Math.min(...xs);
-    const minY = Math.min(...ys);
-    const maxX = Math.max(...xs);
-    const maxY = Math.max(...ys);
-
-    return {
-      width: maxX - minX,
-      height: maxY - minY,
-    };
-  }
-
-  /**
-   * Calculate convex hull using Andrew's monotone chain algorithm
-   */
-  private calculateConvexHull(points: Point[]): Point[] {
-    if (points.length < 3) {
-      return points;
-    }
-
-    // Sort points by x-coordinate, then by y-coordinate
-    const sortedPoints = [...points].sort((a, b) => {
-      if (a.x === b.x) {
-        return a.y - b.y;
-      }
-      return a.x - b.x;
-    });
-
-    // Build lower hull
-    const lower: Point[] = [];
-    for (const point of sortedPoints) {
-      while (
-        lower.length >= 2 &&
-        this.cross(lower[lower.length - 2], lower[lower.length - 1], point) <= 0
-      ) {
-        lower.pop();
-      }
-      lower.push(point);
-    }
-
-    // Build upper hull
-    const upper: Point[] = [];
-    for (let i = sortedPoints.length - 1; i >= 0; i--) {
-      const point = sortedPoints[i];
-      while (
-        upper.length >= 2 &&
-        this.cross(upper[upper.length - 2], upper[upper.length - 1], point) <= 0
-      ) {
-        upper.pop();
-      }
-      upper.push(point);
-    }
-
-    // Remove last point of each half because it's repeated
-    lower.pop();
-    upper.pop();
-
-    return lower.concat(upper);
-  }
-
-  /**
-   * Calculate cross product for convex hull algorithm
-   */
-  private cross(o: Point, a: Point, b: Point): number {
-    return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
-  }
-
-  /**
-   * Calculate distance between two points
-   */
-  private distance(p1: Point, p2: Point): number {
-    const dx = p2.x - p1.x;
-    const dy = p2.y - p1.y;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  /**
-   * Calculate the distance from a point to a line segment defined by two endpoints
-   */
-  private pointToLineDistance(
-    point: Point,
-    lineStart: Point,
-    lineEnd: Point
-  ): number {
-    const A = point.x - lineStart.x;
-    const B = point.y - lineStart.y;
-    const C = lineEnd.x - lineStart.x;
-    const D = lineEnd.y - lineStart.y;
-
-    const dot = A * C + B * D;
-    const lenSq = C * C + D * D;
-
-    if (lenSq === 0) {
-      return this.distance(point, lineStart);
-    }
-
-    const param = dot / lenSq;
-
-    let xx: number, yy: number;
-
-    if (param < 0) {
-      xx = lineStart.x;
-      yy = lineStart.y;
-    } else if (param > 1) {
-      xx = lineEnd.x;
-      yy = lineEnd.y;
-    } else {
-      xx = lineStart.x + param * C;
-      yy = lineStart.y + param * D;
-    }
-
-    const dx = point.x - xx;
-    const dy = point.y - yy;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  /**
-   * Find Feret diameters via brute-force pairwise distance on the convex hull.
-   * Returns max, min, and orthogonal Feret diameters.
-   */
-  private rotatingCalipers(hull: Point[]): {
-    max: number;
-    min: number;
-    orthogonal: number;
-  } {
-    if (hull.length < 3) {
-      return { max: 0, min: 0, orthogonal: 0 };
-    }
-
-    let maxDist = 0;
-    let minDist = Infinity;
-    let orthogonalDist = 0;
-    let maxPair: [Point, Point] | null = null;
-
-    // Find maximum Feret diameter (max distance between any two hull points)
-    for (let i = 0; i < hull.length; i++) {
-      for (let j = i + 1; j < hull.length; j++) {
-        const dist = this.distance(hull[i], hull[j]);
-        if (dist > maxDist) {
-          maxDist = dist;
-          maxPair = [hull[i], hull[j]];
-        }
-      }
-    }
-
-    // Find minimum Feret diameter (min caliper width)
-    // For each edge of the hull, find the furthest point from that edge
-    for (let i = 0; i < hull.length; i++) {
-      const j = (i + 1) % hull.length;
-      let maxDistFromEdge = 0;
-
-      // Find the furthest point from this edge
-      for (let k = 0; k < hull.length; k++) {
-        if (k === i || k === j) {
-          continue;
-        }
-        const dist = this.pointToLineDistance(hull[k], hull[i], hull[j]);
-        maxDistFromEdge = Math.max(maxDistFromEdge, dist);
-      }
-
-      // The caliper width for this orientation is the distance to the furthest point
-      if (maxDistFromEdge > 0 && maxDistFromEdge < minDist) {
-        minDist = maxDistFromEdge;
-      }
-    }
-
-    // Find orthogonal Feret diameter
-    // This is the width perpendicular to the maximum Feret diameter
-    if (maxPair) {
-      const [p1, p2] = maxPair;
-      let maxOrthDist = 0;
-
-      // Find the maximum perpendicular distance from the max Feret line
-      for (const point of hull) {
-        const dist = this.pointToLineDistance(point, p1, p2);
-        maxOrthDist = Math.max(maxOrthDist, dist);
-      }
-
-      // NOTE: This doubles the max one-sided perpendicular distance from the Feret axis.
-      // This is an approximation — a true orthogonal caliper width would measure between
-      // two parallel supporting lines, not double the one-sided distance.
-      orthogonalDist = maxOrthDist * 2;
-    }
-
-    // Handle edge cases
-    if (minDist === Infinity) {
-      // Fallback for degenerate cases
-      minDist = maxDist;
-    }
-
-    return {
-      max: maxDist,
-      min: minDist,
-      orthogonal: orthogonalDist,
-    };
-  }
-
-  /**
-   * Check if a point is inside a polygon using ray-casting algorithm
-   */
-  private isPointInPolygon(point: Point, polygon: Polygon): boolean {
-    if (!polygon?.points || polygon.points.length < 3) {
-      return false;
-    }
-
-    const { x, y } = point;
-    const points = polygon.points;
-    let inside = false;
-
-    for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
-      const xi = points[i]?.x || 0;
-      const yi = points[i]?.y || 0;
-      const xj = points[j]?.x || 0;
-      const yj = points[j]?.y || 0;
-
-      if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
-        inside = !inside;
-      }
-    }
-
-    return inside;
-  }
-
-  /**
-   * Check if inner polygon is completely inside outer polygon
-   * Uses centroid test - checks if centroid of inner polygon is inside outer polygon
-   */
-  private isPolygonInside(inner: Polygon, outer: Polygon): boolean {
-    if (
-      !inner?.points ||
-      !outer?.points ||
-      inner.points.length === 0 ||
-      outer.points.length === 0
-    ) {
-      return false;
-    }
-
-    // Calculate centroid of inner polygon
-    const centroid = this.calculateCentroid(inner.points);
-
-    // Check if centroid is inside outer polygon
-    return this.isPointInPolygon(centroid, outer);
-  }
-
-  /**
-   * Calculate centroid of a polygon
-   */
-  private calculateCentroid(points: Point[]): Point {
-    if (!points || points.length === 0) {
-      return { x: 0, y: 0 };
-    }
-
-    let cx = 0;
-    let cy = 0;
-    let area = 0;
-    const n = points.length;
-
-    for (let i = 0; i < n; i++) {
-      const j = (i + 1) % n;
-      const currentPoint = points[i];
-      const nextPoint = points[j];
-
-      if (
-        !currentPoint ||
-        !nextPoint ||
-        typeof currentPoint.x !== 'number' ||
-        typeof currentPoint.y !== 'number' ||
-        typeof nextPoint.x !== 'number' ||
-        typeof nextPoint.y !== 'number'
-      ) {
-        continue;
-      }
-
-      const cross = currentPoint.x * nextPoint.y - nextPoint.x * currentPoint.y;
-      area += cross;
-      cx += (currentPoint.x + nextPoint.x) * cross;
-      cy += (currentPoint.y + nextPoint.y) * cross;
-    }
-
-    area *= 0.5;
-    if (Math.abs(area) < Number.EPSILON) {
-      // Fallback to simple average for degenerate cases
-      const avgX =
-        points.reduce((sum, p) => sum + (p?.x || 0), 0) / points.length;
-      const avgY =
-        points.reduce((sum, p) => sum + (p?.y || 0), 0) / points.length;
-      return { x: avgX, y: avgY };
-    }
-
-    cx /= 6 * area;
-    cy /= 6 * area;
-
-    return { x: cx, y: cy };
-  }
 
   /**
    * Apply scale conversion to metrics with enhanced validation


### PR DESCRIPTION
## Summary
First substantive split of the large-file cleanup roadmap. \`metricsCalculator.ts\` shrinks **1560 → 1201 LoC** by extracting 9 pure geometric primitive methods to \`geometricPrimitives.ts\`. Each function is stateless, side-effect free, and now reusable outside \`MetricsCalculator\`.

### Extracted (now exported as standalone functions)
- \`calculatePolygonArea\` — shoelace
- \`calculatePerimeter\` — sum of edge lengths
- \`calculateBoundingBox\`
- \`cross\` — positive/negative orientation test
- \`distance\` — Euclidean
- \`calculateConvexHull\` — Andrew's monotone chain
- \`pointToLineDistance\` — clamped to segment endpoints
- \`rotatingCalipers\` — max/min/orthogonal Feret diameters
- \`isPointInPolygon\` — ray-casting
- \`isPolygonInside\` — centroid test
- \`calculateCentroid\` — shoelace-weighted, vertex-average fallback for degenerate inputs

### Class shell
\`MetricsCalculator\` retains \`applyScaleConversion\`, the orchestration methods (\`calculateAllMetrics\`, \`calculateImageMetrics\`, exporters), and private helpers like \`average\` / \`calculateBasicMetrics\`. Call sites in the class lost the \`this.\` prefix; behavior unchanged.

### Why this extraction first
Pure functions with deep characterization tests are the safest possible split — no class state, no IO, no DB, no logger. If the test suite goes green, behavior is provably preserved.

## Verification
- [x] \`npx tsc --noEmit\` passes
- [x] **10/10 existing metricsCalculator.test.ts** still pass — strongest signal that the orchestration call sites still produce correct values.
- [x] **28/28 new geometricPrimitives.test.ts** all pass — covers each function with empty input, normal input, and degenerate edge cases (collinear points, zero-length segments, cw vs ccw orientation, points on segment endpoints, ).
- [x] Pre-commit hooks pass

## Risk
Low. Pure-function extraction with comprehensive new test coverage. The remaining \`MetricsCalculator\` class still owns all orchestration; only the leaf-level primitives moved.

## Next steps (separate PRs, deferred)
- \`exportPolygonMetricsToExcel\` / \`exportToExcel\` / \`exportSpermToExcel\` / \`exportToCSV\` — IO operations could split to a \`metricsExporter.ts\` module
- Domain-specific metric orchestration (spheroid vs wound vs sperm) is mixed inside \`calculateBasicMetrics\` — needs its own analysis pass before splitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for geometric calculations including polygon operations, distance metrics, and containment checks.

* **Refactor**
  * Centralized geometric utilities into a dedicated module for improved code maintainability and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->