### PR TITLE
refactor(types): consolidate backend Polygon definitions via shared base

### DIFF
--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -9,19 +9,17 @@ import {
   groupPolylinesByInstanceId,
   findPart,
 } from '../../utils/spermGrouping';
+import type { BasePolygon, PolygonPoint } from '../../types/polygon';
 
-export interface Point {
-  x: number;
-  y: number;
-}
+/** Local alias kept for the many call sites in this file that already
+ *  use `Point`. Structurally identical to `PolygonPoint`. */
+export type Point = PolygonPoint;
 
-export interface Polygon {
-  points: Point[];
-  type: 'external' | 'internal';
-  id?: string;
-  geometry?: 'polygon' | 'polyline';
+/** Export polygon — `BasePolygon` plus the narrower `SpermPartClass`
+ *  union. Spheroid 'core' annotations don't appear in exports, so the
+ *  visualization-side `PolygonPartClass` is intentionally too wide here. */
+export interface Polygon extends BasePolygon {
   partClass?: SpermPartClass;
-  instanceId?: string;
 }
 
 const isPolyline = (p: Polygon): boolean => p.geometry === 'polyline';

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -13,6 +13,10 @@ import type {
   PolygonPartClass,
   SpermPartClass,
 } from '../../utils/polygonValidation';
+import type {
+  MinimalPolygon,
+  PolygonPoint,
+} from '../../types/polygon';
 import { polylineLength } from '../../utils/polygonGeometry';
 import { groupPolylinesByInstanceId, findPart } from '../../utils/spermGrouping';
 import {
@@ -76,15 +80,14 @@ export interface ImageMetrics {
   invasionArea: number; // totalSpheroidArea − coreArea, clamped at 0
 }
 
-export interface Point {
-  x: number;
-  y: number;
-}
+// Local Point alias kept so the many call sites in this file stay terse.
+// Structurally identical to PolygonPoint from ../../types/polygon.
+export type Point = PolygonPoint;
 
-export interface Polygon {
-  points: Point[];
-  type: 'external' | 'internal';
-}
+/** Re-export of the shared minimal polygon shape — metrics math only
+ *  needs `points` + `type`. Kept named `Polygon` so existing call sites
+ *  inside this file don't need to be touched. */
+export type Polygon = MinimalPolygon;
 
 export interface ParsedPolygon {
   points: Point[];

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -4,6 +4,7 @@ import sharp from 'sharp';
 import path from 'path';
 import { logger } from '../../utils/logger';
 import type { PolygonPartClass } from '../../utils/polygonValidation';
+import type { BasePolygon } from '../../types/polygon';
 
 export interface VisualizationOptions {
   showNumbers?: boolean;
@@ -16,13 +17,11 @@ export interface VisualizationOptions {
   transparency?: number;
 }
 
-export interface Polygon {
-  points: Array<{ x: number; y: number }>;
-  type: 'external' | 'internal';
-  id?: string;
-  geometry?: 'polygon' | 'polyline';
+/** Visualization polygon — `BasePolygon` plus the wider `PolygonPartClass`
+ *  union (sperm sub-parts plus spheroid 'core'). The export layer
+ *  intentionally uses the narrower `SpermPartClass` flavour. */
+export interface Polygon extends BasePolygon {
   partClass?: PolygonPartClass;
-  instanceId?: string;
 }
 
 const POLYLINE_COLORS: Record<string, string> = {

--- a/backend/src/types/polygon.ts
+++ b/backend/src/types/polygon.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared polygon type building blocks for backend services.
+ *
+ * Background: before this file existed, the same 5 fields (points, type,
+ * id?, geometry?, instanceId?) were redeclared verbatim in three service
+ * files (visualizationGenerator, formatConverter, metricsCalculator).
+ * Each redeclaration was a chance for the shape to drift; if a new field
+ * (e.g. `confidence`) needed to flow through render → export, four files
+ * had to be edited in lockstep.
+ *
+ * What IS NOT shared here:
+ * - `partClass`. Visualization renders BOTH sperm sub-parts and the
+ *   spheroid 'core' annotation, so its `partClass` is `PolygonPartClass`
+ *   (4 values). Exports never carry the 'core' value, so format
+ *   converters use `SpermPartClass` (3 values). The two services
+ *   intentionally differ on this one field — combining them would
+ *   either widen the export contract incorrectly or lose 'core'
+ *   annotations from rendered visualizations.
+ * - `polygonValidation.Polygon`. That type represents the wire-format
+ *   payload (snake_case `parent_id`, optional `type`, plus
+ *   color/category/confidence) and serves a different purpose
+ *   (parsing/validation). Leaving it separate keeps the two domains
+ *   distinct.
+ *
+ * What IS shared:
+ * - `MinimalPolygon` — points + type. The metrics layer only needs
+ *   these; broader downstream metadata is irrelevant to area/perimeter
+ *   math.
+ * - `BasePolygon` — extends Minimal with the 3 optional render-side
+ *   fields (id, geometry, instanceId). Both visualization and export
+ *   polygons extend this; they each add only their `partClass` flavor.
+ */
+
+export interface PolygonPoint {
+  x: number;
+  y: number;
+}
+
+/** Smallest polygon shape — just the geometry needed for area/perimeter
+ *  calculations. Used by the metrics layer where richer metadata isn't
+ *  relevant. */
+export interface MinimalPolygon {
+  points: PolygonPoint[];
+  type: 'external' | 'internal';
+}
+
+/** Render/export-ready polygon with optional identity and geometry
+ *  variant. Service-specific `partClass` flavors are added by extending
+ *  this interface. */
+export interface BasePolygon extends MinimalPolygon {
+  id?: string;
+  geometry?: 'polygon' | 'polyline';
+  instanceId?: string;
+}


### PR DESCRIPTION
## Summary

3 of the 5 backend Polygon definitions had identical 5-field cores. This PR extracts that core into \`backend/src/types/polygon.ts\` and makes the service-specific types extend it. The semantically-different ones (validation wire-format, frontend) are left alone.

| File | Before | After |
|---|---|---|
| visualizationGenerator.ts | full interface (7 fields) | \`extends BasePolygon\` + partClass |
| formatConverter.ts | full interface (7 fields, narrower partClass) | \`extends BasePolygon\` + partClass |
| metricsCalculator.ts | minimal {points, type} | \`type Polygon = MinimalPolygon\` |
| polygonValidation.ts | unique snake_case wire shape | **untouched** (different purpose) |
| src/lib/segmentation.ts | frontend canonical | **untouched** (different conventions) |

## Why the partClass union stays split

- \`visualizationGenerator\` renders BOTH sperm sub-parts and the spheroid \`'core'\` annotation → needs \`PolygonPartClass\` (4 values).
- \`formatConverter\` produces COCO/YOLO/JSON exports which never carry \`'core'\` → narrower \`SpermPartClass\` (3 values).
- Forcing one type would either widen the export contract incorrectly or lose 'core' data from rendered visualizations.

## Test plan

- [x] \`cd backend && npx tsc --noEmit\` clean
- [x] \`npx vitest run src/services/__tests__/exportService.test.ts src/services/metrics src/services/export src/utils\` — **161/162 pass** (1 pre-existing skip)
- [ ] Post-merge: smoke test (segment → export Excel/COCO) on dev env to verify polygon flow end-to-end

## Risk

Low. The structural shape of all three migrated types is **byte-identical** to before — every field that existed pre-PR still exists, with the same optionality. TypeScript treats \`interface X extends Base { partClass?: P }\` as identical to a manually-written union of those fields. The PR is pure refactor with no observable behavior delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and type consistency across backend modules to enhance maintainability and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->