### PR TITLE
fix(editor): plumb projectType into context menu (was undefined), MT kymograph + Hide-all + Pentagon icon

### DIFF
--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -92,6 +92,7 @@ const SegmentationEditor = () => {
   // Instead, we fetch only metadata and load segmentation data on-demand
   const {
     projectTitle,
+    projectType,
     images,
     loading: projectLoading,
     refreshImageSegmentation,
@@ -1295,7 +1296,7 @@ const SegmentationEditor = () => {
           {videoContainerId && (
             <VideoModeOverlay
               videoContainerId={videoContainerId}
-              projectType={project?.type as ProjectType | undefined}
+              projectType={projectType}
             />
           )}
 
@@ -1451,6 +1452,11 @@ const SegmentationEditor = () => {
                             }
                             onDeleteVertex={handleDeleteVertexFromContextMenu}
                             onHover={setHoveredPolygonId}
+                            // Drives sperm-vs-microtubule context-menu
+                            // gating inside PolygonContextMenu — sperm
+                            // items appear only on sperm projects, the
+                            // kymograph item only on microtubule projects.
+                            projectType={projectType}
                           />
                         ))}
 

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -58,9 +58,22 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
 
   if (sorted.length === 0) return null;
 
+  const allHidden = sorted.every(mt => hiddenPolygonIds?.has(mt.id) ?? false);
+  const handleToggleAll = () => {
+    if (!onToggleVisibility) return;
+    // Iterating onToggleVisibility per row is the only API we have; the
+    // current set drives the direction so a single click reaches a
+    // consistent end-state (no flicker between mixed states).
+    for (const mt of sorted) {
+      const isHidden = hiddenPolygonIds?.has(mt.id) ?? false;
+      if (allHidden && isHidden) onToggleVisibility(mt.id);
+      else if (!allHidden && !isHidden) onToggleVisibility(mt.id);
+    }
+  };
+
   return (
     <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 dark:bg-gray-900">
-      <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+      <div className="p-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
           <Spline className="h-4 w-4" />
           {t('microtubule.instancePanel')}{' '}
@@ -68,6 +81,25 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
             ({sorted.length})
           </span>
         </h4>
+        {onToggleVisibility && (
+          <button
+            type="button"
+            onClick={handleToggleAll}
+            className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+            title={
+              allHidden ? t('microtubule.showAll') : t('microtubule.hideAll')
+            }
+          >
+            {allHidden ? (
+              <EyeOff className="h-3.5 w-3.5" />
+            ) : (
+              <Eye className="h-3.5 w-3.5" />
+            )}
+            <span>
+              {allHidden ? t('microtubule.showAll') : t('microtubule.hideAll')}
+            </span>
+          </button>
+        )}
       </div>
 
       <div className="max-h-64 overflow-y-auto">

--- a/src/pages/segmentation/components/VerticalToolbar.tsx
+++ b/src/pages/segmentation/components/VerticalToolbar.tsx
@@ -4,7 +4,7 @@ import {
   MousePointer,
   Edit3,
   Plus,
-  PenTool,
+  Pentagon,
   Spline,
   Scissors,
   Trash2,
@@ -48,7 +48,7 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
       case EditMode.AddPoints:
         return Plus;
       case EditMode.CreatePolygon:
-        return PenTool;
+        return Pentagon;
       case EditMode.CreatePolyline:
         return Spline;
       case EditMode.Slice:

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -4,6 +4,7 @@ import { Polygon } from '@/lib/segmentation';
 import PolygonVertices from './PolygonVertices';
 import PolygonContextMenu from '../context-menu/PolygonContextMenu';
 import { VertexDragState, EditMode } from '@/pages/segmentation/types';
+import type { ProjectType } from '@/types';
 import {
   colorFromInstanceId,
   isMicrotubuleInstance,
@@ -33,6 +34,11 @@ interface CanvasPolygonProps {
   onDuplicateVertex?: (polygonId: string, vertexIndex: number) => void;
   onHover?: (polygonId: string | null) => void;
   editMode?: EditMode;
+  /** Project-type gate for the polyline context menu. Sperm items only
+   *  appear for ``'sperm'`` projects; the kymograph item is exclusive
+   *  to ``'microtubules'``. Without this gate, MT users saw the sperm
+   *  head/midpiece/tail items just because the callbacks were truthy. */
+  projectType?: ProjectType;
 }
 
 const CanvasPolygon = React.memo(
@@ -57,6 +63,7 @@ const CanvasPolygon = React.memo(
     onDuplicateVertex,
     onHover,
     editMode,
+    projectType,
   }: CanvasPolygonProps) => {
     const { id, points, type = 'external', parent_id } = polygon;
 
@@ -263,6 +270,7 @@ const CanvasPolygon = React.memo(
         onSlice={handleSlice}
         onEdit={handleEdit}
         isPolyline={isPolyline}
+        projectType={projectType}
         onChangePartClass={isPolyline ? handleChangePartClass : undefined}
         onChangeInstanceId={isPolyline ? handleChangeInstanceId : undefined}
         currentInstanceId={isPolyline ? polygon.instanceId : undefined}
@@ -447,7 +455,12 @@ const CanvasPolygon = React.memo(
       sameDragOffset &&
       prevProps.onChangePartClass === nextProps.onChangePartClass &&
       prevProps.onChangeInstanceId === nextProps.onChangeInstanceId &&
-      prevProps.availableInstanceIds === nextProps.availableInstanceIds
+      prevProps.availableInstanceIds === nextProps.availableInstanceIds &&
+      // projectType drives the context-menu's sperm-vs-MT gating; if
+      // we forget to compare it here, switching project types in the
+      // same session (or a per-polygon override one day) wouldn't
+      // re-render the menu and the user would see stale options.
+      prevProps.projectType === nextProps.projectType
     );
   }
 );

--- a/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
+++ b/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
@@ -6,8 +6,9 @@ import {
   ContextMenuTrigger,
   ContextMenuSeparator,
 } from '@/components/ui/context-menu';
-import { Trash, Scissors, Edit, Link } from 'lucide-react';
+import { Trash, Scissors, Edit, Link, BarChart3 } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
+import type { ProjectType } from '@/types';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,6 +27,11 @@ interface PolygonContextMenuProps {
   onEdit: () => void;
   polygonId: string;
   isPolyline?: boolean;
+  /** Drives which polyline-specific items render. ``'sperm'`` shows the
+   *  head/midpiece/tail re-classify + "Assign to instance N" submenu;
+   *  ``'microtubules'`` shows "Show kymograph"; other types fall back
+   *  to edit + delete only. */
+  projectType?: ProjectType;
   onChangePartClass?: (partClass: 'head' | 'midpiece' | 'tail') => void;
   onChangeInstanceId?: (instanceId: string) => void;
   currentInstanceId?: string;
@@ -37,13 +43,28 @@ const PolygonContextMenu = ({
   onDelete,
   onSlice,
   onEdit,
-  polygonId: _polygonId,
+  polygonId,
   isPolyline = false,
+  projectType,
   onChangePartClass,
   onChangeInstanceId,
   currentInstanceId,
   availableInstanceIds,
 }: PolygonContextMenuProps) => {
+  const isSperm = projectType === 'sperm';
+  const isMicrotubules = projectType === 'microtubules';
+
+  // Fire the global "open kymograph" event that VideoModeOverlay
+  // already listens for — no new prop plumbing needed. The overlay
+  // mounts the KymographModal for the selected polylineId.
+  const handleShowKymograph = React.useCallback(() => {
+    if (typeof document === 'undefined') return;
+    document.dispatchEvent(
+      new CustomEvent('segmentation:open-kymograph', {
+        detail: { polylineId: polygonId },
+      })
+    );
+  }, [polygonId]);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
   const { t } = useLanguage();
 
@@ -66,7 +87,23 @@ const PolygonContextMenu = ({
               <span>{t('contextMenu.splitPolygon')}</span>
             </ContextMenuItem>
           )}
-          {isPolyline && onChangePartClass && (
+          {isPolyline && isMicrotubules && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={handleShowKymograph}
+                className="cursor-pointer"
+              >
+                <BarChart3 className="mr-2 h-4 w-4" />
+                <span>
+                  {t('editor.kymograph.showKymograph', {
+                    defaultValue: 'Show kymograph',
+                  })}
+                </span>
+              </ContextMenuItem>
+            </>
+          )}
+          {isPolyline && isSperm && onChangePartClass && (
             <>
               <ContextMenuSeparator />
               <ContextMenuItem
@@ -102,6 +139,7 @@ const PolygonContextMenu = ({
             </>
           )}
           {isPolyline &&
+            isSperm &&
             onChangeInstanceId &&
             availableInstanceIds &&
             availableInstanceIds.length > 0 && (

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2010,6 +2010,8 @@ export default {
     instance: 'Mikrotubulus',
     hideInstance: 'Skrýt mikrotubulus',
     showInstance: 'Zobrazit mikrotubulus',
+    hideAll: 'Skrýt vše',
+    showAll: 'Zobrazit vše',
   },
   sperm: {
     instancePanel: 'Instance spermií',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2001,6 +2001,8 @@ export default {
     instance: 'Mikrotubulus',
     hideInstance: 'Mikrotubulus ausblenden',
     showInstance: 'Mikrotubulus einblenden',
+    hideAll: 'Alle ausblenden',
+    showAll: 'Alle einblenden',
   },
   sperm: {
     instancePanel: 'Spermien-Instanzen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2072,6 +2072,8 @@ export default {
     instance: 'Microtubule',
     hideInstance: 'Hide microtubule',
     showInstance: 'Show microtubule',
+    hideAll: 'Hide all',
+    showAll: 'Show all',
   },
   sperm: {
     instancePanel: 'Sperm Instances',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2039,6 +2039,8 @@ export default {
     instance: 'Microtúbulo',
     hideInstance: 'Ocultar microtúbulo',
     showInstance: 'Mostrar microtúbulo',
+    hideAll: 'Ocultar todo',
+    showAll: 'Mostrar todo',
   },
   sperm: {
     instancePanel: 'Instancias de espermatozoides',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1988,6 +1988,8 @@ export default {
     instance: 'Microtubule',
     hideInstance: 'Masquer le microtubule',
     showInstance: 'Afficher le microtubule',
+    hideAll: 'Tout masquer',
+    showAll: 'Tout afficher',
   },
   sperm: {
     instancePanel: 'Instances de spermatozoïdes',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1870,6 +1870,8 @@ export default {
     instance: '微管',
     hideInstance: '隐藏微管',
     showInstance: '显示微管',
+    hideAll: '全部隐藏',
+    showAll: '全部显示',
   },
   sperm: {
     instancePanel: '精子实例',


### PR DESCRIPTION
## Summary

User reported (still after PR #171):
1. Right-click on MT polyline shows sperm "Set as head/midpiece/tail" actions
2. Wants "Show kymograph" via right-click on MT
3. Wants "Hide all" toggle in MT instances panel
4. Wants Polygon icon (not PenTool) for Create Polygon button

## Root cause of #1

PR #171 gated sperm callbacks by `polylineKind === 'sperm'` AND by `projectType === 'sperm'` in one of two `PolygonContextMenu` components — but the editor's `project` memo only had `{ name }`, never destructuring `projectType` from `useProjectData`. So `project?.type` was `undefined`, and the gate `projectType === 'sperm'` (or `'microtubules'`) never matched. Sperm options leaked through anyway.

## Fix

- Destructure `projectType` from `useProjectData`, pass to `<VideoModeOverlay>` and to every `<CanvasPolygon>`
- Add `projectType?: ProjectType` to `CanvasPolygon` props + memo comparator
- `context-menu/PolygonContextMenu` (the menu `CanvasPolygon` actually uses) now gates:
  - **Sperm head/midpiece/tail + "Assign to instance N"** → `projectType === 'sperm'` only
  - **"Show kymograph"** (new) → `projectType === 'microtubules'` only; dispatches the existing `segmentation:open-kymograph` event that `VideoModeOverlay` already listens for
- MT users: edit + delete + kymograph (polylines), nothing else

## #3 Hide-all in MT instances panel

Header gets a single Eye / EyeOff toggle iterating `onToggleVisibility` over the sibling list. i18n: `microtubule.hideAll` / `microtubule.showAll` across all 6 locales.

## #4 Pentagon icon

lucide `PenTool` → `Pentagon`. Active colour unchanged.

## Verification

- TS clean, i18n clean
- Built + deployed
- User hard-refresh required (or the stale-chunk auto-reload from PR #169 kicks in on next dynamic import)

## Follow-up tasks deferred to separate PRs

- Polyline slice (split at cut-point)
- Persist channel-color choices per user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk visibility control in the microtubule panel to show or hide all instances at once.
  * Added "Show kymograph" option in the polyline context menu for enhanced microtubule analysis.

* **UI/UX**
  * Updated the polygon creation tool icon in the toolbar for improved visual consistency.

* **Translations**
  * Added show/hide action labels in English, French, German, Spanish, Czech, and Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/174)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->