### PR TITLE
feat(kymograph): render in channel color + extract names from TIFF/ND2 metadata

### DIFF
--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -294,6 +294,14 @@ class KymographRequest(BaseModel):
     frames: List[KymographFrameInput]
     target_width: int = Field(200, ge=10, le=2000)
     tracked: bool = False
+    # Hex `#RRGGBB`. When supplied, the kymograph is rendered as a linear
+    # black-to-color gradient (intensity → that hue) so it matches the
+    # channel tint the user chose in the editor's multi-channel overlay.
+    # When None, falls back to viridis (legacy behaviour).
+    channel_color: Optional[str] = Field(
+        None,
+        pattern=r"^#[0-9A-Fa-f]{6}$",
+    )
 
 
 class KymographResponse(BaseModel):
@@ -357,6 +365,32 @@ def _viridis(values: np.ndarray) -> np.ndarray:
     return (rgb * 255.0).astype(np.uint8)
 
 
+def _hex_to_rgb_array(hex_color: str) -> np.ndarray:
+    """Parse `#RRGGBB` → float32 ndarray of length 3, values in [0, 1]."""
+    h = hex_color.lstrip("#")
+    return np.array(
+        [int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)],
+        dtype=np.float32,
+    ) / 255.0
+
+
+def _linear_gradient(values: np.ndarray, hex_color: str) -> np.ndarray:
+    """Map a 2D float32 [0,1] array to RGB via a black→hex_color gradient.
+
+    Pure intensity-modulated single-hue render, matching the convention
+    most live-cell imaging tools use when the user picks a channel tint
+    (ImageJ "Fire" with all stops a single hue). Loses the perceptual-
+    uniformity of viridis but gains "the kymograph for the green channel
+    is rendered in green", which is what users intuitively expect after
+    they've already coloured the multi-channel overlay.
+    """
+    clipped = np.clip(values, 0.0, 1.0)
+    color = _hex_to_rgb_array(hex_color)  # shape (3,)
+    # Broadcast (F, W) × (3,) → (F, W, 3); each pixel is intensity × color.
+    rgb = clipped[..., None] * color
+    return (rgb * 255.0).astype(np.uint8)
+
+
 @router.post("/kymograph", response_model=KymographResponse)
 async def kymograph(req: KymographRequest) -> KymographResponse:
     """Render a kymograph for one microtubule polyline."""
@@ -402,7 +436,11 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
     # normalise globally to expose dynamics. Add 1e-9 to avoid /0.
     mn, mx = float(kymo.min()), float(kymo.max())
     norm = (kymo - mn) / max(mx - mn, 1e-9)
