### PR TITLE
fix(channel-picker): strip SyntheticEvent from handleSegmentAll

### DIFF
--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1271,8 +1271,11 @@ const ProjectDetail = () => {
 
     // Multi-channel video project: pick the channel first. The dialog calls
     // back into handleSegmentAll with the picked channel so we can reuse the
-    // rest of this function unchanged.
-    if (channelOverride === undefined) {
+    // rest of this function unchanged. Defense-in-depth: also bail when a
+    // non-string slipped in via an onClick adapter (React passes the
+    // SyntheticEvent as the first arg when handleSegmentAll is wired
+    // directly, instead of through an arrow wrapper).
+    if (typeof channelOverride !== 'string') {
       const detectedChannels = extractChannelsFromPaths(
         images.map(img => (img as { originalPath?: string }).originalPath)
       );
@@ -1544,7 +1547,7 @@ const ProjectDetail = () => {
             <QueueStatsPanel
               stats={queueStats}
               isConnected={isConnected}
-              onSegmentAll={handleSegmentAll}
+              onSegmentAll={() => handleSegmentAll()}
               onCancelSegmentation={handleCancelSegmentation}
               batchSubmitted={batchSubmitted || hasActiveQueue}
               isCancelling={isCancelling}


### PR DESCRIPTION
Hotfix #3 follow-up to #156/#157/#158. The picker check never fired in prod because handleSegmentAll was wired into QueueStatsPanel as onSegmentAll={handleSegmentAll} — Button onClick passes the SyntheticEvent as the first arg, so 'channelOverride === undefined' was false. Wrap with arrow + harden type check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for segment operations to prevent unintended errors and improve stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->