### PR TITLE
chore(ops): wire daily PostgreSQL backups + fix script reliability bugs

### DIFF
--- a/docs/database-backup.md
+++ b/docs/database-backup.md
@@ -1,0 +1,107 @@
+# Database backup
+
+Production runs PostgreSQL (`spheroseg_blue` on container `spheroseg-postgres`).
+This page covers the automated backup / retention strategy and how to restore.
+
+## Status
+
+`scripts/backup-database.sh` exists and works (PostgreSQL `pg_dump` with
+gzip + integrity check + retention pruning), but historically nothing
+scheduled it. Two install paths are documented below — pick one.
+
+## Layout
+
+| Path                                          | Purpose                                                                        | Owner  |
+| --------------------------------------------- | ------------------------------------------------------------------------------ | ------ |
+| `~/spheroseg-backups/`                        | Daily compressed dumps, named `postgres_spheroseg_blue_YYYYMMDD_HHMMSS.sql.gz` | `cvat` |
+| `~/spheroseg-backups/backup.log`              | Append-only log of each run                                                    | `cvat` |
+| `scripts/backup-database.sh`                  | The actual backup script (env-overridable)                                     | repo   |
+| `scripts/spheroseg-backup.service` + `.timer` | systemd units (oneshot daily)                                                  | repo   |
+| `scripts/install-backup-systemd.sh`           | Helper to install the units                                                    | repo   |
+
+`BACKUP_DIR`, `LOG_FILE`, and `RETENTION_DAYS` are env-overridable, so
+the script also works when invoked directly without root privileges.
+
+## Install (systemd, recommended)
+
+```bash
+cd /home/cvat/cell-segmentation-hub
+./scripts/install-backup-systemd.sh
+```
+
+That:
+
+1. Installs both unit files into `/etc/systemd/system/`.
+2. Creates `~/spheroseg-backups/` with `0750` perms.
+3. `systemctl enable --now spheroseg-backup.timer`.
+
+Next firing:
+
+```bash
+sudo systemctl list-timers spheroseg-backup.timer
+```
+
+Run on demand:
+
+```bash
+sudo systemctl start spheroseg-backup.service
+journalctl -u spheroseg-backup.service -n 50
+```
+
+## Install (cron alternative)
+
+If you don't have systemd or prefer cron, drop this into `crontab -e`:
+
+```cron
+30 3 * * *   cd /home/cvat/cell-segmentation-hub && BACKUP_DIR=$HOME/spheroseg-backups LOG_FILE=$HOME/spheroseg-backups/backup.log /bin/bash scripts/backup-database.sh
+```
+
+The script self-tolerates non-writable log paths, so it'll fall back to
+stderr (which cron mails to root by default).
+
+## What the script does
+
+1. Reads `DATABASE_URL` from `.env.production` (parsed via Python `urllib`).
+2. Creates a temporary `~/.pgpass`-style file (mode `0600`, removed in `trap EXIT`).
+3. `pg_dump --no-owner --no-acl --clean --if-exists | gzip` → `BACKUP_DIR/postgres_<db>_<ts>.sql.gz`.
+4. Verifies gzip integrity (`gunzip -t`).
+5. Prunes files older than `RETENTION_DAYS` (default 30) in `BACKUP_DIR`.
+
+## Restore
+
+```bash
+# Pick the dump you want (latest example)
+LATEST=$(ls -t ~/spheroseg-backups/postgres_spheroseg_blue_*.sql.gz | head -1)
+
+# Stop services that write to the DB so the restore is consistent
+docker compose -f docker-compose.production.yml stop backend ml
+
+# Drop + recreate the schema (SQL contains DROP TABLE/INDEX/etc.)
+gunzip -c "$LATEST" | docker exec -i spheroseg-postgres psql \
+    -U spheroseg -d spheroseg_blue
+
+# Restart writers
+docker compose -f docker-compose.production.yml start backend ml
+```
+
+> ⚠️ The dump uses `--clean --if-exists`, which means restore wipes the
+> existing schema before reloading. Confirm you have the right file
+> before running this against production. For a partial restore, extract
+> specific tables from the .sql.gz with `grep`/`pg_restore`'s
+> `--list`/`--use-list` flow.
+
+## Off-site copy (recommended next step)
+
+Local backups protect against application-level corruption but not
+against host loss. After confirming the daily timer fires, add an
+off-site copy: `rclone sync ~/spheroseg-backups/ remote:spheroseg-bak/`
+in a second timer is a one-line addition.
+
+## Verification checklist
+
+After installing:
+
+- [ ] `sudo systemctl start spheroseg-backup.service` produces a `.sql.gz` in `~/spheroseg-backups/`.
+- [ ] `gunzip -t` on the latest file exits 0.
+- [ ] Smoke-test restore against a throwaway database (`docker run --rm postgres ...`).
+- [ ] `systemctl list-timers spheroseg-backup.timer` shows the next run within 24h.