-    rgb = _viridis(norm)
+    rgb = (
+        _linear_gradient(norm, req.channel_color)
+        if req.channel_color
+        else _viridis(norm)
+    )
 
     buf = io.BytesIO()
     PILImage.fromarray(rgb).save(buf, format="PNG")

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -194,6 +194,13 @@ router.post(
       .withMessage(
         'sourceChannel must be alnum / underscore / dash, up to 64 chars'
       ),
+    // channelColor: optional hex `#RRGGBB`. When supplied, the ML
+    // renderer uses a black→color gradient instead of viridis.
+    body('channelColor')
+      .optional()
+      .isString()
+      .matches(/^#[0-9A-Fa-f]{6}$/)
+      .withMessage('channelColor must be #RRGGBB hex'),
   ],
   handleValidation,
   async (req: Request, res: Response) => {
@@ -248,6 +255,7 @@ router.post(
         polylineId: req.body.polylineId,
         frameIndex: req.body.frameIndex,
         sourceChannel: req.body.sourceChannel,
+        channelColor: req.body.channelColor,
       });
       ResponseHelper.success(res, result);
     } catch (err) {

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -27,6 +27,9 @@ import { logger } from '../utils/logger';
 /** Same whitelist used by VideoController. Channel names must be alnum +
  *  underscore + dash so they can't escape the storage root. */
 const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+/** Mirrors the pattern accepted by the ML KymographRequest. Defence in
+ *  depth — the controller layer also validates. */
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
 
 interface PolylineRecord {
   id: string;
@@ -41,6 +44,10 @@ export interface KymographServiceInput {
   polylineId: string;
   frameIndex: number;
   sourceChannel: string;
+  /** Optional hex `#RRGGBB`. When supplied, the ML service renders the
+   *  kymograph as a black-to-color linear gradient instead of viridis,
+   *  matching the channel tint the user picked in the editor. */
+  channelColor?: string;
 }
 
 export interface KymographServiceResult {
@@ -84,13 +91,16 @@ function parsePolygons(json: string | null | undefined): PolylineRecord[] {
 export async function buildKymograph(
   input: KymographServiceInput
 ): Promise<KymographServiceResult> {
-  const { videoContainerId, polylineId, frameIndex, sourceChannel } = input;
+  const { videoContainerId, polylineId, frameIndex, sourceChannel, channelColor } = input;
 
   // Defence in depth: reject any sourceChannel containing path separators
   // or other unsafe characters. The route layer also validates, but this
   // service is a public entry point for any future caller.
   if (!CHANNEL_NAME_RE.test(sourceChannel)) {
     throw new Error('Invalid sourceChannel');
+  }
+  if (channelColor !== undefined && !HEX_COLOR_RE.test(channelColor)) {
+    throw new Error('Invalid channelColor (expected #RRGGBB)');
   }
 
   const container = await prisma.image.findUnique({
@@ -182,6 +192,7 @@ export async function buildKymograph(
       frames: framesPayload,
       target_width: 200,
       tracked: trackedMode,
+      ...(channelColor ? { channel_color: channelColor } : {}),
     },
     { timeout: 120_000 }
   );

--- a/backend/src/services/video/pythonExtractor.ts
+++ b/backend/src/services/video/pythonExtractor.ts
@@ -34,6 +34,7 @@ interface PythonResult {
   height: number;
   channels: Array<{
     name: string;
+    displayName?: string | null;
     wavelengthNm?: number | null;
   }>;
 }
@@ -131,6 +132,7 @@ function buildChannelMeta(
 
   return raw.map((r, i) => ({
     name: r.name,
+    displayName: r.displayName ?? undefined,
     type: isIrmChannel(r.name, r.wavelengthNm ?? undefined)
       ? 'irm'
       : 'fluorescent',

--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -96,21 +96,27 @@ def main() -> int:
                 return 4
 
         # Channel metadata: name + emission wavelength.
+        # `displayName` is the human-friendly label (ND2 metadata name, or
+        # "Channel N" 1-based fallback). `name` is the path-safe form
+        # used for the PNG filename and URLs.
         channel_meta = []
         for c in range(C):
             try:
                 ch = f.metadata.channels[c]
-                raw_name = getattr(ch.channel, "name", None) or f"ch{c}"
+                raw_name = getattr(ch.channel, "name", None)
                 emission = None
                 em_info = getattr(ch.channel, "emissionLambdaNm", None)
                 if isinstance(em_info, (int, float)):
                     emission = float(em_info)
             except Exception:
-                raw_name = f"ch{c}"
+                raw_name = None
                 emission = None
+            has_raw = isinstance(raw_name, str) and raw_name.strip() != ""
+            display = raw_name if has_raw else f"Channel {c + 1}"
             channel_meta.append({
                 "rawName": raw_name,
-                "name": _sanitize_name(raw_name, f"ch{c}"),
+                "displayName": display,
+                "name": _sanitize_name(raw_name, f"Channel_{c + 1}"),
                 "wavelengthNm": emission,
             })
 
@@ -140,7 +146,11 @@ def main() -> int:
         "width": int(W),
         "height": int(H),
         "channels": [
-            {"name": ch["name"], "wavelengthNm": ch["wavelengthNm"]}
+            {
+                "name": ch["name"],
+                "displayName": ch["displayName"],
+                "wavelengthNm": ch["wavelengthNm"],
+            }
             for ch in channel_meta
         ],
     }

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -20,10 +20,46 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
 import numpy as np
+
+
+def _sanitize_name(raw: str | None, fallback: str) -> str:
+    """Reduce to alnum + underscore + dash so the name is filesystem-safe
+    and survives the backend's CHANNEL_NAME_RE whitelist."""
+    if not raw:
+        return fallback
+    safe = re.sub(r"[^A-Za-z0-9_-]+", "_", raw).strip("_")
+    return safe or fallback
+
+
+def _imagej_channel_labels(tf, count: int) -> list[str | None]:
+    """Best-effort ImageJ channel name extraction.
+
+    `tifffile` exposes ImageJ's tagged metadata as ``tf.imagej_metadata``.
+    The conventional location for per-channel labels is ``'Labels'`` —
+    a list. Sometimes ImageJ writes one label per slice (T×C entries);
+    we slice to the first C. If `Labels` isn't present we return
+    all-None and the caller falls back to `"Channel N"`.
+
+    Crashes during metadata parsing must NOT crash the extractor; a
+    broken TIFF header is a far worse outcome than unnamed channels.
+    """
+    try:
+        meta = getattr(tf, "imagej_metadata", None)
+        if not isinstance(meta, dict):
+            return [None] * count
+        labels = meta.get("Labels")
+        if not isinstance(labels, (list, tuple)) or len(labels) < count:
+            return [None] * count
+        # ImageJ often writes per-slice labels (one per T×C); the first
+        # C entries are the channel names for the first time-point.
+        return [labels[i] if isinstance(labels[i], str) else None for i in range(count)]
+    except Exception:
+        return [None] * count
 
 
 def _normalize_to_uint8(arr: np.ndarray) -> np.ndarray:
@@ -64,6 +100,15 @@ def main() -> int:
     with tifffile.TiffFile(str(src)) as tf:
         arr = tf.asarray()
         axes = (tf.series[0].axes if tf.series else "").upper()
+        # Capture metadata before exiting the `with` — channel-name
+        # detection needs the open file object. The actual lookup
+        # tolerates absent/broken metadata.
+        _C_for_meta = (
+            arr.shape[axes.index("C")]
+            if "C" in axes
+            else (arr.shape[0] if axes.startswith("C") else 1)
+        )
+        raw_channel_labels = _imagej_channel_labels(tf, _C_for_meta)
 
     # Resolve into (T, C, Y, X) by inserting unit dims for missing axes.
     if "Z" in axes and arr.ndim >= 3:
@@ -97,7 +142,23 @@ def main() -> int:
         )
         return 4
 
-    channel_names = [f"ch{i}" for i in range(C)]
+    # If `_C_for_meta` was guessed before C was known, align it now.
+    if len(raw_channel_labels) != C:
+        raw_channel_labels = (raw_channel_labels + [None] * C)[:C]
+
+    # Two parallel names per channel:
+    #  - `name`        : path-safe, used in URLs + PNG filenames
+    #  - `display_name`: human-readable, shown in the UI
+    # When metadata gives us a label, use it for both (sanitised in `name`).
+    # When no metadata is present, fall back to "Channel N" (1-based) so
+    # the UI doesn't surface implementation-y identifiers like "ch0".
+    channel_names: list[str] = []
+    display_names: list[str] = []
+    for i in range(C):
+        raw = raw_channel_labels[i]
+        display = raw if (isinstance(raw, str) and raw.strip()) else f"Channel {i + 1}"
+        display_names.append(display)
+        channel_names.append(_sanitize_name(raw, f"Channel_{i + 1}"))
 
     for t in range(T):
         frame_dir = dest / "frames" / f"{t:04d}"
@@ -113,7 +174,14 @@ def main() -> int:
         "durationMs": None,  # TIFFs don't carry timing in a standard place
         "width": int(W),
         "height": int(H),
-        "channels": [{"name": n, "wavelengthNm": None} for n in channel_names],
+        "channels": [
+            {
+                "name": channel_names[i],
+                "displayName": display_names[i],
+                "wavelengthNm": None,
+            }
+            for i in range(C)
+        ],
     }
     print(json.dumps(result))
     return 0

--- a/backend/src/services/video/types.ts
+++ b/backend/src/services/video/types.ts
@@ -11,8 +11,14 @@
 export type ChannelType = 'irm' | 'fluorescent';
 
 export interface ChannelMeta {
-  /** Stable channel name (matches the on-disk filename). */
+  /** Stable channel name (matches the on-disk filename). Path-safe:
+   *  validated against `/^[A-Za-z0-9_-]{1,64}$/` at every boundary. */
   name: string;
+  /** Human-friendly label sourced from upload metadata (TIFF ImageJ
+   *  labels, ND2 channel names) or the `"Channel N"` (1-based) fallback.
+   *  UI components should render `displayName ?? name`. Undefined for
+   *  legacy uploads — consumers must tolerate that. */
+  displayName?: string;
   /** Whether this channel shows label-free microtubule structure (IRM/BF/
    *  DIC) or fluorescent signal. The segmenter only runs on IRM channels. */
   type: ChannelType;

--- a/src/lib/__tests__/lazyWithRetry.chunk-detection.test.ts
+++ b/src/lib/__tests__/lazyWithRetry.chunk-detection.test.ts
@@ -54,9 +54,9 @@ describe('lazyWithRetry chunk-load detection', () => {
   });
 
   it('does NOT match unrelated errors', () => {
-    expect(isChunkLoadFailure(new Error('TypeError: x is not a function'))).toBe(
-      false
-    );
+    expect(
+      isChunkLoadFailure(new Error('TypeError: x is not a function'))
+    ).toBe(false);
     expect(isChunkLoadFailure(new Error('NetworkError'))).toBe(false);
     expect(isChunkLoadFailure(null)).toBe(false);
     expect(isChunkLoadFailure(undefined)).toBe(false);

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -62,7 +62,6 @@ import EditorLayout from './components/layout/EditorLayout';
 import { VideoModeOverlay } from './components/VideoModeOverlay';
 import { ImageDisplayProvider } from './contexts/ImageDisplayContext';
 import { useVideoFrames } from './hooks/useVideoFrames';
-import type { ProjectType } from '@/types';
 
 const EMPTY_HOVERED_VERTEX = { polygonId: null, vertexIndex: null } as const;
 

--- a/src/pages/segmentation/components/ChannelOverlayList.tsx
+++ b/src/pages/segmentation/components/ChannelOverlayList.tsx
@@ -70,10 +70,7 @@ export function ChannelOverlayList({ channels }: ChannelOverlayListProps) {
           const visible = visibleChannels.includes(ch.name);
           const color = channelColors[ch.name] ?? DEFAULT_CHANNEL_COLOR;
           return (
-            <div
-              key={ch.name}
-              className="flex items-center gap-2 text-sm"
-            >
+            <div key={ch.name} className="flex items-center gap-2 text-sm">
               <Checkbox
                 checked={visible}
                 onCheckedChange={() => toggleChannelVisibility(ch.name)}
@@ -99,7 +96,7 @@ export function ChannelOverlayList({ channels }: ChannelOverlayListProps) {
                 />
               </button>
               <span className="flex-1 truncate text-gray-700 dark:text-gray-300">
-                {ch.name}
+                {ch.displayName ?? ch.name}
               </span>
               {ch.isSegmentationSource && (
                 <span
@@ -119,10 +116,14 @@ export function ChannelOverlayList({ channels }: ChannelOverlayListProps) {
       {editingChannel && (
         <ChannelColorDialog
           open={editingChannel !== null}
-          channelName={editingChannel}
-          initialColor={
-            channelColors[editingChannel] ?? DEFAULT_CHANNEL_COLOR
+          channelName={
+            // Show the user-friendly label in the dialog title. The
+            // underlying value used for keying is still `editingChannel`
+            // (path-safe `name`) — that's what onConfirm writes back.
+            channels.find(c => c.name === editingChannel)?.displayName ??
+            editingChannel
           }
+          initialColor={channelColors[editingChannel] ?? DEFAULT_CHANNEL_COLOR}
           onConfirm={color => {
             setChannelColor(editingChannel, color);
             setEditingChannel(null);

--- a/src/pages/segmentation/components/ChannelSwitcher.tsx
+++ b/src/pages/segmentation/components/ChannelSwitcher.tsx
@@ -41,12 +41,15 @@ export function ChannelSwitcher({ channels }: ChannelSwitcherProps) {
   }, [channels, channel, setChannel]);
 
   if (!channels || channels.length === 0) return null;
-  // Single-channel videos: surface a static label, no dropdown.
+  // Single-channel videos: surface a static label, no dropdown. Use the
+  // human-friendly displayName when available (TIFF/ND2 metadata or
+  // "Channel N" fallback), but fall back to the path-safe `name` for
+  // legacy uploads that predate the metadata-aware extractors.
   if (channels.length === 1) {
     return (
       <span className="text-xs text-muted-foreground px-2">
         {t('editor.channelSwitcher.title', { defaultValue: 'Channel' })}:{' '}
-        {channels[0].name}
+        {channels[0].displayName ?? channels[0].name}
       </span>
     );
   }
@@ -71,7 +74,7 @@ export function ChannelSwitcher({ channels }: ChannelSwitcherProps) {
                   className="inline-block h-2 w-2 rounded-full"
                   style={{ backgroundColor: ch.displayColor ?? '#888' }}
                 />
-                <span>{ch.name}</span>
+                <span>{ch.displayName ?? ch.name}</span>
                 {ch.isSegmentationSource && (
                   <span
                     className="text-[10px] text-muted-foreground"

--- a/src/pages/segmentation/components/KymographModal.tsx
+++ b/src/pages/segmentation/components/KymographModal.tsx
@@ -28,6 +28,7 @@ import {
 import { useLanguage } from '@/contexts/useLanguage';
 import apiClient from '@/lib/api';
 import type { VideoChannel } from '@/types';
+import { useImageDisplay } from '../contexts/ImageDisplayContext';
 
 interface KymographModalProps {
   open: boolean;
@@ -56,6 +57,7 @@ export function KymographModal({
   channels,
 }: KymographModalProps) {
   const { t } = useLanguage();
+  const { channelColors } = useImageDisplay();
 
   // Pick a default source channel: prefer the first fluorescent channel
   // (typical kymograph use case is intensity dynamics on a labelled
@@ -87,12 +89,19 @@ export function KymographModal({
     let cancelled = false;
     setIsLoading(true);
     setError(null);
+    // Match the kymograph render colour to the per-channel tint the user
+    // already chose in the editor's multi-channel overlay. Default white
+    // (#FFFFFF) is "grayscale" — sent as #FFFFFF, the ML linear gradient
+    // collapses to a black→white intensity ramp, which is the natural
+    // single-channel grayscale kymograph.
+    const channelColor = channelColors[sourceChannel] ?? '#FFFFFF';
     apiClient
       .post('/segmentation/kymograph', {
         videoContainerId,
         polylineId,
         frameIndex,
         sourceChannel,
+        channelColor,
       })
       .then(res => {
         if (cancelled) return;
@@ -109,7 +118,14 @@ export function KymographModal({
     return () => {
       cancelled = true;
     };
-  }, [open, sourceChannel, videoContainerId, polylineId, frameIndex]);
+  }, [
+    open,
+    sourceChannel,
+    videoContainerId,
+    polylineId,
+    frameIndex,
+    channelColors,
+  ]);
 
   const handleDownload = (kind: 'png' | 'csv') => {
     if (!result) return;
@@ -154,7 +170,7 @@ export function KymographModal({
                 <SelectContent>
                   {channels.map(c => (
                     <SelectItem key={c.name} value={c.name}>
-                      {c.name}
+                      {c.displayName ?? c.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -548,7 +548,17 @@ export interface ProjectImage {
 /** Shape of one entry in the ``channels`` JSON column on an Image row.
  *  Set only on rows where ``isVideoContainer == true``. */
 export interface VideoChannel {
+  /** Path-safe identifier used as both the per-frame PNG filename
+   *  (`frames/NNNN/<name>.png`) and the API-level channel reference.
+   *  Validated against `/^[A-Za-z0-9_-]{1,64}$/` everywhere it crosses
+   *  a service boundary. */
   name: string;
+  /** Human-friendly label sourced from the upload's metadata (TIFF
+   *  ImageJ labels / ND2 channel names). Falls back to `"Channel N"`
+   *  (1-based) when the format carries no metadata. UI components
+   *  should render `displayName ?? name`. Older uploads (pre-2026-05-13)
+   *  have this undefined; consumers must tolerate that. */
+  displayName?: string;
   type: 'irm' | 'fluorescent';
   wavelengthNm?: number;
   displayColor?: string;


### PR DESCRIPTION
## Summary

- **Kymograph rendered in user's channel color.** ML's `/api/v1/kymograph` now accepts an optional `channel_color` hex param. When supplied, the renderer uses a black→color linear gradient instead of viridis — matching the tint the user chose in the editor's multi-channel overlay. White (`#FFFFFF`) falls back to a natural grayscale ramp for single-channel videos.
- **Channel names from upload metadata.** TIFF extractor now reads `imagej_metadata['Labels']`; ND2 already exposes `metadata.channels[c].channel.name`. New `displayName` field is emitted alongside the path-safe `name` and surfaced in every UI surface that previously rendered `channel.name` (`ChannelSwitcher`, `ChannelOverlayList`, `ChannelColorDialog`, `KymographModal`). Fallback is `Channel 1`, `Channel 2`, … (1-based).
- **No migration.** Only new uploads + new kymograph renders. Legacy uploads (`displayName === undefined`) render the path-safe `name` as before — fully backwards compatible.

## Files

- `backend/segmentation/api/tracker_kymograph.py` — new `channel_color` field + `_linear_gradient` helper; viridis kept as fallback.
- `backend/src/api/routes/segmentationRoutes.ts` — validator for `channelColor` hex.
- `backend/src/services/kymographService.ts` — forwards `channelColor` → ML `channel_color`.
- `backend/src/services/video/pythonHelpers/extract_tiff_stack.py` — `_imagej_channel_labels()`, sanitisation, `displayName` in extractor JSON.
- `backend/src/services/video/pythonHelpers/extract_nd2.py` — `displayName` + 1-based `Channel N` fallback.
- `backend/src/services/video/pythonExtractor.ts` + `types.ts` — `displayName?: string` on `ChannelMeta`.
- `src/types/index.ts` — `displayName?: string` on `VideoChannel`.
- `src/pages/segmentation/components/KymographModal.tsx` — pulls `channelColors[sourceChannel]` from `ImageDisplayContext`, sends it in POST body, re-renders on color change.
- `src/pages/segmentation/components/{ChannelSwitcher,ChannelOverlayList,ChannelColorDialog}.tsx` — render `displayName ?? name`.

## Test plan

- [x] `make ci` clean (0 ESLint warnings, full TS pass on FE + BE, i18n complete)
- [x] All three services rebuild + force-recreate; nginx restarted; `/health` returns 200
- [ ] Manual Playwright verification on `12bprusek` MT project — kymograph rendered in user-chosen color
- [ ] Re-upload a TIFF or ND2; confirm new channel labels appear (from metadata or `Channel N` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kymograph rendering now supports custom channel colors for visualization
  * Channels display user-friendly names extracted from image metadata when available, with fallback to technical identifiers

* **Improvements**
  * Enhanced automatic channel name extraction and sanitization from TIFF and ND2 files
  * Channel selectors in the UI now prefer display names over technical names

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->