### PR TITLE
fix(api): restore getProjectImages/WithThumbnails/reorder method names

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -959,7 +959,7 @@ class ApiClient {
   /**
    * Get project images with optimized thumbnail data
    */
-  async getProjectImageDTOsWithThumbnails(
+  async getProjectImagesWithThumbnails(
     projectId: string,
     params?: {
       page?: number;
@@ -998,7 +998,7 @@ class ApiClient {
    * displayOrder 0, index 1 → 1, etc. The backend applies the change in a
    * single transaction.
    */
-  async reorderProjectImageDTOs(
+  async reorderProjectImages(
     projectId: string,
     imageIds: string[]
   ): Promise<void> {
@@ -1007,7 +1007,7 @@ class ApiClient {
     });
   }
 
-  async getProjectImageDTOs(
+  async getProjectImages(
     projectId: string,
     params?: { page?: number; limit?: number }
   ): Promise<{


### PR DESCRIPTION
## Critical production fix

PR #113's \`replace_all\` mangled three method names while renaming the type:

| Method | Before | After (broken) |
|---|---|---|
| \`apiClient.getProjectImages\` | ✓ | \`getProjectImageDTOs\` |
| \`apiClient.getProjectImagesWithThumbnails\` | ✓ | \`getProjectImageDTOsWithThumbnails\` |
| \`apiClient.reorderProjectImages\` | ✓ | \`reorderProjectImageDTOs\` |

\`npx tsc --noEmit\` passed because internal call sites (\`this.X\`) were
also renamed consistently. External callers (Dashboard, Profile,
ProjectDetail, useOptimizedProjectImages, useStatusReconciliation,
useProjectData) kept original names → runtime \`TypeError\` on every
Dashboard load.

This PR restores method names. Type rename (interface \`ProjectImage\` →
\`ProjectImageDTO\`) is preserved.

## Verification
- \`npx tsc --noEmit\` passes
- Diff is 3 lines: \`-\` 3 wrong method names, \`+\` 3 correct ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming of image-related API methods while preserving all existing functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->