### PR TITLE
fix(video): surface isVideoContainer + frame metadata via images-with-thumbnails

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1032,6 +1032,17 @@ export class ImageController {
             segmentationResult: thumbnailData,
             segmentationThumbnailUrl: segmentationThumbnailUrl,
             segmentationThumbnailPath: image.segmentationThumbnailPath,
+            // Video-container metadata (ND2 / TIFF stack / MP4) — without
+            // these the editor's VideoModeOverlay can't tell a container
+            // from a standalone image, so frame slider / play / channel
+            // switcher never render and the canvas stays empty.
+            isVideoContainer: image.isVideoContainer,
+            parentVideoId: image.parentVideoId,
+            frameIndex: image.frameIndex,
+            frameCount: image.frameCount,
+            videoDurationMs: image.videoDurationMs,
+            channels: image.channels,
+            displayOrder: image.displayOrder,
           };
         })
       );


### PR DESCRIPTION
User report: 'nefunguje zobrazení v editoru' + 'chybí mi tam press/play tlačítko' for ND2 video container in production.

Root cause: `/api/projects/:id/images-with-thumbnails` hand-picked fields, dropping `isVideoContainer`, `parentVideoId`, `frameIndex`, `frameCount`, `videoDurationMs`, `channels`. The editor's selectedImage lookup hydrated from this endpoint, so `videoContainerId` evaluated to `null` → VideoModeOverlay never mounted → no frame slider, no play/pause, no canvas frame load.

Add the seven video fields to the response shape. Pure additive change; no schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include expanded video metadata containing container information, frame indices, frame counts, video duration, and channel details to support improved video content handling and UI rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->