### PR TITLE
fix(video): widen Image.fileSize to BigInt + Redis-auth ND2 upload 500

### DIFF
--- a/backend/prisma/migrations/20260512_filesize_bigint/migration.sql
+++ b/backend/prisma/migrations/20260512_filesize_bigint/migration.sql
@@ -1,0 +1,4 @@
+-- ND2 / TIFF stacks routinely exceed 2 GB; the previous Int (INT4) column
+-- caused Prisma "Unable to fit '2499837952' into INT4" failures on upload.
+-- 2^31-1 = 2,147,483,647 bytes ≈ 2.0 GB; BIGINT covers up to ~9 EB.
+ALTER TABLE "images" ALTER COLUMN "fileSize" TYPE BIGINT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -87,7 +87,11 @@ model Image {
   segmentationThumbnailPath String?          // New field for segmentation thumbnail
   projectId              String
   segmentationStatus     String              @default("no_segmentation")
-  fileSize               Int?
+  // BigInt because ND2 / TIFF stacks routinely exceed 2 GB (INT4 max);
+  // the previous Int caused Prisma "Unable to fit … into INT4" on upload.
+  // Frontend receives this as a JS number via the controller mapper —
+  // 2^53 covers up to 9 PB which is well beyond any conceivable file size.
+  fileSize               BigInt?
   width                  Int?
   height                 Int?
   mimeType               String?

--- a/backend/src/api/controllers/authController.ts
+++ b/backend/src/api/controllers/authController.ts
@@ -699,8 +699,9 @@ export const getStorageStats = asyncHandler(
       },
     });
 
+    // fileSize is BigInt — coerce per row to stay in number arithmetic.
     const totalBytes = images.reduce(
-      (sum, img) => sum + (img.fileSize || 0),
+      (sum, img) => sum + Number(img.fileSize ?? 0n),
       0
     );
     const totalMB = Math.round((totalBytes / (1024 * 1024)) * 100) / 100;
@@ -754,7 +755,8 @@ export const getUserStorageStats = asyncHandler(
     for (const project of userProjects) {
       for (const image of project.images) {
         if (image.fileSize) {
-          totalStorageBytes += image.fileSize;
+          // fileSize is BigInt — coerce per row to stay in number arithmetic.
+          totalStorageBytes += Number(image.fileSize);
         }
         totalImages++;
       }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -34,6 +34,16 @@ import {
   cleanupRateLimitingSystem,
 } from './monitoring/rateLimitingInitialization';
 
+// JSON.stringify throws on BigInt by default; Image.fileSize is now
+// BigInt (PostgreSQL BIGINT) to support files > 2 GB (ND2 stacks).
+// Serialise as JS number — covers any file size up to ~9 PB (2^53),
+// well beyond the 100 GB upload cap.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(BigInt.prototype as any).toJSON = function (): number {
+  return Number(this);
+};
+
 const app = express();
 
 // Trust proxy (important for rate limiting and logging real IPs)

--- a/backend/src/services/imageService.ts
+++ b/backend/src/services/imageService.ts
@@ -1130,7 +1130,12 @@ export class ImageService {
     });
 
     const totalImages = images.length;
-    const totalSize = images.reduce((sum, img) => sum + (img.fileSize || 0), 0);
+    // fileSize is BigInt — coerce per row before summing; 2^53 covers any
+    // realistic file size, so number arithmetic is safe.
+    const totalSize = images.reduce(
+      (sum, img) => sum + Number(img.fileSize ?? 0n),
+      0
+    );
 
     // Count by status
     const byStatus = {

--- a/backend/src/services/projectService.ts
+++ b/backend/src/services/projectService.ts
@@ -584,7 +584,10 @@ export async function getProjectStats(
           completed: segmentationStatusCounts.completed || 0,
           failed: segmentationStatusCounts.failed || 0,
         },
-        totalFileSize: totalFileSize._sum.fileSize || 0,
+        // _sum.fileSize is BigInt | null — coerce so the JSON response
+        // is a plain number (BigInt.toJSON in server.ts handles direct
+        // BigInt values too, but explicit coercion keeps the shape stable).
+        totalFileSize: Number(totalFileSize._sum.fileSize ?? 0n),
       },
       segmentations: {
         total: totalSegmentations,

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -202,7 +202,9 @@ export async function calculateUserStorage(
       },
     });
 
-    const totalImageBytes = imagesSizeResult._sum.fileSize || 0;
+    // _sum.fileSize is BigInt | null since the column moved to BigInt
+    // — coerce to number for the downstream Math.floor / percentage math.
+    const totalImageBytes = Number(imagesSizeResult._sum.fileSize ?? 0n);
 
     // Estimate thumbnail sizes (typically 10-20% of original)
     const estimatedThumbnailBytes = Math.floor(totalImageBytes * 0.15);


### PR DESCRIPTION
Two prod-blocking issues for ND2 video uploads >2 GB:

1. **Prisma INT4 overflow** on `Image.fileSize` — schema was `Int` (PostgreSQL INT4, ≤2 GB). User's 2.3 GB ND2 hit `Unable to fit '2499837952' into INT4`. Widened to `BigInt` (BIGINT, ~9 EB).
2. **Redis backend connection refused** — Redis container running without `requirepass` (4-week drift) while backend's `REDIS_URL` embedded a password. Backend retried 9× then gave up; broke session refresh too.

### Source changes
- `schema.prisma`: `Image.fileSize Int? → BigInt?`
- New migration `20260512_filesize_bigint` (already applied to prod)
- `server.ts`: `BigInt.prototype.toJSON = Number` global patch so API responses still JSON.stringify
- 4 arithmetic sites coerce per-row (`+= Number(img.fileSize ?? 0n)`) to avoid `bigint + number` TypeError

### Production already mitigated
- `ALTER TABLE images ALTER COLUMN "fileSize" TYPE BIGINT` ✓
- `redis-cli CONFIG SET requirepass …` ✓ (won't persist across Redis restart — follow-up: add `command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]` to compose)

### Test plan
- [x] `npx tsc --noEmit` (backend) clean
- [ ] Backend rebuild + recreate → upload 2.3 GB ND2 → 201 Created
- [ ] Playwright smoke: gallery thumbnail renders, no console 404/500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved file upload failures occurring with large files exceeding approximately 2GB in size.
  * Enhanced file size tracking and storage statistics calculations across the system to accurately support large uploads and provide reliable storage capacity reporting and data consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->