### PR TITLE
fix(api): expose originalPath in images-with-thumbnails for channel picker

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1061,6 +1061,11 @@ export class ImageController {
             videoDurationMs: image.videoDurationMs,
             channels: image.channels,
             displayOrder: image.displayOrder,
+            // Exposed so the Segment-All channel picker can derive the set
+            // of distinct channels for multi-channel video projects
+            // (extractChannelsFromPaths reads the /frames/NNNN/<ch>.<ext>
+            // shape). Not used by the canvas — that goes through `url`.
+            originalPath: image.originalPath,
           };
         })
       );


### PR DESCRIPTION
Follow-up to #156. The channel picker reads img.originalPath to derive distinct channels; the images-with-thumbnails endpoint didn't expose it, so the picker never opened on multi-channel video projects. Adds the field to the response transformer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced image data retrieval to include additional path information, improving support for multi-channel projects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->