### PR TITLE
fix(polygons): preserve trackId in PolygonValidator (BE-side of mapper drop)

### DIFF
--- a/backend/src/utils/polygonValidation.ts
+++ b/backend/src/utils/polygonValidation.ts
@@ -36,6 +36,12 @@ export interface Polygon {
   type?: 'external' | 'internal';
   parent_id?: string;
   area?: number;
+  /** Cross-frame microtubule track ID populated by trackerService after a
+   *  video container's batch finishes segmentation. The validator must
+   *  preserve it so the response builder in segmentationService can
+   *  conditionally spread it; otherwise the editor never sees the field
+   *  and MT cross-frame colour stability is silently defeated. */
+  trackId?: string;
 }
 
 export interface ParsedPolygonResult {
@@ -313,6 +319,10 @@ export const PolygonValidator = {
     }
     if (polygonObj.instanceId && typeof polygonObj.instanceId === 'string') {
       (validatedPolygon as any).instanceId = polygonObj.instanceId;
+    }
+    // Preserve cross-frame trackId written by trackerService.
+    if (polygonObj.trackId && typeof polygonObj.trackId === 'string') {
+      validatedPolygon.trackId = polygonObj.trackId;
     }
 
     return validatedPolygon;


### PR DESCRIPTION
End-to-end test after #182 deploy uncovered the BE-side of the same enumeration-drop bug.

## Reproducer
- Triggered `trackerService.runTrackingForContainer` on the 3-frame MT test video.
- Prisma confirmed all 432 polylines carry matching trackIds (e.g. `polyline_1 = track_71c8924ba8` in frames 0/1/2).
- API response `GET /api/segmentation/images/<id>/results` returned **zero** trackId fields because `PolygonValidator.validateSinglePolygon` strips it on the read path.

## Root cause
`validateSinglePolygon` rebuilds the polygon object from an allowlist (id/color/category/confidence/type/parent_id/area + geometry/partClass/instanceId). `trackId` was never in the allowlist, so even after PR #182 fixed the FE mapper, the data never reached the editor.

## Fix
- Add `trackId?: string` to the `Polygon` interface.
- Add a preservation branch in `validateSinglePolygon` mirroring the existing instanceId/geometry/partClass branches.

## Test plan
- [x] BE typecheck clean
- [ ] Post-merge: re-fetch `/api/segmentation/images/<id>/results` after tracker run, verify all 432 polylines carry trackId across all 3 frames
- [ ] Editor frames 0/1/2 visually: same MT keeps same colour when scrubbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polygon validation now preserves track identifier information for use in downstream responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->