--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -3,13 +3,20 @@
 # Database Backup Script for Cell Segmentation Hub
 # Supports both PostgreSQL and SQLite databases
 
-set -e
+# pipefail is critical: without it, `pg_dump | gzip` masks pg_dump
+# failures (e.g. wrong credentials, missing pg_dump binary) because
+# gzip happily exits 0 on empty input and produces a 20-byte "valid"
+# gzip header. The `-s` size check below would still pass, and we'd
+# silently install a useless backup.
+set -eo pipefail
 
-# Configuration
-BACKUP_DIR="/backups/database"
-RETENTION_DAYS=30
+# Configuration — env-overridable so the script works for both root
+# (default `/backups/database` + `/var/log/backup.log`) and non-root
+# users (e.g. systemd timer running as `cvat` writing under `~/spheroseg-backups`).
+BACKUP_DIR="${BACKUP_DIR:-/backups/database}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-LOG_FILE="/var/log/backup.log"
+LOG_FILE="${LOG_FILE:-/var/log/backup.log}"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -44,14 +51,18 @@ elif [ -f ".env" ]; then
     load_env_file ".env"
 fi
 
-# Logging function
+# Logging function — tolerate non-writable LOG_FILE (e.g. when running
+# as a non-root systemd user that can't touch /var/log). Fall back to
+# stderr only.
 log() {
     echo -e "$1"
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> $LOG_FILE
+    if [ -w "$(dirname "$LOG_FILE")" ] 2>/dev/null; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE" 2>/dev/null || true
+    fi
 }
 
 # Create backup directory if it doesn't exist
-mkdir -p $BACKUP_DIR
+mkdir -p "$BACKUP_DIR"
 
 log "${GREEN}Starting database backup...${NC}"
 
@@ -136,14 +147,24 @@ except Exception as e:
     # Remove temporary pgpass file
     rm -f "$PGPASS_FILE"
     
-    # Verify backup
-    if [ -f "$BACKUP_FILE" ] && [ -s "$BACKUP_FILE" ]; then
-        SIZE=$(du -h $BACKUP_FILE | cut -f1)
+    # Verify backup. Minimum size check is critical — a 20-byte gzip
+    # header on its own passes `-s` (size > 0) but is unusable. A real
+    # spheroseg dump is megabytes; require at least 1 KiB so an empty
+    # pg_dump (e.g. credential failure that pipefail somehow missed)
+    # surfaces as a backup error rather than a silent zero-content file.
+    MIN_BACKUP_BYTES=1024
+    if [ -f "$BACKUP_FILE" ]; then
+        BYTES=$(stat -c %s "$BACKUP_FILE" 2>/dev/null || stat -f %z "$BACKUP_FILE")
+        if [ "$BYTES" -lt "$MIN_BACKUP_BYTES" ]; then
+            log "${RED}❌ Backup is suspiciously small ($BYTES B < $MIN_BACKUP_BYTES B). Aborting.${NC}"
+            rm -f "$BACKUP_FILE"
+            exit 1
+        fi
+        SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
         log "${GREEN}✅ PostgreSQL backup successful: $BACKUP_FILE (Size: $SIZE)${NC}"
-        
-        # Test restore capability (dry run)
-        gunzip -t $BACKUP_FILE
-        if [ $? -eq 0 ]; then
+
+        # Test restore capability (gzip integrity)
+        if gunzip -t "$BACKUP_FILE"; then
             log "${GREEN}✅ Backup integrity verified${NC}"
         else
             log "${RED}❌ Backup integrity check failed${NC}"
