### PR TITLE
fix(batch-delete): chunk apiClient.deleteBatch to ≤100 ids per request

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,7 +9,7 @@ import {
 } from '@/types';
 import { logger } from '@/lib/logger';
 import config from '@/lib/config';
-import { TIMEOUTS } from '@/lib/constants';
+import { TIMEOUTS, FILE_LIMITS } from '@/lib/constants';
 import { retryWithBackoff, RETRY_CONFIGS } from '@/lib/retryUtils';
 import {
   chunkFiles,
@@ -1843,17 +1843,42 @@ class ApiClient {
     failedIds: string[];
     errors: string[];
   }> {
-    const response = await this.instance.delete('/images/batch', {
-      data: {
-        imageIds,
-        projectId,
-      },
-    });
-    return this.extractData<{
-      deletedCount: number;
-      failedIds: string[];
-      errors: string[];
-    }>(response);
+    // Backend caps each request at FILE_LIMITS.CHUNK_SIZE_FILES via
+    // imageBatchDeleteSchema. Chunk sequentially so callers can pass any
+    // size — a 301-frame MT video would otherwise 400 with
+    // "Maximálně 100 obrázků může být smazáno najednou". Sequential (not
+    // parallel) because the service runs each chunk inside a Prisma
+    // transaction with sync storage deletes; parallel chunks would stress
+    // the DB pool + S3 throttling without real wall-clock win.
+    const chunkSize = FILE_LIMITS.CHUNK_SIZE_FILES;
+    let deletedCount = 0;
+    const failedIds: string[] = [];
+    const errors: string[] = [];
+
+    for (let i = 0; i < imageIds.length; i += chunkSize) {
+      const chunk = imageIds.slice(i, i + chunkSize);
+      try {
+        const response = await this.instance.delete('/images/batch', {
+          data: { imageIds: chunk, projectId },
+        });
+        const data = this.extractData<{
+          deletedCount: number;
+          failedIds: string[];
+          errors: string[];
+        }>(response);
+        deletedCount += data.deletedCount;
+        failedIds.push(...data.failedIds);
+        errors.push(...data.errors);
+      } catch (err) {
+        // Chunk-level failure (network blip, 5xx) — preserve partial
+        // progress instead of throwing away the whole operation.
+        const msg = err instanceof Error ? err.message : String(err);
+        failedIds.push(...chunk);
+        errors.push(`Chunk ${Math.floor(i / chunkSize) + 1}: ${msg}`);
+      }
+    }
+
+    return { deletedCount, failedIds, errors };
   }
 
   async getQueueStats(projectId: string): Promise<QueueStats> {


### PR DESCRIPTION
## Summary

- Backend `imageBatchDeleteSchema` caps each `DELETE /api/images/batch` request at **100 image ids** (`backend/src/types/validation.ts:357`).
- FE `apiClient.deleteBatch` previously forwarded the whole array, so `Select All → Delete` on a 301-frame microtubule video 400'd with `Maximálně 100 obrázků může být smazáno najednou` and the user saw "delete doesn't work".
- This PR chunks the FE call to `FILE_LIMITS.CHUNK_SIZE_FILES` (100), runs chunks sequentially (BE uses a single Prisma transaction with sync storage deletes — parallel chunks would only contend on the DB pool + S3 throttling), and aggregates `{deletedCount, failedIds, errors}` across chunks. A per-chunk catch preserves partial successes when one chunk fails mid-flight.

## Verification (production)

Test account `12bprusek@gym-nymburk.cz`, MT project `ff6b0bde-...` (301 frames):
- Before: `DELETE /api/images/batch` → **400** with `Maximálně 100 obrázků může být smazáno najednou` (single-request)
- After: 4× `DELETE /api/images/batch` → **4× 200** (chunks 100+100+100+1), gallery shows `0 images`, 0 console errors from the delete flow.

## Test plan

- [x] TS clean (`npx tsc --noEmit`)
- [x] Pre-commit hook passes (ESLint, prettier, type-check, code-quality, commit-msg)
- [x] Production bundle inspection: `ue.CHUNK_SIZE_FILES` loop confirmed in `index-*.js`
- [x] End-to-end Playwright run on prod: 301-frame select-all → delete → 4× 200 OK + UI clears
- [ ] Reviewer eyes — chunked API client patterns / partial-failure handling

## Follow-up debt (separate)

After deleting all frames of a video the parent `Image` row (`isVideoContainer=true`) remains in the DB because the gallery filter (`isVideoContainer: false`) hides containers from selection. Cleanup needs either FE batch-delete to include the container, or BE cascade when last frame of a container is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced batch deletion to process large file sets in sequential chunks, ensuring operations continue even if individual batches encounter errors, with comprehensive error reporting across all attempted deletions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/163)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->