### PR TITLE
fix(upload): persist floating card across page refresh + show interrupted state

### DIFF
--- a/src/components/FloatingUploadProgress.tsx
+++ b/src/components/FloatingUploadProgress.tsx
@@ -36,6 +36,25 @@ const FloatingUploadProgress: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSession?.id]);
 
+  // On mount (e.g. after a page refresh that aborted an in-flight upload),
+  // the UploadContext restores sessions from localStorage and flips the
+  // 'uploading' status to 'cancelled'. activeSession is null in that case,
+  // so without picking the most recent restored session here, the card
+  // would never reappear and the user would lose any sense of what
+  // happened. Pick the most recent restored session so the X-to-dismiss
+  // surface is reachable.
+  useEffect(() => {
+    if (visibleSessionId) return;
+    if (activeSession) return;
+    const candidates = Object.values(sessions);
+    if (candidates.length === 0) return;
+    const mostRecent = candidates.reduce((best, s) =>
+      s.startedAt > best.startedAt ? s : best
+    );
+    setVisibleSessionId(mostRecent.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Auto-collapse completed sessions after 8 seconds
   useEffect(() => {
     if (!displaySession) return;

--- a/src/contexts/UploadContext.tsx
+++ b/src/contexts/UploadContext.tsx
@@ -45,11 +45,80 @@ interface UploadContextType {
 
 export const UploadContext = createContext<UploadContextType | null>(null);
 
+// Persist session metadata across page refreshes so the bottom-right
+// FloatingUploadProgress card doesn't vanish (and the user retains a
+// dismiss/cancel surface) when the user reloads mid-upload. Only metadata
+// is persisted — File objects are gone after refresh and can't be revived
+// from a string, so the AbortController + axios request are simply lost.
+// The restore step flips 'uploading' sessions to 'cancelled' with an
+// explicit message so the UX is honest about what happened.
+export const UPLOAD_SESSIONS_STORAGE_KEY = 'spheroseg.uploadSessions.v1';
+const STALE_SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24h cutoff
+
+function loadPersistedSessions(): Record<string, UploadSession> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(UPLOAD_SESSIONS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, UploadSession>;
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    const now = Date.now();
+    const restored: Record<string, UploadSession> = {};
+    for (const [id, s] of Object.entries(parsed)) {
+      // Drop sessions older than the TTL — stale completed/cancelled
+      // cards aren't useful and would otherwise accumulate forever.
+      if (
+        !s ||
+        typeof s !== 'object' ||
+        typeof s.startedAt !== 'number' ||
+        now - s.startedAt > STALE_SESSION_TTL_MS
+      ) {
+        continue;
+      }
+      if (s.status === 'uploading') {
+        // The AbortController died with the previous page; the axios
+        // request was aborted by the browser. Surface the truth.
+        restored[id] = {
+          ...s,
+          status: 'cancelled',
+          chunkProgress: null,
+          currentOperation: 'Upload interrupted by page refresh',
+        };
+      } else {
+        restored[id] = s;
+      }
+    }
+    return restored;
+  } catch {
+    // Corrupt JSON or quota error — start fresh rather than crash boot.
+    return {};
+  }
+}
+
 export const UploadProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [sessions, setSessions] = useState<Record<string, UploadSession>>({});
+  // Lazy initialiser: restore persisted sessions on first render so the
+  // card reappears synchronously, before any paint.
+  const [sessions, setSessions] = useState<Record<string, UploadSession>>(
+    loadPersistedSessions
+  );
   const { socket } = useWebSocket();
+
+  // Persist on every state change. Wrapped in try/catch because Safari
+  // private-mode + quota-exceeded throw — the card UX is best-effort.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(
+        UPLOAD_SESSIONS_STORAGE_KEY,
+        JSON.stringify(sessions)
+      );
+    } catch {
+      /* storage unavailable — silently degrade */
+    }
+  }, [sessions]);
 
   // AbortController in a ref — NOT using useAbortController hook to avoid
   // auto-abort on unmount. The context provider lives at the app root and

--- a/src/contexts/__tests__/UploadContext.persistence.test.tsx
+++ b/src/contexts/__tests__/UploadContext.persistence.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React, { ReactNode } from 'react';
+import {
+  UploadProvider,
+  UPLOAD_SESSIONS_STORAGE_KEY,
+} from '@/contexts/UploadContext';
+import { useUpload } from '@/contexts/useUpload';
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    isAuthenticated: vi.fn(() => false),
+    uploadImages: vi.fn(),
+    uploadImagesChunked: vi.fn(),
+    uploadVideo: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/authEvents', () => ({
+  authEventEmitter: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock('@/lib/tokenRefresh', () => ({
+  tokenRefreshManager: {
+    startTokenRefreshManager: vi.fn(),
+    stopTokenRefreshManager: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/useWebSocket', () => ({
+  useWebSocket: vi.fn(() => ({
+    socket: null,
+    isConnected: false,
+  })),
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <UploadProvider>{children}</UploadProvider>
+);
+
+describe('UploadContext — persistence across page refresh', () => {
+  // The global test setup (src/test/setup.ts) installs a stub
+  // localStorage that returns null for everything except 'theme' and
+  // 'language'. Replace it per-test with a Map-backed storage so our
+  // round-trips persist as they would in the browser.
+  let backing: Map<string, string>;
+  beforeEach(() => {
+    backing = new Map();
+    const stub = {
+      getItem: vi.fn((key: string) => backing.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        backing.set(key, String(value));
+      }),
+      removeItem: vi.fn((key: string) => {
+        backing.delete(key);
+      }),
+      clear: vi.fn(() => {
+        backing.clear();
+      }),
+      key: vi.fn((i: number) => Array.from(backing.keys())[i] ?? null),
+      get length() {
+        return backing.size;
+      },
+    } as unknown as Storage;
+    Object.defineProperty(global, 'localStorage', {
+      value: stub,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'localStorage', {
+      value: stub,
+      configurable: true,
+    });
+    vi.clearAllMocks();
+  });
+
+  it('restores persisted sessions on mount', () => {
+    const fixture = {
+      upload_1: {
+        id: 'upload_1',
+        projectId: 'proj_a',
+        projectName: 'Project A',
+        status: 'completed',
+        totalFiles: 3,
+        successCount: 3,
+        failedCount: 0,
+        overallProgress: 100,
+        chunkProgress: null,
+        currentOperation: '3 files uploaded successfully',
+        startedAt: Date.now() - 60_000, // 1 minute ago
+      },
+    };
+    window.localStorage.setItem(
+      UPLOAD_SESSIONS_STORAGE_KEY,
+      JSON.stringify(fixture)
+    );
+
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    expect(result.current.sessions).toHaveProperty('upload_1');
+    expect(result.current.sessions['upload_1'].status).toBe('completed');
+    expect(result.current.sessions['upload_1'].successCount).toBe(3);
+  });
+
+  it('flips uploading sessions to cancelled on restore (browser aborted request on refresh)', () => {
+    const fixture = {
+      upload_2: {
+        id: 'upload_2',
+        projectId: 'proj_b',
+        status: 'uploading',
+        totalFiles: 1,
+        successCount: 0,
+        failedCount: 0,
+        overallProgress: 42,
+        chunkProgress: null,
+        currentOperation: 'Uploading big.tif',
+        startedAt: Date.now() - 5_000,
+      },
+    };
+    window.localStorage.setItem(
+      UPLOAD_SESSIONS_STORAGE_KEY,
+      JSON.stringify(fixture)
+    );
+
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    // Restored session should NOT be 'uploading' — the AbortController is
+    // gone with the previous page; surfacing 'uploading' would leave a
+    // permanent spinner.
+    expect(result.current.sessions['upload_2'].status).toBe('cancelled');
+    expect(result.current.sessions['upload_2'].currentOperation).toMatch(
+      /interrupted/i
+    );
+    // activeSession only counts 'uploading' status, so the restored
+    // cancelled session must not be treated as active.
+    expect(result.current.activeSession).toBeNull();
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it('drops sessions older than 24h on restore', () => {
+    const fixture = {
+      fresh: {
+        id: 'fresh',
+        projectId: 'p',
+        status: 'completed',
+        totalFiles: 1,
+        successCount: 1,
+        failedCount: 0,
+        overallProgress: 100,
+        chunkProgress: null,
+        currentOperation: 'done',
+        startedAt: Date.now() - 60_000, // fresh
+      },
+      stale: {
+        id: 'stale',
+        projectId: 'p',
+        status: 'completed',
+        totalFiles: 1,
+        successCount: 1,
+        failedCount: 0,
+        overallProgress: 100,
+        chunkProgress: null,
+        currentOperation: 'done',
+        startedAt: Date.now() - 25 * 60 * 60 * 1000, // 25h ago
+      },
+    };
+    window.localStorage.setItem(
+      UPLOAD_SESSIONS_STORAGE_KEY,
+      JSON.stringify(fixture)
+    );
+
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    expect(result.current.sessions).toHaveProperty('fresh');
+    expect(result.current.sessions).not.toHaveProperty('stale');
+  });
+
+  it('survives invalid JSON in localStorage', () => {
+    window.localStorage.setItem(
+      UPLOAD_SESSIONS_STORAGE_KEY,
+      'not valid json {{{ '
+    );
+
+    // Should not throw on mount.
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    expect(result.current.sessions).toEqual({});
+  });
+
+  it('writes sessions to localStorage when state changes', () => {
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    // Initially empty.
+    expect(window.localStorage.getItem(UPLOAD_SESSIONS_STORAGE_KEY)).toBe('{}');
+
+    // Triggering a state change (clearSession on a non-existent id is a
+    // no-op for state but still flushes through the effect).
+    act(() => {
+      result.current.clearSession('nope');
+    });
+
+    expect(window.localStorage.getItem(UPLOAD_SESSIONS_STORAGE_KEY)).toBe('{}');
+  });
+
+  it('skips entries with missing or malformed fields', () => {
+    const fixture = {
+      bad_no_started_at: { id: 'x', status: 'completed' },
+      bad_null: null,
+      good: {
+        id: 'good',
+        projectId: 'p',
+        status: 'completed',
+        totalFiles: 1,
+        successCount: 1,
+        failedCount: 0,
+        overallProgress: 100,
+        chunkProgress: null,
+        currentOperation: 'done',
+        startedAt: Date.now() - 10_000,
+      },
+    };
+    window.localStorage.setItem(
+      UPLOAD_SESSIONS_STORAGE_KEY,
+      JSON.stringify(fixture)
+    );
+
+    const { result } = renderHook(() => useUpload(), { wrapper });
+
+    expect(Object.keys(result.current.sessions)).toEqual(['good']);
+  });
+});


### PR DESCRIPTION
## Summary

User report (CZ): _"když refreshnu stránku, tak mi zmizí upload modal vpravo dole a nejde mi dát cancel upload"_.

`UploadContext` kept all session state in React `useState` — a page refresh reset it, the `FloatingUploadProgress` card vanished, and the user had no surface to acknowledge or dismiss the interrupted upload.

The underlying request is unrecoverable (browser aborts in-flight XHR on navigation, `File` objects can't be revived from serialization), so this fix is **honest UX**: persist session metadata to localStorage, restore on mount, and flip any `'uploading'` status to `'cancelled'` with `currentOperation = "Upload interrupted by page refresh"`.

## Mechanism

- **Storage key**: `spheroseg.uploadSessions.v1` → `Record<sessionId, UploadSession>`
- **Lazy useState initializer** hydrates synchronously, no flicker
- **`useEffect` on `sessions`** writes every change → dismissal automatically clears storage (no stale 'completed' card after dismiss + refresh)
- **24h TTL** drops stale completed/cancelled entries on restore
- **Malformed JSON / missing fields / quota errors** degrade silently
- **`FloatingUploadProgress`** gets a mount effect that picks the most-recent restored session as `visibleSessionId` so the card actually shows up — `activeSession` only matches `status='uploading'` which we've flipped to `'cancelled'` during restore

## Verification

**Tests:** 6 new vitest cases in `UploadContext.persistence.test.tsx` covering restore + flip + TTL + invalid JSON + malformed entries. All 16 existing UploadContext tests still pass (no regression).

**E2E on prod** (test account):
1. Seeded an `'uploading'` session in localStorage
2. Navigated to dashboard
3. Card appeared with text **"Upload cancelled"** (yellow X icon)
4. localStorage normalized: `status: 'cancelled'`, `currentOperation: "Upload interrupted by page refresh"`
5. After 8s auto-clear, card gone and storage cleared to `{}`

## Test plan

- [x] TS clean (`npx tsc --noEmit`)
- [x] Pre-commit passes (ESLint, prettier, type-check)
- [x] `vitest run src/contexts/__tests__/UploadContext.*` → 22/22 pass
- [x] E2E on prod with seeded session
- [ ] Real-world: start a 3.5 GB TIFF upload (when paired with #164), refresh mid-flight, confirm card appears with interrupted message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload session data now persists across page refreshes, maintaining visibility of active uploads
  * Session metadata is automatically cleaned up after 24 hours

* **Bug Fixes**
  * In-flight uploads interrupted by page refresh are now properly marked as cancelled with status messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/166)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->