### PR TITLE
chore(ci): add fast Playwright smoke gate for production bundle

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -131,6 +131,46 @@ jobs:
           fi
           echo "Bundle size: $BUNDLE_SIZE bytes"
 
+  # 3.1 SMOKE GATE — fast Playwright run against the built bundle to
+  #     catch runtime regressions like a tree-shaking error
+  #     (e.g. PR #128: `R.getProjectImages is not a function`) that
+  #     pass tsc + lint + unit tests but kill the page on load. No
+  #     backend; runs purely against `vite preview`.
+  smoke-test:
+    name: Frontend Smoke
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: build
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright (chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npm run test:e2e:smoke
+
+      - name: Upload smoke report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: |
+            playwright-report/
+            test-results-smoke/
+          retention-days: 14
+
   # 4. DOCKER BUILD
   docker-build:
     name: Docker Build
@@ -352,6 +392,7 @@ jobs:
       - code-quality
       - unit-tests
       - build
+      - smoke-test
       - docker-build
       - integration-tests
       - e2e-tests

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ SECURE_CREDENTIALS.md
 
 # Test results and reports
 test-results/
+test-results-smoke/
 playwright-report/
 coverage/
 .nyc_output/

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
     "i18n:check": "node scripts/check-i18n.cjs",
     "i18n:lint": "eslint . --config .eslintrc-i18n.js",
     "i18n:validate": "npm run i18n:check && npm run i18n:lint",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the *smoke gate*: fast bundle-mount checks
+ * against the built frontend, with no backend dependency.
+ *
+ * Distinct from `playwright.config.ts` (full E2E with Docker stack)
+ * because:
+ *   - smoke must finish in ~60s on CI to be useful as an early gate.
+ *   - smoke uses `vite preview` so it tests the production bundle
+ *     (the bundle that ships) rather than the dev server.
+ *   - smoke has no global setup, no auth fixtures, no database.
+ */
+export default defineConfig({
+  testDir: './tests/smoke',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Build then preview the production bundle. CI build can take ~30s,
+  // first-run cold start; subsequent reuse via reuseExistingServer.
+  webServer: {
+    command: 'npm run build && npx vite preview --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  outputDir: 'test-results-smoke/',
+});

--- a/tests/smoke/route-smoke.spec.ts
+++ b/tests/smoke/route-smoke.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Route smoke tests — fast bundle-execution gate.
+ *
+ * These tests are NOT about user flows. They verify that the production
+ * frontend bundle loads and the React tree mounts on each public route
+ * without throwing. They are designed to run against `vite preview`
+ * (built bundle) WITHOUT a real backend: API calls 401/network-fail,
+ * but the bundle itself must not crash.
+ *
+ * Catches the class of regression where a tree-shaken / minified
+ * bundle silently loses a method (e.g. PR #128: `R.getProjectImages is
+ * not a function`) — those don't show up in tsc but kill the page on
+ * load.
+ *
+ * Runtime budget: ~30s for the whole file in CI. Keep it fast.
+ */
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test';
+
+// Routes that must mount cleanly. Auth-gated routes will redirect to
+// /sign-in (which is fine — that's a successful render, not a crash).
+const ROUTES = [
+  '/',
+  '/sign-in',
+  '/sign-up',
+  '/dashboard',
+  '/profile',
+  '/settings',
+];
+
+/** Console messages we ignore — expected fetch failures from the
+ * absent backend, dev-mode warnings, third-party noise. */
+const IGNORE_PATTERNS: RegExp[] = [
+  // Expected: API calls fail with 401/Network Error when smoke-test
+  // runs without a backend. These are not bundle bugs.
+  /Failed to load resource/i,
+  /401 \(Unauthorized\)/,
+  /Network Error/,
+  /ERR_CONNECTION_REFUSED/,
+  /ERR_FAILED/,
+  /AxiosError/,
+  /\[axios\]/i,
+  // React DevTools recommendation in dev — irrelevant for smoke.
+  /Download the React DevTools/,
+  // i18next missing-key warnings should fail loudly in unit tests; in
+  // a smoke we only care about catastrophic crashes.
+  /i18next::translator/,
+];
+
+function capturePageErrors(page: Page): { errors: string[] } {
+  const errors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (IGNORE_PATTERNS.some(re => re.test(text))) return;
+    errors.push(`[console.error] ${text}`);
+  });
+  page.on('pageerror', err => {
+    errors.push(`[pageerror] ${err.name}: ${err.message}`);
+  });
+  return { errors };
+}
+
+for (const route of ROUTES) {
+  test(`mounts without bundle errors: ${route}`, async ({ page }) => {
+    const { errors } = capturePageErrors(page);
+
+    // Block all network requests to /api/** so the bundle's runtime
+    // doesn't sit in retry loops and doesn't depend on a backend.
+    await page.route('**/api/**', route => route.abort());
+
+    const response = await page.goto(route, { waitUntil: 'load' });
+    expect(response, `navigation to ${route} must succeed`).not.toBeNull();
+    expect(response!.status(), `${route} returned non-OK`).toBeLessThan(500);
+
+    // Allow any deferred React effects / lazy chunks to mount.
+    // (waitForLoadState 'networkidle' is the default-ish "page is settled".)
+    await page.waitForLoadState('networkidle', { timeout: 5_000 });
+
+    // Page must show *something* — empty body suggests the React tree
+    // failed to render even if no console error fired. (Some bundle
+    // bugs swallow themselves silently.)
+    const bodyText = await page.locator('body').textContent();
+    expect(
+      bodyText?.trim().length ?? 0,
+      `${route} body is empty`
+    ).toBeGreaterThan(0);
+
+    // Critical assertion: no real console errors / page exceptions.
+    expect(errors, `bundle errors on ${route}:\n${errors.join('\n')}`).toEqual(
+      []
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **fast pre-merge smoke gate** that catches runtime bundle regressions like PR #128's `R.getProjectImages is not a function` — bugs that pass tsc + lint + unit tests but kill the page on load because tree-shaking / minification mangled a referenced symbol.

| Phase | Existing E2E job | New smoke gate |
|---|---|---|
| Run time | 10+ minutes (Docker stack + full Playwright) | **~30 seconds** (vite preview only) |
| What it tests | Full user flows w/ real backend | Bundle mounts cleanly on each route |
| When it runs | Late in PR pipeline | After build, before slow jobs |
| Cost on a regression | 15+ min wasted CI minutes | Fail in <2 min |

## What it does

1. Builds the frontend (`npm run build`).
2. Boots `vite preview` on port 4173.
3. For each of 6 public routes (`/`, `/sign-in`, `/sign-up`, `/dashboard`, `/profile`, `/settings`):
   - Aborts all `/api/**` requests (no backend dependency).
   - Navigates with chromium.
   - Asserts: status < 500, body has content, **zero `console.error` and `pageerror` events**.

Expected console errors (axios 401, "Failed to load resource", i18n missing-key dev warnings) are filtered via an `IGNORE_PATTERNS` list in the spec — only catastrophic bundle errors fail the test.

## Why test the production bundle?

PR #128's regression *only* manifested in the minified bundle. A dev-server smoke test would have missed it. We use `vite preview` so the suite runs against the same artifact that ships.

## Files

- **`tests/smoke/route-smoke.spec.ts`** — single parameterized spec.
- **`playwright.smoke.config.ts`** — minimal config (chromium-only, no globalSetup, no auth).
- **`package.json`**: `npm run test:e2e:smoke`.
- **`.github/workflows/pre-merge-checks.yml`**: new `smoke-test` job (`needs: build`), 8-min timeout, wired into the `merge-ready` gate.
- **`.gitignore`**: `test-results-smoke/`.

## Test plan

- [x] `CI=1 npm run test:e2e:smoke` locally → all 6 tests pass in 16s
- [x] Verified bundle compiles + preview serves on port 4173
- [ ] **Once merged**: introduce an artificial regression (e.g. rename a method on `apiClient`) on a feature branch and confirm the CI smoke job fails

## Out of scope

- Login flows, form submission, contract testing — covered by the existing full E2E job.
- Mobile viewports, multiple browsers — chromium-only per minimal-cost philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)