### PR TITLE
feat(export): cap concurrent export jobs at 1 per user (HTTP 429)

### DIFF
--- a/backend/src/api/controllers/__tests__/exportController.test.ts
+++ b/backend/src/api/controllers/__tests__/exportController.test.ts
@@ -202,6 +202,22 @@ describe('ExportController', () => {
       expect(response.body.error).toBe('Failed to start export');
     });
 
+    it('should return 429 when service rejects due to per-user concurrency cap', async () => {
+      mockService.startExportJob.mockRejectedValueOnce(
+        new Error(
+          'Rate limit exceeded: you already have an export in progress. ' +
+            'Wait for it to finish or cancel it before starting another.'
+        )
+      );
+
+      const response = await request(app)
+        .post(`/projects/${projectId}/export`)
+        .send({ options: {} })
+        .expect(429);
+
+      expect(response.body.error).toContain('Rate limit exceeded');
+    });
+
     it('should use empty options when options not provided', async () => {
       mockService.startExportJob.mockResolvedValueOnce(jobId);
 

--- a/backend/src/api/controllers/exportController.ts
+++ b/backend/src/api/controllers/exportController.ts
@@ -114,12 +114,16 @@ export class ExportController {
         message: 'Export job started successfully',
       });
     } catch (error) {
-      ResponseHelper.internalError(
-        res,
-        toErr(error),
-        'Failed to start export',
-        CTX
-      );
+      const err = toErr(error);
+      // Per-user concurrency rate limit (1 active export at a time) —
+      // surfaces as 429 instead of 500 so the frontend can show a sensible
+      // toast ("wait for current export to finish") rather than a generic
+      // server error.
+      if (err.message.startsWith('Rate limit exceeded:')) {
+        ResponseHelper.rateLimit(res, err.message, CTX);
+        return;
+      }
+      ResponseHelper.internalError(res, err, 'Failed to start export', CTX);
     }
   }
 

--- a/backend/src/services/__tests__/exportService.test.ts
+++ b/backend/src/services/__tests__/exportService.test.ts
@@ -187,6 +187,66 @@ describe('ExportService', () => {
 
       expect(jobId).toBe(JOB_ID);
     });
+
+    it('rejects a second concurrent export from the same user', async () => {
+      // Pre-seed a pending job for the user. We don't await startExportJob
+      // again because the first call kicks off async processing — using
+      // the internal map keeps the test deterministic.
+      const jobs = (service as any).exportJobs as Map<string, ExportJob>;
+      jobs.set('existing-job', {
+        id: 'existing-job',
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        status: 'pending',
+        progress: 0,
+        createdAt: new Date(),
+        options: {},
+      });
+
+      await expect(
+        service.startExportJob(PROJECT_ID, USER_ID, {
+          annotationFormats: ['json'],
+        })
+      ).rejects.toThrow(/Rate limit exceeded/);
+    });
+
+    it('allows a new export after the previous one finishes', async () => {
+      const jobs = (service as any).exportJobs as Map<string, ExportJob>;
+      jobs.set('past-job', {
+        id: 'past-job',
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        status: 'completed', // terminal state — no longer "active"
+        progress: 100,
+        createdAt: new Date(),
+        options: {},
+      });
+
+      const jobId = await service.startExportJob(PROJECT_ID, USER_ID, {
+        annotationFormats: ['json'],
+      });
+
+      expect(jobId).toBe(JOB_ID);
+    });
+
+    it('does not block a different user from exporting concurrently', async () => {
+      const jobs = (service as any).exportJobs as Map<string, ExportJob>;
+      jobs.set('other-users-job', {
+        id: 'other-users-job',
+        projectId: PROJECT_ID,
+        userId: 'other-user',
+        status: 'processing',
+        progress: 50,
+        createdAt: new Date(),
+        options: {},
+      });
+
+      const jobId = await service.startExportJob(PROJECT_ID, USER_ID, {
+        annotationFormats: ['json'],
+      });
+
+      expect(jobId).toBe(JOB_ID);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -198,6 +198,26 @@ export class ExportService {
     }
   }
 
+  /** How many concurrent export jobs a single user can have running. */
+  private static readonly MAX_ACTIVE_JOBS_PER_USER = 1;
+
+  /** True if the given user already has an active (non-terminal) export. */
+  private hasActiveJobForUser(userId: string): boolean {
+    let active = 0;
+    for (const job of this.exportJobs.values()) {
+      if (
+        job.userId === userId &&
+        (job.status === 'pending' || job.status === 'processing')
+      ) {
+        active++;
+        if (active >= ExportService.MAX_ACTIVE_JOBS_PER_USER) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   async startExportJob(
     projectId: string,
     userId: string,
@@ -212,6 +232,17 @@ export class ExportService {
     if (!accessCheck.hasAccess) {
       throw new Error(
         'Access denied: You do not have permission to export this project'
+      );
+    }
+
+    // Per-user concurrency cap: each export burns I/O + CPU + RAM. Without
+    // this gate a user could spam POST /api/export/... and exhaust shared
+    // resources for everyone else. Caller (controller) translates this
+    // error to HTTP 429 in PR follow-up.
+    if (this.hasActiveJobForUser(userId)) {
+      throw new Error(
+        'Rate limit exceeded: you already have an export in progress. ' +
+          'Wait for it to finish or cancel it before starting another.'
       );
     }
 


### PR DESCRIPTION
## Summary

- ExportService rejects a second export from the same user while their previous one is still `pending`/`processing`, with a `Rate limit exceeded:` error.
- exportController maps that error to **HTTP 429**, so the frontend can show a "wait for current export to finish" toast instead of a generic 500.
- Other users can still export concurrently — the cap is per-userId, not global.

## Why

Each export burns considerable I/O + CPU + RAM (polygon serialization, ZIP archiving, image copying). Without a per-user gate, a user could spam POST /api/export/... and starve shared resources for the whole instance.

## What about other rate-limiting?

This is **per-user concurrency**, not request-rate. Existing global throttles (Redis-based) handle bursts but don't cap the *active* expensive job count per principal — that's the gap this PR closes.

## Test plan

- [x] `cd backend && npx vitest run src/services/__tests__/exportService.test.ts src/api/controllers/__tests__/exportController.test.ts` — 45/45 pass (4 new)
- [ ] Manual: trigger 2 concurrent exports from same account → second returns 429
- [ ] Manual: trigger concurrent exports from 2 different accounts → both succeed

## Behavioral spec for new tests

- **block same user**: pre-seed pending job → second `startExportJob` rejects with `/Rate limit exceeded/`
- **allow after completed**: pre-seed `status: 'completed'` job → new export succeeds
- **allow other user**: pre-seed processing job for `other-user` → user-id can still start
- **controller 429 mapping**: service rejects with rate-limit prefix → response code is 429, body contains `Rate limit exceeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)