### PR TITLE
fix(editor): correct back/next ordering for video frames + use BE projectChannels for Segment All

### DIFF
--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -21,6 +21,13 @@ export const useProjectData = (
     import('@/types').ProjectType | undefined
   >(undefined);
   const [images, setImages] = useState<ProjectImage[]>([]);
+  // Distinct channel names across all video containers in this project,
+  // sourced from the BE response metadata. Used by the Segment-All channel
+  // picker — `extractChannelsFromPaths` only sees the segmentation-source
+  // channel per frame (others live on disk but aren't referenced in
+  // `originalPath`), so deriving from paths alone misses multi-channel
+  // videos. Container `channels` JSON is the source of truth.
+  const [projectChannels, setProjectChannels] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
 
   // Track pending requests to prevent duplicates
@@ -54,6 +61,7 @@ export const useProjectData = (
         // Backend max is 100 per request; we use lod: 'low' which
         // returns only metadata counts (no polygon arrays) — fast & light.
         let allImages: any[] = [];
+        let aggregatedChannels: string[] = [];
         let page = 1;
         let hasMore = true;
         const limit = 100; // Use max backend limit for fewer round-trips
@@ -76,6 +84,15 @@ export const useProjectData = (
             }
 
             allImages = [...allImages, ...imagesResponse.images];
+            // BE recomputes projectChannels on every page (it queries all
+            // containers, not just the page slice), so keeping the last
+            // response's list is safe and avoids needing a separate fetch.
+            if (
+              imagesResponse.metadata?.projectChannels &&
+              Array.isArray(imagesResponse.metadata.projectChannels)
+            ) {
+              aggregatedChannels = imagesResponse.metadata.projectChannels;
+            }
 
             const totalImages =
               imagesResponse.pagination?.total || imagesResponse.total || 0;
@@ -141,6 +158,7 @@ export const useProjectData = (
         // The grid view uses server-generated thumbnail images, not raw polygons.
         // The segmentation editor loads full polygon data on its own.
         setImages(formattedImages);
+        setProjectChannels(aggregatedChannels);
 
         logger.debug(
           `Loaded ${formattedImages.length} images for project ${projectId}`
@@ -301,6 +319,7 @@ export const useProjectData = (
     projectType,
     setProjectType,
     images,
+    projectChannels,
     loading,
     updateImages,
     refreshImageSegmentation,

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -80,6 +80,7 @@ const ProjectDetail = () => {
     projectType,
     setProjectType,
     images,
+    projectChannels,
     loading,
     updateImages,
     refreshImageSegmentation,
@@ -1276,9 +1277,19 @@ const ProjectDetail = () => {
     // SyntheticEvent as the first arg when handleSegmentAll is wired
     // directly, instead of through an arrow wrapper).
     if (typeof channelOverride !== 'string') {
-      const detectedChannels = extractChannelsFromPaths(
-        images.map(img => (img as { originalPath?: string }).originalPath)
-      );
+      // Prefer the BE-aggregated `projectChannels` (sourced from the video
+      // container's `channels` JSON — all declared channels regardless of
+      // which one is the segmentation source). `extractChannelsFromPaths`
+      // is a fallback for legacy data: it only sees the channel that's
+      // referenced in `originalPath` (per-frame ch0.png), so it would
+      // hide ch1/ch2 even though they live on disk and the user wants
+      // to pick one to segment.
+      const detectedChannels =
+        projectChannels && projectChannels.length > 0
+          ? projectChannels
+          : extractChannelsFromPaths(
+              images.map(img => (img as { originalPath?: string }).originalPath)
+            );
       if (detectedChannels.length > 1 && !pendingChannelChoice) {
         // Default to the first channel; backend already validates against the
         // queue row's set so an unknown token returns 400 cleanly.

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -960,18 +960,44 @@ const SegmentationEditor = () => {
   const navigateToImage = (direction: 'prev' | 'next') => {
     if (!projectImages?.length) return;
 
+    const current = projectImages.find(img => img.id === imageId);
+    if (!current) return;
+
+    // Video frame children navigate by `frameIndex` ascending, not by
+    // gallery sort order. The gallery defaults to `updatedAt DESC` which
+    // would otherwise invert the meaning of next/back for users — frame 3
+    // sits at array index 0 (newest), frame 1 at index N-1 (oldest), so
+    // clicking "next" from frame 2 (array index 1) would jump to frame 1.
+    if (current.parentVideoId) {
+      const siblings = projectImages
+        .filter(img => img.parentVideoId === current.parentVideoId)
+        .sort((a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0));
+      const idx = siblings.findIndex(img => img.id === imageId);
+      if (idx < 0) return;
+      const target =
+        direction === 'next'
+          ? siblings[(idx + 1) % siblings.length]
+          : siblings[(idx - 1 + siblings.length) % siblings.length];
+      if (target) {
+        startTransition(() => {
+          navigate(`/segmentation/${projectId}/${target.id}`);
+        });
+      }
+      return;
+    }
+
+    // Standalone image: fall back to gallery sort order.
     const currentIndex = projectImages.findIndex(img => img.id === imageId);
     if (currentIndex === -1) return;
 
-    let nextIndex;
-
-    if (direction === 'next') {
-      nextIndex =
-        currentIndex < projectImages.length - 1 ? currentIndex + 1 : 0;
-    } else {
-      nextIndex =
-        currentIndex > 0 ? currentIndex - 1 : projectImages.length - 1;
-    }
+    const nextIndex =
+      direction === 'next'
+        ? currentIndex < projectImages.length - 1
+          ? currentIndex + 1
+          : 0
+        : currentIndex > 0
+          ? currentIndex - 1
+          : projectImages.length - 1;
 
     const nextImage = projectImages[nextIndex];
     if (nextImage) {
@@ -1129,8 +1155,34 @@ const SegmentationEditor = () => {
     [editor.editMode]
   );
 
-  const currentImageIndex =
-    projectImages?.findIndex(img => img.id === imageId) ?? -1;
+  // Compute navigation context that EditorHeader uses for the
+  // currentImageIndex / totalImages display + the Back/Next disabled
+  // gating. For video frame children we treat the sibling frames as the
+  // navigation domain (sorted by frameIndex ascending) so that the
+  // "X / Y" counter reads "Frame 2 / 3" instead of "Frame 1 of 301" and
+  // the Back button on the first frame (frameIndex 0) is correctly
+  // disabled regardless of gallery sort order.
+  const navContext = useMemo(() => {
+    if (!projectImages?.length) {
+      return { index: -1, total: 0 };
+    }
+    const current = projectImages.find(img => img.id === imageId);
+    if (current?.parentVideoId) {
+      const siblings = projectImages
+        .filter(img => img.parentVideoId === current.parentVideoId)
+        .sort((a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0));
+      return {
+        index: siblings.findIndex(img => img.id === imageId),
+        total: siblings.length,
+      };
+    }
+    return {
+      index: projectImages.findIndex(img => img.id === imageId),
+      total: projectImages.length,
+    };
+  }, [projectImages, imageId]);
+
+  const currentImageIndex = navContext.index;
 
   const visiblePolygons = useMemo(
     () =>
@@ -1222,7 +1274,7 @@ const SegmentationEditor = () => {
               selectedImage.name ? selectedImage.name.normalize('NFC') : ''
             }
             currentImageIndex={currentImageIndex !== -1 ? currentImageIndex : 0}
-            totalImages={projectImages?.length || 0}
+            totalImages={navContext.total}
             onNavigate={navigateToImage}
             hasUnsavedChanges={editor.hasUnsavedChanges}
             onSave={editor.handleSave}

--- a/src/pages/segmentation/__tests__/navigateToImage.test.ts
+++ b/src/pages/segmentation/__tests__/navigateToImage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirror of the navigation logic in SegmentationEditor.tsx — keeps the
+// test isolated from React rendering. If the implementation changes,
+// keep this mirror in sync.
+function chooseNextFrame(
+  projectImages: Array<{
+    id: string;
+    parentVideoId?: string | null;
+    frameIndex?: number | null;
+  }>,
+  currentId: string,
+  direction: 'prev' | 'next'
+): string | null {
+  const current = projectImages.find(img => img.id === currentId);
+  if (!current) return null;
+
+  if (current.parentVideoId) {
+    const siblings = projectImages
+      .filter(img => img.parentVideoId === current.parentVideoId)
+      .sort((a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0));
+    const idx = siblings.findIndex(img => img.id === currentId);
+    if (idx < 0) return null;
+    const target =
+      direction === 'next'
+        ? siblings[(idx + 1) % siblings.length]
+        : siblings[(idx - 1 + siblings.length) % siblings.length];
+    return target?.id ?? null;
+  }
+
+  const currentIndex = projectImages.findIndex(img => img.id === currentId);
+  if (currentIndex === -1) return null;
+
+  const nextIndex =
+    direction === 'next'
+      ? currentIndex < projectImages.length - 1
+        ? currentIndex + 1
+        : 0
+      : currentIndex > 0
+        ? currentIndex - 1
+        : projectImages.length - 1;
+  return projectImages[nextIndex]?.id ?? null;
+}
+
+describe('SegmentationEditor navigateToImage', () => {
+  // The gallery defaults to updatedAt DESC, so a 3-frame video has the
+  // newest frame at index 0 and the oldest at index 2. Without the
+  // sibling-by-frameIndex special case, "next" from the middle frame
+  // would land on the oldest frame, surprising the user.
+  const galleryDescByUpdatedAt = [
+    {
+      id: 'frame-3',
+      parentVideoId: 'video-1',
+      frameIndex: 2,
+    },
+    {
+      id: 'frame-2',
+      parentVideoId: 'video-1',
+      frameIndex: 1,
+    },
+    {
+      id: 'frame-1',
+      parentVideoId: 'video-1',
+      frameIndex: 0,
+    },
+  ];
+
+  it('next from frame 2 lands on frame 3 (frameIndex order, NOT gallery sort)', () => {
+    expect(chooseNextFrame(galleryDescByUpdatedAt, 'frame-2', 'next')).toBe(
+      'frame-3'
+    );
+  });
+
+  it('prev from frame 2 lands on frame 1 (frameIndex order, NOT gallery sort)', () => {
+    expect(chooseNextFrame(galleryDescByUpdatedAt, 'frame-2', 'prev')).toBe(
+      'frame-1'
+    );
+  });
+
+  it('next wraps from last frame back to first frame', () => {
+    expect(chooseNextFrame(galleryDescByUpdatedAt, 'frame-3', 'next')).toBe(
+      'frame-1'
+    );
+  });
+
+  it('prev wraps from first frame to last frame', () => {
+    expect(chooseNextFrame(galleryDescByUpdatedAt, 'frame-1', 'prev')).toBe(
+      'frame-3'
+    );
+  });
+
+  it('frames of different containers do not interfere', () => {
+    const twoVideos = [
+      { id: 'a-1', parentVideoId: 'video-A', frameIndex: 0 },
+      { id: 'a-2', parentVideoId: 'video-A', frameIndex: 1 },
+      { id: 'b-1', parentVideoId: 'video-B', frameIndex: 0 },
+      { id: 'b-2', parentVideoId: 'video-B', frameIndex: 1 },
+    ];
+    expect(chooseNextFrame(twoVideos, 'a-1', 'next')).toBe('a-2');
+    expect(chooseNextFrame(twoVideos, 'a-2', 'next')).toBe('a-1'); // wraps within A
+    expect(chooseNextFrame(twoVideos, 'b-1', 'next')).toBe('b-2');
+  });
+
+  it('standalone images use the gallery sort order', () => {
+    const standalones = [
+      { id: 'newest', parentVideoId: null, frameIndex: null },
+      { id: 'middle', parentVideoId: null, frameIndex: null },
+      { id: 'oldest', parentVideoId: null, frameIndex: null },
+    ];
+    expect(chooseNextFrame(standalones, 'middle', 'next')).toBe('oldest');
+    expect(chooseNextFrame(standalones, 'middle', 'prev')).toBe('newest');
+    expect(chooseNextFrame(standalones, 'newest', 'prev')).toBe('oldest');
+    expect(chooseNextFrame(standalones, 'oldest', 'next')).toBe('newest');
+  });
+
+  it('returns null for an unknown image id', () => {
+    expect(chooseNextFrame(galleryDescByUpdatedAt, 'unknown', 'next')).toBe(
+      null
+    );
+  });
+});


### PR DESCRIPTION
## Summary

User report (CZ): _"tlačítka back a next jsou i videa nějak špatně. back funguje jako next a obráceně. a segment all neví, jaký channel má segmentovat - má se zeptat uživatele."_

Two unrelated bugs sharing the symptom "video editor doesn't behave correctly":

## 1. Back / Next swap

**Root cause**: `projectImages` is sorted by `updatedAt DESC` (gallery default), so a 3-frame video puts Frame 3 (newest) at array index 0 and Frame 1 (oldest) at index 2. The editor's `navigateToImage` used array index, so "Next" from Frame 2 (index 1) jumped to Frame 1 (index 2) instead of Frame 3 — and vice versa.

**Fix**: when the current image has `parentVideoId`, navigate within siblings sorted by `frameIndex` ascending. Also derive `currentImageIndex` / `totalImages` from the sibling list so the disabled state matches first/last frame, not first/last gallery position.

## 2. Segment All channel picker silent

**Root cause**: `extractChannelsFromPaths` derives channels from each frame's `originalPath`, but `originalPath` only references the segmentation-source channel (`ch0.png`). The other channels live on disk + in the container's `channels` JSON but never reach the helper. Multi-channel videos showed `length === 1`, so the channel-picker dialog never opened and Segment All silently used ch0.

The BE already aggregates `metadata.projectChannels` from all containers' JSON in `getProjectImagesWithThumbnails`. FE had the type but never consumed the value.

**Fix**: `useProjectData` stores `projectChannels` and exposes it from the hook. `handleSegmentAll` prefers `projectChannels` (all declared) over `extractChannelsFromPaths` (segmentation-source only). Path-based extraction stays as a fallback.

## Verification

**Tests**: 7 new vitest cases in `src/pages/segmentation/__tests__/navigateToImage.test.ts` covering forward/backward navigation, wrap behavior, multi-container isolation, standalone-image fallback, unknown id handling. All pass.

**E2E on prod** (test account `12bprusek`, MT project, 3-frame TIFF with ch0/ch1/ch2):
- ✅ Frame 2 → Next → Frame 3 (was: Frame 1); Frame 2 → Back → Frame 1 (was: Frame 3)
- ✅ Back disabled on Frame 1, Next disabled on Frame 3
- ✅ Segment All opens dialog "Select channel to segment" with options **ch0 / ch1 / ch2** (was: silent submit with ch0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Video projects now use backend-provided channel lists for improved channel selection during segmentation workflows.

* **Improvements**
  * Frame navigation in the segmentation editor is now optimized for video projects—frames navigate within their parent video instead of the entire gallery.

* **Tests**
  * Added test coverage for video frame navigation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/168)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->