### PR TITLE
fix(channel-picker): aggregate channels from container rows + forward originalPath

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1070,6 +1070,27 @@ export class ImageController {
         })
       );
 
+      // Aggregate distinct channels across all video containers in this
+      // project so the Segment-All picker can populate even on page 1
+      // (one channel's frames may all sort before the other's, so the
+      // paginated images alone aren't sufficient).
+      const containers = await prisma.image.findMany({
+        where: { projectId, isVideoContainer: true },
+        select: { channels: true },
+      });
+      const projectChannels = Array.from(
+        new Set(
+          containers
+            .flatMap(c => (Array.isArray(c.channels) ? c.channels : []))
+            .map((ch: unknown) =>
+              ch && typeof ch === 'object' && 'name' in ch
+                ? String((ch as { name: unknown }).name)
+                : null
+            )
+            .filter((n): n is string => !!n)
+        )
+      ).sort();
+
       const response = {
         images: transformedImages,
         pagination: {
@@ -1084,6 +1105,10 @@ export class ImageController {
           imagesWithThumbnails: transformedImages.filter(
             img => img.segmentationResult
           ).length,
+          // Distinct channel names across all video containers in the
+          // project. Empty for non-video projects. Drives the
+          // Segment-All channel picker on the frontend.
+          projectChannels,
         },
       };
 

--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -130,6 +130,10 @@ export const useProjectData = (
             frameCount: img.frameCount,
             videoDurationMs: img.videoDurationMs,
             channels: img.channels,
+            // Surface originalPath for the Segment-All channel picker —
+            // extractChannelsFromPaths derives distinct channels from the
+            // /frames/NNNN/<channel>.<ext> shape across all pages.
+            originalPath: img.originalPath,
           };
         });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1003,6 +1003,9 @@ class ApiClient {
       levelOfDetail: 'low' | 'medium' | 'high';
       totalImages: number;
       imagesWithThumbnails: number;
+      // Distinct channels across all video containers in this project.
+      // Empty for non-video projects. Drives the Segment-All channel picker.
+      projectChannels?: string[];
     };
   }> {
     const response = await this.instance.get(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -539,6 +539,10 @@ export interface ProjectImage {
   frameCount?: number | null;
   videoDurationMs?: number | null;
   channels?: VideoChannel[] | null;
+  // Storage key of the underlying file (e.g. frames/NNNN/<channel>.png).
+  // Surfaced so the Segment-All channel picker can derive distinct channels
+  // by regex over the path; not used by the canvas.
+  originalPath?: string | null;
 }
 
 /** Shape of one entry in the ``channels`` JSON column on an Image row.


### PR DESCRIPTION
Follow-up #2 to #156/#157. Two layered bugs prevented the channel picker from triggering in prod despite the originalPath response from #157: (a) FE mapper stripped originalPath; (b) page 1 of MT project contained only one channel due to displayOrder sorting. Backend now returns projectChannels aggregate in response.metadata; FE mapper threads originalPath through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Segment-All channel picker that aggregates and displays distinct channels across video container images, allowing users to view all channels simultaneously without pagination limitations.

* **Refactor**
  * Enhanced internal data structures to track channel metadata across paginated image results, enabling improved project organization and channel selection capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->