### PR TITLE
fix(video): propagate isVideoContainer + frame metadata to ProjectImage

### DIFF
--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -119,6 +119,17 @@ export const useProjectData = (
             // counts only — sufficient for the grid view. The segmentation
             // editor loads full polygon data independently.
             segmentationResult: img.segmentationResult || undefined,
+            // Video-container metadata (ND2 / TIFF / MP4). Without these
+            // the segmentation editor's VideoModeOverlay can't tell a
+            // container from a standalone image, so frame slider /
+            // play-pause / channel switcher never render and the canvas
+            // stays empty when the user opens a video in the editor.
+            isVideoContainer: img.isVideoContainer,
+            parentVideoId: img.parentVideoId,
+            frameIndex: img.frameIndex,
+            frameCount: img.frameCount,
+            videoDurationMs: img.videoDurationMs,
+            channels: img.channels,
           };
         });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -531,6 +531,11 @@ export interface ProjectImage {
   // Frame children are filtered from the gallery on the backend; UI only
   // ever sees container rows here.
   isVideoContainer?: boolean;
+  // Frame-row identifiers — set when the row IS a child frame; null on
+  // containers and standalone images. Editor uses these to load polygons
+  // for a specific frame inside a video.
+  parentVideoId?: string | null;
+  frameIndex?: number | null;
   frameCount?: number | null;
   videoDurationMs?: number | null;
   channels?: VideoChannel[] | null;


### PR DESCRIPTION
Sibling fix to #146. Frontend mapper in useProjectData was dropping video fields too; editor still saw isVideoContainer=undefined, VideoModeOverlay never mounted, canvas stayed empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video metadata support to project images, enabling frame-specific controls and overlay functionality for video content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->