### PR TITLE
refactor(types): migrate Profile.tsx off wire DTO via dtoToProjectImage helper

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -131,6 +131,46 @@ jobs:
           fi
           echo "Bundle size: $BUNDLE_SIZE bytes"
 
+  # 3.1 SMOKE GATE — fast Playwright run against the built bundle to
+  #     catch runtime regressions like a tree-shaking error
+  #     (e.g. PR #128: `R.getProjectImages is not a function`) that
+  #     pass tsc + lint + unit tests but kill the page on load. No
+  #     backend; runs purely against `vite preview`.
+  smoke-test:
+    name: Frontend Smoke
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: build
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright (chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npm run test:e2e:smoke
+
+      - name: Upload smoke report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: |
+            playwright-report/
+            test-results-smoke/
+          retention-days: 14
+
   # 4. DOCKER BUILD
   docker-build:
     name: Docker Build
@@ -352,6 +392,7 @@ jobs:
       - code-quality
       - unit-tests
       - build
+      - smoke-test
       - docker-build
       - integration-tests
       - e2e-tests

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ SECURE_CREDENTIALS.md
 
 # Test results and reports
 test-results/
+test-results-smoke/
 playwright-report/
 coverage/
 .nyc_output/

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
     "i18n:check": "node scripts/check-i18n.cjs",
     "i18n:lint": "eslint . --config .eslintrc-i18n.js",
     "i18n:validate": "npm run i18n:check && npm run i18n:lint",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the *smoke gate*: fast bundle-mount checks
+ * against the built frontend, with no backend dependency.
+ *
+ * Distinct from `playwright.config.ts` (full E2E with Docker stack)
+ * because:
+ *   - smoke must finish in ~60s on CI to be useful as an early gate.
+ *   - smoke uses `vite preview` so it tests the production bundle
+ *     (the bundle that ships) rather than the dev server.
+ *   - smoke has no global setup, no auth fixtures, no database.
+ */
+export default defineConfig({
+  testDir: './tests/smoke',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Build then preview the production bundle. CI build can take ~30s,
+  // first-run cold start; subsequent reuse via reuseExistingServer.
+  webServer: {
+    command: 'npm run build && npx vite preview --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  outputDir: 'test-results-smoke/',
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ import {
   UpdateProfile,
   isProjectType,
   type ProjectType,
+  type ProjectImage,
   type SegmentationStatus,
 } from '@/types';
 import { logger } from '@/lib/logger';
@@ -1890,3 +1891,39 @@ class ApiClient {
 // Create and export a singleton instance
 export const apiClient = new ApiClient();
 export default apiClient;
+
+/**
+ * Convert a wire `ProjectImageDTO` (snake_case, narrow status union) into
+ * a domain `ProjectImage` (camelCase, superset status, Date instances).
+ *
+ * Use this at the seam between `apiClient.*` (which returns DTOs) and
+ * UI/business code (which expects the domain shape from `@/types`).
+ * Keeps snake_case field access from leaking into components — the
+ * historical cause of subtle bugs when wire format changed without
+ * consumer updates.
+ *
+ * Domain fields not present on the DTO (e.g. `segmentationResult`) are
+ * left undefined; callers that need them should fetch via the dedicated
+ * segmentation API.
+ */
+export function dtoToProjectImage(dto: ProjectImageDTO): ProjectImage {
+  return {
+    id: dto.id,
+    name: dto.name,
+    url: dto.url ?? dto.image_url,
+    displayUrl: dto.displayUrl,
+    width: dto.width,
+    height: dto.height,
+    createdAt: new Date(dto.created_at),
+    updatedAt: new Date(dto.updated_at),
+    segmentationStatus: dto.segmentation_status,
+    project_id: dto.project_id,
+    thumbnail_url: dto.thumbnail_url,
+    segmentationThumbnailPath: dto.segmentationThumbnailPath,
+    segmentationThumbnailUrl: dto.segmentationThumbnailUrl,
+    image_url: dto.image_url,
+    created_at: dto.created_at,
+    updated_at: dto.updated_at,
+    user_id: dto.user_id,
+  };
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -18,7 +18,8 @@ import { useAuth, useLanguage } from '@/contexts/exports';
 // Note: Profile functionality now handled by AuthContext and Settings page
 import AvatarUploadButton from '@/components/profile/AvatarUploadButton';
 import AvatarCropDialog from '@/components/profile/AvatarCropDialog';
-import { apiClient, Project, ProjectImageDTO } from '@/lib/api';
+import { apiClient, dtoToProjectImage, Project } from '@/lib/api';
+import type { ProjectImage } from '@/types';
 import { logger } from '@/lib/logger';
 import { createImagePreviewUrl } from '@/lib/tiffConverter';
 
@@ -176,8 +177,10 @@ const Profile = () => {
           setCompletedCountError(completedError);
         }
 
-        // Get recent images for activity (from recent projects)
-        let recentImages: ProjectImageDTO[] = [];
+        // Get recent images for activity (from recent projects).
+        // Convert DTOs to domain ProjectImage at the API seam — keeps
+        // snake_case wire fields out of UI logic.
+        let recentImages: ProjectImage[] = [];
         let recentImagesError = null;
         try {
           for (const project of recentProjects.slice(0, 3)) {
@@ -187,7 +190,9 @@ const Profile = () => {
                 project.id,
                 { limit: 5 }
               );
-              recentImages.push(...(imagesResponse.images || []));
+              recentImages.push(
+                ...(imagesResponse.images || []).map(dtoToProjectImage)
+              );
             } catch (error) {
               logger.warn(
                 `Error fetching recent images for project ${project.id}:`,
@@ -197,9 +202,7 @@ const Profile = () => {
           }
           // Sort by creation date and take most recent
           recentImages.sort(
-            (a, b) =>
-              new Date(b.created_at).getTime() -
-              new Date(a.created_at).getTime()
+            (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
           );
           recentImages = recentImages.slice(0, 10); // Keep only 10 most recent
         } catch (error) {
@@ -229,13 +232,13 @@ const Profile = () => {
 
         if (recentImages) {
           recentImages.forEach(image => {
-            const createdDate = new Date(image.created_at);
+            const createdDate = image.createdAt;
             const now = new Date();
             const diffDays = Math.floor(
               (now.getTime() - createdDate.getTime()) / (1000 * 3600 * 24)
             );
 
-            if (image.segmentation_status === 'completed') {
+            if (image.segmentationStatus === 'completed') {
               activity.push({
                 action: `${t('profile.completedSegmentation')} '${image.name}'`,
                 date: createdDate.toISOString(),

--- a/tests/smoke/route-smoke.spec.ts
+++ b/tests/smoke/route-smoke.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Route smoke tests — fast bundle-execution gate.
+ *
+ * These tests are NOT about user flows. They verify that the production
+ * frontend bundle loads and the React tree mounts on each public route
+ * without throwing. They are designed to run against `vite preview`
+ * (built bundle) WITHOUT a real backend: API calls 401/network-fail,
+ * but the bundle itself must not crash.
+ *
+ * Catches the class of regression where a tree-shaken / minified
+ * bundle silently loses a method (e.g. PR #128: `R.getProjectImages is
+ * not a function`) — those don't show up in tsc but kill the page on
+ * load.
+ *
+ * Runtime budget: ~30s for the whole file in CI. Keep it fast.
+ */
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test';
+
+// Routes that must mount cleanly. Auth-gated routes will redirect to
+// /sign-in (which is fine — that's a successful render, not a crash).
+const ROUTES = [
+  '/',
+  '/sign-in',
+  '/sign-up',
+  '/dashboard',
+  '/profile',
+  '/settings',
+];
+
+/** Console messages we ignore — expected fetch failures from the
+ * absent backend, dev-mode warnings, third-party noise. */
+const IGNORE_PATTERNS: RegExp[] = [
+  // Expected: API calls fail with 401/Network Error when smoke-test
+  // runs without a backend. These are not bundle bugs.
+  /Failed to load resource/i,
+  /401 \(Unauthorized\)/,
+  /Network Error/,
+  /ERR_CONNECTION_REFUSED/,
+  /ERR_FAILED/,
+  /AxiosError/,
+  /\[axios\]/i,
+  // React DevTools recommendation in dev — irrelevant for smoke.
+  /Download the React DevTools/,
+  // i18next missing-key warnings should fail loudly in unit tests; in
+  // a smoke we only care about catastrophic crashes.
+  /i18next::translator/,
+];
+
+function capturePageErrors(page: Page): { errors: string[] } {
+  const errors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (IGNORE_PATTERNS.some(re => re.test(text))) return;
+    errors.push(`[console.error] ${text}`);
+  });
+  page.on('pageerror', err => {
+    errors.push(`[pageerror] ${err.name}: ${err.message}`);
+  });
+  return { errors };
+}
+
+for (const route of ROUTES) {
+  test(`mounts without bundle errors: ${route}`, async ({ page }) => {
+    const { errors } = capturePageErrors(page);
+
+    // Block all network requests to /api/** so the bundle's runtime
+    // doesn't sit in retry loops and doesn't depend on a backend.
+    await page.route('**/api/**', route => route.abort());
+
+    const response = await page.goto(route, { waitUntil: 'load' });
+    expect(response, `navigation to ${route} must succeed`).not.toBeNull();
+    expect(response!.status(), `${route} returned non-OK`).toBeLessThan(500);
+
+    // Allow any deferred React effects / lazy chunks to mount.
+    // (waitForLoadState 'networkidle' is the default-ish "page is settled".)
+    await page.waitForLoadState('networkidle', { timeout: 5_000 });
+
+    // Page must show *something* — empty body suggests the React tree
+    // failed to render even if no console error fired. (Some bundle
+    // bugs swallow themselves silently.)
+    const bodyText = await page.locator('body').textContent();
+    expect(
+      bodyText?.trim().length ?? 0,
+      `${route} body is empty`
+    ).toBeGreaterThan(0);
+
+    // Critical assertion: no real console errors / page exceptions.
+    expect(errors, `bundle errors on ${route}:\n${errors.join('\n')}`).toEqual(
+      []
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes the last external consumer of \`ProjectImageDTO\`. After this PR, the wire DTO is referenced **only inside \`src/lib/api.ts\`**; UI code consumes the canonical domain \`ProjectImage\` from \`@/types\`.

## Why

The wire-vs-domain split is intentional — an anti-corruption layer between REST snake_case + ISO strings and the React tree's camelCase + Date conventions. The split was working, but Profile.tsx bypassed it by importing \`ProjectImageDTO\` directly, leaking snake_case field access (\`image.created_at\`, \`image.segmentation_status\`) into UI logic.

A change to the wire format (e.g. server adds a status value) would silently miss Profile.tsx and surface as a runtime crash. With this refactor, the conversion happens once in \`dtoToProjectImage()\` so additions land in one place.

## Changes

- **\`src/lib/api.ts\`**: new exported helper \`dtoToProjectImage(dto: ProjectImageDTO): ProjectImage\` — maps snake_case → camelCase, ISO strings → Date instances, narrow status union → domain superset.
- **\`src/pages/Profile.tsx\`**: imports the helper, calls \`.map(dtoToProjectImage)\` on the API response. Field accesses switch from \`created_at\` → \`createdAt\`, \`segmentation_status\` → \`segmentationStatus\`.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:e2e:smoke\` — 6/6 routes pass, including /profile
- [x] \`grep -rn ProjectImageDTO src/ | grep -v src/lib/api.ts\` — empty
- [ ] Manual: log in, open /profile, confirm "Recent Activity" section renders project + image events with correct \"X days ago\" labels

## Out of scope

Migrating the apiClient methods themselves to return domain types. That's a bigger change with many call sites; this helper provides a stepping-stone so each caller can be migrated independently in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated smoke testing into the pre-merge CI/CD workflow to detect critical build issues early.

* **Tests**
  * Added smoke test suite that validates key public application routes load successfully without critical runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->