### PR TITLE
fix(polyline-canvas): wider hit area + endpoint dots only when selected

### DIFF
--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -279,6 +279,29 @@ const CanvasPolygon = React.memo(
           onMouseLeave={isPolyline ? handleMouseLeave : undefined}
           style={{ outline: 'none' }}
         >
+          {/* Polyline hit-area: invisible thick stroke layered UNDER the
+              visible path. Polylines are 1-D — the visible stroke is only
+              a couple of pixels wide, so right-click / hover would
+              otherwise demand pixel-perfect aim. A 12× wider transparent
+              stroke makes the click target comfortable without changing
+              the rendered look. Pointer-events confined to the stroke so
+              the surrounding canvas drag/zoom still works. */}
+          {isPolyline && pathString && (
+            <path
+              d={pathString}
+              fill="none"
+              stroke="transparent"
+              strokeWidth={Math.max(strokeWidth * 12, 6)}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              onClick={handleClick}
+              onDoubleClick={handleDoubleClick}
+              vectorEffect="non-scaling-stroke"
+              pointerEvents="stroke"
+              style={{ cursor: 'pointer' }}
+            />
+          )}
+
           {/* Polygon/Polyline path - render even if path is empty for testing */}
           <path
             d={pathString || 'M0,0'}
@@ -319,8 +342,12 @@ const CanvasPolygon = React.memo(
             pointerEvents={isPolyline ? 'stroke' : 'all'}
           />
 
-          {/* Polyline endpoint markers (small circles at start and end) */}
-          {isPolyline && validPoints.length >= 2 && (
+          {/* Polyline endpoint markers — only when the polyline is
+              selected. In the default non-selected state we want the MTs
+              to read as plain curves on the image (no extra dots
+              cluttering the visual). When selected they reappear as a
+              visual aid for the vertex-editing workflow. */}
+          {isPolyline && isSelected && validPoints.length >= 2 && (
             <>
               <circle
                 cx={validPoints[0].x}


### PR DESCRIPTION
## Summary

Follow-up to user feedback on MT polyline UX:
- Right-click landed only on the few visible stroke pixels — needs pixel-perfect aim
- Small endpoint dots clutter the rendered image; user wants polylines to read as **plain curves** in non-selected state

## Two scoped changes in `CanvasPolygon.tsx`

### 1. Wider hit area

Layer an invisible "hit-area" path **under** the visible polyline stroke — same `d`, 12× the visible stroke width, `stroke="transparent"`, `pointer-events="stroke"`. The visible look is unchanged; right-click / hover become forgiving without disturbing the surrounding canvas drag/zoom.

### 2. Endpoint dots only when selected

The start / end circle markers are gated by `isSelected`. Default (non-selected) state renders the polyline as a plain curve — no decoration. Click the polyline → dots reappear as the vertex-editing affordance.

Applies uniformly to **all polylines** (MT / sperm / future) — the user reported on MT but the same UX benefit lands everywhere.

## Notes

- No new props → `React.memo` comparator untouched. Existing `isSelected` + `pathString` deps already trigger re-render on selection / point edits.
- TS clean (`npx tsc --noEmit`).
- Built + deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interaction targeting for polylines in the segmentation canvas—clicking and hovering on thin lines is now more responsive.

* **Improvements**
  * Endpoint markers on polylines now display only when selected, reducing visual clutter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->