### PR TITLE
feat(editor): Enter commits AddPoints extension on a polyline endpoint

### DIFF
--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -718,8 +718,70 @@ export const useEnhancedSegmentationEditor = ({
   // Ref to hold the polyline finalization callback (set after interactions hook)
   const polylineDoubleClickRef = useRef<(() => void) | null>(null);
   const handleEnterPolyline = useCallback(() => {
-    polylineDoubleClickRef.current?.();
-  }, []);
+    // CreatePolyline mode: forward to the interactions-hook finaliser.
+    if (editMode === EditMode.CreatePolyline) {
+      polylineDoubleClickRef.current?.();
+      return;
+    }
+
+    // AddPoints mode on a polyline endpoint: pressing Enter commits the
+    // tempPoints as an extension of the polyline. This is the only path
+    // that makes sense for open paths — extending from the END outward
+    // never wraps back to a different vertex, so there's no "click
+    // another vertex to finish" trigger. Enter is the natural finish key.
+    if (editMode !== EditMode.AddPoints) return;
+    if (!selectedPolygonId) return;
+    if (!interactionState.isAddingPoints) return;
+    if (!interactionState.addPointStartVertex) return;
+    if (tempPoints.length === 0) return;
+
+    const polygon = polygons.find(p => p.id === selectedPolygonId);
+    if (!polygon || polygon.geometry !== 'polyline') return;
+
+    const startIdx = interactionState.addPointStartVertex.vertexIndex;
+    const last = polygon.points.length - 1;
+    let extended;
+    if (startIdx === 0) {
+      // Extending from the head: new points were placed in click order
+      // from the head outward, so reverse them to land the most recent
+      // click furthest from the original head.
+      extended = [...[...tempPoints].reverse(), ...polygon.points];
+    } else if (startIdx === last) {
+      // Extending from the tail: append in order.
+      extended = [...polygon.points, ...tempPoints];
+    } else {
+      // Not an endpoint — Enter is undefined here. Fall back to no-op
+      // so the user gets ESC + retry instead of a corrupt geometry.
+      return;
+    }
+
+    updatePolygons(
+      polygons.map(p =>
+        p.id === selectedPolygonId ? { ...p, points: extended } : p
+      )
+    );
+    setTempPoints([]);
+    setInteractionState(s => ({
+      ...s,
+      isAddingPoints: false,
+      addPointStartVertex: null,
+      addPointEndVertex: null,
+    }));
+    // Drop back to vertex editing so the user can refine the freshly
+    // extended path right away.
+    setEditMode(EditMode.EditVertices);
+  }, [
+    editMode,
+    selectedPolygonId,
+    interactionState.isAddingPoints,
+    interactionState.addPointStartVertex,
+    tempPoints,
+    polygons,
+    updatePolygons,
+    setTempPoints,
+    setInteractionState,
+    setEditMode,
+  ]);
 
   // Escape handler - always return to View mode
   const handleEscape = useCallback(() => {

--- a/src/pages/segmentation/hooks/useKeyboardShortcuts.tsx
+++ b/src/pages/segmentation/hooks/useKeyboardShortcuts.tsx
@@ -215,9 +215,17 @@ export const useKeyboardShortcuts = ({
           }
           break;
 
-        // Enter - finalize polyline creation
+        // Enter - finalize polyline creation OR commit AddPoints extension
+        // when the user is extending a polyline endpoint outward. The
+        // single onEnter callback in the editor handles both contexts;
+        // it inspects editMode + interactionState to pick the right
+        // path, so the keyboard layer just routes Enter for both.
         case 'enter':
-          if (editMode === EditMode.CreatePolyline && onEnter) {
+          if (
+            (editMode === EditMode.CreatePolyline ||
+              editMode === EditMode.AddPoints) &&
+            onEnter
+          ) {
             event.preventDefault();
             onEnter();
           }


### PR DESCRIPTION
## Summary

User report: extending an MT polyline in **Add Points** mode from the head or tail of the curve has no commit affordance — the existing logic only finishes a sequence when the user clicks a *different* vertex. For an open path going outward there is no second vertex to click, so the user gets stuck halfway through extending.

## Fix

Pressing **Enter** while in Add-Points mode on a polyline endpoint commits the current `tempPoints` sequence as a polyline extension:

- **Head** (vertexIndex 0) → new points prepended in reverse click order, so the most recent click sits furthest from the original head (matches the visual "growing outward" the user sees on each click).
- **Tail** (last index) → new points appended in click order.

State resets and the editor drops back to `EditVertices` so the user can refine the freshly extended path immediately.

## Wiring

- **`useKeyboardShortcuts.tsx`**: Enter now forwards to `onEnter` for both `CreatePolyline` **and** `AddPoints` modes
- **`useEnhancedSegmentationEditor.tsx`**: `handleEnterPolyline` dispatches:
  - `CreatePolyline` → existing `polylineDoubleClickRef` finaliser (unchanged)
  - `AddPoints` with valid endpoint + non-empty tempPoints → new extension geometry

Mid-polyline (non-endpoint) Enter is a no-op — "weld interior insertion" semantic is ambiguous and the existing "click another vertex" path already handles that case correctly.

## Verification

- TS clean (`npx tsc --noEmit`)
- Built + deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard navigation in the segmentation editor. The Enter key now intelligently supports polyline finalization during creation mode and commits added point extensions when in add-points mode, enabling faster keyboard-driven workflows and significantly reducing the need for frequent mouse interactions during polyline and polygon editing and refinement tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->