### PR TITLE
fix(editor): make hover-radius + polyline slice universal again (revert PR #179 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,38 @@ The most important section is **[Verification Rules](#verification-rules)**. Rea
 
 ---
 
+## Ask when unclear — do not assume scope
+
+When a request is ambiguous or could be interpreted multiple ways,
+**use `AskUserQuestion` BEFORE coding**. Guessing what the user meant
+and shipping the wrong interpretation wastes a round-trip and erodes
+trust. Concrete situations that demand a clarification question:
+
+- **"All / everything"** statements that might have exceptions. Example
+  ("all today's changes should affect only MT projects") may exclude
+  changes the user actually wants kept universal (hover radius, slice
+  geometry). Ask which specific changes are in scope.
+- **Project-type or polyline-kind gating decisions** — features that
+  could plausibly belong to one project type, all of them, or some
+  subset. Don't assume; ask.
+- **Destructive operations on shared data** — even on a test account,
+  ask before wiping fixtures the user might still need.
+- **Choice between a simple FE-only fix and a broader BE/ML
+  refactor** — ask which trade-off the user wants.
+- **"Rotate / reformat / re-orient"** UI requests where the existing
+  orientation might already be correct (kymograph axes are a recent
+  example).
+
+When asking, surface 2–3 concrete options via `AskUserQuestion` rather
+than open-ended "what do you want?" — the user can compare side-by-side
+and pick. Always state the trade-offs.
+
+If you've already coded something and only THEN realise it was
+ambiguous, stop and ask before going further; don't keep building on
+the guess.
+
+---
+
 ## Production Safety
 
 **Never modify or deploy to production without explicit permission.** Production runs on `docker-compose.production.yml` with `.env.production`. Service: `spheroseg_blue`. URL: `https://spherosegapp.utia.cas.cz`. Test account: `12bprusek@gym-nymburk.cz` / `spheroids2026`.

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -294,7 +294,7 @@ const CanvasPolygon = React.memo(
               stroke makes the click target comfortable without changing
               the rendered look. Pointer-events confined to the stroke so
               the surrounding canvas drag/zoom still works. */}
-          {isPolyline && projectType === 'microtubules' && pathString && (
+          {isPolyline && pathString && (
             <path
               d={pathString}
               fill="none"

--- a/src/pages/segmentation/hooks/__tests__/usePolygonSlicing.test.tsx
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonSlicing.test.tsx
@@ -733,13 +733,11 @@ describe('usePolygonSlicing', () => {
     });
   });
 
-  // Sperm projects must keep their pre-session slicing behaviour:
-  // attempting to slice an open polyline should NOT use the new MT
-  // polyline path — it should fall through to slicePolygon, which
-  // returns null on open shapes and triggers the legacy "Slicing
-  // failed" toast. The gating lives in usePolygonSlicing.handleSliceAction.
-  describe('projectType gating', () => {
-    // Minimal polyline fixture (2 points = open path with one segment)
+  // Polyline slicing is geometry-driven (not project-type-gated):
+  // any polyline — sperm, microtubule, future types — gets the
+  // split-at-one-crossing dispatch. Closed polygons keep the
+  // legacy two-crossing chord path.
+  describe('geometry dispatch', () => {
     const polyline: Polygon = {
       id: 'polyline-1',
       points: [
@@ -753,7 +751,7 @@ describe('usePolygonSlicing', () => {
       instanceId: 'sperm_x',
     };
 
-    it('uses slicePolyline + validateSlicePolyline when projectType === microtubules', () => {
+    it('uses slicePolyline + validateSlicePolyline for any polyline (sperm included)', () => {
       (validateSlicePolyline as unknown as vi.Mock).mockReturnValue({
         isValid: true,
       });
@@ -772,7 +770,6 @@ describe('usePolygonSlicing', () => {
           polygons: [polyline],
           selectedPolygonId: 'polyline-1',
           tempPoints: slicePoints,
-          projectType: 'microtubules',
         })
       );
 
@@ -790,54 +787,9 @@ describe('usePolygonSlicing', () => {
         slicePoints[0],
         slicePoints[1]
       );
-      // Polygon-path validators must NOT have been called for an MT polyline
+      // Polygon-path validators must NOT be called on a polyline
       expect(validateSliceLine).not.toHaveBeenCalled();
       expect(slicePolygon).not.toHaveBeenCalled();
-    });
-
-    it('falls back to slicePolygon for sperm projects (no MT polyline gate)', () => {
-      (validateSliceLine as unknown as vi.Mock).mockReturnValue({
-        isValid: true,
-      });
-      // slicePolygon legitimately returns null on open shapes — that
-      // triggers the legacy "Slicing failed" toast which is the
-      // intended sperm UX.
-      (slicePolygon as unknown as vi.Mock).mockReturnValue(null);
-
-      const slicePoints: Point[] = [
-        { x: 50, y: -5 },
-        { x: 50, y: 5 },
-      ];
-      const { result } = renderHook(() =>
-        usePolygonSlicing({
-          ...mockProps,
-          polygons: [polyline],
-          selectedPolygonId: 'polyline-1',
-          tempPoints: slicePoints,
-          projectType: 'sperm',
-        })
-      );
-
-      let sliceResult: boolean | undefined;
-      act(() => {
-        sliceResult = result.current.handleSliceAction();
-      });
-
-      expect(sliceResult).toBe(false);
-      // Polygon path was used (the legacy behaviour for sperm polylines)
-      expect(validateSliceLine).toHaveBeenCalledWith(
-        polyline,
-        slicePoints[0],
-        slicePoints[1]
-      );
-      expect(slicePolygon).toHaveBeenCalledWith(
-        polyline,
-        slicePoints[0],
-        slicePoints[1]
-      );
-      // MT-only branch must NOT have been reached
-      expect(validateSlicePolyline).not.toHaveBeenCalled();
-      expect(slicePolyline).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -851,11 +851,6 @@ export const useEnhancedSegmentationEditor = ({
     setInteractionState,
     setEditMode,
     updatePolygons,
-    // Forward project type so the slicing hook can gate the
-    // polyline-specific dispatch (split-at-cut) to MT only — sperm
-    // polylines fall through to the existing slicePolygon path which
-    // rejects them, preserving the legacy "Slicing failed" toast UX.
-    projectType,
   });
 
   // Handle slice completion when two temp points are placed in slice mode

--- a/src/pages/segmentation/hooks/usePolygonSlicing.tsx
+++ b/src/pages/segmentation/hooks/usePolygonSlicing.tsx
@@ -25,12 +25,6 @@ interface UsePolygonSlicingProps {
 
   // Data operations
   updatePolygons: (polygons: Polygon[]) => void;
-
-  /** Active project type — gates the polyline-specific slice dispatch
-   *  to ``'microtubules'`` only. Sperm polylines fall through to the
-   *  polygon slicer (which rejects open paths → existing "Slicing
-   *  failed" toast), preserving the legacy UX. */
-  projectType?: import('@/types').ProjectType;
 }
 
 /**
@@ -47,7 +41,6 @@ export const usePolygonSlicing = ({
   setInteractionState,
   setEditMode,
   updatePolygons,
-  projectType,
 }: UsePolygonSlicingProps) => {
   const { t } = useLanguage();
 
@@ -71,15 +64,14 @@ export const usePolygonSlicing = ({
       }
 
       const [sliceStart, sliceEnd] = pointsToUse;
-      // The polyline-specific "split at one crossing" dispatch is an
-      // MT-only feature. For sperm polylines we fall through to the
-      // closed-polygon path (`slicePolygon` returns null on open
-      // shapes → user sees the legacy "Slicing failed" toast,
-      // preserving pre-session behaviour).
-      const useMtPolylineSlice =
-        polygon.geometry === 'polyline' && projectType === 'microtubules';
+      // Geometry-based dispatch — polyline slicing is available for any
+      // polyline regardless of project type ("polyline slice is the
+      // same for all projects" per user request). Closed polygons need
+      // two edge crossings (chord across the inside); open polylines
+      // need exactly one crossing of any segment.
+      const isPolyline = polygon.geometry === 'polyline';
 
-      const validation = useMtPolylineSlice
+      const validation = isPolyline
         ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
         : validateSliceLine(polygon, sliceStart, sliceEnd);
 
@@ -91,7 +83,7 @@ export const usePolygonSlicing = ({
         return false;
       }
 
-      const result = useMtPolylineSlice
+      const result = isPolyline
         ? slicePolyline(polygon, sliceStart, sliceEnd)
         : slicePolygon(polygon, sliceStart, sliceEnd);
 
@@ -146,7 +138,6 @@ export const usePolygonSlicing = ({
       setTempPoints,
       setInteractionState,
       setEditMode,
-      projectType,
       t,
     ]
   );
@@ -245,14 +236,13 @@ export const usePolygonSlicing = ({
     }
 
     const [sliceStart, sliceEnd] = tempPoints;
-    const useMtPolylineSlice =
-      polygon.geometry === 'polyline' && projectType === 'microtubules';
-    const validation = useMtPolylineSlice
-      ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
-      : validateSliceLine(polygon, sliceStart, sliceEnd);
+    const validation =
+      polygon.geometry === 'polyline'
+        ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
+        : validateSliceLine(polygon, sliceStart, sliceEnd);
 
     return validation.isValid;
-  }, [selectedPolygonId, tempPoints, polygons, projectType]);
+  }, [selectedPolygonId, tempPoints, polygons]);
 
   /**
    * Get slice preview information
@@ -272,12 +262,10 @@ export const usePolygonSlicing = ({
     }
 
     const [sliceStart, sliceEnd] = tempPoints;
-    const useMtPolylineSlice =
-      polygon.geometry === 'polyline' && projectType === 'microtubules';
-    return useMtPolylineSlice
+    return polygon.geometry === 'polyline'
       ? validateSlicePolyline(polygon, sliceStart, sliceEnd)
       : validateSliceLine(polygon, sliceStart, sliceEnd);
-  }, [selectedPolygonId, tempPoints, polygons, projectType]);
+  }, [selectedPolygonId, tempPoints, polygons]);
 
   return {
     // Actions


### PR DESCRIPTION
## Summary

User clarified: **hover-radius and polyline slicing should be GLOBAL** for all polylines, not gated to MT. Only **endpoint-dot visibility** + **Enter-commits-AddPoints** should remain MT-only.

PR #179 over-corrected and pulled all four polyline features into the MT gate. This partially reverts that.

## Changes (revert)

- **`CanvasPolygon.tsx`**: hit-area path condition drops the `projectType === 'microtubules'` clause — wide hit area is back for sperm + MT.
- **`usePolygonSlicing.tsx`**: removes the `projectType` prop entirely; `handleSliceAction` / `canSlice` / `getSlicePreview` dispatch on `polygon.geometry === 'polyline'` alone (original PR #177 shape).
- **`useEnhancedSegmentationEditor.tsx`**: stops forwarding `projectType` to `usePolygonSlicing` (still keeps it for its own Enter-AddPoints gating, which stays MT-only).
- **Tests**: replace "projectType gating" describe block with a smaller "geometry dispatch" check confirming the polyline path runs for ANY polyline regardless of project type.

## Stays MT-only (unchanged from PR #179)

- Endpoint dots only-when-selected (sperm keeps always-visible dots as head/tail markers)
- Enter in Add-Points mode commits an endpoint extension (sperm keeps click-another-vertex flow)

## Process change

Adds an "Ask when unclear — do not assume scope" section to `CLAUDE.md`. The "all polyline UX should be MT-only" request was ambiguous (which exact items?) and I shipped the broadest interpretation, forcing this revert. Future ambiguity → use `AskUserQuestion` BEFORE coding, with 2-3 labelled options the user can compare.

## Verification

- TS clean (`npx tsc --noEmit`)
- 26/26 slicing tests pass
- Built + deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent polyline interaction behavior across different project types. Polyline click and hover targeting now operates consistently.

* **Improvements**
  * Segmentation slicing logic now uniformly operates based on shape geometry type rather than project configuration for a more consistent experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/180)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->