### PR TITLE
fix(editor): gate today's polyline UX changes to MT projects only (revert leaks to sperm)

### DIFF
--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -459,6 +459,10 @@ const SegmentationEditor = () => {
     isFromGallery: shouldAutoCenter.current, // Use our auto-center flag
     activePartClassRef,
     activeInstanceIdRef,
+    // Drives MT-only polyline behaviours inside the hook + the
+    // slicing hook it owns (Enter-extends, polyline-slice). Sperm
+    // and other types fall back to the legacy paths.
+    projectType,
     onSave: async (polygons, targetImageId, targetDimensions, signal) => {
       const saveToImageId = targetImageId || imageId;
       if (!projectId || !saveToImageId) return;

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -294,7 +294,7 @@ const CanvasPolygon = React.memo(
               stroke makes the click target comfortable without changing
               the rendered look. Pointer-events confined to the stroke so
               the surrounding canvas drag/zoom still works. */}
-          {isPolyline && pathString && (
+          {isPolyline && projectType === 'microtubules' && pathString && (
             <path
               d={pathString}
               fill="none"
@@ -350,35 +350,40 @@ const CanvasPolygon = React.memo(
             pointerEvents={isPolyline ? 'stroke' : 'all'}
           />
 
-          {/* Polyline endpoint markers — only when the polyline is
-              selected. In the default non-selected state we want the MTs
-              to read as plain curves on the image (no extra dots
-              cluttering the visual). When selected they reappear as a
-              visual aid for the vertex-editing workflow. */}
-          {isPolyline && isSelected && validPoints.length >= 2 && (
-            <>
-              <circle
-                cx={validPoints[0].x}
-                cy={validPoints[0].y}
-                r={Math.max(3 / zoom, 1.5)}
-                fill={pathColor}
-                stroke="white"
-                strokeWidth={Math.max(1 / zoom, 0.3)}
-                opacity={0.9}
-                pointerEvents="none"
-              />
-              <circle
-                cx={validPoints[validPoints.length - 1].x}
-                cy={validPoints[validPoints.length - 1].y}
-                r={Math.max(3 / zoom, 1.5)}
-                fill={pathColor}
-                stroke="white"
-                strokeWidth={Math.max(1 / zoom, 0.3)}
-                opacity={0.9}
-                pointerEvents="none"
-              />
-            </>
-          )}
+          {/* Polyline endpoint markers.
+              - Microtubule projects: only render when selected — the
+                MT visual identity is "plain curve on the image",
+                clutter-free in the default state.
+              - Sperm (and any other future polyline-bearing project):
+                always render the start + end dots. Sperm artwork has
+                always shown them and biologists expect that affordance
+                to mark head / tail orientation. */}
+          {isPolyline &&
+            validPoints.length >= 2 &&
+            (projectType === 'microtubules' ? isSelected : true) && (
+              <>
+                <circle
+                  cx={validPoints[0].x}
+                  cy={validPoints[0].y}
+                  r={Math.max(3 / zoom, 1.5)}
+                  fill={pathColor}
+                  stroke="white"
+                  strokeWidth={Math.max(1 / zoom, 0.3)}
+                  opacity={0.9}
+                  pointerEvents="none"
+                />
+                <circle
+                  cx={validPoints[validPoints.length - 1].x}
+                  cy={validPoints[validPoints.length - 1].y}
+                  r={Math.max(3 / zoom, 1.5)}
+                  fill={pathColor}
+                  stroke="white"
+                  strokeWidth={Math.max(1 / zoom, 0.3)}
+                  opacity={0.9}
+                  pointerEvents="none"
+                />
+              </>
+            )}
 
           {/* Render vertices using separate component for performance */}
           {!hideVertices && (

--- a/src/pages/segmentation/hooks/__tests__/usePolygonSlicing.test.tsx
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonSlicing.test.tsx
@@ -31,14 +31,21 @@ vi.mock('@/contexts/LanguageContext', () => ({
 
 vi.mock('@/lib/polygonSlicing', () => ({
   slicePolygon: vi.fn(),
+  slicePolyline: vi.fn(),
   validateSliceLine: vi.fn(),
+  validateSlicePolyline: vi.fn(),
 }));
 
 vi.mock('@/lib/errorUtils', () => ({
   getLocalizedErrorMessage: vi.fn((key: string) => key),
 }));
 
-import { slicePolygon, validateSliceLine } from '@/lib/polygonSlicing';
+import {
+  slicePolygon,
+  slicePolyline,
+  validateSliceLine,
+  validateSlicePolyline,
+} from '@/lib/polygonSlicing';
 
 describe('usePolygonSlicing', () => {
   let _testPolygons: ReturnType<typeof createTestPolygons>;
@@ -723,6 +730,114 @@ describe('usePolygonSlicing', () => {
 
       // Should not throw on unmount
       expect(() => unmount()).not.toThrow();
+    });
+  });
+
+  // Sperm projects must keep their pre-session slicing behaviour:
+  // attempting to slice an open polyline should NOT use the new MT
+  // polyline path — it should fall through to slicePolygon, which
+  // returns null on open shapes and triggers the legacy "Slicing
+  // failed" toast. The gating lives in usePolygonSlicing.handleSliceAction.
+  describe('projectType gating', () => {
+    // Minimal polyline fixture (2 points = open path with one segment)
+    const polyline: Polygon = {
+      id: 'polyline-1',
+      points: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      type: 'external',
+      geometry: 'polyline',
+      area: 0,
+      confidence: 1,
+      instanceId: 'sperm_x',
+    };
+
+    it('uses slicePolyline + validateSlicePolyline when projectType === microtubules', () => {
+      (validateSlicePolyline as unknown as vi.Mock).mockReturnValue({
+        isValid: true,
+      });
+      (slicePolyline as unknown as vi.Mock).mockReturnValue([
+        { ...polyline, id: 'a' },
+        { ...polyline, id: 'b' },
+      ]);
+
+      const slicePoints: Point[] = [
+        { x: 50, y: -5 },
+        { x: 50, y: 5 },
+      ];
+      const { result } = renderHook(() =>
+        usePolygonSlicing({
+          ...mockProps,
+          polygons: [polyline],
+          selectedPolygonId: 'polyline-1',
+          tempPoints: slicePoints,
+          projectType: 'microtubules',
+        })
+      );
+
+      act(() => {
+        result.current.handleSliceAction();
+      });
+
+      expect(validateSlicePolyline).toHaveBeenCalledWith(
+        polyline,
+        slicePoints[0],
+        slicePoints[1]
+      );
+      expect(slicePolyline).toHaveBeenCalledWith(
+        polyline,
+        slicePoints[0],
+        slicePoints[1]
+      );
+      // Polygon-path validators must NOT have been called for an MT polyline
+      expect(validateSliceLine).not.toHaveBeenCalled();
+      expect(slicePolygon).not.toHaveBeenCalled();
+    });
+
+    it('falls back to slicePolygon for sperm projects (no MT polyline gate)', () => {
+      (validateSliceLine as unknown as vi.Mock).mockReturnValue({
+        isValid: true,
+      });
+      // slicePolygon legitimately returns null on open shapes — that
+      // triggers the legacy "Slicing failed" toast which is the
+      // intended sperm UX.
+      (slicePolygon as unknown as vi.Mock).mockReturnValue(null);
+
+      const slicePoints: Point[] = [
+        { x: 50, y: -5 },
+        { x: 50, y: 5 },
+      ];
+      const { result } = renderHook(() =>
+        usePolygonSlicing({
+          ...mockProps,
+          polygons: [polyline],
+          selectedPolygonId: 'polyline-1',
+          tempPoints: slicePoints,
+          projectType: 'sperm',
+        })
+      );
+
+      let sliceResult: boolean | undefined;
+      act(() => {
+        sliceResult = result.current.handleSliceAction();
+      });
+
+      expect(sliceResult).toBe(false);
+      // Polygon path was used (the legacy behaviour for sperm polylines)
+      expect(validateSliceLine).toHaveBeenCalledWith(
+        polyline,
+        slicePoints[0],
+        slicePoints[1]
+      );
+      expect(slicePolygon).toHaveBeenCalledWith(
+        polyline,
+        slicePoints[0],
+        slicePoints[1]
+      );
+      // MT-only branch must NOT have been reached
+      expect(validateSlicePolyline).not.toHaveBeenCalled();
+      expect(slicePolyline).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -46,6 +46,12 @@ interface UseEnhancedSegmentationEditorProps {
   isFromGallery?: boolean; // Add flag to trigger auto-reset
   activePartClassRef?: React.RefObject<'head' | 'midpiece' | 'tail'>;
   activeInstanceIdRef?: React.RefObject<string>;
+  /** Project type drives MT-only polyline behaviours (Enter-commits
+   *  AddPoints extension, polyline slice geometry). Sperm and other
+   *  polyline-bearing projects must keep their pre-MT-feature UX, so
+   *  any new behaviour gated on this flag falls through to the legacy
+   *  paths when the value isn't ``'microtubules'``. */
+  projectType?: import('@/types').ProjectType;
   // onPolygonSelection is now handled internally via usePolygonSelection for SSOT
 }
 
@@ -65,6 +71,7 @@ export const useEnhancedSegmentationEditor = ({
   isFromGallery = false,
   activePartClassRef,
   activeInstanceIdRef,
+  projectType,
   // onPolygonSelection is now handled internally
 }: UseEnhancedSegmentationEditorProps) => {
   const { t } = useLanguage();
@@ -730,6 +737,11 @@ export const useEnhancedSegmentationEditor = ({
     // never wraps back to a different vertex, so there's no "click
     // another vertex to finish" trigger. Enter is the natural finish key.
     if (editMode !== EditMode.AddPoints) return;
+    // Gate to MT only: sperm projects predate the Enter-extends-polyline
+    // workflow and rely on "click another vertex to finalise" the old
+    // way. Leaving this active for sperm would silently change their
+    // muscle memory.
+    if (projectType !== 'microtubules') return;
     if (!selectedPolygonId) return;
     if (!interactionState.isAddingPoints) return;
     if (!interactionState.addPointStartVertex) return;
@@ -772,6 +784,7 @@ export const useEnhancedSegmentationEditor = ({
     setEditMode(EditMode.EditVertices);
   }, [
     editMode,
+    projectType,
     selectedPolygonId,
     interactionState.isAddingPoints,
     interactionState.addPointStartVertex,
@@ -838,6 +851,11 @@ export const useEnhancedSegmentationEditor = ({
     setInteractionState,
     setEditMode,
     updatePolygons,
+    // Forward project type so the slicing hook can gate the
+    // polyline-specific dispatch (split-at-cut) to MT only — sperm
+    // polylines fall through to the existing slicePolygon path which
+    // rejects them, preserving the legacy "Slicing failed" toast UX.
+    projectType,
   });
 
   // Handle slice completion when two temp points are placed in slice mode

--- a/src/pages/segmentation/hooks/usePolygonSlicing.tsx
+++ b/src/pages/segmentation/hooks/usePolygonSlicing.tsx
@@ -25,6 +25,12 @@ interface UsePolygonSlicingProps {
 
   // Data operations
   updatePolygons: (polygons: Polygon[]) => void;
+
+  /** Active project type — gates the polyline-specific slice dispatch
+   *  to ``'microtubules'`` only. Sperm polylines fall through to the
+   *  polygon slicer (which rejects open paths → existing "Slicing
+   *  failed" toast), preserving the legacy UX. */
+  projectType?: import('@/types').ProjectType;
 }
 
 /**
@@ -41,6 +47,7 @@ export const usePolygonSlicing = ({
   setInteractionState,
   setEditMode,
   updatePolygons,
+  projectType,
 }: UsePolygonSlicingProps) => {
   const { t } = useLanguage();
 
@@ -64,12 +71,15 @@ export const usePolygonSlicing = ({
       }
 
       const [sliceStart, sliceEnd] = pointsToUse;
-      const isPolyline = polygon.geometry === 'polyline';
+      // The polyline-specific "split at one crossing" dispatch is an
+      // MT-only feature. For sperm polylines we fall through to the
+      // closed-polygon path (`slicePolygon` returns null on open
+      // shapes → user sees the legacy "Slicing failed" toast,
+      // preserving pre-session behaviour).
+      const useMtPolylineSlice =
+        polygon.geometry === 'polyline' && projectType === 'microtubules';
 
-      // Dispatch by geometry. Closed polygons need two edge crossings
-      // (chord across the inside); open polylines need exactly one
-      // crossing of any segment, then split that segment in place.
-      const validation = isPolyline
+      const validation = useMtPolylineSlice
         ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
         : validateSliceLine(polygon, sliceStart, sliceEnd);
 
@@ -81,7 +91,7 @@ export const usePolygonSlicing = ({
         return false;
       }
 
-      const result = isPolyline
+      const result = useMtPolylineSlice
         ? slicePolyline(polygon, sliceStart, sliceEnd)
         : slicePolygon(polygon, sliceStart, sliceEnd);
 
@@ -136,6 +146,7 @@ export const usePolygonSlicing = ({
       setTempPoints,
       setInteractionState,
       setEditMode,
+      projectType,
       t,
     ]
   );
@@ -234,13 +245,14 @@ export const usePolygonSlicing = ({
     }
 
     const [sliceStart, sliceEnd] = tempPoints;
-    const validation =
-      polygon.geometry === 'polyline'
-        ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
-        : validateSliceLine(polygon, sliceStart, sliceEnd);
+    const useMtPolylineSlice =
+      polygon.geometry === 'polyline' && projectType === 'microtubules';
+    const validation = useMtPolylineSlice
+      ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
+      : validateSliceLine(polygon, sliceStart, sliceEnd);
 
     return validation.isValid;
-  }, [selectedPolygonId, tempPoints, polygons]);
+  }, [selectedPolygonId, tempPoints, polygons, projectType]);
 
   /**
    * Get slice preview information
@@ -260,10 +272,12 @@ export const usePolygonSlicing = ({
     }
 
     const [sliceStart, sliceEnd] = tempPoints;
-    return polygon.geometry === 'polyline'
+    const useMtPolylineSlice =
+      polygon.geometry === 'polyline' && projectType === 'microtubules';
+    return useMtPolylineSlice
       ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
       : validateSliceLine(polygon, sliceStart, sliceEnd);
-  }, [selectedPolygonId, tempPoints, polygons]);
+  }, [selectedPolygonId, tempPoints, polygons, projectType]);
 
   return {
     // Actions


### PR DESCRIPTION
## Summary

User caught a regression: today's polyline-affecting PRs (#172, #176, #177) were geometry-gated (`if isPolyline`) but **not project-type gated**, so sperm polylines inherited the new MT-flavoured behaviour. User asked to restore sperm UX to its pre-session state.

Audit identified 4 leak sites; adding `projectType === 'microtubules'` checks at each keeps the new UX for MT while sperm falls back to legacy paths.

## Leaks gated

| PR  | What was leaking                                          | Fix                                                            |
| --- | --------------------------------------------------------- | -------------------------------------------------------------- |
| #172 | 12× wider invisible hit-area path on every polyline       | Add `projectType === 'microtubules'` to render condition       |
| #172 | Endpoint dots hidden in non-selected state every polyline | Ternary: MT = selection-gated, others = always visible (legacy) |
| #176 | Enter commits AddPoints extension on every polyline       | Early-return in `handleEnterPolyline` when not MT              |
| #177 | Polyline slice path runs on every polyline                | `useMtPolylineSlice` flag in `usePolygonSlicing`               |

## Plumbing

- `useEnhancedSegmentationEditor` gets a `projectType?: ProjectType` prop; destructures + forwards into `handleEnterPolyline` deps and into the `usePolygonSlicing` initialiser
- `usePolygonSlicing` gets a matching prop and threads it through `handleSliceAction`, `canSlice`, `getSlicePreview`
- `SegmentationEditor` passes `projectType` (already destructured from `useProjectData` in PR #174) into the editor hook

## Sperm fall-through behaviour

- Hit-area = visible stroke only (need pixel-accurate aim as before)
- Endpoint dots = always rendered (sperm visual identity expects them as head/tail markers)
- Enter in Add-Points mode = no-op (must click another vertex)
- Slice on a sperm polyline = `slicePolygon` returns null on open paths → legacy "Slicing failed" toast (unchanged pre-session UX)

## Tests

2 new vitest cases in `usePolygonSlicing.test.tsx`:
- `projectType === 'microtubules'` + polyline → uses `validateSlicePolyline` + `slicePolyline`, never the polygon path
- `projectType === 'sperm'` + polyline → uses `validateSliceLine` + `slicePolygon` (which returns null), never the MT branch

✅ 27/27 tests pass (25 original + 2 new). TS clean. Built + deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-type-specific polyline behavior for improved segmentation workflows in different project contexts.
  * Endpoint markers now render contextually based on project type, enhancing visual feedback during editing.
  * Polyline extension and slicing operations now adapt behavior based on active project type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->