### PR TITLE
fix(api): send ML-safe filename for video-frame segmentation requests

### DIFF
--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -15,6 +15,7 @@ import { ImageService } from './imageService';
 import { SegmentationThumbnailService } from './segmentationThumbnailService';
 import { ThumbnailManager } from './thumbnailManager';
 import { getStorageProvider } from '../storage/index';
+import { safeMlFilename } from '../utils/mlFilename';
 
 export interface SegmentationPoint {
   x: number;
@@ -409,10 +410,13 @@ export class SegmentationService {
         throw new Error('Failed to load image from storage');
       }
 
-      // Prepare form data for Python service
+      // Prepare form data for Python service. The filename has to
+      // satisfy the ML service's split('.')-based extension check;
+      // video-frame Image rows carry names like "video.nd2 (frame 98)"
+      // which fail that check. safeMlFilename normalises both shapes.
       const formData = new FormData();
       formData.append('file', imageBuffer, {
-        filename: image.name,
+        filename: safeMlFilename(image),
         contentType: image.mimeType || 'image/jpeg',
       });
 
@@ -977,7 +981,7 @@ export class SegmentationService {
         }
         const imageBuffer = await storage.getBuffer(image.originalPath);
         formData.append('files', imageBuffer, {
-          filename: image.name,
+          filename: safeMlFilename(image),
           contentType: image.mimeType || 'image/jpeg',
         });
 

--- a/backend/src/utils/__tests__/mlFilename.test.ts
+++ b/backend/src/utils/__tests__/mlFilename.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { safeMlFilename } from '../mlFilename';
+
+describe('safeMlFilename', () => {
+  it('prefers mimeType-derived extension for PNG', () => {
+    expect(
+      safeMlFilename({
+        id: 'abc-123',
+        name: 'doesnt-matter.weird',
+        mimeType: 'image/png',
+      })
+    ).toBe('abc-123.png');
+  });
+
+  it('maps image/jpeg to .jpg', () => {
+    expect(
+      safeMlFilename({ id: 'xyz', name: 'photo.jpg', mimeType: 'image/jpeg' })
+    ).toBe('xyz.jpg');
+  });
+
+  it('maps image/tiff to .tif', () => {
+    expect(
+      safeMlFilename({ id: 'tif-1', name: 'stack.tif', mimeType: 'image/tiff' })
+    ).toBe('tif-1.tif');
+  });
+
+  it('case-insensitive mimeType lookup', () => {
+    expect(
+      safeMlFilename({ id: 'casing', name: null, mimeType: 'Image/PNG' })
+    ).toBe('casing.png');
+  });
+
+  it('sanitises spaces and parens in fallback name', () => {
+    // The video-frame bug: name contains "(frame 98)" with spaces and
+    // parens, ML extension validator fails. Helper either uses mimeType
+    // or sanitises this safely.
+    expect(
+      safeMlFilename({
+        id: 'frame-xyz',
+        name: 'video.nd2 (frame 98)',
+        mimeType: undefined,
+      })
+    ).toBe('frame-xyz.png');
+  });
+
+  it('passes through a clean image-extension filename', () => {
+    expect(
+      safeMlFilename({
+        id: 'std-1',
+        name: 'clean_image.png',
+        mimeType: null,
+      })
+    ).toBe('clean_image.png');
+  });
+
+  it('preserves clean tiff/jpeg filenames in fallback', () => {
+    expect(
+      safeMlFilename({
+        id: 's',
+        name: 'sample.jpeg',
+        mimeType: undefined,
+      })
+    ).toBe('sample.jpeg');
+    expect(
+      safeMlFilename({
+        id: 's',
+        name: 'stack.tiff',
+        mimeType: undefined,
+      })
+    ).toBe('stack.tiff');
+  });
+
+  it('falls back to id-based .png when mimeType missing and name has unsupported ext', () => {
+    expect(
+      safeMlFilename({
+        id: 'fallback-id',
+        name: 'binary.bin',
+        mimeType: undefined,
+      })
+    ).toBe('fallback-id.png');
+  });
+
+  it('regression: ND2-frame style name no longer trips ML validator', () => {
+    // Exact shape of the failing case from production logs (2026-05-12):
+    // ML extracts ext via split('.').pop() → 'nd2 (frame 98)' which is
+    // not in {.png, .jpg, .jpeg, .tiff, .tif, .bmp}. Helper either uses
+    // mimeType to short-circuit or sanitises away the spaces/parens.
+    const out = safeMlFilename({
+      id: '62a94898-b2c7-4503-a935-41c336d61859',
+      name: '20260429_CH2_DNA_origami_BRB80MB_DO1_v2_10x_.nd2 (frame 98)',
+      mimeType: 'image/png',
+    });
+    expect(out).toBe('62a94898-b2c7-4503-a935-41c336d61859.png');
+    // Critically: the result's last '.' token IS in the allowed set.
+    const ext = '.' + out.split('.').pop()!.toLowerCase();
+    expect(['.png', '.jpg', '.jpeg', '.tiff', '.tif', '.bmp']).toContain(ext);
+  });
+});

--- a/backend/src/utils/mlFilename.ts
+++ b/backend/src/utils/mlFilename.ts
@@ -1,0 +1,65 @@
+/**
+ * Build a safe filename for the ML service multipart upload.
+ *
+ * The Python ML service validates uploads by `filename.split('.').pop()`
+ * (see backend/segmentation/api/routes.py:39 validate_image). For most
+ * standalone images this works — they're named "sample.png", split on
+ * '.', last token is "png", happy path. But video-frame Image rows
+ * inherit their container's human-readable name with a frame suffix,
+ * e.g. "20260429_CH2_DNA_origami_BRB80MB_DO1_v2_10x_.nd2 (frame 98)".
+ * That last '.' token becomes "nd2 (frame 98)", which is not in the
+ * allowed extension set → ML returns 400 "Invalid image file" even
+ * though the underlying buffer is a perfectly valid PNG.
+ *
+ * Fix: send the ML service a synthetic filename derived from the
+ * mimeType so the extension always matches the bytes. The actual
+ * filename is irrelevant once validation passes — the ML service
+ * opens via PIL.Image.open() on the buffer, not on disk.
+ */
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/tiff': '.tif',
+  'image/tif': '.tif',
+  'image/bmp': '.bmp',
+};
+
+/**
+ * Returns a filename guaranteed to satisfy the ML service's
+ * extension-based validator.
+ */
+export function safeMlFilename(input: {
+  id: string;
+  name?: string | null;
+  mimeType?: string | null;
+}): string {
+  // Prefer mimeType — it's what tells the truth about the bytes the
+  // backend is about to send. For PNG frames the mimeType is
+  // "image/png" regardless of the human-readable name.
+  if (input.mimeType) {
+    const ext = EXT_BY_MIME[input.mimeType.toLowerCase()];
+    if (ext) {
+      return `${input.id}${ext}`;
+    }
+  }
+
+  // Fall back to sanitising the name. Replace whitespace and parens
+  // (the troublemakers for ML's split('.')-on-last-token validator)
+  // with underscores. Drop anything after the last dot in the
+  // remaining name and use the file's extension if it looks safe.
+  if (input.name) {
+    const sanitised = input.name.replace(/[\s()]+/g, '_');
+    // Already safe filename → use as-is.
+    if (/\.(png|jpe?g|tiff?|bmp)$/i.test(sanitised)) {
+      return sanitised;
+    }
+    // Otherwise fall through to id-based filename below.
+  }
+
+  // Last resort: pretend it's a PNG. The ML service still tries to
+  // PIL.Image.open() the buffer, so if the bytes aren't really PNG
+  // the error surface stays meaningful.
+  return `${input.id}.png`;
+}


### PR DESCRIPTION
Production ML 400'd on Segment All because video-frame Image.name ('video.nd2 (frame 98)') failed the ML's extension validator. Send mimeType-derived synthetic filename instead. 9 unit tests cover the regression + fallback branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced image filename handling when uploading to the ML service to ensure compatibility with various naming conventions and patterns, including video-frame style names, for both individual and batch segmentation operations.

* **Tests**
  * Added comprehensive test coverage for filename sanitization processes, including edge cases and file extension validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->