### PR TITLE
fix(editor): canvas follows play head + channel + prefetch

### DIFF
--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -44,6 +44,7 @@ import SegmentationErrorBoundary from './components/SegmentationErrorBoundary';
 import CanvasContainer from './components/canvas/CanvasContainer';
 import CanvasContent from './components/canvas/CanvasContent';
 import CanvasImage from './components/canvas/CanvasImage';
+import VideoFrameImage from './components/canvas/VideoFrameImage';
 import CanvasPolygon from './components/canvas/CanvasPolygon';
 import CanvasSvgFilters from './components/canvas/CanvasSvgFilters';
 import ModeInstructions from './components/canvas/ModeInstructions';
@@ -1254,10 +1255,29 @@ const SegmentationEditor = () => {
                     deleteMode={legacyModes.deleteMode}
                   >
                     <CanvasContent transform={editor.transform}>
-                      {/* Base Image */}
+                      {/* Base Image — video mode binds src to the play
+                          head (useVideoFrames.currentFrame.id) and the
+                          active channel (useImageDisplay.channel), so
+                          scrubbing / Play / channel-switch actually
+                          swap the canvas image. Prefetch warms the
+                          next ten frames during playback so the swap
+                          is instant rather than a roundtrip per frame.
+                          Standalone images keep the static URL. */}
                       {selectedImage && (
-                        <CanvasImage
-                          src={ensureBrowserCompatibleUrl(
+                        <VideoFrameImage
+                          isVideoMode={isVideoMode}
+                          currentFrameId={video.currentFrame?.id ?? null}
+                          upcomingFrameIds={
+                            isVideoMode && video.isPlaying && video.container
+                              ? video.container.frames
+                                  .slice(
+                                    video.frameIndex + 1,
+                                    video.frameIndex + 11
+                                  )
+                                  .map(f => f.id)
+                              : undefined
+                          }
+                          fallbackSrc={ensureBrowserCompatibleUrl(
                             selectedImage.id,
                             selectedImage.url,
                             selectedImage.name

--- a/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
+++ b/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
@@ -1,0 +1,113 @@
+/**
+ * Canvas image source resolver for video-mode editing.
+ *
+ * Two jobs:
+ *   1. Compute the right URL for the canvas <img>:
+ *      - Video mode: /api/images/<currentFrameId>/frame-data?channel=<channel>
+ *        so flipping the channel in the sidebar swaps PNG to the right
+ *        per-channel file, and so changing frameIndex (Play / scrubber /
+ *        Next / Back) follows the play head instead of staying on the
+ *        URL imageId.
+ *      - Otherwise: pass through the static URL the parent computed.
+ *   2. Prefetch the next N frames while playback is live so when the
+ *      timer ticks, the browser already has the PNG cached and the
+ *      <img> swap is instant rather than a full HTTP roundtrip per
+ *      frame.
+ *
+ * Lives in the JSX subtree wrapped by ImageDisplayProvider so it can
+ * read the current channel via useImageDisplay().
+ */
+
+import { useEffect, useMemo } from 'react';
+import CanvasImage from './CanvasImage';
+import { useImageDisplay } from '../../contexts/ImageDisplayContext';
+
+interface VideoFrameImageProps {
+  /** True when the row is part of a video container. Off → fallback. */
+  isVideoMode: boolean;
+  /** Frame id from useVideoFrames.currentFrame.id — drives playback,
+   *  scrubber, prev/next. */
+  currentFrameId: string | null;
+  /** Frame ids to warm in the browser HTTP cache. Caller supplies the
+   *  ones it expects the user to hit next (e.g. the next 10 forward
+   *  frames during playback). */
+  upcomingFrameIds?: string[];
+  /** Static image URL used when not in video mode (standalone image). */
+  fallbackSrc: string;
+  /** Forwarded to <CanvasImage>. */
+  width?: number;
+  height?: number;
+  alt?: string;
+  onLoad?: (width: number, height: number) => void;
+}
+
+const PREFETCH_FRAME_COUNT = 10;
+
+/** Build the per-channel display URL for one video frame. The channel
+ *  query is omitted when there is no active channel (single-channel
+ *  videos / channel-context not initialised yet); the backend resolver
+ *  falls back to the segmentation-source channel in that case. */
+function buildFrameSrc(frameId: string, channel: string | null): string {
+  if (channel) {
+    return `/api/images/${frameId}/frame-data?channel=${encodeURIComponent(channel)}`;
+  }
+  return `/api/images/${frameId}/display`;
+}
+
+export default function VideoFrameImage({
+  isVideoMode,
+  currentFrameId,
+  upcomingFrameIds,
+  fallbackSrc,
+  width,
+  height,
+  alt,
+  onLoad,
+}: VideoFrameImageProps) {
+  const { channel } = useImageDisplay();
+
+  // Compute the URL the canvas actually renders. Video mode binds to the
+  // play head; standalone keeps the parent's pre-computed src.
+  const src = useMemo(() => {
+    if (isVideoMode && currentFrameId) {
+      return buildFrameSrc(currentFrameId, channel);
+    }
+    return fallbackSrc;
+  }, [isVideoMode, currentFrameId, channel, fallbackSrc]);
+
+  // Prefetch warm-up: kick off HTTP requests for the upcoming frames so
+  // the browser has them cached when the <img> src swap happens. We
+  // never read the resulting Image objects — they exist only to populate
+  // the disk/memory cache. Cleanup via .src = '' aborts in-flight
+  // requests when the dependency changes (e.g. user pauses).
+  useEffect(() => {
+    if (!isVideoMode || !upcomingFrameIds || upcomingFrameIds.length === 0) {
+      return;
+    }
+    const slice = upcomingFrameIds.slice(0, PREFETCH_FRAME_COUNT);
+    const handles: HTMLImageElement[] = [];
+    for (const frameId of slice) {
+      const img = new Image();
+      img.src = buildFrameSrc(frameId, channel);
+      handles.push(img);
+    }
+    return () => {
+      for (const img of handles) {
+        // Setting src='' is the documented way to cancel a pending
+        // HTTP request issued by `new Image()`. Browsers ignore the
+        // partial response and the connection is reused.
+        img.src = '';
+      }
+    };
+  }, [isVideoMode, upcomingFrameIds, channel]);
+
+  return (
+    <CanvasImage
+      src={src}
+      width={width}
+      height={height}
+      alt={alt}
+      onLoad={onLoad}
+    />
+  );
+}


### PR DESCRIPTION
Two bugs: (1) image canvas src bound to URL imageId so Play/scrubber/Next didn't actually swap the image, (2) channel dropdown had no effect because /display is hardcoded to source channel. Fix: <VideoFrameImage> wrapper resolves src to /api/images/<currentFrameId>/frame-data?channel=<channel>, plus prefetches next 10 frames during playback so the swap is instant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video playback in the segmentation editor now includes automatic prefetching of upcoming frames to enable smoother frame-to-frame transitions during playback and navigation.

* **Enhancement**
  * Improved video frame handling with support for seamless transitions as you navigate through video content, providing a more responsive editing experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->