### PR TITLE
fix(video): show frames (not containers) in gallery + editor controls

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -905,11 +905,17 @@ export class ImageController {
         return;
       }
 
+      // Hide video container rows from the gallery — users see frame
+      // children directly (one row per extracted frame), so the
+      // container becomes a service-only entity. Standalone images
+      // (isVideoContainer = false, parentVideoId = null) and extracted
+      // frames (isVideoContainer = false, parentVideoId set) are both
+      // returned by this filter; only the parent container is hidden.
+      const galleryWhere = { projectId, isVideoContainer: false };
+
       // Get images with segmentation data in a single optimized query
       const images = await prisma.image.findMany({
-        where: {
-          projectId,
-        },
+        where: galleryWhere,
         include: {
           segmentation: true,
         },
@@ -922,7 +928,7 @@ export class ImageController {
 
       // Get total count for pagination
       const totalCount = await prisma.image.count({
-        where: { projectId },
+        where: galleryWhere,
       });
 
       // Get storage provider for URL generation

--- a/backend/src/services/imageService.ts
+++ b/backend/src/services/imageService.ts
@@ -586,13 +586,15 @@ export class ImageService {
     const { page, limit, status, sortBy, sortOrder } = options;
     const skip = (page - 1) * limit;
 
-    // Build where clause. Hide individual video frame rows from the
-    // gallery — only top-level rows (standalone images + video containers)
-    // are returned. Video frames are reachable via the editor's video-mode
-    // routes, not the project gallery.
+    // Build where clause. Hide video CONTAINER rows from the gallery —
+    // users see frame children directly (one row per extracted frame),
+    // so the container becomes a service-only entity. Standalone images
+    // (isVideoContainer = false, parentVideoId = null) and extracted
+    // frames (isVideoContainer = false, parentVideoId set) are both
+    // returned by this filter; only the parent container is hidden.
     const where: Prisma.ImageWhereInput = {
       projectId,
-      parentVideoId: null,
+      isVideoContainer: false,
     };
 
     if (status) {

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1140,14 +1140,22 @@ const SegmentationEditor = () => {
   const visiblePolygonsCount = editor.polygons.length - hiddenPolygonIds.size;
   const hiddenPolygonsCount = hiddenPolygonIds.size;
 
-  // Video mode: when the selected image is a video container, render the
-  // VideoModeOverlay (frame slider, channel switcher, window/level, kymo
-  // modal) alongside the static-image editor. The overlay is a no-op for
-  // standalone images so the existing single-image flow stays untouched.
-  const videoContainerId = (selectedImage as { isVideoContainer?: boolean })
-    .isVideoContainer
+  // Video mode: render the VideoModeOverlay (frame slider, play/pause,
+  // channel switcher, window/level, kymograph modal) whenever the
+  // selected image is part of a video — either the container row OR any
+  // of its extracted frame children. Frames are what the user actually
+  // opens in practice (containers are filtered out of the gallery), so
+  // the overlay has to keep working from frame URLs too.
+  //
+  // The overlay scopes itself to the container (parent), not the frame,
+  // because the frame list + channels live on the container row.
+  const videoMeta = selectedImage as {
+    isVideoContainer?: boolean;
+    parentVideoId?: string | null;
+  };
+  const videoContainerId = videoMeta.isVideoContainer
     ? imageId
-    : null;
+    : (videoMeta.parentVideoId ?? null);
 
   return (
     <SegmentationErrorBoundary>


### PR DESCRIPTION
Video uploads now present as N frame rows everywhere (gallery + editor). Containers remain as schema-only metadata holders. Fixes 'chybí play tlačítko' on frame URLs and aligns counter to actual frame count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gallery display to properly exclude video container entities from results.
  * Improved video frame filtering to correctly show extracted frames while hiding parent containers.
  * Enhanced segmentation editor's video mode activation for better video content handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/150)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->