### PR TITLE
fix(kymograph): make the image actually visible + add 6-locale translations

### DIFF
--- a/src/pages/segmentation/components/KymographModal.tsx
+++ b/src/pages/segmentation/components/KymographModal.tsx
@@ -188,7 +188,22 @@ export function KymographModal({
             <img
               src={`data:image/png;base64,${result.pngBase64}`}
               alt={`Kymograph for ${polylineId}`}
-              className="max-w-full max-h-[500px]"
+              // The BE returns the kymograph as a (frame_count × 200 px)
+              // heatmap. For short videos (e.g. 3 frames → 200×3 native
+              // pixels) the original `max-w-full max-h-[500px]` rendered
+              // it at natural size — a sub-pixel-thin strip. Force a
+              // full-width fill + pixelated upscaling + min-height so the
+              // bands stay visible regardless of frame count, and
+              // `object-fit: fill` makes the heatmap blocks stretch to
+              // the assigned box (we don't need pixel-aspect fidelity —
+              // the *colours* carry the kymograph signal, not the pixel
+              // grid).
+              className="w-full max-h-[500px] block"
+              style={{
+                imageRendering: 'pixelated',
+                minHeight: '200px',
+                objectFit: 'fill',
+              }}
             />
           )}
         </div>

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2065,6 +2065,16 @@ export default {
       title: 'Kanály',
       detectionSource: 'Zdroj segmentace',
     },
+    kymograph: {
+      title: 'Kymograf',
+      sourceChannel: 'Zdrojový kanál',
+      tracked: '🔗 Sledováno napříč snímky',
+      untracked: '⚠ Statická čára (bez sledování)',
+      computing: 'Počítám kymograf…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: 'Zobrazit kymograf',
+    },
     channels: {
       toggleVisibility: 'Přepnout viditelnost kanálu',
       editColor: 'Upravit barvu',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2056,6 +2056,16 @@ export default {
       title: 'Kanäle',
       detectionSource: 'Segmentierungsquelle',
     },
+    kymograph: {
+      title: 'Kymograph',
+      sourceChannel: 'Quellkanal',
+      tracked: '🔗 Über Frames hinweg verfolgt',
+      untracked: '⚠ Statische Linie (keine Verfolgung)',
+      computing: 'Kymograph wird berechnet…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: 'Kymograph anzeigen',
+    },
     channels: {
       toggleVisibility: 'Kanal-Sichtbarkeit umschalten',
       editColor: 'Farbe bearbeiten',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2126,6 +2126,16 @@ export default {
       title: 'Channels',
       detectionSource: 'Segmentation source',
     },
+    kymograph: {
+      title: 'Kymograph',
+      sourceChannel: 'Source channel',
+      tracked: '🔗 Tracked across frames',
+      untracked: '⚠ Static line (no tracking)',
+      computing: 'Computing kymograph…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: 'Show kymograph',
+    },
     channels: {
       toggleVisibility: 'Toggle channel visibility',
       editColor: 'Edit colour',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2094,6 +2094,16 @@ export default {
       title: 'Canales',
       detectionSource: 'Fuente de segmentación',
     },
+    kymograph: {
+      title: 'Kimógrafo',
+      sourceChannel: 'Canal de origen',
+      tracked: '🔗 Seguido entre fotogramas',
+      untracked: '⚠ Línea estática (sin seguimiento)',
+      computing: 'Calculando kimógrafo…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: 'Mostrar kimógrafo',
+    },
     channels: {
       toggleVisibility: 'Alternar visibilidad del canal',
       editColor: 'Editar color',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2043,6 +2043,16 @@ export default {
       title: 'Canaux',
       detectionSource: 'Source de segmentation',
     },
+    kymograph: {
+      title: 'Kymographe',
+      sourceChannel: 'Canal source',
+      tracked: '🔗 Suivi à travers les images',
+      untracked: '⚠ Ligne statique (sans suivi)',
+      computing: 'Calcul du kymographe…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: 'Afficher le kymographe',
+    },
     channels: {
       toggleVisibility: 'Basculer la visibilité du canal',
       editColor: 'Modifier la couleur',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1921,6 +1921,16 @@ export default {
       title: '通道',
       detectionSource: '分割源',
     },
+    kymograph: {
+      title: '时空图',
+      sourceChannel: '源通道',
+      tracked: '🔗 跨帧跟踪',
+      untracked: '⚠ 静态线（无跟踪）',
+      computing: '正在计算时空图…',
+      downloadPng: 'PNG',
+      downloadCsv: 'CSV',
+      showKymograph: '显示时空图',
+    },
     channels: {
       toggleVisibility: '切换通道可见性',
       editColor: '编辑颜色',


### PR DESCRIPTION
## Summary

Two visible bugs in the right-click **Show kymograph** modal:

### 1. Thin strip instead of image

The BE returns the kymograph PNG with shape `(frame_count, length_px=200)` — 200 px wide × N rows tall. For the 3-frame test fixture the native PNG is **200×3 px**. The `<img>` had only `max-w-full max-h-[500px]` (no explicit width, no min-height, no image-rendering hint), so the browser rendered at natural size — a 200×3 sub-pixel-thin strip.

**Fix**: force the heatmap to fill the modal width with crisp pixelated scaling, and guarantee a minimum height so short videos still get readable bands.

```tsx
className="w-full max-h-[500px] block"
style={{
  imageRendering: 'pixelated',
  minHeight: '200px',
  objectFit: 'fill',
}}
```

Orientation matches the user's request: **time on the vertical axis** (rows = frames flow top→bottom), **position along the polyline on the horizontal axis** (cols = 200 resampled samples flow left→right).

### 2. Missing translations

`KymographModal.tsx` and `context-menu/PolygonContextMenu.tsx` together reference 8 `editor.kymograph.*` keys, but **none of the 6 translation files** (EN/CS/ES/DE/FR/ZH) had a `kymograph` block under `editor:`. i18next in this app does not honour `defaultValue` as a runtime fallback — it returns the raw key — so users saw `editor.kymograph.title`, `editor.kymograph.computing` etc.

Added a full `editor.kymograph` block to each locale. `check-i18n.cjs` clean.

## Verification

Prod test account, MT 3-frame TIFF, right-click Show kymograph:
- ✅ Title reads `Kymograph: polyline_1`, not the raw key
- ✅ Image dimensions: **718 × 200 px** (was 200 × 3 native)
- ✅ Visible 3-band viridis heatmap, time vertical, position horizontal
- ✅ Source channel dropdown + Tracked label + PNG/CSV buttons all localised
- ✅ Console: 0 errors from the modal mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive multilingual UI labels for the kymograph feature across all supported languages, enabling proper localization of controls and messaging.

* **Bug Fixes**
  * Improved kymograph image rendering and sizing to ensure proper display across varying frame counts with pixelated upscaling for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/178)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->