### PR TITLE
fix(video): store full storage key in Image.originalPath / thumbnailPath

### DIFF
--- a/backend/src/api/controllers/videoController.ts
+++ b/backend/src/api/controllers/videoController.ts
@@ -255,13 +255,11 @@ export class VideoController {
           `${channelName}.png`
         );
       } else {
-        absPath = path.join(
-          config.UPLOAD_DIR,
-          'projects',
-          image.projectId,
-          'images',
-          image.originalPath
-        );
+        // ``originalPath`` is the full storage key relative to UPLOAD_DIR
+        // (e.g. ``projects/<pid>/images/<cid>/original.nd2`` for a video
+        // container, or ``<userId>/<projectId>/originals/...`` for a
+        // standalone upload). Joining directly preserves both shapes.
+        absPath = path.join(config.UPLOAD_DIR, image.originalPath);
       }
 
       // Defence in depth: ensure the resolved path is still under the

--- a/backend/src/services/videoUploadService.ts
+++ b/backend/src/services/videoUploadService.ts
@@ -48,8 +48,20 @@ export interface VideoUploadResult {
   channels: ChannelMeta[];
 }
 
-/** Top-level path under the configured uploads directory that holds a
- *  given video container and its extracted frames. */
+/** Storage-key prefix (relative to UPLOAD_DIR) under which a container
+ *  and its extracted frames live. This is what gets persisted to
+ *  Image.originalPath / thumbnailPath so `storage.getUrl(path)` resolves
+ *  correctly to `/uploads/projects/<pid>/images/<cid>/...`. */
+function videoContainerStorageKey(
+  projectId: string,
+  containerId: string
+): string {
+  return path.posix.join('projects', projectId, 'images', containerId);
+}
+
+/** Absolute filesystem path for the container directory — UPLOAD_DIR
+ *  prepended to the storage key. Used for `mkdir`, `rm`, sharp/extract
+ *  I/O. Stays in node `path` (OS separators) so Windows dev still works. */
 function videoContainerDir(projectId: string, containerId: string): string {
   return path.join(
     config.UPLOAD_DIR,
@@ -65,12 +77,13 @@ function videoContainerDir(projectId: string, containerId: string): string {
  *  consumers that need a different channel build their own URL via the
  *  /frame-data?channel=X route. */
 function frameStorageKey(
+  projectId: string,
   containerId: string,
   frameIndex: number,
   channelName: string
 ): string {
   return path.posix.join(
-    containerId,
+    videoContainerStorageKey(projectId, containerId),
     'frames',
     String(frameIndex).padStart(4, '0'),
     `${channelName}.png`
@@ -228,7 +241,7 @@ export async function uploadVideoFromFile(options: {
     reportProgress('persisting', 0.9, 'Persisting frame records');
     const frameRows = Array.from({ length: result.frameCount }, (_, i) => ({
       name: `${originalName} (frame ${i + 1})`,
-      originalPath: frameStorageKey(containerId, i, defaultChannel),
+      originalPath: frameStorageKey(projectId, containerId, i, defaultChannel),
       thumbnailPath: null,
       projectId,
       width: result.width || null,
@@ -244,11 +257,12 @@ export async function uploadVideoFromFile(options: {
       await prisma.image.createMany({ data: frameRows });
     }
 
+    const containerKey = videoContainerStorageKey(projectId, containerId);
     await prisma.image.update({
       where: { id: containerId },
       data: {
-        originalPath: path.posix.join(containerId, `original${ext}`),
-        thumbnailPath: path.posix.join(containerId, 'thumbnail.jpg'),
+        originalPath: path.posix.join(containerKey, `original${ext}`),
+        thumbnailPath: path.posix.join(containerKey, 'thumbnail.jpg'),
         width: result.width || null,
         height: result.height || null,
         frameCount: result.frameCount,


### PR DESCRIPTION
## Summary

Hotfix for **404 on ND2 (and other video) container assets** in production. The `videoUploadService` was writing storage keys missing the `projects/<projectId>/images/` prefix, so the URLs generated by `storage.getUrl()` never matched the actual on-disk locations:

```
URL the frontend requested:  /uploads/<containerId>/thumbnail.jpg   →  404
File on disk:                /app/uploads/projects/<pid>/images/<containerId>/thumbnail.jpg
```

The same mismatch affected `original.<ext>` (ND2 / MP4 / TIFF) and `frames/NNNN/<channel>.png` rows.

A workaround in `videoController.getFrameData` re-prepended the prefix for the channel-fallback path, masking the bug for that one code path only. `storage.getUrl()`, `exportService`, and direct `/uploads/...` URLs (which the frontend uses for thumbnails) still 404'd.

### Fix

- `videoContainerStorageKey(projectId, containerId)` returns the canonical full key relative to UPLOAD_DIR.
- `frameStorageKey` now takes `projectId` and builds the full key.
- Container `originalPath` and `thumbnailPath` written via the same helper.
- Removed the double-prefix workaround in `getFrameData` — both standalone images (`<userId>/<projectId>/originals/...` layout) and video containers/frames resolve via the same `path.join(UPLOAD_DIR, originalPath)` call.

### Production migration applied

The 2 broken rows in production DB (1 container + 1 frame) already corrected via:

```sql
UPDATE images
SET "originalPath" = 'projects/' || "projectId" || '/images/' || "originalPath"
WHERE ("isVideoContainer" = true OR "parentVideoId" IS NOT NULL)
  AND "originalPath" NOT LIKE 'projects/%' AND "originalPath" IS NOT NULL;

UPDATE images
SET "thumbnailPath" = 'projects/' || "projectId" || '/images/' || "thumbnailPath"
WHERE "isVideoContainer" = true
  AND "thumbnailPath" NOT LIKE 'projects/%' AND "thumbnailPath" IS NOT NULL;
```

URL verification post-migration:
```
thumbnail: HTTP 200
original:  HTTP 200
```

Backend rebuild still required so future ND2 uploads write the canonical shape from the start (otherwise this migration will need to run again).

## Test plan

- [x] `npx tsc --noEmit` (backend) — clean
- [x] Production curl `/uploads/projects/.../thumbnail.jpg` → HTTP 200
- [x] Production curl `/uploads/projects/.../original.nd2` → HTTP 200
- [ ] After backend rebuild: re-upload an ND2 → confirm DB row has full `projects/<pid>/images/<cid>/...` keys without the SQL workaround needed

## Out of scope (follow-up)

The user also reports the editor "won't display" the container. That's a separate frontend routing issue — clicking a video container in the gallery navigates to the editor with the container's image ID, but per CLAUDE.md "the container is never segmented; queue items always reference frame rows." For single-frame ND2 (`frameCount = 1`), the gallery should navigate to the child frame instead. Will land in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved video frame data retrieval and storage path handling for more reliable access to video uploads and associated frame data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->