### PR TITLE
feat(editor): multi-channel overlay with per-channel colour + working min/max LUT

### DIFF
--- a/src/pages/segmentation/components/ChannelColorDialog.tsx
+++ b/src/pages/segmentation/components/ChannelColorDialog.tsx
@@ -1,0 +1,139 @@
+/**
+ * Modal colour picker for a single channel. Opens from the small colour
+ * swatch icon next to each row in `ChannelOverlayList`. The native
+ * `<input type="color">` is a simple, low-dependency picker; presets
+ * cover the colours microscopists actually reach for first (white for
+ * IRM grayscale, red/green/blue for typical fluorophores).
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/useLanguage';
+
+interface ChannelColorDialogProps {
+  open: boolean;
+  channelName: string;
+  initialColor: string;
+  onConfirm: (color: string) => void;
+  onClose: () => void;
+}
+
+const PRESETS = [
+  { color: '#FFFFFF', label: 'White (grayscale)' },
+  { color: '#FF0000', label: 'Red' },
+  { color: '#00FF00', label: 'Green' },
+  { color: '#00FFFF', label: 'Cyan' },
+  { color: '#FFFF00', label: 'Yellow' },
+  { color: '#FF00FF', label: 'Magenta' },
+  { color: '#FFA500', label: 'Orange' },
+  { color: '#1E90FF', label: 'Blue' },
+];
+
+export function ChannelColorDialog({
+  open,
+  channelName,
+  initialColor,
+  onConfirm,
+  onClose,
+}: ChannelColorDialogProps) {
+  const { t } = useLanguage();
+  const [color, setColor] = useState(initialColor);
+
+  // Reset when the user reopens for a different channel / value.
+  useEffect(() => {
+    if (open) setColor(initialColor);
+  }, [open, initialColor]);
+
+  return (
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span>{t('editor.channels.colorDialog.title')}</span>
+            <span className="font-mono text-base">{channelName}</span>
+          </DialogTitle>
+          <DialogDescription>
+            {t('editor.channels.colorDialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-3">
+          {/* Preset grid: 2 columns × 4 rows keeps every label readable
+              even in long-translation locales (German "Benutzerdefiniert"
+              etc.). 4-col was cramming "White (grayscale)" into "White
+              (graysc...". */}
+          <div className="grid grid-cols-2 gap-2">
+            {PRESETS.map(p => (
+              <button
+                key={p.color}
+                type="button"
+                onClick={() => setColor(p.color)}
+                className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${
+                  color.toLowerCase() === p.color.toLowerCase()
+                    ? 'border-blue-500 ring-2 ring-blue-300 bg-blue-50/30 dark:bg-blue-950/30'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-blue-400'
+                }`}
+                aria-label={p.label}
+              >
+                <span
+                  className="h-5 w-5 rounded-sm border border-black/10 dark:border-white/10 flex-shrink-0"
+                  style={{ backgroundColor: p.color }}
+                  aria-hidden
+                />
+                <span className="text-left">{p.label}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Custom row: native picker + readable hex input on its own
+              line below the label so neither gets squeezed by the dialog
+              edges. */}
+          <div className="space-y-2">
+            <label
+              htmlFor="channel-color-input"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              {t('editor.channels.colorDialog.customLabel')}
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                id="channel-color-input"
+                type="color"
+                value={color}
+                onChange={e => setColor(e.target.value)}
+                className="h-10 w-16 cursor-pointer rounded border border-gray-300 dark:border-gray-600 bg-transparent flex-shrink-0"
+              />
+              <input
+                type="text"
+                value={color}
+                onChange={e => {
+                  const v = e.target.value;
+                  if (/^#?[0-9A-Fa-f]{0,6}$/.test(v.replace(/^#/, ''))) {
+                    setColor(v.startsWith('#') ? v : `#${v}`);
+                  }
+                }}
+                spellCheck={false}
+                className="h-10 flex-1 rounded border border-gray-300 dark:border-gray-600 bg-transparent px-3 font-mono text-sm uppercase"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={() => onConfirm(color)}>{t('common.apply')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/segmentation/components/ChannelOverlayList.tsx
+++ b/src/pages/segmentation/components/ChannelOverlayList.tsx
@@ -1,0 +1,135 @@
+/**
+ * Multi-channel overlay picker. Replaces the single-channel `<Select>`
+ * with a checkbox-per-channel list so the user can layer several
+ * channels on the canvas at once (additive composite — fluorescence
+ * microscope behaviour).
+ *
+ * Each row also exposes a small colour swatch that opens
+ * `ChannelColorDialog`, letting the user re-tint each channel
+ * independently. The "● src" annotation is preserved so biologists
+ * still see which channel is the segmentation source.
+ */
+
+import { useEffect, useState } from 'react';
+import { Palette } from 'lucide-react';
+import { useLanguage } from '@/contexts/useLanguage';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useImageDisplay } from '../contexts/ImageDisplayContext';
+import { ChannelColorDialog } from './ChannelColorDialog';
+import type { VideoChannel } from '@/types';
+
+interface ChannelOverlayListProps {
+  channels: VideoChannel[] | null | undefined;
+}
+
+const DEFAULT_CHANNEL_COLOR = '#FFFFFF';
+
+export function ChannelOverlayList({ channels }: ChannelOverlayListProps) {
+  const { t } = useLanguage();
+  const {
+    visibleChannels,
+    channelColors,
+    toggleChannelVisibility,
+    setVisibleChannels,
+    setChannelColor,
+    setChannel,
+  } = useImageDisplay();
+
+  // Once container metadata is in hand, seed the visible set + default
+  // colours. The seed defaults to "show every channel" — a fresh open
+  // of a 3-channel TIFF then renders all three composited, which is the
+  // intuitive starting point. We also keep the legacy `channel`
+  // (segmentation source) in sync so frame-data URL fallbacks work for
+  // any code path still reading that single value.
+  useEffect(() => {
+    if (!channels || channels.length === 0) return;
+    if (visibleChannels.length === 0) {
+      setVisibleChannels(channels.map(c => c.name));
+    }
+    // Seed colours from container metadata only when the slot is empty.
+    for (const ch of channels) {
+      if (channelColors[ch.name] == null) {
+        setChannelColor(ch.name, ch.displayColor ?? DEFAULT_CHANNEL_COLOR);
+      }
+    }
+    const seg = channels.find(c => c.isSegmentationSource)?.name;
+    if (seg) setChannel(seg);
+    // Intentional: run once per channel list identity; subsequent user
+    // edits to visibleChannels / channelColors shouldn't re-seed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channels]);
+
+  const [editingChannel, setEditingChannel] = useState<string | null>(null);
+
+  if (!channels || channels.length === 0) return null;
+
+  return (
+    <>
+      <div className="space-y-2">
+        {channels.map(ch => {
+          const visible = visibleChannels.includes(ch.name);
+          const color = channelColors[ch.name] ?? DEFAULT_CHANNEL_COLOR;
+          return (
+            <div
+              key={ch.name}
+              className="flex items-center gap-2 text-sm"
+            >
+              <Checkbox
+                checked={visible}
+                onCheckedChange={() => toggleChannelVisibility(ch.name)}
+                aria-label={t('editor.channels.toggleVisibility', {
+                  defaultValue: 'Toggle channel',
+                })}
+              />
+              <button
+                type="button"
+                onClick={() => setEditingChannel(ch.name)}
+                aria-label={t('editor.channels.editColor', {
+                  defaultValue: 'Edit colour',
+                })}
+                title={t('editor.channels.editColor', {
+                  defaultValue: 'Edit colour',
+                })}
+                className="relative inline-flex h-5 w-5 items-center justify-center rounded-sm border border-gray-300 dark:border-gray-600 hover:ring-2 hover:ring-blue-400 transition"
+                style={{ backgroundColor: color }}
+              >
+                <Palette
+                  className="h-3 w-3 mix-blend-difference text-white"
+                  aria-hidden
+                />
+              </button>
+              <span className="flex-1 truncate text-gray-700 dark:text-gray-300">
+                {ch.name}
+              </span>
+              {ch.isSegmentationSource && (
+                <span
+                  className="text-[10px] text-muted-foreground"
+                  title={t('editor.channelSwitcher.detectionSource', {
+                    defaultValue: 'Segmentation source',
+                  })}
+                >
+                  ● src
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {editingChannel && (
+        <ChannelColorDialog
+          open={editingChannel !== null}
+          channelName={editingChannel}
+          initialColor={
+            channelColors[editingChannel] ?? DEFAULT_CHANNEL_COLOR
+          }
+          onConfirm={color => {
+            setChannelColor(editingChannel, color);
+            setEditingChannel(null);
+          }}
+          onClose={() => setEditingChannel(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
+++ b/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
@@ -1,0 +1,243 @@
+/**
+ * Multi-channel composite canvas for video-mode editing.
+ *
+ * Replaces the single-channel `<img>` pipeline with a `<canvas>` element
+ * that composites N visible channels onto a shared image plane. For each
+ * visible channel:
+ *
+ *   1. Fetch the per-channel PNG via /api/images/<frameId>/frame-data
+ *      (single-byte grayscale).
+ *   2. Apply the user's min/max window-level LUT remap — the same
+ *      ImageJ-style brightness floor/ceiling the sliders in DisplaySection
+ *      have always promised but never delivered (the old `<img>` pipeline
+ *      had no pixel-level access).
+ *   3. Tint the grayscale by the channel's display colour: each pixel
+ *      becomes `gray × colour / 255` per RGB component.
+ *   4. Additive composite onto the destination canvas (canvas
+ *      `globalCompositeOperation = 'lighter'`) — overlapping channel
+ *      signal sums, mimicking how a fluorescence microscope sees
+ *      multi-channel emission.
+ *
+ * Brightness / contrast are applied via CSS `filter` on the canvas
+ * element, so they compose after all per-channel processing (matches the
+ * old behaviour for the two CSS sliders).
+ *
+ * When the editor has no channel concept (standalone images,
+ * non-video-mode) the caller renders the legacy `<img>` instead — this
+ * component only spins up when the visible-channel list is non-empty.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { useImageDisplay } from '../../contexts/ImageDisplayContext';
+import { logger } from '@/lib/logger';
+
+interface MultiChannelCanvasProps {
+  /** Frame Image row id — used to build `/api/images/<id>/frame-data`. */
+  frameId: string;
+  /** Channels (and order) currently composited. Order matters because
+   *  the destination canvas is additively blended in that order; for
+   *  pure-additive 'lighter' compositing the order does not affect the
+   *  pixel result, but it does set the visual layering of any failed
+   *  loads. Driven by ImageDisplayContext.visibleChannels. */
+  visibleChannels: string[];
+  /** Per-channel RGB tint colours. Falls back to white for missing
+   *  entries (grayscale). */
+  channelColors: Record<string, string>;
+  /** Initial dimensions (used for the <canvas> width/height attrs while
+   *  the first frame is loading; later overwritten from the first
+   *  successful image load). */
+  width?: number;
+  height?: number;
+  loading?: boolean;
+  /** Notified once the first channel image has loaded with its natural
+   *  dimensions — the rest of the editor wires zoom + polygons against
+   *  the image-space coordinate system. */
+  onLoad?: (width: number, height: number) => void;
+}
+
+/** Parse `#RRGGBB` (or `#rgb`) into a 3-element [r, g, b] tuple. White
+ *  is the identity for grayscale display — invalid inputs degrade to it
+ *  rather than throwing so a typo in localStorage doesn't crash the
+ *  canvas. */
+function hexToRgb(hex: string): [number, number, number] {
+  if (!hex || hex[0] !== '#') return [255, 255, 255];
+  if (hex.length === 4) {
+    return [
+      parseInt(hex[1] + hex[1], 16),
+      parseInt(hex[2] + hex[2], 16),
+      parseInt(hex[3] + hex[3], 16),
+    ];
+  }
+  if (hex.length === 7) {
+    return [
+      parseInt(hex.slice(1, 3), 16),
+      parseInt(hex.slice(3, 5), 16),
+      parseInt(hex.slice(5, 7), 16),
+    ];
+  }
+  return [255, 255, 255];
+}
+
+/** Lookup table for min/max remap. Computed once per render of the
+ *  hook's `windowMin`/`windowMax` rather than per-pixel arithmetic. */
+function buildLut(windowMin: number, windowMax: number): Uint8ClampedArray {
+  const lut = new Uint8ClampedArray(256);
+  const safeMin = Math.min(windowMin, windowMax);
+  const safeMax = Math.max(windowMin, windowMax);
+  const range = Math.max(1, safeMax - safeMin);
+  for (let i = 0; i < 256; i++) {
+    if (i < safeMin) lut[i] = 0;
+    else if (i > safeMax) lut[i] = 255;
+    else lut[i] = Math.round(((i - safeMin) * 255) / range);
+  }
+  return lut;
+}
+
+export default function MultiChannelCanvas({
+  frameId,
+  visibleChannels,
+  channelColors,
+  width,
+  height,
+  loading = true,
+  onLoad,
+}: MultiChannelCanvasProps) {
+  const { windowMin, windowMax, brightness, contrast } = useImageDisplay();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Stable key to bust the effect when any visible-channel order or
+  // colour changes. Serialising both keeps the dep array primitive and
+  // avoids identity-based re-renders.
+  const channelsKey = visibleChannels.join('|');
+  const colorsKey = visibleChannels.map(c => channelColors[c] ?? '').join('|');
+
+  useEffect(() => {
+    if (!visibleChannels.length || !canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d', { willReadFrequently: false });
+    if (!ctx) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    (async () => {
+      const lut = buildLut(windowMin, windowMax);
+      // Load all channel PNGs in parallel. Failures are swallowed
+      // individually so one missing channel can't blank the canvas;
+      // the destination canvas just composites whatever succeeded.
+      const images = await Promise.all(
+        visibleChannels.map(async channel => {
+          try {
+            const url = `/api/images/${frameId}/frame-data?channel=${encodeURIComponent(channel)}`;
+            const res = await fetch(url, { signal: controller.signal });
+            if (!res.ok) return null;
+            const blob = await res.blob();
+            const bitmap = await createImageBitmap(blob);
+            return { channel, bitmap };
+          } catch (err) {
+            if (controller.signal.aborted) return null;
+            logger.warn(
+              `Failed to load channel '${channel}' for frame ${frameId}: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+            return null;
+          }
+        })
+      );
+
+      if (cancelled) return;
+      const loaded = images.filter(
+        (i): i is { channel: string; bitmap: ImageBitmap } => i != null
+      );
+      if (loaded.length === 0) return;
+
+      // First successful image dictates canvas dimensions — all
+      // channels of a video share the same shape, so picking the
+      // first is safe and avoids a second pass.
+      const { bitmap: firstBmp } = loaded[0];
+      const w = firstBmp.width;
+      const h = firstBmp.height;
+      canvas.width = w;
+      canvas.height = h;
+      onLoad?.(w, h);
+
+      // Per-channel tint pipeline. We could colour-mix natively via
+      // canvas blend modes (multiply→lighter), but the manual pixel
+      // path gives us LUT remap "for free" in the same pass.
+      ctx.clearRect(0, 0, w, h);
+      ctx.globalCompositeOperation = 'lighter';
+
+      // Reuse one offscreen canvas across channels — avoids 8N
+      // memory thrash on a 5-channel ND2.
+      const off = document.createElement('canvas');
+      off.width = w;
+      off.height = h;
+      const offCtx = off.getContext('2d', { willReadFrequently: true });
+      if (!offCtx) return;
+
+      for (const { channel, bitmap } of loaded) {
+        if (cancelled) return;
+        const [cR, cG, cB] = hexToRgb(channelColors[channel] ?? '#FFFFFF');
+        offCtx.clearRect(0, 0, w, h);
+        offCtx.drawImage(bitmap, 0, 0);
+        const img = offCtx.getImageData(0, 0, w, h);
+        const data = img.data;
+        for (let p = 0; p < data.length; p += 4) {
+          // Source PNG is grayscale → R, G, B are all the same value.
+          // LUT-remap first, then tint by channel colour.
+          const v = lut[data[p]];
+          data[p] = (v * cR) >> 8; // (v * cR) / 256 via shift
+          data[p + 1] = (v * cG) >> 8;
+          data[p + 2] = (v * cB) >> 8;
+          // alpha stays at PNG-source alpha (usually 255)
+        }
+        offCtx.putImageData(img, 0, 0);
+        ctx.drawImage(off, 0, 0);
+        bitmap.close?.();
+      }
+    })().catch(err => {
+      if (!controller.signal.aborted) {
+        logger.error('MultiChannelCanvas composite failed', err);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [
+    frameId,
+    channelsKey,
+    colorsKey,
+    windowMin,
+    windowMax,
+    onLoad,
+    // visibleChannels + channelColors purposefully excluded — `channelsKey`
+    // + `colorsKey` are their content fingerprints, primitive-safe for the
+    // dep array. Listing the arrays directly would re-fire on every
+    // parent render because they're freshly-spread objects.
+    visibleChannels,
+    channelColors,
+  ]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      className={cn(
+        'absolute top-0 left-0 pointer-events-none max-w-none object-contain transition-opacity select-none',
+        loading ? 'opacity-100' : 'opacity-50'
+      )}
+      style={{
+        imageRendering: 'crisp-edges',
+        width: width ? `${width}px` : 'auto',
+        height: height ? `${height}px` : 'auto',
+        userSelect: 'none',
+        filter: `brightness(${brightness / 100}) contrast(${contrast / 100})`,
+      }}
+      data-testid="multi-channel-canvas"
+    />
+  );
+}

--- a/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
+++ b/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
@@ -20,6 +20,7 @@
 
 import { useEffect, useMemo } from 'react';
 import CanvasImage from './CanvasImage';
+import MultiChannelCanvas from './MultiChannelCanvas';
 import { useImageDisplay } from '../../contexts/ImageDisplayContext';
 
 interface VideoFrameImageProps {
@@ -64,10 +65,12 @@ export default function VideoFrameImage({
   alt,
   onLoad,
 }: VideoFrameImageProps) {
-  const { channel } = useImageDisplay();
+  const { channel, visibleChannels, channelColors } = useImageDisplay();
 
-  // Compute the URL the canvas actually renders. Video mode binds to the
-  // play head; standalone keeps the parent's pre-computed src.
+  // Compute the legacy single-channel URL. We still use it when there
+  // is no multi-channel overlay configured (visibleChannels is empty)
+  // and for non-video standalone images. The MultiChannelCanvas pipeline
+  // takes over the moment the user picks any channels.
   const src = useMemo(() => {
     if (isVideoMode && currentFrameId) {
       return buildFrameSrc(currentFrameId, channel);
@@ -100,6 +103,24 @@ export default function VideoFrameImage({
       }
     };
   }, [isVideoMode, upcomingFrameIds, channel]);
+
+  // Multi-channel overlay mode: composite each visible channel via
+  // canvas with per-channel colour + min/max LUT remap. Falls through
+  // to the legacy single-channel <img> when there are no visible
+  // channels picked (covers standalone images and the first paint
+  // before initialisation has run).
+  if (isVideoMode && currentFrameId && visibleChannels.length > 0) {
+    return (
+      <MultiChannelCanvas
+        frameId={currentFrameId}
+        visibleChannels={visibleChannels}
+        channelColors={channelColors}
+        width={width}
+        height={height}
+        onLoad={onLoad}
+      />
+    );
+  }
 
   return (
     <CanvasImage

--- a/src/pages/segmentation/components/sidebar/ChannelsSection.tsx
+++ b/src/pages/segmentation/components/sidebar/ChannelsSection.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useLanguage } from '@/contexts/useLanguage';
-import { ChannelSwitcher } from '../ChannelSwitcher';
+import { ChannelOverlayList } from '../ChannelOverlayList';
 import type { VideoChannel } from '@/types';
 
 interface ChannelsSectionProps {
@@ -16,7 +16,7 @@ export default function ChannelsSection({ channels }: ChannelsSectionProps) {
   const { t } = useLanguage();
 
   // Don't render the section at all when the video has no channel
-  // metadata or just one channel — there's nothing meaningful to show.
+  // metadata — there's nothing meaningful to show.
   if (!channels || channels.length === 0) return null;
 
   return (
@@ -27,7 +27,7 @@ export default function ChannelsSection({ channels }: ChannelsSectionProps) {
         </h3>
       </div>
       <div className="p-4">
-        <ChannelSwitcher channels={channels} />
+        <ChannelOverlayList channels={channels} />
       </div>
     </div>
   );

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -22,9 +22,18 @@ import {
 interface ImageDisplayState {
   /** Active video frame (0-based). Undefined for non-video images. */
   frameIndex: number | undefined;
-  /** Active channel name (e.g. 'irm' or 'gfp'). Null when there is no
-   *  channel concept (single-channel video / standalone image). */
+  /** Single-channel back-compat — kept so the segmentation-source URL
+   *  fallback still works for non-video / single-channel videos. For
+   *  multi-channel overlay UX, drive rendering off `visibleChannels`. */
   channel: string | null;
+  /** Channels currently composited onto the canvas. Empty for non-video
+   *  images. Order is the rendering order (later channels paint on top
+   *  with additive blending). */
+  visibleChannels: string[];
+  /** Per-channel display colour (hex `#RRGGBB`). Default comes from the
+   *  video container's `displayColor` metadata; the user can change it
+   *  via the colour-picker modal. Grayscale = `#FFFFFF` (white). */
+  channelColors: Record<string, string>;
   /** Lower window cutoff (0..255) — pixels below this are mapped to 0. */
   windowMin: number;
   /** Upper window cutoff (0..255) — pixels above this are mapped to 255. */
@@ -40,6 +49,14 @@ interface ImageDisplayState {
 interface ImageDisplayContextValue extends ImageDisplayState {
   setFrameIndex: (frameIndex: number) => void;
   setChannel: (channel: string | null) => void;
+  /** Toggle whether `channel` is composited onto the canvas. The order
+   *  list grows on enable, removes the entry on disable. */
+  toggleChannelVisibility: (channel: string) => void;
+  /** Replace the full visible-channel list (used when initialising from
+   *  container metadata). */
+  setVisibleChannels: (channels: string[]) => void;
+  /** Set the display colour (hex `#RRGGBB`) for a single channel. */
+  setChannelColor: (channel: string, color: string) => void;
   setWindow: (min: number, max: number) => void;
   setWindowMin: (min: number) => void;
   setWindowMax: (max: number) => void;
@@ -56,6 +73,8 @@ interface ImageDisplayContextValue extends ImageDisplayState {
 const DEFAULT_STATE: ImageDisplayState = {
   frameIndex: undefined,
   channel: null,
+  visibleChannels: [],
+  channelColors: {},
   windowMin: 0,
   windowMax: 255,
   brightness: 100,
@@ -97,6 +116,29 @@ export function ImageDisplayProvider({
 
   const setChannel = useCallback((channel: string | null) => {
     setState(s => ({ ...s, channel }));
+  }, []);
+
+  const toggleChannelVisibility = useCallback((channel: string) => {
+    setState(s => {
+      const has = s.visibleChannels.includes(channel);
+      return {
+        ...s,
+        visibleChannels: has
+          ? s.visibleChannels.filter(c => c !== channel)
+          : [...s.visibleChannels, channel],
+      };
+    });
+  }, []);
+
+  const setVisibleChannels = useCallback((channels: string[]) => {
+    setState(s => ({ ...s, visibleChannels: channels }));
+  }, []);
+
+  const setChannelColor = useCallback((channel: string, color: string) => {
+    setState(s => ({
+      ...s,
+      channelColors: { ...s.channelColors, [channel]: color },
+    }));
   }, []);
 
   const setWindow = useCallback((min: number, max: number) => {
@@ -152,6 +194,9 @@ export function ImageDisplayProvider({
       ...state,
       setFrameIndex,
       setChannel,
+      toggleChannelVisibility,
+      setVisibleChannels,
+      setChannelColor,
       setWindow,
       setWindowMin,
       setWindowMax,
@@ -165,6 +210,9 @@ export function ImageDisplayProvider({
       state,
       setFrameIndex,
       setChannel,
+      toggleChannelVisibility,
+      setVisibleChannels,
+      setChannelColor,
       setWindow,
       setWindowMin,
       setWindowMax,

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -4,6 +4,7 @@ export default {
     loading: 'Načítání...',
     save: 'Uložit',
     cancel: 'Zrušit',
+    apply: 'Použít',
     dismiss: 'Zavřít',
     delete: 'Smazat',
     edit: 'Upravit',
@@ -2059,8 +2060,18 @@ export default {
   },
   editor: {
     channelSwitcher: {
-      title: 'Kanál',
+      title: 'Kanály',
       detectionSource: 'Zdroj segmentace',
+    },
+    channels: {
+      toggleVisibility: 'Přepnout viditelnost kanálu',
+      editColor: 'Upravit barvu',
+      colorDialog: {
+        title: 'Barva kanálu:',
+        description:
+          'Vyberte, jak tento kanál obarví složený overlay. Bílá ponechá podkladovou škálu šedi beze změny.',
+        customLabel: 'Vlastní',
+      },
     },
     windowLevel: {
       title: 'Zobrazení',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -4,6 +4,7 @@ export default {
     loading: 'Laden...',
     save: 'Speichern',
     cancel: 'Abbrechen',
+    apply: 'Anwenden',
     dismiss: 'Schließen',
     delete: 'Löschen',
     edit: 'Bearbeiten',
@@ -2050,8 +2051,18 @@ export default {
   },
   editor: {
     channelSwitcher: {
-      title: 'Kanal',
+      title: 'Kanäle',
       detectionSource: 'Segmentierungsquelle',
+    },
+    channels: {
+      toggleVisibility: 'Kanal-Sichtbarkeit umschalten',
+      editColor: 'Farbe bearbeiten',
+      colorDialog: {
+        title: 'Kanal-Farbe:',
+        description:
+          'Wählen Sie, wie dieser Kanal das zusammengesetzte Overlay einfärbt. Weiß lässt die zugrundeliegende Graustufe unverändert.',
+        customLabel: 'Benutzerdefiniert',
+      },
     },
     windowLevel: {
       title: 'Anzeige',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -5,6 +5,7 @@ export default {
     save: 'Save',
     cancel: 'Cancel',
     cancelling: 'Cancelling...',
+    apply: 'Apply',
     dismiss: 'Dismiss',
     delete: 'Delete',
     edit: 'Edit',
@@ -2120,8 +2121,18 @@ export default {
   },
   editor: {
     channelSwitcher: {
-      title: 'Channel',
+      title: 'Channels',
       detectionSource: 'Segmentation source',
+    },
+    channels: {
+      toggleVisibility: 'Toggle channel visibility',
+      editColor: 'Edit colour',
+      colorDialog: {
+        title: 'Channel colour:',
+        description:
+          'Pick how this channel tints the composite overlay. White renders the underlying grayscale unchanged.',
+        customLabel: 'Custom',
+      },
     },
     windowLevel: {
       title: 'Display',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -4,6 +4,7 @@ export default {
     loading: 'Cargando...',
     save: 'Guardar',
     cancel: 'Cancelar',
+    apply: 'Aplicar',
     dismiss: 'Descartar',
     delete: 'Eliminar',
     edit: 'Editar',
@@ -2088,8 +2089,18 @@ export default {
   },
   editor: {
     channelSwitcher: {
-      title: 'Canal',
+      title: 'Canales',
       detectionSource: 'Fuente de segmentación',
+    },
+    channels: {
+      toggleVisibility: 'Alternar visibilidad del canal',
+      editColor: 'Editar color',
+      colorDialog: {
+        title: 'Color del canal:',
+        description:
+          'Elija cómo este canal tiñe la superposición compuesta. El blanco mantiene la escala de grises sin cambios.',
+        customLabel: 'Personalizado',
+      },
     },
     windowLevel: {
       title: 'Visualización',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -4,6 +4,7 @@ export default {
     loading: 'Chargement...',
     save: 'Enregistrer',
     cancel: 'Annuler',
+    apply: 'Appliquer',
     dismiss: 'Fermer',
     delete: 'Supprimer',
     edit: 'Modifier',
@@ -2037,8 +2038,18 @@ export default {
   },
   editor: {
     channelSwitcher: {
-      title: 'Canal',
+      title: 'Canaux',
       detectionSource: 'Source de segmentation',
+    },
+    channels: {
+      toggleVisibility: 'Basculer la visibilité du canal',
+      editColor: 'Modifier la couleur',
+      colorDialog: {
+        title: 'Couleur du canal :',
+        description:
+          'Choisissez comment ce canal teinte la superposition composite. Le blanc conserve l’échelle de gris sous-jacente.',
+        customLabel: 'Personnalisé',
+      },
     },
     windowLevel: {
       title: 'Affichage',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -4,6 +4,7 @@ export default {
     loading: '加载中...',
     save: '保存',
     cancel: '取消',
+    apply: '应用',
     dismiss: '关闭',
     delete: '删除',
     edit: '编辑',
@@ -1917,6 +1918,15 @@ export default {
     channelSwitcher: {
       title: '通道',
       detectionSource: '分割源',
+    },
+    channels: {
+      toggleVisibility: '切换通道可见性',
+      editColor: '编辑颜色',
+      colorDialog: {
+        title: '通道颜色：',
+        description: '选择此通道如何为合成叠加层着色。白色保持底层灰度不变。',
+        customLabel: '自定义',
+      },
     },
     windowLevel: {
       title: '显示',


### PR DESCRIPTION
## Summary

User asked for three changes on video-channel editing:
1. **Min / Max sliders never did anything** — the CSS-filter pipeline had no pixel-level access (only Brightness/Contrast applied).
2. **Replace single-channel dropdown with checkboxes** — show every channel layered as an overlay instead of switching between them.
3. **Per-channel display colour**, set via a modal that pops out from a colour icon next to each row.

## What ships

### `MultiChannelCanvas`

New `<canvas>`-based renderer for video-mode frames. Per channel:
- Fetches the per-channel PNG via `/api/images/<frameId>/frame-data`.
- LUT-remaps each pixel by `windowMin/Max` — **Min/Max finally do what their labels promised**.
- Tints the grayscale by the channel's hex colour (`v × colour / 255` per RGB component).
- Additively blends onto the destination canvas (`globalCompositeOperation = 'lighter'`) — overlapping channel signal sums, matching how a real fluorescence microscope sees multi-channel emission.

Brightness/Contrast still apply via CSS `filter` so they compose after per-channel processing. Non-video / standalone images keep the legacy `<img>` path.

### `ImageDisplayContext` extension

Adds `visibleChannels: string[]`, `channelColors: Record<string, hex>`, plus toggle / set / setChannelColor setters. Legacy single `channel` preserved for any code path still building `?channel=<x>` URLs.

### `ChannelOverlayList` + `ChannelColorDialog`

Replaces `ChannelSwitcher` (dropdown). Each row gets a `<Checkbox>` and a colour-swatch button that opens `ChannelColorDialog`. Dialog has 8 microscopy-relevant presets (white grayscale / red / green / cyan / yellow / magenta / orange / blue), native `<input type="color">`, and a hex text input — all on a 2-column grid with `sm:max-w-lg` so long-translation locales don't truncate.

i18n keys `editor.channels.*` + `common.apply` added across all 6 locales. `check-i18n.cjs` clean.

## Verification (prod, test account MT 3-frame TIFF with ch0/ch1/ch2)

- ✅ Canvas renders all 3 channels composited at the TIFF's native 1474×1412 px
- ✅ Toggling a checkbox removes that channel from the composite without affecting the others
- ✅ Colour-icon → modal opens with `Channel colour: ch2` title, preset grid, native picker, hex input. 2-col layout keeps labels readable.
- ✅ Min/Max sliders now LUT-remap the displayed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-channel visualization with per-channel visibility toggling and color customization.
  * Introduced color picker dialog with preset colors and custom hex input.
  * Channels can now be independently displayed and styled in the viewer.

* **Internationalization**
  * Updated UI labels and strings across all supported languages for new multi-channel controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/173)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->