@@ -189,7 +210,11 @@ if [[ ! $RETENTION_DAYS =~ ^[0-9]+$ ]]; then
     log "${RED}❌ RETENTION_DAYS must be a positive integer${NC}"
     exit 1
 fi
-find -- "$BACKUP_DIR" -type f -name "*.gz" -mtime +"$RETENTION_DAYS" -print0 | xargs -0 rm --
+# xargs -r is required: without it, an empty find result (no files
+# older than RETENTION_DAYS, common on a fresh install) calls
+# `rm --` with no arguments and rm errors with "missing operand".
+find -- "$BACKUP_DIR" -type f -name "*.gz" -mtime +"$RETENTION_DAYS" -print0 \
+    | xargs -0 -r rm --
 
 # List recent backups
 log "${GREEN}Recent backups:${NC}"

--- a/scripts/install-backup-systemd.sh
+++ b/scripts/install-backup-systemd.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Install scripts/spheroseg-backup.{service,timer} as a systemd timer
+# that runs daily at 03:30 local time.
+#
+# Idempotent: re-running just refreshes the unit files in place.
+#
+# Requires sudo (writes to /etc/systemd/system/). Does NOT modify the
+# database; only schedules existing scripts/backup-database.sh.
+
+set -euo pipefail
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Don't run this as root directly — use sudo so the User= field"
+    echo "in the service unit stays correct (the unit runs as cvat by default)."
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+UNIT_DIR=/etc/systemd/system
+
+echo "Installing systemd units from $SCRIPT_DIR …"
+
+# Replace ${PROJECT_ROOT} placeholder so the unit doesn't depend on the
+# install location matching the source tree.
+TMP_SERVICE=$(mktemp)
+TMP_TIMER=$(mktemp)
+trap 'rm -f "$TMP_SERVICE" "$TMP_TIMER"' EXIT
+
+sed "s#/home/cvat/cell-segmentation-hub#$PROJECT_ROOT#g" \
+    "$SCRIPT_DIR/spheroseg-backup.service" > "$TMP_SERVICE"
+cp "$SCRIPT_DIR/spheroseg-backup.timer" "$TMP_TIMER"
+
+sudo install -m 0644 "$TMP_SERVICE" "$UNIT_DIR/spheroseg-backup.service"
+sudo install -m 0644 "$TMP_TIMER"   "$UNIT_DIR/spheroseg-backup.timer"
+
+# Ensure backup directory and log file exist with the right ownership.
+sudo install -d -m 0750 -o "$USER" -g "$USER" /home/"$USER"/spheroseg-backups
+sudo touch /home/"$USER"/spheroseg-backups/backup.log
+sudo chown "$USER:$USER" /home/"$USER"/spheroseg-backups/backup.log
+sudo chmod 0640 /home/"$USER"/spheroseg-backups/backup.log
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now spheroseg-backup.timer
+
+echo
+echo "Installed. Next run:"
+sudo systemctl list-timers spheroseg-backup.timer --no-pager | head -5
+echo
+echo "Run a backup right now (won't wait for the timer):"
+echo "    sudo systemctl start spheroseg-backup.service"
+echo
+echo "View logs:"
+echo "    journalctl -u spheroseg-backup.service -n 50"
+echo "    tail -f /home/$USER/spheroseg-backups/backup.log"

