### PR TITLE
fix(video): route canvas image src through /display for containers + frames

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1015,12 +1015,24 @@ export class ImageController {
             ? await storage.getUrl(image.segmentationThumbnailPath)
             : null;
 
+          // Video containers / extracted frames are not directly
+          // browser-renderable — the original is a binary ND2 / TIFF
+          // stack or a per-channel PNG buried in frames/. Route the
+          // canvas image source through the /display endpoint, which
+          // resolves to the segmentation-source channel PNG (see
+          // getVideoFrameForDisplay in imageService). Standalone
+          // images keep using the direct /uploads/<path> URL.
+          const displayUrl =
+            image.isVideoContainer || image.parentVideoId
+              ? `/api/images/${image.id}/display`
+              : originalUrl;
+
           return {
             id: image.id,
             name: image.name,
             thumbnail_url: thumbnailUrl,
-            url: originalUrl,
-            image_url: originalUrl,
+            url: displayUrl,
+            image_url: displayUrl,
             projectId: image.projectId,
             segmentationStatus: image.segmentationStatus,
             fileSize: image.fileSize,


### PR DESCRIPTION
Final piece: response.url was still pointing to /uploads/<originalPath>, so canvas requested raw ND2 bytes. Switch to /api/images/<id>/display for video containers and frames (which /display now resolves to frame PNG).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image and video display routing to ensure proper rendering of video containers and child frames.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/149)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->