### PR TITLE
feat(editor): persist channel-colour preferences per user (localStorage)

### DIFF
--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1264,7 +1264,7 @@ const SegmentationEditor = () => {
           (frame # / scrubber), the sidebar (Channels + Display
           sections, future PR), and the canvas (brightness/contrast
           CSS filter) can all read/write the same display state. */}
-      <ImageDisplayProvider>
+      <ImageDisplayProvider userId={user?.id}>
         <EditorLayout>
           {/* Header */}
           <EditorHeader

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -15,6 +15,7 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -95,17 +96,72 @@ export const ImageDisplayContext =
 const clampWindow = (n: number) => Math.max(0, Math.min(255, n));
 const clampPercent = (n: number) => Math.max(0, Math.min(200, n));
 
+/** localStorage key prefix for per-user channel-colour overrides. We
+ *  key on userId so two researchers sharing a browser don't see each
+ *  other's custom tints, and so an anonymous reload doesn't resurrect
+ *  the previous user's choices. */
+const COLOR_PREFS_KEY_PREFIX = 'spheroseg.channelColors.';
+
+function loadColorPrefs(userId: string | undefined): Record<string, string> {
+  if (!userId || typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(COLOR_PREFS_KEY_PREFIX + userId);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
 export function ImageDisplayProvider({
   children,
   initialChannel = null,
+  userId,
 }: {
   children: ReactNode;
   initialChannel?: string | null;
+  /** Drives per-user persistence of channel-colour overrides. When
+   *  unset (anonymous browsing) channel colours stay session-only. */
+  userId?: string;
 }) {
-  const [state, setState] = useState<ImageDisplayState>({
+  // Lazy initializer: hydrate the user's channel-colour preferences
+  // from localStorage on first render so reopens of the editor preserve
+  // "ch0 → red", "ch1 → green", etc.
+  const [state, setState] = useState<ImageDisplayState>(() => ({
     ...DEFAULT_STATE,
     channel: initialChannel,
-  });
+    channelColors: loadColorPrefs(userId),
+  }));
+
+  // Re-hydrate when userId becomes available (auth init races the
+  // first ImageDisplayProvider mount on cold loads). Keep any session
+  // edits made before auth landed — they take precedence over the
+  // persisted value.
+  useEffect(() => {
+    if (!userId) return;
+    setState(s => {
+      const persisted = loadColorPrefs(userId);
+      const merged: Record<string, string> = { ...persisted };
+      for (const [k, v] of Object.entries(s.channelColors)) merged[k] = v;
+      return { ...s, channelColors: merged };
+    });
+  }, [userId]);
+
+  // Persist on every channelColors change. Safari private + quota
+  // errors degrade silently — colour preference is best-effort UX.
+  useEffect(() => {
+    if (!userId || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(
+        COLOR_PREFS_KEY_PREFIX + userId,
+        JSON.stringify(state.channelColors)
+      );
+    } catch {
+      /* storage unavailable — silently degrade */
+    }
+  }, [userId, state.channelColors]);
 
   // Frame/channel changes used to reset windowMin/Max — the user found
   // that annoying when scrubbing a 300-frame video. Now we only update


### PR DESCRIPTION
## Summary

User asked to make the per-channel colour choices in the editor stick across reloads ("uložit do settings"). Going through the BE profile-settings model would be overkill for a UX preference that doesn't need to follow the user across machines — `localStorage` keyed by `userId` is the right tier.

## Implementation

- New `userId?: string` prop on `ImageDisplayProvider`. When set:
  - **Lazy useState** hydrates `channelColors` from `localStorage[spheroseg.channelColors.<userId>]` on first render so the persisted tints land before paint
  - **useEffect** re-hydrates when `userId` arrives later (cold-load race with auth init — session edits made before auth landed take precedence on merge)
  - **useEffect** writes the JSON on every `channelColors` change
- `SegmentationEditor` passes `user?.id` from `useAuth` to the provider

## Why per-user

Two researchers sharing a browser shouldn't see each other's red/green/cyan tints, and an anonymous reload shouldn't resurrect the previous user's preferences.

Safari private + quota errors degrade silently — best-effort UX.

## Verification

- TS clean
- Built + deployed
- Set ch1 to red in the dialog → reload → ch1 swatch is red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User channel color preferences are now persisted automatically and restored across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->