### PR TITLE
chore(settings): remove confidence threshold UI; derive per-model

### DIFF
--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { Label } from '@/components/ui/label';
-import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
@@ -21,10 +20,8 @@ const ModelSettingsSection = () => {
   const { t } = useLanguage();
   const {
     selectedModel,
-    confidenceThreshold,
     detectHoles,
     setSelectedModel,
-    setConfidenceThreshold,
     setDetectHoles,
     availableModels,
   } = useLocalizedModels();
@@ -43,29 +40,8 @@ const ModelSettingsSection = () => {
   );
 
   const handleModelChange = (modelId: string) => {
-    const model = availableModels.find(m => m.id === modelId);
     setSelectedModel(modelId as ModelType);
-    if (model) {
-      setConfidenceThreshold(model.defaultThreshold);
-      if (model.defaultThreshold !== 0.5) {
-        toast.success(
-          t('settings.thresholdAutoAdjusted').replace(
-            '{threshold}',
-            String(Math.round(model.defaultThreshold * 100))
-          )
-        );
-      } else {
-        toast.success(t('settings.modelSelected'));
-      }
-    }
-  };
-
-  const handleThresholdChange = (value: number[]) => {
-    setConfidenceThreshold(value[0] / 100); // Convert from 0-100 to 0-1
-  };
-
-  const handleThresholdCommit = (_value: number[]) => {
-    toast.success(t('settings.modelSettingsSaved'));
+    toast.success(t('settings.modelSelected'));
   };
 
   const handleDetectHolesChange = (checked: boolean) => {
@@ -155,42 +131,6 @@ const ModelSettingsSection = () => {
             {woundModels.map(renderModelCard)}
           </div>
         </RadioGroup>
-      </div>
-
-      <div className="space-y-4">
-        <div>
-          <Label htmlFor="threshold" className="text-base font-medium">
-            {t('settings.confidenceThreshold')}
-          </Label>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-            {t('settings.confidenceThresholdDescription')}
-          </p>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-600 dark:text-gray-400">
-              10%
-            </span>
-            <span className="text-sm font-medium">
-              {Math.round(confidenceThreshold * 100)}%
-            </span>
-            <span className="text-sm text-gray-600 dark:text-gray-400">
-              90%
-            </span>
-          </div>
-
-          <Slider
-            id="threshold"
-            min={10}
-            max={90}
-            step={1}
-            value={[confidenceThreshold * 100]}
-            onValueChange={handleThresholdChange}
-            onValueCommit={handleThresholdCommit}
-            className="w-full"
-          />
-        </div>
       </div>
 
       <div className="space-y-4">

--- a/src/components/settings/__tests__/ModelSettingsSection.test.tsx
+++ b/src/components/settings/__tests__/ModelSettingsSection.test.tsx
@@ -18,7 +18,6 @@ vi.mock('@/hooks/useLocalizedModels', () => ({
     confidenceThreshold: 0.5,
     detectHoles: true,
     setSelectedModel: vi.fn(),
-    setConfidenceThreshold: vi.fn(),
     setDetectHoles: vi.fn(),
     availableModels: [
       {
@@ -26,12 +25,14 @@ vi.mock('@/hooks/useLocalizedModels', () => ({
         displayName: 'HRNet',
         size: 'medium',
         description: 'High-resolution network',
+        category: 'spheroid',
       },
       {
         id: 'unet',
         displayName: 'U-Net',
         size: 'small',
         description: 'Classic U-Net',
+        category: 'spheroid',
       },
     ],
   })),
@@ -67,15 +68,14 @@ describe('ModelSettingsSection', () => {
     expect(hrnetRadio).toBeChecked();
   });
 
-  it('renders confidence threshold slider', () => {
+  it('does not render any confidence threshold slider', () => {
+    // The threshold is now a per-model constant (calibrated in
+    // modelUtils.ts), not a user-tunable setting — no slider in the UI.
     render(<ModelSettingsSection />);
-    expect(screen.getByRole('slider')).toBeInTheDocument();
-  });
-
-  it('shows current threshold percentage', () => {
-    render(<ModelSettingsSection />);
-    // 0.5 * 100 = 50%
-    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+    // Also no rendered "50%" or similar threshold indicator from the
+    // removed slider block.
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
   });
 
   it('renders detect holes toggle switch', () => {
@@ -97,11 +97,22 @@ describe('ModelSettingsSection', () => {
       confidenceThreshold: 0.5,
       detectHoles: true,
       setSelectedModel,
-      setConfidenceThreshold: vi.fn(),
       setDetectHoles: vi.fn(),
       availableModels: [
-        { id: 'hrnet', displayName: 'HRNet', size: 'medium', description: '' },
-        { id: 'unet', displayName: 'U-Net', size: 'small', description: '' },
+        {
+          id: 'hrnet',
+          displayName: 'HRNet',
+          size: 'medium',
+          description: '',
+          category: 'spheroid',
+        },
+        {
+          id: 'unet',
+          displayName: 'U-Net',
+          size: 'small',
+          description: '',
+          category: 'spheroid',
+        },
       ],
       getLocalizedModel: vi.fn(),
       getAllModels: vi.fn(),

--- a/src/contexts/ModelContext.tsx
+++ b/src/contexts/ModelContext.tsx
@@ -4,11 +4,8 @@ import {
   ModelContext,
   type ModelType,
   type ModelInfo,
-  // type ModelContextType,
 } from './ModelContext.types';
 import { AuthContext } from './AuthContext.types';
-
-// ModelType and ModelInfo are exported from './exports' to avoid Fast Refresh warnings
 
 const AVAILABLE_MODELS: ModelInfo[] = Object.values(BASIC_MODEL_INFO);
 
@@ -16,7 +13,6 @@ interface ModelProviderProps {
   children: ReactNode;
 }
 
-// Helper function to get user-specific storage key
 const getUserStorageKey = (userId: string | undefined, key: string): string => {
   return userId ? `user_${userId}_${key}` : `guest_${key}`;
 };
@@ -24,19 +20,13 @@ const getUserStorageKey = (userId: string | undefined, key: string): string => {
 export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
   const { user } = useContext(AuthContext);
   const [selectedModel, setSelectedModelState] = useState<ModelType>('hrnet');
-  const [confidenceThreshold, setConfidenceThresholdState] =
-    useState<number>(0.5);
   const [detectHoles, setDetectHolesState] = useState<boolean>(true);
 
-  // Load settings from localStorage on mount and when user changes
   useEffect(() => {
     const userId = user?.id;
     const savedModel = localStorage.getItem(
       getUserStorageKey(userId, 'selectedModel')
     ) as ModelType;
-    const savedThreshold = localStorage.getItem(
-      getUserStorageKey(userId, 'confidenceThreshold')
-    );
     const savedDetectHoles = localStorage.getItem(
       getUserStorageKey(userId, 'detectHoles')
     );
@@ -45,48 +35,15 @@ export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
       setSelectedModelState(savedModel);
     }
 
-    if (savedThreshold) {
-      const threshold = parseFloat(savedThreshold);
-      // Ensure loaded threshold is within valid range (0.1 to 0.9)
-      if (threshold >= 0.1 && threshold <= 0.9) {
-        setConfidenceThresholdState(threshold);
-      } else if (threshold > 0 && threshold < 0.1) {
-        // If old value is below minimum, set to minimum
-        setConfidenceThresholdState(0.1);
-        localStorage.setItem(
-          getUserStorageKey(userId, 'confidenceThreshold'),
-          '0.1'
-        );
-      } else if (threshold > 0.9 && threshold <= 1) {
-        // If old value is above maximum, set to maximum
-        setConfidenceThresholdState(0.9);
-        localStorage.setItem(
-          getUserStorageKey(userId, 'confidenceThreshold'),
-          '0.9'
-        );
-      }
-    }
-
     if (savedDetectHoles !== null) {
       setDetectHolesState(savedDetectHoles === 'true');
     }
-  }, [user?.id]); // Re-load when user changes
+  }, [user?.id]);
 
   const setSelectedModel = (model: ModelType) => {
     const userId = user?.id;
     setSelectedModelState(model);
     localStorage.setItem(getUserStorageKey(userId, 'selectedModel'), model);
-  };
-
-  const setConfidenceThreshold = (threshold: number) => {
-    const userId = user?.id;
-    // Ensure threshold is between 0.1 and 0.9 (10% to 90%)
-    const normalizedThreshold = Math.max(0.1, Math.min(0.9, threshold));
-    setConfidenceThresholdState(normalizedThreshold);
-    localStorage.setItem(
-      getUserStorageKey(userId, 'confidenceThreshold'),
-      normalizedThreshold.toString()
-    );
   };
 
   const setDetectHoles = (detectHoles: boolean) => {
@@ -105,6 +62,12 @@ export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
     );
   };
 
+  // Per-model calibrated threshold — read-only, derived from the model
+  // catalogue. Old per-user localStorage entries are intentionally not
+  // migrated; the new model-specific defaults supersede whatever value the
+  // user had previously dialled in.
+  const confidenceThreshold = getModelInfo(selectedModel).defaultThreshold;
+
   return (
     <ModelContext.Provider
       value={{
@@ -112,7 +75,6 @@ export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
         confidenceThreshold,
         detectHoles,
         setSelectedModel,
-        setConfidenceThreshold,
         setDetectHoles,
         getModelInfo,
         availableModels: AVAILABLE_MODELS,
@@ -122,5 +84,3 @@ export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
     </ModelContext.Provider>
   );
 };
-
-// useModel is exported from './exports' to avoid Fast Refresh warnings

--- a/src/contexts/ModelContext.types.ts
+++ b/src/contexts/ModelContext.types.ts
@@ -11,10 +11,16 @@ export type { ModelType, ModelInfo, ModelPerformance };
 
 export interface ModelContextType {
   selectedModel: ModelType;
+  /**
+   * Read-only inference threshold for the currently selected model.
+   * Derived from `getModelInfo(selectedModel).defaultThreshold` — calibrated
+   * per-model in `modelUtils.ts`. No longer user-configurable: each model
+   * has its own calibrated value (e.g. `unet_attention_aspp` uses 0.2,
+   * others 0.5) and a global slider produced inconsistent results.
+   */
   confidenceThreshold: number;
   detectHoles: boolean;
   setSelectedModel: (model: ModelType) => void;
-  setConfidenceThreshold: (threshold: number) => void;
   setDetectHoles: (detectHoles: boolean) => void;
   getModelInfo: (modelId: ModelType) => ModelInfo;
   availableModels: ModelInfo[];
@@ -27,7 +33,6 @@ export const ModelContext = createContext<ModelContextType>({
   confidenceThreshold: 0.5,
   detectHoles: true,
   setSelectedModel: () => {},
-  setConfidenceThreshold: () => {},
   setDetectHoles: () => {},
   getModelInfo: () => AVAILABLE_MODELS[0],
   availableModels: AVAILABLE_MODELS,

--- a/src/contexts/__tests__/ModelContext.test.tsx
+++ b/src/contexts/__tests__/ModelContext.test.tsx
@@ -121,7 +121,7 @@ describe('ModelContext', () => {
       expect(result.current.detectHoles).toBe(true);
     });
 
-    it('exposes all four models in availableModels', async () => {
+    it('exposes the full model catalogue in availableModels', async () => {
       const { result } = renderHook(() => useModel(), { wrapper });
 
       await waitFor(() => {
@@ -132,8 +132,9 @@ describe('ModelContext', () => {
       expect(modelIds).toContain('hrnet');
       expect(modelIds).toContain('cbam_resunet');
       expect(modelIds).toContain('unet_spherohq');
+      expect(modelIds).toContain('unet_attention_aspp');
       expect(modelIds).toContain('sperm');
-      expect(result.current.availableModels).toHaveLength(4);
+      expect(modelIds).toContain('wound');
     });
   });
 
@@ -193,51 +194,45 @@ describe('ModelContext', () => {
     });
   });
 
-  describe('setConfidenceThreshold', () => {
-    it('clamps values below the minimum (0.1) to 0.1', async () => {
+  describe('confidenceThreshold is read-only and derived from selected model', () => {
+    it('returns the selected model defaultThreshold (0.5 for hrnet)', async () => {
       const { result } = renderHook(() => useModel(), { wrapper });
 
       await waitFor(() => {
         expect(result.current.selectedModel).toBe('hrnet');
       });
 
-      act(() => {
-        result.current.setConfidenceThreshold(0.01);
-      });
-
-      expect(result.current.confidenceThreshold).toBe(0.1);
+      expect(result.current.confidenceThreshold).toBe(0.5);
     });
 
-    it('clamps values above the maximum (0.9) to 0.9', async () => {
+    it('updates automatically when the selected model changes', async () => {
       const { result } = renderHook(() => useModel(), { wrapper });
 
       await waitFor(() => {
         expect(result.current.selectedModel).toBe('hrnet');
       });
+      expect(result.current.confidenceThreshold).toBe(0.5);
 
+      // unet_attention_aspp is calibrated to 0.2; switching the selected
+      // model must propagate to the threshold reported by the context.
       act(() => {
-        result.current.setConfidenceThreshold(1.0);
+        result.current.setSelectedModel('unet_attention_aspp');
       });
 
-      expect(result.current.confidenceThreshold).toBe(0.9);
+      expect(result.current.confidenceThreshold).toBe(0.2);
     });
 
-    it('accepts a valid threshold within range and persists it', async () => {
+    it('no longer exposes setConfidenceThreshold', async () => {
       const { result } = renderHook(() => useModel(), { wrapper });
 
       await waitFor(() => {
         expect(result.current.selectedModel).toBe('hrnet');
       });
 
-      act(() => {
-        result.current.setConfidenceThreshold(0.7);
-      });
-
-      expect(result.current.confidenceThreshold).toBe(0.7);
-      expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        'guest_confidenceThreshold',
-        '0.7'
-      );
+      expect(
+        (result.current as { setConfidenceThreshold?: unknown })
+          .setConfidenceThreshold
+      ).toBeUndefined();
     });
   });
 
@@ -302,7 +297,6 @@ describe('ModelContext', () => {
     it('reads saved settings from localStorage using guest key when no user', async () => {
       localStorageMock.getItem.mockImplementation((key: string) => {
         if (key === 'guest_selectedModel') return 'sperm';
-        if (key === 'guest_confidenceThreshold') return '0.8';
         if (key === 'guest_detectHoles') return 'false';
         return null;
       });
@@ -313,23 +307,28 @@ describe('ModelContext', () => {
         expect(result.current.selectedModel).toBe('sperm');
       });
 
-      expect(result.current.confidenceThreshold).toBe(0.8);
+      // sperm has defaultThreshold 0.5 — threshold is no longer read
+      // from localStorage, only the model id is.
+      expect(result.current.confidenceThreshold).toBe(0.5);
       expect(result.current.detectHoles).toBe(false);
     });
 
-    it('handles invalid (out-of-range) saved threshold by clamping on load', async () => {
-      // Value stored is 0.05 — below minimum 0.1 — should be clamped to 0.1
+    it('ignores any guest_confidenceThreshold left over from older builds', async () => {
+      // Older builds persisted a per-user threshold; the new context
+      // ignores those entries (they are stale and the per-model default
+      // takes precedence). Verifies the migration path doesn't leak.
       localStorageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'guest_confidenceThreshold') return '0.05';
+        if (key === 'guest_confidenceThreshold') return '0.8';
         return null;
       });
 
       const { result } = renderHook(() => useModel(), { wrapper });
 
       await waitFor(() => {
-        // After clamping, should be set to minimum 0.1
-        expect(result.current.confidenceThreshold).toBe(0.1);
+        expect(result.current.selectedModel).toBe('hrnet');
       });
+      // hrnet defaultThreshold is 0.5, not the stale 0.8
+      expect(result.current.confidenceThreshold).toBe(0.5);
     });
 
     it('ignores invalid model ids from localStorage and keeps default', async () => {

--- a/src/hooks/__tests__/useLocalizedModels.test.ts
+++ b/src/hooks/__tests__/useLocalizedModels.test.ts
@@ -21,7 +21,6 @@ vi.mock('@/contexts/useModel', () => ({
     confidenceThreshold: 0.5,
     detectHoles: true,
     setSelectedModel: vi.fn(),
-    setConfidenceThreshold: vi.fn(),
     setDetectHoles: vi.fn(),
     getModelInfo: vi.fn(),
     availableModels: [],
@@ -66,15 +65,19 @@ describe('useLocalizedModels', () => {
   });
 
   describe('return shape', () => {
-    it('exposes selectedModel, confidenceThreshold, detectHoles and setters', () => {
+    it('exposes selectedModel, confidenceThreshold (read-only), detectHoles and setters', () => {
       const { result } = renderHook(() => useLocalizedModels());
 
       expect(result.current.selectedModel).toBe('hrnet');
       expect(result.current.confidenceThreshold).toBe(0.5);
       expect(result.current.detectHoles).toBe(true);
       expect(typeof result.current.setSelectedModel).toBe('function');
-      expect(typeof result.current.setConfidenceThreshold).toBe('function');
       expect(typeof result.current.setDetectHoles).toBe('function');
+      // confidenceThreshold is now read-only — no setter exposed.
+      expect(
+        (result.current as { setConfidenceThreshold?: unknown })
+          .setConfidenceThreshold
+      ).toBeUndefined();
     });
 
     it('exposes getLocalizedModel, getAllModels, getSelectedModelInfo, availableModels', () => {

--- a/src/hooks/useLocalizedModels.ts
+++ b/src/hooks/useLocalizedModels.ts
@@ -16,7 +16,6 @@ export function useLocalizedModels() {
     confidenceThreshold,
     detectHoles,
     setSelectedModel,
-    setConfidenceThreshold,
     setDetectHoles,
   } = useModel();
   const { t } = useLanguage();
@@ -38,7 +37,6 @@ export function useLocalizedModels() {
     confidenceThreshold,
     detectHoles,
     setSelectedModel,
-    setConfidenceThreshold,
     setDetectHoles,
     getLocalizedModel,
     getAllModels,

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -454,17 +454,11 @@ export default {
         },
       },
     },
-    confidenceThreshold: 'Práh Spolehlivosti',
-    confidenceThresholdDescription:
-      'Minimální spolehlivost požadovaná pro predikce segmentace',
     detectHoles: 'Detekce Děr',
     detectHolesDescription:
       'Povolit detekci vnitřních struktur a děr uvnitř buněk',
-    currentThreshold: 'Současný práh',
     modelSelected: 'Model úspěšně vybrán',
     modelSettingsSaved: 'Nastavení modelu úspěšně uloženo',
-    thresholdAutoAdjusted:
-      'Model vybrán — práh automaticky nastaven na {threshold}% (optimalizováno pro tento model)',
     modelSize: {
       small: 'Malý',
       medium: 'Střední',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -474,17 +474,11 @@ export default {
         },
       },
     },
-    confidenceThreshold: 'Vertrauensschwelle',
-    confidenceThresholdDescription:
-      'Mindestvertrauen für Segmentierungsvorhersagen erforderlich',
     detectHoles: 'Löcher Erkennen',
     detectHolesDescription:
       'Erkennung von inneren Strukturen und Löchern in Zellen aktivieren',
-    currentThreshold: 'Aktuelle Schwelle',
     modelSelected: 'Modell erfolgreich ausgewählt',
     modelSettingsSaved: 'Modelleinstellungen erfolgreich gespeichert',
-    thresholdAutoAdjusted:
-      'Modell ausgewählt — Schwellenwert automatisch auf {threshold}% eingestellt (optimiert für dieses Modell)',
     modelSize: {
       small: 'Klein',
       medium: 'Mittel',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -468,17 +468,11 @@ export default {
         },
       },
     },
-    confidenceThreshold: 'Confidence Threshold',
-    confidenceThresholdDescription:
-      'Minimum confidence required for segmentation predictions',
     detectHoles: 'Detect Holes',
     detectHolesDescription:
       'Enable detection of internal structures and holes within cells',
-    currentThreshold: 'Current threshold',
     modelSelected: 'Model selected successfully',
     modelSettingsSaved: 'Model settings saved successfully',
-    thresholdAutoAdjusted:
-      'Model selected — threshold automatically set to {threshold}% (optimized for this model)',
     modelSize: {
       small: 'Small',
       medium: 'Medium',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -452,17 +452,11 @@ export default {
         },
       },
     },
-    confidenceThreshold: 'Umbral de Confianza',
-    confidenceThresholdDescription:
-      'Confianza mínima requerida para las predicciones de segmentación',
     detectHoles: 'Detectar Agujeros',
     detectHolesDescription:
       'Habilitar la detección de estructuras internas y agujeros dentro de las células',
-    currentThreshold: 'Umbral actual',
     modelSelected: 'Modelo seleccionado con éxito',
     modelSettingsSaved: 'Configuración de modelo guardada con éxito',
-    thresholdAutoAdjusted:
-      'Modelo seleccionado — umbral ajustado automáticamente a {threshold}% (optimizado para este modelo)',
     modelSize: {
       small: 'Pequeño',
       medium: 'Mediano',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -465,17 +465,11 @@ export default {
         },
       },
     },
-    confidenceThreshold: 'Seuil de confiance',
-    confidenceThresholdDescription:
-      'Confiance minimale requise pour les prédictions de segmentation',
     detectHoles: 'Détecter les Trous',
     detectHolesDescription:
       'Activer la détection des structures internes et des trous dans les cellules',
-    currentThreshold: 'Seuil actuel',
     modelSelected: 'Modèle sélectionné avec succès',
     modelSettingsSaved: 'Paramètres du modèle enregistrés avec succès',
-    thresholdAutoAdjusted:
-      'Modèle sélectionné — seuil automatiquement réglé à {threshold}% (optimisé pour ce modèle)',
     modelSize: {
       small: 'Petit',
       medium: 'Moyen',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -421,15 +421,10 @@ export default {
         },
       },
     },
-    confidenceThreshold: '置信度阈值',
-    confidenceThresholdDescription: '分割预测所需的最小置信度',
     detectHoles: '检测空洞',
     detectHolesDescription: '启用细胞内部结构和空洞的检测',
-    currentThreshold: '当前阈值',
     modelSelected: '模型选择成功',
     modelSettingsSaved: '模型设置保存成功',
-    thresholdAutoAdjusted:
-      '模型已选择 — 阈值已自动设置为{threshold}%（针对此模型优化）',
     modelSize: {
       small: '小',
       medium: '中',


### PR DESCRIPTION
## Summary

Each segmentation model has its own calibrated threshold:
- `unet_attention_aspp` → 0.2
- `hrnet`, `cbam_resunet`, `unet_spherohq`, `wound`, `sperm` → 0.5
- `sperm` ignores the threshold entirely (dual mask/score gates in `predict_sperm`)

A single user-set slider therefore produced inconsistent quality across models — switching models without re-tuning the slider was easy to miss, and the slider on the sperm model did nothing.

Replace the user-settable threshold with a context value derived directly from `getModelInfo(selectedModel).defaultThreshold`. Callers (`useProjectImageActions`, `ProjectDetail`) keep reading `confidenceThreshold` from `useModel()` unchanged — they automatically get the right model-specific value as the user switches models.

## Changes

- **`src/contexts/ModelContext.tsx`**: drop `confidenceThreshold` state + `setConfidenceThreshold`; expose `confidenceThreshold` as a derived getter from the selected model's `defaultThreshold`
- **`src/contexts/ModelContext.types.ts`**: drop `setConfidenceThreshold` from `ModelContextType`
- **`src/components/settings/ModelSettingsSection.tsx`**: remove the slider, label, handlers, and the threshold-auto-adjusted toast
- **`src/hooks/useLocalizedModels.ts`**: drop `setConfidenceThreshold` passthrough
- **Tests** (`ModelContext.test.tsx`, `ModelSettingsSection.test.tsx`, `useLocalizedModels.test.ts`): rewritten threshold assertions; pre-existing mock-category gaps fixed
- **Translations** (en, cs, es, de, fr, zh): remove `confidenceThreshold`, `confidenceThresholdDescription`, `currentThreshold`, `thresholdAutoAdjusted`

## Backwards compatibility

Stale `guest_confidenceThreshold` / `user_*_confidenceThreshold` localStorage entries are intentionally not migrated — the per-model default supersedes whatever value the user had previously chosen. No code reads the old key, so the stale value is harmless dead data.

## Test plan

- [x] Frontend unit tests pass: 33/33 across `ModelContext`, `ModelSettingsSection`, `useLocalizedModels`
- [x] TypeScript: `tsc --noEmit` clean
- [x] Pre-commit hook (lint, prettier, type check) passes
- [ ] After deploy: open Settings → Model section, verify slider is gone, only model selection + detect-holes toggle remain
- [ ] After deploy: select `unet_attention_aspp` from settings, run segmentation, verify `confidence threshold = 0.2` is sent in the request payload (devtools / backend log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)