### PR TITLE
fix(editor): make /api/images/:id/frame-data public so <img> tags can fetch it

### DIFF
--- a/backend/src/api/controllers/videoController.ts
+++ b/backend/src/api/controllers/videoController.ts
@@ -85,14 +85,9 @@ async function assertProjectAccess(
   return userId;
 }
 
-/** Resolve the container row for an arbitrary imageId, asserting that the
- *  caller has access to its parent project. Returns null on access denial
- *  (handler should then return). */
-async function loadAuthorisedContainer(
-  req: Request,
-  res: Response,
-  imageId: string
-) {
+/** Common image row loader used by the video / frame controllers.
+ *  Returns null on bad id / missing row after writing the response. */
+async function loadImageById(req: Request, res: Response, imageId: string) {
   if (typeof imageId !== 'string' || imageId.length === 0) {
     ResponseHelper.error(res, 'imageId required', 400);
     return null;
@@ -118,6 +113,19 @@ async function loadAuthorisedContainer(
     ResponseHelper.error(res, 'Image not found', 404);
     return null;
   }
+  return image;
+}
+
+/** Resolve the container row for an arbitrary imageId, asserting that the
+ *  caller has access to its parent project. Returns null on access denial
+ *  (handler should then return). */
+async function loadAuthorisedContainer(
+  req: Request,
+  res: Response,
+  imageId: string
+) {
+  const image = await loadImageById(req, res, imageId);
+  if (!image) return null;
   const userId = await assertProjectAccess(req, res, image.projectId);
   if (!userId) return null;
   return image;
@@ -204,6 +212,12 @@ export class VideoController {
    * Streams the raw PNG for a specific channel of a video-frame image.
    * For standalone (non-video) images and missing channel queries we
    * fall back to ``originalPath``.
+   *
+   * **No authentication required** — same security model as
+   * `/images/:imageId/display`: the image UUID is the capability token.
+   * Browser `<img>` tags can't attach a JWT, and adding a signed-URL
+   * scheme just for canvas rendering is more attack surface than the
+   * UUID-as-capability model already in use across the gallery.
    */
   static async getFrameData(req: Request, res: Response): Promise<void> {
     try {
@@ -222,7 +236,7 @@ export class VideoController {
         return;
       }
 
-      const image = await loadAuthorisedContainer(req, res, imageId);
+      const image = await loadImageById(req, res, imageId);
       if (!image) return;
 
       let absPath: string;

--- a/backend/src/api/routes/imageRoutes.ts
+++ b/backend/src/api/routes/imageRoutes.ts
@@ -35,6 +35,15 @@ const imageController = new ImageController();
  */
 router.get('/:imageId/display', imageController.getImageForDisplay);
 
+/**
+ * Fetch the raw PNG for a specific channel of a video frame.
+ * GET /images/:imageId/frame-data?channel=irm
+ * Note: No authentication required — same UUID-as-capability model as
+ * /display above. Browser `<img>` tags can't attach a JWT, so requiring
+ * auth here would break the canvas image source in the editor.
+ */
+router.get('/:imageId/frame-data', VideoController.getFrameData);
+
 // All other routes require authentication (email verification disabled for development)
 router.use(authenticate);
 // router.use(requireEmailVerification); // Temporarily disabled for development
@@ -106,15 +115,6 @@ router.post(
   uploadSingleVideo,
   handleUploadError,
   VideoController.upload
-);
-
-/**
- * Fetch the raw PNG for a specific channel of a video frame.
- * GET /images/:imageId/frame-data?channel=irm
- */
-router.get(
-  '/:imageId/frame-data',
-  VideoController.getFrameData
 );
 
 /**


### PR DESCRIPTION
## Summary

User report: just-uploaded test video failed to display in the editor with a 401 on `/api/images/<id>/frame-data?channel=ch0`.

**Root cause**: `VideoFrameImage.tsx` builds the canvas `<img src="..."/>` URL pointing at `/api/images/<frameId>/frame-data`. Browser `<img>` tags don't attach Authorization headers — JWT travels only through axios interceptors — so the request landed on the `authenticate` middleware without credentials and returned 401. The sibling `/display` endpoint already solves this by living BEFORE `router.use(authenticate)` and is documented as "no authentication required". `frame-data` should follow the same pattern.

## Changes

- **`imageRoutes.ts`**: move `/:imageId/frame-data` into the public block (alongside `/display`, before `router.use(authenticate)`) with an explicit comment stating the same UUID-as-capability security model.
- **`videoController.ts`**: extract `loadImageById` (no-auth data loader) from `loadAuthorisedContainer` (no-auth loader + project-access assertion). `getFrameData` now uses the no-auth loader. The other endpoints (`video-frames` list, `channels` PATCH, upload) still go through `loadAuthorisedContainer` + `authenticate` middleware.

## Defense in depth (preserved)

- Channel name regex/whitelist (path-traversal cover)
- Resolved-path-inside-UPLOAD_DIR check (defense against `originalPath` corruption)
- Channel whitelist against the container's declared channels

## Verification

- ✅ TS check clean (`npx tsc --noEmit`)
- ✅ Anonymous fetch on prod: `/api/images/<frame>/frame-data?channel=ch0` → **200** `image/png`
- ✅ Editor at `/segmentation/<pid>/<fid>` now renders the canvas image (DNA origami microtubule frame visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Video frame data endpoint is now publicly accessible without requiring authentication or project authorization; access is controlled through UUID-based capability model

* **Refactoring**
  * Internal image loading and validation logic reorganized for improved code reusability across multiple handlers and access contexts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->