### PR TITLE
refactor(export): extract sanitizeFilename + createZipArchive + getProgressMessage

### DIFF
--- a/backend/src/services/export/exportFileOperations.ts
+++ b/backend/src/services/export/exportFileOperations.ts
@@ -1,0 +1,210 @@
+/**
+ * IO + utility functions extracted from `exportService.ts`. Pure or
+ * pseudo-pure (filesystem operations only) — no class state, no DB, no
+ * progress tracking. Job-orchestration concerns stay in the class.
+ */
+
+import path from 'path';
+import { promises as fs } from 'fs';
+import archiver from 'archiver';
+import { logger } from '../../utils/logger';
+
+const RESERVED_WINDOWS_NAMES = [
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+];
+
+/**
+ * Strip filesystem-unsafe characters from a candidate filename. Replaces
+ * Windows-reserved chars + control chars with `_`, trims leading/trailing
+ * dots and whitespace, truncates to 100 chars, and avoids Windows reserved
+ * device names. Returns 'export' if the result is empty.
+ */
+export function sanitizeFilename(filename: string): string {
+  if (!filename || typeof filename !== 'string') {
+    return 'export';
+  }
+
+  let sanitized = filename
+    .replace(/[<>:"|?*\\/]/g, '_')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u0080-\u009f]/g, '_')
+    .trim();
+
+  // Remove leading/trailing dots and spaces (Windows compatibility)
+  sanitized = sanitized.replace(/^[.\s]+|[.\s]+$/g, '');
+
+  if (!sanitized || sanitized.length === 0) {
+    sanitized = 'export';
+  } else if (sanitized.length > 100) {
+    sanitized = sanitized.substring(0, 100).trim();
+  }
+
+  if (RESERVED_WINDOWS_NAMES.includes(sanitized.toUpperCase())) {
+    sanitized = `${sanitized}_export`;
+  }
+
+  return sanitized;
+}
+
+export type ExportProgressStage =
+  | 'images'
+  | 'visualizations'
+  | 'annotations'
+  | 'metrics'
+  | 'compression';
+
+export interface ExportProgressDetail {
+  current: number;
+  total: number;
+  currentItem?: string;
+}
+
+/**
+ * Build a human-readable progress message for WebSocket broadcasting.
+ * Pure function — no IO, no state. Output format is the contract the
+ * frontend toast/progress UI consumes.
+ */
+export function getProgressMessage(
+  progress: number,
+  stage?: ExportProgressStage,
+  stageProgress?: ExportProgressDetail
+): string {
+  if (stage && stageProgress) {
+    const { current, total, currentItem } = stageProgress;
+    const itemSuffix = currentItem ? `: ${currentItem}` : '';
+    switch (stage) {
+      case 'images':
+        return `Copying original images (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'visualizations':
+        return `Generating visualizations (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'annotations':
+        return `Creating annotation files (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'metrics':
+        return `Calculating metrics (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'compression':
+        return `Creating archive... ${progress}%`;
+      default:
+        return `Processing ${stage} (${current}/${total})... ${progress}%`;
+    }
+  } else if (stage) {
+    switch (stage) {
+      case 'images':
+        return `Copying original images... ${progress}%`;
+      case 'visualizations':
+        return `Generating visualizations... ${progress}%`;
+      case 'annotations':
+        return `Creating annotation files... ${progress}%`;
+      case 'metrics':
+        return `Calculating metrics... ${progress}%`;
+      case 'compression':
+        return `Creating archive... ${progress}%`;
+      default:
+        return `Processing ${stage}... ${progress}%`;
+    }
+  }
+  return `Processing... ${progress}%`;
+}
+
+/**
+ * Create a zip archive of an export staging directory and write it to
+ * disk under `process.env.EXPORT_DIR || './exports'`. Resolves with the
+ * absolute path to the produced ZIP. Caller is responsible for cleaning
+ * up the staging directory.
+ *
+ * Robustness: dual error handlers on writeStream + archive both delegate
+ * to a single idempotent cleanup that destroys the archive, closes the
+ * file handle, and removes listeners (memory-leak guard for long-running
+ * processes that produce many exports).
+ */
+export async function createZipArchive(
+  exportDir: string,
+  projectName: string
+): Promise<string> {
+  const sanitizedProjectName = sanitizeFilename(projectName);
+  const zipName = `${sanitizedProjectName}.zip`;
+  const zipPath = path.join(process.env.EXPORT_DIR || './exports', zipName);
+
+  const output = await fs.open(zipPath, 'w');
+  const archive = archiver('zip', {
+    zlib: { level: 6 }, // Balanced compression
+    highWaterMark: 16 * 1024 * 1024, // 16MB buffer for streaming
+  });
+
+  return new Promise((resolve, reject) => {
+    let cleanupCalled = false;
+
+    const cleanup = async (): Promise<void> => {
+      if (cleanupCalled) {
+        return;
+      }
+      cleanupCalled = true;
+
+      try {
+        if (archive.readable || archive.writable) {
+          archive.destroy();
+        }
+      } catch (error) {
+        logger.warn('Failed to destroy archive:', 'ExportFileOps', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      try {
+        await output.close();
+      } catch (error) {
+        logger.warn('Failed to close file handle:', 'ExportFileOps', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      writeStream.removeAllListeners();
+      archive.removeAllListeners();
+    };
+
+    const writeStream = output.createWriteStream();
+
+    writeStream.on('error', error => {
+      cleanup().finally(() => reject(error));
+    });
+
+    writeStream.on('close', () => {
+      cleanup().finally(() => resolve(zipPath));
+    });
+
+    archive.on('error', error => {
+      cleanup().finally(() => reject(error));
+    });
+
+    archive.pipe(writeStream);
+    archive.directory(exportDir, false);
+
+    try {
+      archive.finalize().catch(error => {
+        cleanup().finally(() => reject(error));
+      });
+    } catch (error) {
+      cleanup().finally(() => reject(error));
+    }
+  });
+}

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -27,6 +27,11 @@ import {
   generateMetricsGuide,
   generateAnnotationGuides,
 } from './export/exportDocs';
+import {
+  sanitizeFilename,
+  getProgressMessage,
+  createZipArchive,
+} from './export/exportFileOperations';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -527,7 +532,7 @@ export class ExportService {
       checkCancellation();
 
       // Create ZIP archive (no compression)
-      const zipPath = await this.createZipArchive(exportDir, project.title);
+      const zipPath = await createZipArchive(exportDir, project.title);
 
       // Check for cancellation after ZIP creation
       checkCancellation();
@@ -1261,85 +1266,6 @@ export class ExportService {
     await fs.writeFile(path.join(docDir, 'metrics_guide.md'), metricsGuide);
   }
 
-  private async createZipArchive(
-    exportDir: string,
-    projectName: string
-  ): Promise<string> {
-    // Sanitize project name for filesystem safety
-    const sanitizedProjectName = this.sanitizeFilename(projectName);
-    // Use simple project name for export file (as requested by user)
-    const zipName = `${sanitizedProjectName}.zip`;
-    const zipPath = path.join(process.env.EXPORT_DIR || './exports', zipName);
-
-    const output = await fs.open(zipPath, 'w');
-    const archive = archiver('zip', {
-      zlib: { level: 6 }, // Balanced compression (6 is default, good balance of speed vs size)
-      highWaterMark: 16 * 1024 * 1024, // 16MB buffer for better streaming performance
-    });
-
-    return new Promise((resolve, reject) => {
-      let cleanupCalled = false;
-
-      const cleanup = async (): Promise<void> => {
-        if (cleanupCalled) {
-          return;
-        }
-        cleanupCalled = true;
-
-        try {
-          // Destroy archive first
-          if (archive.readable || archive.writable) {
-            archive.destroy();
-          }
-        } catch (error) {
-          logger.warn('Failed to destroy archive:', 'ExportService', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          // Close file handle
-          await output.close();
-        } catch (error) {
-          logger.warn('Failed to close file handle:', 'ExportService', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        // Remove event listeners to prevent memory leaks
-        writeStream.removeAllListeners();
-        archive.removeAllListeners();
-      };
-
-      const writeStream = output.createWriteStream();
-
-      // Add error handler for writeStream
-      writeStream.on('error', error => {
-        cleanup().finally(() => reject(error));
-      });
-
-      writeStream.on('close', () => {
-        cleanup().finally(() => resolve(zipPath));
-      });
-
-      archive.on('error', error => {
-        cleanup().finally(() => reject(error));
-      });
-
-      archive.pipe(writeStream);
-      archive.directory(exportDir, false);
-
-      // Wrap finalize in try/catch and handle its promise rejection
-      try {
-        archive.finalize().catch(error => {
-          cleanup().finally(() => reject(error));
-        });
-      } catch (error) {
-        cleanup().finally(() => reject(error));
-      }
-    });
-  }
-
   private updateJobProgress(
     jobId: string,
     progress: number,
@@ -1359,7 +1285,7 @@ export class ExportService {
       const phase = progress < 90 ? 'processing' : 'downloading';
 
       // Generate contextual message
-      const message = this.getProgressMessage(progress, stage, stageProgress);
+      const message = getProgressMessage(progress, stage, stageProgress);
 
       // Enhanced progress data for WebSocket
       const progressData = {
@@ -1375,51 +1301,6 @@ export class ExportService {
       // Send to user via WebSocket
       this.sendToUser(job.userId, 'export:progress', progressData);
     }
-  }
-
-  private getProgressMessage(
-    progress: number,
-    stage?:
-      | 'images'
-      | 'visualizations'
-      | 'annotations'
-      | 'metrics'
-      | 'compression',
-    stageProgress?: { current: number; total: number; currentItem?: string }
-  ): string {
-    if (stage && stageProgress) {
-      const { current, total, currentItem } = stageProgress;
-      switch (stage) {
-        case 'images':
-          return `Copying original images (${current}/${total})${currentItem ? `: ${currentItem}` : ''}... ${progress}%`;
-        case 'visualizations':
-          return `Generating visualizations (${current}/${total})${currentItem ? `: ${currentItem}` : ''}... ${progress}%`;
-        case 'annotations':
-          return `Creating annotation files (${current}/${total})${currentItem ? `: ${currentItem}` : ''}... ${progress}%`;
-        case 'metrics':
-          return `Calculating metrics (${current}/${total})${currentItem ? `: ${currentItem}` : ''}... ${progress}%`;
-        case 'compression':
-          return `Creating archive... ${progress}%`;
-        default:
-          return `Processing ${stage} (${current}/${total})... ${progress}%`;
-      }
-    } else if (stage) {
-      switch (stage) {
-        case 'images':
-          return `Copying original images... ${progress}%`;
-        case 'visualizations':
-          return `Generating visualizations... ${progress}%`;
-        case 'annotations':
-          return `Creating annotation files... ${progress}%`;
-        case 'metrics':
-          return `Calculating metrics... ${progress}%`;
-        case 'compression':
-          return `Creating archive... ${progress}%`;
-        default:
-          return `Processing ${stage}... ${progress}%`;
-      }
-    }
-    return `Processing... ${progress}%`;
   }
 
   private setupJobCleanup(): void {
@@ -1619,62 +1500,6 @@ export class ExportService {
   /**
    * Sanitize filename for filesystem safety
    */
-  private sanitizeFilename(filename: string): string {
-    if (!filename || typeof filename !== 'string') {
-      return 'export';
-    }
-
-    // Replace invalid characters with underscores
-    // Invalid characters: < > : " | ? * \ / and control characters
-    let sanitized = filename
-      .replace(/[<>:"|?*\\/]/g, '_')
-      // eslint-disable-next-line no-control-regex
-      .replace(/[\u0000-\u001f\u0080-\u009f]/g, '_')
-      .trim();
-
-    // Remove leading/trailing dots and spaces (Windows compatibility)
-    sanitized = sanitized.replace(/^[.\s]+|[.\s]+$/g, '');
-
-    // Ensure filename is not empty and not too long
-    if (!sanitized || sanitized.length === 0) {
-      sanitized = 'export';
-    } else if (sanitized.length > 100) {
-      // Truncate to 100 characters to avoid filesystem limits
-      sanitized = sanitized.substring(0, 100).trim();
-    }
-
-    // Avoid reserved Windows names
-    const reservedNames = [
-      'CON',
-      'PRN',
-      'AUX',
-      'NUL',
-      'COM1',
-      'COM2',
-      'COM3',
-      'COM4',
-      'COM5',
-      'COM6',
-      'COM7',
-      'COM8',
-      'COM9',
-      'LPT1',
-      'LPT2',
-      'LPT3',
-      'LPT4',
-      'LPT5',
-      'LPT6',
-      'LPT7',
-      'LPT8',
-      'LPT9',
-    ];
-    if (reservedNames.includes(sanitized.toUpperCase())) {
-      sanitized = `${sanitized}_export`;
-    }
-
-    return sanitized;
-  }
-
   // Cleanup method for graceful shutdown
   public destroy(): void {
     if (this.cleanupInterval) {


### PR DESCRIPTION
## Summary
Third extraction pass on \`exportService.ts\`. **1824 → 1651 LoC (-173)** by hoisting three self-contained utilities into \`backend/src/services/export/exportFileOperations.ts\`.

### Extracted
- **\`sanitizeFilename\`** — strips filesystem-unsafe chars + Windows reserved device names. Pure function. Now reusable outside \`ExportService\`.
- **\`getProgressMessage\`** — builds human-readable WebSocket progress strings. Pure function. Type aliases \`ExportProgressStage\` and \`ExportProgressDetail\` exported for reuse.
- **\`createZipArchive\`** — async filesystem op writing a zip from staging directory to \`EXPORT_DIR || './exports'\`. Idempotent cleanup guards against memory leaks across many exports.

### Class shell retains
- Job lifecycle (\`exportJobs\` map, TTL, max-job cap)
- \`updateJobProgress\`, \`isJobCancelled\`, \`sendToUser\` (need WS service + state)
- \`setupJobCleanup\`, \`cleanupOldJobs\` (interval + state)
- Job-state CRUD methods (\`getJobStatus\`, \`cancelJob\`, etc.)
- Pipeline orchestrators (\`startExportJob\`, \`processExportJob\`, etc.)

## Verification
- [x] Backend \`npx tsc --noEmit\` passes
- [x] **41/41 tests pass** — \`exportService.test.ts\` + \`exportController.test.ts\` together
- [x] Pre-commit hooks pass

## Cumulative reduction
\`exportService.ts\` across this session:
- 2480 LoC start
- → 1824 (PR #118 docs extract: -656)
- → 1651 (this PR: -173)
- = **-829 LoC total (-33%)**

## Risk
Low. Self-contained pure-ish utilities. \`createZipArchive\` is the only one with side-effects (filesystem); behavior is byte-identical to before — same archiver config, same cleanup logic, same return contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)