### PR TITLE
feat(export): task-type-specific metrics_guide.md

### DIFF
--- a/backend/src/services/export/__tests__/exportDocs.test.ts
+++ b/backend/src/services/export/__tests__/exportDocs.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { generateMetricsGuide } from '../exportDocs';
+import type { ExportOptions } from '../../exportService';
+
+const baseOptions: ExportOptions = {
+  includeOriginalImages: false,
+  includeVisualizations: false,
+  includeDocumentation: true,
+  annotationFormats: [],
+  metricsFormats: ['excel'],
+};
+
+const scaledOptions: ExportOptions = {
+  ...baseOptions,
+  pixelToMicrometerScale: 0.5,
+};
+
+describe('generateMetricsGuide — type-specific dispatch', () => {
+  describe('spheroid (default)', () => {
+    const guide = generateMetricsGuide('spheroid', baseOptions);
+
+    it('emits the full polygon metrics catalogue', () => {
+      expect(guide).toContain('# Polygon Metrics Reference Guide');
+      expect(guide).toContain('### Area');
+      expect(guide).toContain('### Perimeter');
+      expect(guide).toContain('### Circularity');
+      expect(guide).toContain('### Solidity');
+      expect(guide).toContain('### Feret Diameters');
+    });
+
+    it('excludes disintegration / sperm / wound-time-series sections', () => {
+      expect(guide).not.toContain('Disintegration Index');
+      expect(guide).not.toContain('Head Length');
+      expect(guide).not.toContain('Time-Series Analysis');
+      expect(guide).not.toContain('partClass');
+    });
+
+    it('reports pixel units when scale is not configured', () => {
+      expect(guide).toContain('All measurements are in pixel units');
+      expect(guide).not.toContain('## Scale Conversion');
+    });
+
+    it('reports micrometer units when scale is configured', () => {
+      const scaled = generateMetricsGuide('spheroid', scaledOptions);
+      expect(scaled).toContain('## Scale Conversion');
+      expect(scaled).toContain('0.5 um/pixel');
+    });
+  });
+
+  describe('spheroid_invasive', () => {
+    const guide = generateMetricsGuide('spheroid_invasive', baseOptions);
+
+    it('emits only the disintegration analysis sections', () => {
+      expect(guide).toContain('# Disintegration Analysis Metrics Guide');
+      expect(guide).toContain('Total Spheroid Area');
+      expect(guide).toContain('Core Area');
+      expect(guide).toContain('Invasion Area');
+      expect(guide).toContain('Disintegration Index');
+      expect(guide).toContain('## Pipeline Overview');
+      expect(guide).toContain('## Core Detection');
+    });
+
+    it('excludes per-polygon catalogue sections', () => {
+      expect(guide).not.toContain('### Circularity');
+      expect(guide).not.toContain('### Solidity');
+      expect(guide).not.toContain('### Feret Diameters');
+      expect(guide).not.toContain('### Compactness');
+      expect(guide).not.toContain('# Polygon Metrics Reference Guide');
+    });
+
+    it('excludes sperm and wound-specific sections', () => {
+      expect(guide).not.toContain('Head Length');
+      expect(guide).not.toContain('Midpiece Length');
+      expect(guide).not.toContain('Time-Series Analysis');
+    });
+  });
+
+  describe('wound', () => {
+    const guide = generateMetricsGuide('wound', baseOptions);
+
+    it('emits the Area metric only and the time-series section', () => {
+      expect(guide).toContain('# Wound Healing Metrics Reference Guide');
+      expect(guide).toContain('## Area');
+      expect(guide).toContain('## Time-Series Analysis');
+      expect(guide).toContain('Time-Point Detection');
+      expect(guide).toContain('Wound Area Series');
+    });
+
+    it('excludes other polygon metrics that are irrelevant for wound healing', () => {
+      expect(guide).not.toContain('### Circularity');
+      expect(guide).not.toContain('### Solidity');
+      expect(guide).not.toContain('### Feret Diameters');
+      expect(guide).not.toContain('### Compactness');
+      expect(guide).not.toContain('### Equivalent Diameter');
+    });
+
+    it('excludes sperm / disintegration sections', () => {
+      expect(guide).not.toContain('Head Length');
+      expect(guide).not.toContain('Disintegration Index');
+      expect(guide).not.toContain('Core Area');
+    });
+  });
+
+  describe('sperm', () => {
+    const guide = generateMetricsGuide('sperm', baseOptions);
+
+    it('emits the head/midpiece/tail morphology sections', () => {
+      expect(guide).toContain('# Sperm Morphology Metrics Reference Guide');
+      expect(guide).toContain('### Head Length');
+      expect(guide).toContain('### Midpiece Length');
+      expect(guide).toContain('### Tail Length');
+      expect(guide).toContain('### Total Length');
+      expect(guide).toContain('## Polyline Geometry');
+      expect(guide).toContain('## Instance Grouping');
+      expect(guide).toContain('partClass');
+      expect(guide).toContain('instanceId');
+    });
+
+    it('excludes polygon catalogue sections', () => {
+      expect(guide).not.toContain('### Area');
+      expect(guide).not.toContain('### Perimeter');
+      expect(guide).not.toContain('### Circularity');
+      expect(guide).not.toContain('### Solidity');
+      expect(guide).not.toContain('### Feret Diameters');
+    });
+
+    it('excludes disintegration and wound-specific sections', () => {
+      expect(guide).not.toContain('Disintegration Index');
+      expect(guide).not.toContain('Total Spheroid Area');
+      expect(guide).not.toContain('Time-Series Analysis');
+    });
+
+    it('reports micrometer units when scale is configured', () => {
+      const scaled = generateMetricsGuide('sperm', scaledOptions);
+      expect(scaled).toContain('## Scale Conversion');
+      expect(scaled).toContain('0.5 um/pixel');
+      // Each length metric carries an explicit Units bullet.
+      expect(scaled).toMatch(/### Head Length[\s\S]+?\*\*Units\*\*: um/);
+    });
+  });
+
+  describe('unknown / undefined project type', () => {
+    it('falls through to spheroid when given an unexpected value', () => {
+      const guide = generateMetricsGuide(
+        'definitely-not-a-real-type' as 'spheroid',
+        baseOptions
+      );
+      expect(guide).toContain('# Polygon Metrics Reference Guide');
+      expect(guide).toContain('### Circularity');
+    });
+  });
+});

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -11,6 +11,7 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 import type { ExportOptions, ProjectWithImages } from '../exportService';
+import type { ProjectType } from '../../types/validation';
 
 export function generateReadme(
   project: ProjectWithImages,
@@ -65,16 +66,50 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 `;
 }
 
-export function generateMetricsGuide(options?: ExportOptions): string {
-  // Determine units based on scale
-  const isScaled =
-    options?.pixelToMicrometerScale && options.pixelToMicrometerScale > 0;
-  const areaUnit = isScaled ? 'um^2' : 'px^2';
-  const lengthUnit = isScaled ? 'um' : 'px';
-  const scaleInfo = isScaled
-    ? `\n## Scale Conversion\n\n- **Scale**: ${options.pixelToMicrometerScale} um/pixel\n- **Linear measurements**: Converted from pixels to micrometers (um)\n- **Area measurements**: Converted from pixels^2 to square micrometers (um^2)\n- **Dimensionless ratios**: Remain unchanged (scale-invariant)\n`
-    : '\n## Units\n\n- **All measurements are in pixel units**\n- **Linear measurements**: pixels (px)\n- **Area measurements**: square pixels (px^2)\n';
+interface UnitContext {
+  areaUnit: 'px^2' | 'um^2';
+  lengthUnit: 'px' | 'um';
+  scaleInfo: string;
+}
 
+function buildUnitContext(options?: ExportOptions): UnitContext {
+  const isScaled =
+    !!options?.pixelToMicrometerScale && options.pixelToMicrometerScale > 0;
+  const areaUnit: UnitContext['areaUnit'] = isScaled ? 'um^2' : 'px^2';
+  const lengthUnit: UnitContext['lengthUnit'] = isScaled ? 'um' : 'px';
+  const scaleInfo = isScaled
+    ? `\n## Scale Conversion\n\n- **Scale**: ${options!.pixelToMicrometerScale} um/pixel\n- **Linear measurements**: Converted from pixels to micrometers (um)\n- **Area measurements**: Converted from pixels^2 to square micrometers (um^2)\n- **Dimensionless ratios**: Remain unchanged (scale-invariant)\n`
+    : '\n## Units\n\n- **All measurements are in pixel units**\n- **Linear measurements**: pixels (px)\n- **Area measurements**: square pixels (px^2)\n';
+  return { areaUnit, lengthUnit, scaleInfo };
+}
+
+/**
+ * Project-type-aware metrics guide generator.
+ *
+ * Each `ProjectType` exports a different Excel layout — the guide must
+ * match. Fanning out by type prevents mismatches like "sperm export
+ * lists Disintegration Index" (real bug, fixed here). The four
+ * branches mirror the dispatch in `exportService.exportMetrics`.
+ */
+export function generateMetricsGuide(
+  projectType: ProjectType,
+  options?: ExportOptions
+): string {
+  const ctx = buildUnitContext(options);
+  switch (projectType) {
+    case 'sperm':
+      return buildSpermGuide(ctx);
+    case 'spheroid_invasive':
+      return buildSpheroidInvasiveGuide(ctx);
+    case 'wound':
+      return buildWoundGuide(ctx);
+    case 'spheroid':
+    default:
+      return buildSpheroidGuide(ctx);
+  }
+}
+
+function buildSpheroidGuide({ areaUnit, lengthUnit, scaleInfo }: UnitContext): string {
   return `# Polygon Metrics Reference Guide
 ${scaleInfo}
 ## Calculated Metrics
@@ -232,20 +267,17 @@ ${scaleInfo}
 - **Edge case handling**: Robust for degenerate and complex polygons
 - **Performance monitoring**: Automatic warnings for large datasets
 - **Error recovery**: Fallback calculations when advanced algorithms fail
+`;
+}
 
----
-
-# Per-Image Metrics: Disintegration Analysis
-
-**Applies to projects with \`type='spheroid_invasive'\` only.** Standard
-\`spheroid\` and \`wound\` projects get the per-polygon metrics report
-described above; \`sperm\` projects get the head/midpiece/tail morphology
-sheet. This section documents the disintegrated-spheroid Excel layout,
-which is one row per image with the four numeric metrics
+function buildSpheroidInvasiveGuide({ areaUnit, scaleInfo }: UnitContext): string {
+  return `# Disintegration Analysis Metrics Guide
+${scaleInfo}
+This export is one row per image with four numeric metrics —
 **Total Spheroid Area**, **Core Area**, **Invasion Area** (all in ${areaUnit})
 and **Disintegration Index** (dimensionless). The metrics target spheroid
 disintegration analysis (Lim, Kang, Lee 2020 — Sci. Rep. PMC6971071) but
-apply equally to compact (t=0) and rozprsknuté (t>0) spheroids.
+apply equally to compact (t=0) and disintegrated (t>0) spheroids.
 
 ## Pipeline Overview
 
@@ -436,6 +468,176 @@ spheroids known to have necrotic centres.
 (\`calculateAllImageMetrics\`)
 - **Excel writer**: same file (\`exportToExcel\` — emits Image Name, Image ID,
 Total Spheroid Area, Core Area, Invasion Area, Disintegration Index)
+`;
+}
+
+function buildWoundGuide({ areaUnit, lengthUnit, scaleInfo }: UnitContext): string {
+  return `# Wound Healing Metrics Reference Guide
+${scaleInfo}
+Wound projects export a single morphological metric per polygon —
+**Area** — together with an automatically generated **time-series chart**
+of wound area progression across the imaged time points. Other geometric
+quantities (perimeter, circularity, Feret, etc.) are not relevant for
+wound-closure analysis and are intentionally not included.
+
+## Area
+
+- **Description**: Total enclosed area of the wound polygon using the
+Shoelace formula with hole subtraction
+- **Formula**: A = A_external - Sum(A_holes)
+- **Implementation**: Shoelace formula:
+A = (1/2)|Sum(x_i * y_{i+1} - x_{i+1} * y_i)|
+- **Units**: ${areaUnit}
+- **Range**: [0, ∞)
+- **ImageJ compatibility**: ✅ Matches ImageJ area calculation
+- **Hole handling**: Internal polygon (hole) areas are subtracted from
+the external polygon area; final area is clamped at zero
+
+## Time-Series Analysis
+
+The wound export includes an automatically generated time-series chart
+embedded as an additional sheet of \`metrics.xlsx\`.
+
+### Time-Point Detection
+
+Each input image's filename is parsed for a numeric time-point token
+(e.g. \`wound_0h.png\`, \`wound_24h.png\`, \`wound_48h.png\`). Recognised
+suffixes include \`h\` (hours), \`min\` (minutes) and bare integers.
+Images are sorted by the parsed time value before charting; images
+without a parseable time are excluded from the chart but still appear
+in the per-polygon Area column.
+
+### Wound Area Series
+
+For each image, the wound area is computed as the **sum of all external
+polygon areas** in ${areaUnit}. The series is plotted as a line chart with
+time on the X-axis and wound area on the Y-axis. A scale conversion
+(if configured at project level) is applied uniformly across the
+series.
+
+### Chart Embedding
+
+The chart is rendered server-side via node-canvas and inserted into
+the Excel workbook as an additional sheet — no client-side rendering
+is required. Source: \`backend/src/services/export/woundTimeSeries.ts\`.
+
+### Edge Cases
+
+- **Single time point**: chart is omitted (no curve to draw); polygon
+Area still exported in the main sheet.
+- **Mixed parseable / unparseable filenames**: the chart includes only
+parseable rows; unparseable rows are listed in the Excel as Area-only.
+- **No external polygons in an image**: that image's wound area is
+reported as 0 in the time series.
+
+## Source Files
+
+- **Wound time-series builder**: \`backend/src/services/export/woundTimeSeries.ts\`
+- **Per-polygon area orchestration**: \`backend/src/services/metrics/metricsCalculator.ts\`
+- **Excel writer**: \`exportPolygonMetricsToExcel\` — emits Image Name,
+Polygon ID, Area (${areaUnit}); time-series sheet appended afterwards.
+
+## Notes for Researchers
+
+1. **Units**: Always verify scale conversion (${lengthUnit}) for
+physical-length comparisons across imaging sessions.
+2. **Holes**: Internal polygons are treated as holes — useful when
+re-epithelialised islands appear inside the wound.
+3. **Time parsing**: Use consistent filename conventions (\`<name>_<N>h.png\`
+or similar) for clean time-series plots.
+`;
+}
+
+function buildSpermGuide({ lengthUnit, scaleInfo }: UnitContext): string {
+  return `# Sperm Morphology Metrics Reference Guide
+${scaleInfo}
+Sperm projects export **per-instance morphology** — one row per detected
+sperm cell, with separate length measurements for each anatomical part
+(head, midpiece, tail) plus the combined total length. Geometric polygon
+metrics (area, circularity, Feret, etc.) are not applicable to the
+polyline-based sperm representation and are not included.
+
+## Calculated Metrics
+
+### Head Length
+- **Description**: Total Euclidean length of the sperm head polyline
+- **Formula**: L = Sum(sqrt((x_{i+1} - x_i)^2 + (y_{i+1} - y_i)^2))
+- **Units**: ${lengthUnit}
+- **Range**: [0, ∞)
+
+### Midpiece Length
+- **Description**: Total Euclidean length of the midpiece polyline
+- **Formula**: same as Head Length, applied to midpiece vertices
+- **Units**: ${lengthUnit}
+- **Range**: [0, ∞)
+
+### Tail Length
+- **Description**: Total Euclidean length of the tail polyline
+- **Formula**: same as Head Length, applied to tail vertices
+- **Units**: ${lengthUnit}
+- **Range**: [0, ∞)
+
+### Total Length
+- **Description**: Sum of head + midpiece + tail lengths for the same
+sperm instance
+- **Formula**: TotalLength = HeadLength + MidpieceLength + TailLength
+- **Units**: ${lengthUnit}
+- **Range**: [0, ∞)
+- **Missing parts**: A part not detected on a given instance contributes
+zero to the total. The row is still emitted (e.g. head + tail without
+detected midpiece is valid output).
+
+## Polyline Geometry
+
+Sperm anatomical parts are represented as **open polylines**, not closed
+polygons. A polyline is an ordered sequence of vertices [(x_1, y_1), …,
+(x_n, y_n)] with no edge connecting (x_n, y_n) back to (x_1, y_1).
+Length is the cumulative Euclidean distance between consecutive
+vertices.
+
+## Instance Grouping
+
+Each sperm instance carries an \`instanceId\` field. Polylines sharing
+the same \`instanceId\` are grouped together and contribute to the
+**same row** of the Excel sheet. The \`partClass\` field on each
+polyline declares which anatomical part it represents:
+
+\`\`\`
+partClass ∈ { "head", "midpiece", "tail" }
+\`\`\`
+
+Polylines without an \`instanceId\` are excluded from the per-instance
+sheet (a warning is logged but the export does not fail). Polylines
+with an unrecognised \`partClass\` are ignored.
+
+## Edge Cases
+
+- **Image with no detected sperm**: that image contributes no rows.
+The export still succeeds.
+- **No sperm detected across the entire project**: \`metrics.xlsx\` is
+not written. The export falls back to the standard polygon metrics
+report, which will be empty for this project type.
+- **Multiple instances in one image**: each instance gets its own row
+keyed by the unique \`instanceId\` value.
+- **Duplicate \`partClass\` for the same instance**: only the first
+polyline of each part is used; subsequent ones are silently skipped.
+
+## Source Files
+
+- **Polyline length**: \`backend/src/services/metrics/polylineLength.ts\`
+- **Instance grouping**: \`backend/src/services/metrics/spermGrouping.ts\`
+- **Excel writer**: \`backend/src/services/metrics/metricsCalculator.ts\`
+(\`exportSpermToExcel\` — emits Image Name, Instance ID, Head/Midpiece/Tail/Total Length)
+
+## Notes for Researchers
+
+1. **Units**: Always verify scale conversion for cross-microscope or
+cross-magnification comparisons.
+2. **Manual completion**: A sperm cell with one missing part is still
+exported with the present parts — useful for partially occluded cells.
+3. **Polyline ordering**: Length is order-independent (Euclidean
+distance is symmetric), but the source-of-truth for which vertex is
+"start" vs. "end" is determined by user annotation.
 `;
 }
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -27,6 +27,7 @@ import {
   generateMetricsGuide,
   generateAnnotationGuides,
 } from './export/exportDocs';
+import { coerceProjectType } from '../types/validation';
 import {
   sanitizeFilename,
   getProgressMessage,
@@ -1292,8 +1293,13 @@ export class ExportService {
       JSON.stringify(metadata, null, 2)
     );
 
-    // Generate metrics guide
-    const metricsGuide = generateMetricsGuide(options);
+    // Generate metrics guide. Project type drives the layout: sperm gets
+    // head/midpiece/tail morphology, spheroid_invasive the DI sheet,
+    // wound area + time-series, spheroid the full polygon catalogue.
+    const metricsGuide = generateMetricsGuide(
+      coerceProjectType(project.type),
+      options
+    );
     await fs.writeFile(path.join(docDir, 'metrics_guide.md'), metricsGuide);
   }
 

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -115,6 +115,19 @@ export type ProjectType = (typeof PROJECT_TYPES)[number];
 const projectTypeSchema = z.enum(PROJECT_TYPES);
 
 /**
+ * Narrow an arbitrary string (e.g. `Project.type` from Prisma, where the
+ * column is a plain `String` despite the comment locking it to the union)
+ * to a known `ProjectType`. Falls back to `'spheroid'` for legacy rows or
+ * unrecognised values — matches the frontend `coerceProjectType` helper
+ * (`src/types/index.ts:343`).
+ */
+export const isProjectType = (v: unknown): v is ProjectType =>
+  typeof v === 'string' && (PROJECT_TYPES as readonly string[]).includes(v);
+
+export const coerceProjectType = (v: unknown): ProjectType =>
+  isProjectType(v) ? v : 'spheroid';
+
+/**
  * Models compatible with each project type. Mirror of the same constant
  * in `src/types/index.ts` (frontend) — kept duplicated because frontend
  * and backend have separate build trees and no shared import path.


### PR DESCRIPTION
## Summary

- Refactor `generateMetricsGuide` from a single one-size-fits-all template into a `ProjectType`-aware dispatcher. Each branch emits **only** the sections that match the actual Excel layout for that project type.
- Add backend `coerceProjectType` helper (mirror of `src/types/index.ts:343`) so callers can safely narrow `Project.type` (Prisma column is `String`, not the union) on the export boundary.
- Add 15 unit tests verifying each branch contains its sections and **excludes** sections from other types — no more "sperm export shipping Disintegration Index docs".

## Per-type guide layout

| Type | Sections in `metrics_guide.md` |
|---|---|
| `spheroid` | Full polygon catalogue (Area, Perimeter, Circularity, Solidity, Extent, Compactness, Convexity, Equivalent Diameter, Feret, BBox, Sphericity) + Hole Handling + Software Compatibility |
| `spheroid_invasive` | Disintegration Analysis only (Total/Core/Invasion Area + DI), Pipeline Overview, Edge Cases. No polygon catalogue. |
| `wound` | Area metric + Time-Series Analysis (chart embedding, time-point detection, edge cases). Other geometric metrics intentionally excluded — irrelevant for wound-closure analysis. |
| `sperm` | Head/Midpiece/Tail/Total Length, polyline geometry, instance grouping via `partClass` + `instanceId`. No polygon catalogue. |

Unknown / undefined types fall back to `spheroid` via `coerceProjectType`.

## Test plan

- [x] Backend unit tests pass: `vitest run src/services/export/` — 70/70
- [x] `exportService` tests still pass: 29/29
- [x] TypeScript: `tsc --noEmit` clean
- [x] Pre-commit hook (lint, prettier, type check, conventional commit) passes
- [ ] After deploy, export a sperm project and verify `metrics_guide.md` no longer contains "Disintegration Index" or "Solidity"
- [ ] After deploy, export a wound project and verify the guide describes only Area + Time-Series

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics documentation now automatically adapts content based on project type (spheroid variants, wound, sperm)
  * Added support for pixel-to-micrometer unit scaling with automatic unit conversion labels in generated documentation

* **Tests**
  * Added comprehensive test suite for metrics guide generation, verifying project-type-specific content and unit scaling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->