### PR TITLE
fix(health): demote monitoring outage from 'degraded' to 'healthy'

### DIFF
--- a/backend/src/services/healthCheckService.ts
+++ b/backend/src/services/healthCheckService.ts
@@ -489,12 +489,21 @@ export class HealthCheckService {
       // Grafana not available
     }
 
+    // Monitoring is ANCILLARY — Prometheus/Grafana are observability
+    // tooling, not part of the request path. App works fully without
+    // them. Don't propagate their absence as 'unhealthy' or even
+    // 'degraded' for the overall app status — that would mask real
+    // production problems behind monitoring container churn.
+    //
+    // We still return granular details so an external observer that
+    // CARES about monitoring (e.g. an SRE dashboard) can inspect them.
     const allHealthy = Object.values(checks).every(v => v);
-    const someHealthy = Object.values(checks).some(v => v);
 
     return {
-      status: allHealthy ? 'healthy' : someHealthy ? 'degraded' : 'unhealthy',
-      message: `Monitoring services: Prometheus ${checks.prometheus ? '✓' : '✗'}, Grafana ${checks.grafana ? '✓' : '✗'}`,
+      status: 'healthy',
+      message: allHealthy
+        ? 'Monitoring services online: Prometheus ✓, Grafana ✓'
+        : `Monitoring services optional and not currently reachable (Prometheus ${checks.prometheus ? '✓' : '✗'}, Grafana ${checks.grafana ? '✓' : '✗'}) — does not affect app health`,
       responseTime: Date.now() - startTime,
       details: checks,
       lastCheck: new Date(),


### PR DESCRIPTION
## Summary

- Health check for Prometheus/Grafana now always returns `status: 'healthy'`. Granular per-collector flags remain in `details` for SRE dashboards.
- Reason: monitoring is **ancillary** — observability tooling, not part of the request path. Bubbling its absence into 'degraded'/'unhealthy' was masking real production issues behind monitoring container churn.

## Why

Production blue env runs without Prometheus/Grafana to save memory. Old code reported the monitoring check as `degraded`, which propagated into the aggregated health response and made `/health` always return non-healthy — defeating the purpose of the endpoint.

## Test plan

- [x] `cd backend && npx vitest run src/services/__tests__/healthCheckService.test.ts` — 10/10 pass
- [ ] Manual: `curl https://spherosegapp.utia.cas.cz/health` returns `{ status: 'healthy', ... }` after deploy
- [ ] No regression in remaining health-aggregator behavior (DB/Redis/disk checks still drive overall status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health check status no longer incorrectly degrades based on monitoring service availability.
  * Clarified that monitoring unavailability does not impact application health or functionality.

* **Chores**
  * Simplified health check status computation logic and improved documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->