--- a/scripts/spheroseg-backup.service
+++ b/scripts/spheroseg-backup.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=SpheroSeg PostgreSQL database backup
+Documentation=https://github.com/michalprusek/cell-segmentation-hub/blob/main/docs/database-backup.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+
+# Adjust User if you install on behalf of a different account.
+User=cvat
+Group=cvat
+
+# Project root — must contain .env.production and scripts/backup-database.sh.
+WorkingDirectory=/home/cvat/cell-segmentation-hub
+
+# Where backups land + log destination. Override on install if your host
+# uses a different volume layout.
+Environment=BACKUP_DIR=/home/cvat/spheroseg-backups
+Environment=LOG_FILE=/home/cvat/spheroseg-backups/backup.log
+Environment=RETENTION_DAYS=30
+
+ExecStart=/bin/bash /home/cvat/cell-segmentation-hub/scripts/backup-database.sh
+
+# Don't fail the timer on a single bad night — Restart=no + RemainAfterExit=no
+# means systemctl status reports the failure for the operator without
+# blocking subsequent runs.
+RemainAfterExit=no
+
+# Hardening — backup script doesn't need elevated privileges or network
+# beyond pg_dump's connection.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/home/cvat/spheroseg-backups /home/cvat/cell-segmentation-hub
+ProtectHome=read-only
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/spheroseg-backup.timer
+++ b/scripts/spheroseg-backup.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=Daily SpheroSeg database backup (pairs with spheroseg-backup.service)
+Documentation=https://github.com/michalprusek/cell-segmentation-hub/blob/main/docs/database-backup.md
+
+[Timer]
+# Daily at 03:30 local time. PostgreSQL load is lowest overnight; offset
+# from common cron times (03:00, 04:00) to avoid pile-up with other host
+# maintenance jobs.
+OnCalendar=*-*-* 03:30:00
+
+# If the host was off at the scheduled time, run as soon as it boots —
+# missing a backup window is more expensive than running late.
+Persistent=true
+
+# Spread up to 5 minutes so multiple machines on the same network don't
+# hit the database at exactly 03:30:00.
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

The repo had `scripts/backup-database.sh` since Sept 2025 but **no schedule** — no cron, no systemd timer, `/backups/database/` never created. Production has been running without an automated DB backup for months.

This PR ships:

1. **systemd timer** + **service** files (oneshot, daily 03:30 + 5min jitter, Persistent=true).
2. **Idempotent installer** `scripts/install-backup-systemd.sh` (configures paths, perms, enables).
3. **Reliability fixes** in the existing `backup-database.sh` (see below).
4. **`docs/database-backup.md`** — install + restore + verification guide.

## Reliability fixes in backup-database.sh

| Bug | Symptom | Fix |
|---|---|---|
| `set -e` (no pipefail) | Failed `pg_dump | gzip` produced 20-byte "valid" gzip; existing `-s` size check passed; logged as success | `set -eo pipefail` |
| Same-flavor follow-up | A real corrupt/empty dump still passes `gunzip -t` (it's gzip-valid) | Added `MIN_BACKUP_BYTES=1024` floor; aborts and deletes if below |
| `xargs ... rm --` on retention | `rm: missing operand` when no files older than retention exist (i.e. fresh install) | `xargs -r` |
| `BACKUP_DIR=/backups/database` hard-coded | Script needed root or pre-existing dir | Now env-overridable: `BACKUP_DIR`, `LOG_FILE`, `RETENTION_DAYS` |
| `LOG_FILE=/var/log/backup.log` hard-coded | systemd User=cvat couldn't write to `/var/log` | log() falls back to stderr if dir not writable |

Repro of the silent-empty-backup bug (pre-fix):

```
$ BACKUP_DIR=/tmp/x bash scripts/backup-database.sh
…
pg_dump: command not found
✅ PostgreSQL backup successful: /tmp/x/postgres_…sql.gz (Size: 4.0K)   ← LIE
✅ Backup integrity verified
```

After fix:

```
$ BACKUP_DIR=/tmp/x bash scripts/backup-database.sh
…
pg_dump: command not found
$ echo \$?
127
```

## Install (after merge)

```bash
./scripts/install-backup-systemd.sh
sudo systemctl list-timers spheroseg-backup.timer
```

See \`docs/database-backup.md\` for restore procedure and verification checklist.

## Test plan

- [x] Script lints (`bash -n`).
- [x] Script returns non-zero exit when pg_dump unavailable (verified locally).
- [x] systemd unit syntactically valid (`systemd-analyze verify` skipped — host has no systemd-analyze, but the unit is straightforward).
- [ ] **Post-merge manual**: `./scripts/install-backup-systemd.sh` then verify ~/spheroseg-backups/ populated after 03:30.
- [ ] **Post-merge manual**: smoke-test restore against a throwaway database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)