### PR TITLE
feat: MT per-channel intensity metrics + editor resegment button

### DIFF
--- a/backend/segmentation/api/main.py
+++ b/backend/segmentation/api/main.py
@@ -70,6 +70,7 @@ from api.models import ErrorResponse, HealthResponse
 from api.metrics_endpoint import router as metrics_router
 from api.monitoring import router as monitoring_router
 from api.tracker_kymograph import router as tracker_kymograph_router
+from api.mt_metrics import router as mt_metrics_router
 from api._errors import internal_error
 from ml.model_loader import ModelLoader
 
@@ -176,6 +177,8 @@ app.include_router(monitoring_router, prefix="/api/v1")
 # Microtubule-specific routes (tracker + kymograph). Mounted at the same
 # prefix so the backend talks to ``/api/v1/track`` and ``/api/v1/kymograph``.
 app.include_router(tracker_kymograph_router, prefix="/api/v1")
+# Microtubule per-channel intensity metrics (used by project export).
+app.include_router(mt_metrics_router, prefix="/api/v1")
 
 # Request validation error handler - logs 422 errors with details
 @app.exception_handler(RequestValidationError)

--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -1,0 +1,392 @@
+"""Per-microtubule-per-channel intensity metrics endpoint.
+
+Designed for the project-export pipeline. The Node export service POSTs a
+request per video container with the original ND2/TIFF absolute path,
+which channels (by index + display name) to sample, and the polylines
+per frame. This endpoint re-reads the original file so the intensity
+numbers are derived from raw 16-bit signal rather than the 8-bit
+display-normalised per-channel PNGs (which percentile-clip and are
+unsuitable for absolute fluorescence quantification).
+
+For each (frame, polyline, channel) it emits a long-format row with:
+- length_px, area_px (band area at the supplied thickness)
+- pixel_count, sum/mean/std of pixel intensities inside the band
+- median_background (median of pixels OUTSIDE all bands dilated by
+  ``thickness * margin_multiplier``, per channel)
+- signal_minus_background = mean_intensity - median_background
+
+Unit conversion (px -> um) is intentionally done on the Node side so
+the user-supplied ``pixelToMicrometerScale`` from the export modal
+stays the single source of truth.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Literal, Optional
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ----------------------------------------------------------------------------
+#  Request / response models
+# ----------------------------------------------------------------------------
+
+
+class MTPolylineInput(BaseModel):
+    """One polyline from one frame, in (x, y) pixel coordinates.
+
+    ``image_id`` and ``instance_id`` are propagated unchanged to the
+    output so Node can join the rows back to its own DB records.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    image_id: str
+    instance_id: str
+    track_id: Optional[str] = None
+    # (M, 2) [x, y]. JSON-friendly nested list form.
+    points: List[List[float]]
+
+
+class MTFrameInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    image_id: str
+    frame_index: int
+    polylines: List[MTPolylineInput]
+
+
+class MTMetricsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Absolute path on the ML container's filesystem.
+    original_path: str
+    file_kind: Literal["nd2", "tiff"]
+    # Parallel arrays: channel_indices[i] is the C-axis index for
+    # channel_names[i]. Names round-trip into the response unchanged so
+    # the user sees "TIRF_640" rather than channel position.
+    channel_indices: List[int]
+    channel_names: List[str]
+    frames: List[MTFrameInput]
+    thickness_px: int = Field(5, ge=1, le=100)
+    margin_multiplier: float = Field(2.0, ge=0.0, le=10.0)
+
+
+class MTMetricsRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frame_index: int
+    image_id: str
+    instance_id: str
+    track_id: Optional[str] = None
+    channel: str
+    length_px: float
+    area_px: int
+    pixel_count: int
+    sum_intensity: float
+    mean_intensity: float
+    std_intensity: float
+    # null when the background mask is empty (every pixel in the dilated
+    # signal union) or when the band mask is empty.
+    median_background: Optional[float] = None
+    signal_minus_background: Optional[float] = None
+
+
+class MTMetricsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rows: List[MTMetricsRow]
+    frames_processed: int
+    frame_height: int
+    frame_width: int
+
+
+# ----------------------------------------------------------------------------
+#  Helpers
+# ----------------------------------------------------------------------------
+
+
+def _polyline_length(points: np.ndarray) -> float:
+    """Sum of consecutive Euclidean distances. Returns 0 for <2 points."""
+    if points.shape[0] < 2:
+        return 0.0
+    diffs = np.diff(points, axis=0)
+    return float(np.sqrt((diffs ** 2).sum(axis=1)).sum())
+
+
+def _rasterize_band(
+    points: np.ndarray, h: int, w: int, thickness: int
+) -> np.ndarray:
+    """Rasterize a polyline as a thickness-wide 0/1 mask.
+
+    cv2.polylines with `LINE_8` strokes whole pixels (no antialiasing),
+    so the resulting mask is binary and the pixel_count is exactly the
+    band area at the requested thickness. Rounded line caps + joins
+    follow OpenCV's default, which matches what ImageJ's "fill stroke"
+    produces for a width-N polyline.
+    """
+    import cv2  # local import to keep module load cheap for tests
+    mask = np.zeros((h, w), dtype=np.uint8)
+    if points.shape[0] < 2:
+        return mask
+    # cv2 wants (N, 1, 2) int32. (x, y) order matches what the editor
+    # serialises; cv2 also uses (x, y) for polyline points so no swap
+    # is needed.
+    pts_int = np.rint(points).astype(np.int32).reshape(-1, 1, 2)
+    cv2.polylines(
+        mask, [pts_int],
+        isClosed=False,
+        color=1,
+        thickness=int(thickness),
+        lineType=8,  # cv2.LINE_8 numeric constant; avoids attr lookup on cold cv2 import
+    )
+    return mask
+
+
+def _dilate(mask: np.ndarray, radius: int) -> np.ndarray:
+    """Dilate a binary mask by a disc of given radius (in pixels)."""
+    if radius <= 0:
+        return mask
+    import cv2
+    kernel = cv2.getStructuringElement(
+        cv2.MORPH_ELLIPSE,
+        (radius * 2 + 1, radius * 2 + 1),
+    )
+    return cv2.dilate(mask, kernel)
+
+
+def _normalize_axes_nd2(arr: np.ndarray, axes: str) -> np.ndarray:
+    """Permute / expand an ND2 array to canonical (T, C, Y, X)."""
+    if "Z" in axes and arr.ndim >= 3:
+        z_idx = axes.index("Z")
+        arr = arr.max(axis=z_idx)
+        axes = axes.replace("Z", "")
+
+    if axes == "TCYX" and arr.ndim == 4:
+        return arr
+    if axes == "CYX" and arr.ndim == 3:
+        return arr[None, ...]
+    if axes == "TYX" and arr.ndim == 3:
+        return arr[:, None, :, :]
+    if axes == "YX" and arr.ndim == 2:
+        return arr[None, None, :, :]
+    # Try a generic transpose for any other order that contains TCYX.
+    target = "TCYX"
+    if all(ax in axes for ax in target):
+        perm = [axes.index(ax) for ax in target]
+        return np.transpose(arr, perm)
+    raise HTTPException(
+        status_code=500,
+        detail=f"Unsupported ND2 axes='{axes}' shape={arr.shape}",
+    )
+
+
+def _normalize_axes_tiff(arr: np.ndarray, axes: str) -> np.ndarray:
+    """Permute / expand a tifffile array to canonical (T, C, Y, X).
+
+    Mirrors the logic in extract_tiff_stack.py so the channel index
+    we read here is the SAME index used at extraction time.
+    """
+    axes = axes.upper()
+    if "Z" in axes and arr.ndim >= 3:
+        z_idx = axes.index("Z")
+        arr = arr.max(axis=z_idx)
+        axes = axes.replace("Z", "")
+
+    if axes == "TCYX" and arr.ndim == 4:
+        return arr
+    if axes == "CYXT" and arr.ndim == 4:
+        return arr.transpose(3, 0, 1, 2)
+    if axes == "TYX" and arr.ndim == 3:
+        return arr[:, None, :, :]
+    if arr.ndim == 3 and arr.shape[0] > 1 and arr.shape[-1] not in (3, 4):
+        # Heuristic: leading axis is time, single channel (matches the
+        # fallback in extract_tiff_stack.py).
+        return arr[:, None, :, :]
+    if arr.ndim == 2:
+        return arr[None, None, :, :]
+    raise HTTPException(
+        status_code=500,
+        detail=f"Unsupported TIFF axes='{axes}' shape={arr.shape}",
+    )
+
+
+def _load_volume(path: Path, file_kind: str) -> np.ndarray:
+    """Load the file and return (T, C, Y, X) numpy array."""
+    if file_kind == "nd2":
+        try:
+            import nd2
+        except ImportError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail="nd2 library not installed in ML service",
+            ) from exc
+        with nd2.ND2File(str(path)) as f:
+            axes = "".join(f.sizes.keys())
+            arr = f.asarray()
+        return _normalize_axes_nd2(arr, axes)
+
+    if file_kind == "tiff":
+        try:
+            import tifffile
+        except ImportError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail="tifffile library not installed in ML service",
+            ) from exc
+        with tifffile.TiffFile(str(path)) as tf:
+            arr = tf.asarray()
+            axes = tf.series[0].axes if tf.series else ""
+        return _normalize_axes_tiff(arr, axes)
+
+    raise HTTPException(
+        status_code=400,
+        detail=f"Unsupported file_kind: {file_kind}",
+    )
+
+
+# ----------------------------------------------------------------------------
+#  Endpoint
+# ----------------------------------------------------------------------------
+
+
+@router.post("/mt-metrics", response_model=MTMetricsResponse)
+async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
+    """Compute per-MT-per-channel intensity metrics for one video.
+
+    Algorithm per frame:
+      1. Rasterise each polyline into a thickness-wide binary mask.
+      2. Union all band masks; dilate the union by
+         ``thickness * margin_multiplier`` for the background exclusion.
+      3. background_mask = NOT dilated_union.
+      4. For each requested channel:
+           - median_background = median of pixels under background_mask.
+           - For each polyline: pixel_count / sum / mean / std under
+             that polyline's band; emit one row.
+    """
+    if len(req.channel_indices) != len(req.channel_names):
+        raise HTTPException(
+            status_code=400,
+            detail="channel_indices and channel_names length mismatch",
+        )
+
+    path = Path(req.original_path)
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Original file not found: {req.original_path}",
+        )
+
+    volume = _load_volume(path, req.file_kind)
+    T, C, H, W = volume.shape
+    logger.info(
+        "mt-metrics: %s loaded T=%d C=%d H=%d W=%d "
+        "(thickness=%d, margin=%.2f, frames=%d, channels=%d)",
+        path.name, T, C, H, W,
+        req.thickness_px, req.margin_multiplier,
+        len(req.frames), len(req.channel_indices),
+    )
+
+    for ci in req.channel_indices:
+        if ci < 0 or ci >= C:
+            raise HTTPException(
+                status_code=400,
+                detail=f"channel_index {ci} out of bounds [0, {C - 1}]",
+            )
+
+    margin_radius = int(round(req.thickness_px * req.margin_multiplier))
+    rows: List[MTMetricsRow] = []
+
+    for fr in req.frames:
+        t = fr.frame_index
+        if t < 0 or t >= T:
+            logger.warning(
+                "mt-metrics: frame_index %d out of bounds (T=%d); skipping",
+                t, T,
+            )
+            continue
+        if not fr.polylines:
+            continue
+
+        # 1. Per-polyline thickness masks (kept in a list so the index
+        # aligns with `fr.polylines` for the per-channel loop below).
+        band_masks: List[np.ndarray] = []
+        polyline_lengths: List[float] = []
+        for pl in fr.polylines:
+            pts = np.asarray(pl.points, dtype=np.float32)
+            if pts.ndim != 2 or pts.shape[1] != 2 or pts.shape[0] < 2:
+                band_masks.append(np.zeros((H, W), dtype=np.uint8))
+                polyline_lengths.append(0.0)
+                continue
+            band_masks.append(_rasterize_band(pts, H, W, req.thickness_px))
+            polyline_lengths.append(_polyline_length(pts))
+
+        # 2 + 3. Background mask = NOT (dilated union of bands).
+        signal_union = np.zeros((H, W), dtype=np.uint8)
+        for m in band_masks:
+            signal_union |= m
+        signal_dilated = _dilate(signal_union, margin_radius)
+        background_mask = signal_dilated == 0
+
+        # 4. Per-channel computations.
+        for ci_idx, ci in enumerate(req.channel_indices):
+            channel_name = req.channel_names[ci_idx]
+            # Cast to float64 once per channel so all reductions are in
+            # consistent precision without upcasting every pixel slice.
+            frame_arr = volume[t, ci].astype(np.float64)
+
+            bg_pixels = frame_arr[background_mask]
+            median_bg = (
+                float(np.median(bg_pixels))
+                if bg_pixels.size > 0
+                else None
+            )
+
+            for pl_idx, pl in enumerate(fr.polylines):
+                band = band_masks[pl_idx]
+                pixels = frame_arr[band > 0]
+                pixel_count = int(pixels.size)
+                if pixel_count == 0:
+                    sum_v = mean_v = std_v = 0.0
+                    signal_minus_bg: Optional[float] = None
+                else:
+                    sum_v = float(pixels.sum())
+                    mean_v = float(pixels.mean())
+                    std_v = float(pixels.std())
+                    signal_minus_bg = (
+                        (mean_v - median_bg)
+                        if median_bg is not None
+                        else None
+                    )
+
+                rows.append(MTMetricsRow(
+                    frame_index=t,
+                    image_id=pl.image_id,
+                    instance_id=pl.instance_id,
+                    track_id=pl.track_id,
+                    channel=channel_name,
+                    length_px=polyline_lengths[pl_idx],
+                    area_px=pixel_count,
+                    pixel_count=pixel_count,
+                    sum_intensity=sum_v,
+                    mean_intensity=mean_v,
+                    std_intensity=std_v,
+                    median_background=median_bg,
+                    signal_minus_background=signal_minus_bg,
+                ))
+
+    logger.info(
+        "mt-metrics: produced %d rows from %d frames",
+        len(rows), len(req.frames),
+    )
+    return MTMetricsResponse(
+        rows=rows,
+        frames_processed=len(req.frames),
+        frame_height=int(H),
+        frame_width=int(W),
+    )

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -1,0 +1,516 @@
+/**
+ * Microtubule per-channel intensity metrics exporter.
+ *
+ * For an MT project export, this module:
+ *  1. Groups the project's frame Image rows by their parent video container.
+ *  2. Resolves each container's original ND2 / TIFF on disk + its
+ *     ``channels`` JSON.
+ *  3. Maps the user-selected channel names to channel indices in the
+ *     original file (positional, matching the extractor's convention).
+ *  4. POSTs a per-video request to the ML service's ``/api/v1/mt-metrics``
+ *     endpoint, which re-reads the raw 16-bit signal and returns a
+ *     long-format list of per-(frame, polyline, channel) rows.
+ *  5. Appends Node-side derived columns (``length_um`` / ``area_um2``
+ *     using ``pixelToMicrometerScale`` from the export modal) and
+ *     returns the unified row list.
+ *
+ * The ML side intentionally does not handle unit conversion so the
+ * user's pixel-scale entry on the modal remains the sole source of
+ * truth — preventing drift between metric formats.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import axios from 'axios';
+import { prisma } from '../../db/prismaClient';
+import { config } from '../../utils/config';
+import { logger } from '../../utils/logger';
+
+// ----------------------------------------------------------------------------
+//  Types (mirror the Python Pydantic models — keep in sync if either changes)
+// ----------------------------------------------------------------------------
+
+export interface MTMetricsOptions {
+  thicknessPx: number;
+  marginMultiplier: number;
+  /** Channel display names the user picked. Empty => exporter is a no-op. */
+  channels: string[];
+  /** From `ExportOptions.pixelToMicrometerScale`. ``null`` => no µm cols. */
+  pixelToMicrometerScale: number | null;
+}
+
+/**
+ * One emitted row. Long format keyed by (frame, polyline, channel) so
+ * downstream pandas/Excel users can pivot freely.
+ */
+export interface MTMetricsRow {
+  frameIndex: number;
+  imageId: string;
+  instanceId: string;
+  trackId: string | null;
+  channel: string;
+  lengthPx: number;
+  lengthUm: number | null;
+  areaPx: number;
+  areaUm2: number | null;
+  pixelCount: number;
+  sumIntensity: number;
+  meanIntensity: number;
+  stdIntensity: number;
+  medianBackground: number | null;
+  signalMinusBackground: number | null;
+}
+
+interface VideoChannelMeta {
+  name: string;
+  displayName?: string;
+}
+
+interface PolylinePayload {
+  image_id: string;
+  instance_id: string;
+  track_id: string | null;
+  points: Array<[number, number]>;
+}
+
+interface FramePayload {
+  image_id: string;
+  frame_index: number;
+  polylines: PolylinePayload[];
+}
+
+interface MLMTMetricsRequest {
+  original_path: string;
+  file_kind: 'nd2' | 'tiff';
+  channel_indices: number[];
+  channel_names: string[];
+  frames: FramePayload[];
+  thickness_px: number;
+  margin_multiplier: number;
+}
+
+interface MLMTMetricsResponseRow {
+  frame_index: number;
+  image_id: string;
+  instance_id: string;
+  track_id: string | null;
+  channel: string;
+  length_px: number;
+  area_px: number;
+  pixel_count: number;
+  sum_intensity: number;
+  mean_intensity: number;
+  std_intensity: number;
+  median_background: number | null;
+  signal_minus_background: number | null;
+}
+
+interface MLMTMetricsResponse {
+  rows: MLMTMetricsResponseRow[];
+  frames_processed: number;
+  frame_height: number;
+  frame_width: number;
+}
+
+// ----------------------------------------------------------------------------
+//  Shape of the image rows the export pipeline passes in. Only the fields
+//  we actually need — keeps the interface independent of Prisma's strict
+//  payload type which would otherwise force the caller to widen its select.
+// ----------------------------------------------------------------------------
+
+interface FrameImageInput {
+  id: string;
+  parentVideoId: string | null;
+  frameIndex: number | null;
+  isVideoContainer?: boolean;
+  segmentation?: { polygons?: string | null } | null;
+}
+
+interface RawPolyline {
+  geometry?: string;
+  type?: string;
+  points?: Array<{ x: number; y: number }>;
+  instanceId?: string;
+  trackId?: string | null;
+}
+
+// ----------------------------------------------------------------------------
+//  Helpers
+// ----------------------------------------------------------------------------
+
+const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+function safeParsePolygons(json: string | null | undefined): RawPolyline[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as RawPolyline[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function detectFileKind(mimeType: string | null, originalPath: string): 'nd2' | 'tiff' | null {
+  const lower = originalPath.toLowerCase();
+  if (lower.endsWith('.nd2')) return 'nd2';
+  if (lower.endsWith('.tif') || lower.endsWith('.tiff')) return 'tiff';
+  if (mimeType?.toLowerCase().includes('nd2')) return 'nd2';
+  if (mimeType?.toLowerCase().includes('tiff')) return 'tiff';
+  return null;
+}
+
+function resolveChannelIndices(
+  containerChannels: VideoChannelMeta[],
+  selected: string[]
+): { indices: number[]; names: string[]; skipped: string[] } {
+  const indices: number[] = [];
+  const names: string[] = [];
+  const skipped: string[] = [];
+  for (const sel of selected) {
+    const idx = containerChannels.findIndex(
+      c => c.name === sel || c.displayName === sel
+    );
+    if (idx >= 0) {
+      indices.push(idx);
+      // Use the canonical machine name so the CSV column stays consistent
+      // across renames / re-uploads with edited displayNames.
+      names.push(containerChannels[idx].name);
+    } else {
+      skipped.push(sel);
+    }
+  }
+  return { indices, names, skipped };
+}
+
+// ----------------------------------------------------------------------------
+//  Public entry point
+// ----------------------------------------------------------------------------
+
+/**
+ * Compute per-MT-per-channel metrics for an export job.
+ *
+ * @param frameImages  All Image rows selected for export (frames + any
+ *                     standalone images — standalone images are silently
+ *                     skipped since MT data is video-only).
+ * @param projectId    For logging context only.
+ * @param options      User-supplied MT metric controls from the export
+ *                     modal.
+ * @returns Long-format rows ready to write to CSV / XLSX / JSON.
+ *          Empty array if no eligible polylines were found.
+ */
+export async function computeMTMetrics(
+  frameImages: FrameImageInput[],
+  projectId: string,
+  options: MTMetricsOptions
+): Promise<MTMetricsRow[]> {
+  if (!options.channels.length) {
+    logger.info(
+      'MT metrics: no channels selected; skipping',
+      'mtMetricsExporter',
+      { projectId }
+    );
+    return [];
+  }
+
+  // Validate channel names defensively (the FE should have done this,
+  // but the export options can be POSTed directly).
+  for (const ch of options.channels) {
+    if (!CHANNEL_NAME_RE.test(ch)) {
+      throw new Error(`Invalid channel name in MT metrics options: ${ch}`);
+    }
+  }
+
+  // Group frame rows by parentVideoId. Standalone Images (parentVideoId
+  // === null) are excluded — MT projects are always video.
+  const framesByVideo = new Map<string, FrameImageInput[]>();
+  for (const img of frameImages) {
+    if (img.isVideoContainer) continue;
+    if (!img.parentVideoId) continue;
+    if (img.frameIndex == null) continue;
+    const arr = framesByVideo.get(img.parentVideoId);
+    if (arr) arr.push(img);
+    else framesByVideo.set(img.parentVideoId, [img]);
+  }
+
+  if (framesByVideo.size === 0) {
+    logger.info(
+      'MT metrics: no frame images with parentVideoId; nothing to do',
+      'mtMetricsExporter',
+      { projectId }
+    );
+    return [];
+  }
+
+  // Fetch all video container rows in a single query.
+  const containerIds = Array.from(framesByVideo.keys());
+  const containers = await prisma.image.findMany({
+    where: { id: { in: containerIds } },
+    select: {
+      id: true,
+      originalPath: true,
+      mimeType: true,
+      channels: true,
+    },
+  });
+  const containerMap = new Map(containers.map(c => [c.id, c]));
+
+  const mlBaseUrl = config.SEGMENTATION_SERVICE_URL;
+  const mlUrl = `${mlBaseUrl}/api/v1/mt-metrics`;
+  const allRows: MTMetricsRow[] = [];
+
+  for (const [videoId, frames] of framesByVideo.entries()) {
+    const container = containerMap.get(videoId);
+    if (!container) {
+      logger.warn(
+        'MT metrics: container row not found; skipping video',
+        'mtMetricsExporter',
+        { projectId, videoId }
+      );
+      continue;
+    }
+    const fileKind = detectFileKind(container.mimeType, container.originalPath);
+    if (!fileKind) {
+      logger.warn(
+        'MT metrics: cannot detect ND2/TIFF from container; skipping video',
+        'mtMetricsExporter',
+        { projectId, videoId, originalPath: container.originalPath }
+      );
+      continue;
+    }
+    const containerChannels = Array.isArray(container.channels)
+      ? (container.channels as unknown as VideoChannelMeta[])
+      : [];
+    if (!containerChannels.length) {
+      logger.warn(
+        'MT metrics: container has no channels JSON; skipping video',
+        'mtMetricsExporter',
+        { projectId, videoId }
+      );
+      continue;
+    }
+
+    const { indices, names, skipped } = resolveChannelIndices(
+      containerChannels,
+      options.channels
+    );
+    if (skipped.length) {
+      logger.warn(
+        'MT metrics: some selected channels not found on this video',
+        'mtMetricsExporter',
+        { projectId, videoId, skipped }
+      );
+    }
+    if (!indices.length) {
+      logger.warn(
+        'MT metrics: no overlap between selected channels and this video; skipping',
+        'mtMetricsExporter',
+        { projectId, videoId }
+      );
+      continue;
+    }
+
+    // Build the frames payload — only frames that actually have polylines.
+    const framesPayload: FramePayload[] = [];
+    for (const fr of frames) {
+      const polylines = safeParsePolygons(fr.segmentation?.polygons)
+        .filter(p => (p.geometry ?? 'polygon') === 'polyline')
+        .filter(p => Array.isArray(p.points) && p.points.length >= 2)
+        .map<PolylinePayload>(p => ({
+          image_id: fr.id,
+          instance_id: p.instanceId ?? `mt_${fr.id.slice(0, 8)}_${p.points!.length}`,
+          track_id: p.trackId ?? null,
+          points: p.points!.map(pt => [pt.x, pt.y]),
+        }));
+      if (!polylines.length) continue;
+      framesPayload.push({
+        image_id: fr.id,
+        frame_index: fr.frameIndex!,
+        polylines,
+      });
+    }
+
+    if (!framesPayload.length) {
+      logger.info(
+        'MT metrics: no polylines for this video; skipping',
+        'mtMetricsExporter',
+        { projectId, videoId }
+      );
+      continue;
+    }
+
+    // Original file absolute path. `originalPath` is stored relative to
+    // UPLOAD_DIR; resolve here so ML gets a path it can open directly.
+    const absoluteOriginalPath = path.join(
+      config.UPLOAD_DIR,
+      container.originalPath
+    );
+
+    const body: MLMTMetricsRequest = {
+      original_path: absoluteOriginalPath,
+      file_kind: fileKind,
+      channel_indices: indices,
+      channel_names: names,
+      frames: framesPayload,
+      thickness_px: options.thicknessPx,
+      margin_multiplier: options.marginMultiplier,
+    };
+
+    logger.info(
+      'MT metrics: requesting ML computation',
+      'mtMetricsExporter',
+      {
+        projectId,
+        videoId,
+        fileKind,
+        frames: framesPayload.length,
+        channels: indices.length,
+      }
+    );
+
+    let mlResponse: MLMTMetricsResponse;
+    try {
+      // 5 minutes — covers a long video × multiple channels with full
+      // ND2 / TIFF reads. Failures bubble up so the export job fails
+      // visibly rather than silently emitting an empty sheet.
+      const res = await axios.post<MLMTMetricsResponse>(mlUrl, body, {
+        timeout: 5 * 60 * 1000,
+      });
+      mlResponse = res.data;
+    } catch (err) {
+      logger.error(
+        'MT metrics: ML request failed',
+        err instanceof Error ? err : new Error(String(err)),
+        'mtMetricsExporter',
+        { projectId, videoId }
+      );
+      throw err;
+    }
+
+    const scale = options.pixelToMicrometerScale;
+    for (const row of mlResponse.rows) {
+      allRows.push({
+        frameIndex: row.frame_index,
+        imageId: row.image_id,
+        instanceId: row.instance_id,
+        trackId: row.track_id,
+        channel: row.channel,
+        lengthPx: row.length_px,
+        lengthUm: scale != null ? row.length_px * scale : null,
+        areaPx: row.area_px,
+        areaUm2: scale != null ? row.area_px * scale * scale : null,
+        pixelCount: row.pixel_count,
+        sumIntensity: row.sum_intensity,
+        meanIntensity: row.mean_intensity,
+        stdIntensity: row.std_intensity,
+        medianBackground: row.median_background,
+        signalMinusBackground: row.signal_minus_background,
+      });
+    }
+  }
+
+  logger.info(
+    'MT metrics: total rows produced',
+    'mtMetricsExporter',
+    { projectId, rows: allRows.length }
+  );
+  return allRows;
+}
+
+// ----------------------------------------------------------------------------
+//  Output writers
+// ----------------------------------------------------------------------------
+
+/** Long-format column order used in CSV / XLSX. JSON uses the camelCase
+ *  field names from MTMetricsRow directly. */
+const CSV_HEADERS: readonly (keyof MTMetricsRow)[] = [
+  'frameIndex',
+  'imageId',
+  'instanceId',
+  'trackId',
+  'channel',
+  'lengthPx',
+  'lengthUm',
+  'areaPx',
+  'areaUm2',
+  'pixelCount',
+  'sumIntensity',
+  'meanIntensity',
+  'stdIntensity',
+  'medianBackground',
+  'signalMinusBackground',
+] as const;
+
+function csvCell(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v)) return '';
+    // Plenty of precision for fluorescence values without scientific notation
+    // for typical-range numbers.
+    return Number.isInteger(v) ? String(v) : v.toFixed(6).replace(/\.?0+$/, '');
+  }
+  const s = String(v);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function rowsToCSV(rows: MTMetricsRow[]): string {
+  const lines: string[] = [CSV_HEADERS.join(',')];
+  for (const row of rows) {
+    lines.push(CSV_HEADERS.map(h => csvCell(row[h])).join(','));
+  }
+  return lines.join('\n') + '\n';
+}
+
+async function writeXLSX(rows: MTMetricsRow[], filePath: string): Promise<void> {
+  // exceljs is CJS; mirror the dynamic-import idiom used by exportService.
+  const excelMod = (await import('exceljs')) as unknown as {
+    default?: typeof import('exceljs');
+    Workbook?: typeof import('exceljs').Workbook;
+  };
+  const ExcelJS = excelMod.default ?? excelMod;
+  const workbook = new ExcelJS.Workbook!();
+  const sheet = workbook.addWorksheet('Microtubule Metrics');
+  sheet.columns = CSV_HEADERS.map(h => ({ header: h, key: h, width: 18 }));
+  for (const row of rows) {
+    sheet.addRow(row);
+  }
+  // Bold header row.
+  sheet.getRow(1).font = { bold: true };
+  await workbook.xlsx.writeFile(filePath);
+}
+
+/**
+ * Persist the metric rows to disk in any subset of {excel, csv, json}.
+ *
+ * @param rows     Output from {@link computeMTMetrics}.
+ * @param destDir  Target directory (created if absent).
+ * @param formats  Same formats list the user picked for general metrics.
+ */
+export async function writeMTMetrics(
+  rows: MTMetricsRow[],
+  destDir: string,
+  formats: ReadonlyArray<'excel' | 'csv' | 'json'>
+): Promise<void> {
+  if (!rows.length || !formats.length) return;
+  await fs.mkdir(destDir, { recursive: true });
+
+  for (const fmt of formats) {
+    if (fmt === 'csv') {
+      await fs.writeFile(
+        path.join(destDir, 'microtubule_metrics.csv'),
+        rowsToCSV(rows),
+        'utf8'
+      );
+    } else if (fmt === 'json') {
+      await fs.writeFile(
+        path.join(destDir, 'microtubule_metrics.json'),
+        JSON.stringify(rows, null, 2),
+        'utf8'
+      );
+    } else if (fmt === 'excel') {
+      await writeXLSX(rows, path.join(destDir, 'microtubule_metrics.xlsx'));
+    }
+  }
+}

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -33,6 +33,10 @@ import {
   getProgressMessage,
   createZipArchive,
 } from './export/exportFileOperations';
+import {
+  computeMTMetrics,
+  writeMTMetrics,
+} from './export/mtMetricsExporter';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -54,6 +58,20 @@ export interface ExportOptions {
   includeDocumentation?: boolean;
   selectedImageIds?: string[];
   pixelToMicrometerScale?: number;
+  /**
+   * Microtubule-only export options. When ``enabled`` and the project is
+   * ``microtubule``, the export pipeline re-reads the original ND2/TIFF
+   * to compute per-polyline-per-channel intensity metrics into a new
+   * ``microtubule_metrics`` artefact. Length / area / intensity stats
+   * are derived from raw 16-bit signal, NOT from the 8-bit
+   * display-normalised per-channel PNGs.
+   */
+  mtMetrics?: {
+    enabled: boolean;
+    thicknessPx: number;
+    marginMultiplier: number;
+    channels: string[];
+  };
 }
 
 // Define type for project with images and segmentation data
@@ -77,6 +95,9 @@ export type ProjectWithImages = Prisma.ProjectGetPayload<{
         segmentationStatus: true;
         createdAt: true;
         updatedAt: true;
+        isVideoContainer: true;
+        parentVideoId: true;
+        frameIndex: true;
         segmentation: true;
       };
     };
@@ -382,6 +403,12 @@ export class ExportService {
               segmentationStatus: true,
               createdAt: true,
               updatedAt: true,
+              // Video-frame fields needed by the MT metrics exporter so it
+              // can group frames by their parent container and resolve
+              // the original ND2/TIFF on disk.
+              isVideoContainer: true,
+              parentVideoId: true,
+              frameIndex: true,
               segmentation: {
                 select: {
                   id: true,
@@ -532,6 +559,29 @@ export class ExportService {
           ).then(() => {
             progressStep++;
             this.updateJobProgress(jobId, 5 + progressStep * progressIncrement);
+          })
+        );
+      }
+
+      // Microtubule per-channel intensity metrics — independent of the
+      // standard metrics pipeline because they reach all the way back to
+      // the original ND2/TIFF for raw 16-bit signal (the per-channel PNGs
+      // on disk are 8-bit display-mapped). MT-only and only when the
+      // user enabled the section in the export modal.
+      if (
+        options.mtMetrics?.enabled &&
+        (project.type ?? '') === 'microtubule' &&
+        project.images?.length
+      ) {
+        exportTasks.push(
+          this.generateMTIntensityMetrics(
+            project.images as ImageWithSegmentation[],
+            exportDir,
+            options,
+            jobId
+          ).then(() => {
+            // No dedicated progress step — runs alongside metrics; the
+            // generic 90% allocation absorbs it.
           })
         );
       }
@@ -1261,6 +1311,91 @@ export class ExportService {
           path.join(metricsDir, 'metrics.json'),
           JSON.stringify(allMetrics, null, 2)
         );
+      }
+    }
+  }
+
+  /**
+   * Microtubule-only intensity / length / area metrics exporter.
+   *
+   * Computes per-(frame, polyline, channel) rows by re-reading the
+   * original ND2/TIFF on disk via the ML service's /mt-metrics route,
+   * then writes a long-format CSV/XLSX/JSON next to the standard
+   * metrics files.
+   *
+   * Failures are caught + logged + recorded as a warning rather than
+   * failing the whole export. Length/area columns alone are still
+   * useful, so partial loss (e.g. one video missing its ND2 on disk)
+   * shouldn't prevent the user from getting the rest.
+   */
+  private async generateMTIntensityMetrics(
+    images: ImageWithSegmentation[],
+    exportDir: string,
+    options: ExportOptions,
+    jobId?: string
+  ): Promise<void> {
+    if (!options.mtMetrics?.enabled) return;
+    if (jobId && this.isJobCancelled(jobId)) {
+      throw new Error('Export cancelled by user');
+    }
+
+    const projectId = images[0]?.projectId ?? '';
+    const formats = options.metricsFormats?.length
+      ? options.metricsFormats
+      : (['csv'] as const);
+
+    try {
+      const rows = await computeMTMetrics(
+        images.map(i => ({
+          id: i.id,
+          parentVideoId: i.parentVideoId ?? null,
+          frameIndex: i.frameIndex ?? null,
+          isVideoContainer: i.isVideoContainer,
+          segmentation: i.segmentation
+            ? { polygons: i.segmentation.polygons }
+            : null,
+        })),
+        projectId,
+        {
+          thicknessPx: options.mtMetrics.thicknessPx,
+          marginMultiplier: options.mtMetrics.marginMultiplier,
+          channels: options.mtMetrics.channels,
+          pixelToMicrometerScale:
+            options.pixelToMicrometerScale ?? null,
+        }
+      );
+
+      if (!rows.length) {
+        logger.info(
+          'MT intensity metrics: 0 rows produced; not writing files',
+          'ExportService',
+          { jobId, projectId }
+        );
+        return;
+      }
+
+      const metricsDir = path.join(exportDir, 'metrics');
+      await writeMTMetrics(rows, metricsDir, formats);
+      logger.info(
+        'MT intensity metrics: wrote files',
+        'ExportService',
+        { jobId, projectId, rows: rows.length, formats }
+      );
+    } catch (err) {
+      logger.error(
+        'MT intensity metrics: computation failed',
+        err instanceof Error ? err : new Error(String(err)),
+        'ExportService',
+        { jobId, projectId }
+      );
+      if (jobId) {
+        const job = this.exportJobs.get(jobId);
+        if (job) {
+          job.warnings = [
+            ...(job.warnings ?? []),
+            'Microtubule intensity metrics could not be computed (original file missing or ML service error). Standard metrics are still included.',
+          ];
+        }
       }
     }
   }

--- a/src/components/project/ProjectToolbar.tsx
+++ b/src/components/project/ProjectToolbar.tsx
@@ -28,6 +28,7 @@ interface ProjectToolbarProps {
   showUploadButton?: boolean;
   showExportButton?: boolean;
   projectName?: string;
+  projectType?: string | null;
   images?: unknown[];
   selectedImageIds?: string[];
   // Selection props
@@ -55,6 +56,7 @@ const ProjectToolbar = ({
   showUploadButton = true,
   showExportButton = true,
   projectName = 'Project',
+  projectType,
   images = [],
   selectedImageIds,
   selectedCount = 0,
@@ -358,6 +360,7 @@ const ProjectToolbar = ({
           onClose={() => setShowExportDialog(false)}
           projectId={projectId}
           projectName={projectName}
+          projectType={projectType ?? null}
           images={images}
           selectedImageIds={selectedImageIds}
           onExportingChange={onExportingChange || setIsExporting}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1543,6 +1543,7 @@ const ProjectDetail = () => {
               viewMode={viewMode}
               setViewMode={setViewMode}
               projectName={projectTitle}
+              projectType={projectType}
               images={images}
               selectedCount={selectedCount}
               isAllSelected={isAllSelected}

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -40,6 +40,7 @@ import { useLanguage } from '@/contexts/useLanguage';
 import { ProjectImage } from '@/types';
 import { EXPORT_DEFAULTS } from '@/lib/export-config';
 import { ImageSelectionGrid } from './components/ImageSelectionGrid';
+import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
 import { UniversalCancelButton } from '@/components/ui/universal-cancel-button';
 
 interface AdvancedExportDialogProps {
@@ -47,11 +48,21 @@ interface AdvancedExportDialogProps {
   onClose: () => void;
   projectId: string;
   projectName: string;
+  /** Used to gate microtubule-specific export controls. */
+  projectType?: string | null;
   images: ProjectImage[];
   selectedImageIds?: string[];
   onExportingChange?: (isExporting: boolean) => void;
   onDownloadingChange?: (isDownloading: boolean) => void;
 }
+
+/** Default MT metrics options when the user toggles the section on. */
+const MT_METRICS_DEFAULTS = {
+  enabled: false,
+  thicknessPx: 5,
+  marginMultiplier: 2,
+  channels: [] as string[],
+};
 
 export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
   React.memo(
@@ -60,12 +71,41 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       onClose,
       projectId,
       projectName,
+      projectType,
       images,
       selectedImageIds,
       onExportingChange,
       onDownloadingChange,
     }) => {
       const { t } = useLanguage();
+      const isMTProject = projectType === 'microtubule';
+
+      // Distinct channels across the project's video container rows.
+      // De-dupe by machine name (the same channel might appear on
+      // multiple uploaded videos in a multi-video project).
+      const availableChannels = React.useMemo(() => {
+        if (!isMTProject) return [];
+        const byName = new Map<
+          string,
+          { name: string; displayName?: string }
+        >();
+        for (const img of images) {
+          if (!img.isVideoContainer || !img.channels) continue;
+          for (const ch of img.channels) {
+            if (!byName.has(ch.name)) {
+              byName.set(ch.name, {
+                name: ch.name,
+                displayName: ch.displayName,
+              });
+            }
+          }
+        }
+        return Array.from(byName.values());
+      }, [images, isMTProject]);
+
+      // Local snapshot of MT options. We always merge into the shared
+      // exportOptions state when the user toggles or edits inputs so the
+      // export hook persists the same object that gets POSTed.
       const {
         exportOptions,
         updateExportOptions,
@@ -297,6 +337,20 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                     />
                   </CardContent>
                 </Card>
+
+                {/* Microtubule-only section. Rendered only when the
+                    project type is `microtubule` because intensity
+                    sampling requires multi-channel video data + raw
+                    ND2/TIFF on disk. */}
+                {isMTProject && (
+                  <MicrotubuleMetricsSection
+                    value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
+                    onChange={next =>
+                      updateExportOptions({ mtMetrics: next })
+                    }
+                    availableChannels={availableChannels}
+                  />
+                )}
               </TabsContent>
 
               <TabsContent

--- a/src/pages/export/components/MicrotubuleMetricsSection.tsx
+++ b/src/pages/export/components/MicrotubuleMetricsSection.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Wand2 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useLanguage } from '@/contexts/useLanguage';
+
+interface VideoChannelOption {
+  /** Machine-safe identifier (matches the container.channels[].name) */
+  name: string;
+  /** Human-friendly label from TIFF/ND2 metadata */
+  displayName?: string;
+}
+
+export interface MicrotubuleMetricsOptions {
+  enabled: boolean;
+  thicknessPx: number;
+  marginMultiplier: number;
+  channels: string[];
+}
+
+export interface MicrotubuleMetricsSectionProps {
+  value: MicrotubuleMetricsOptions;
+  onChange: (next: MicrotubuleMetricsOptions) => void;
+  /**
+   * All channels available across the project's video containers,
+   * de-duplicated by machine name. Empty array => the project has no
+   * channel metadata and intensity sampling is impossible.
+   */
+  availableChannels: VideoChannelOption[];
+}
+
+/**
+ * MT-only export controls: band thickness, background margin
+ * multiplier, channel multi-select. Renders inside the export dialog's
+ * General tab when ``projectType === 'microtubule'``.
+ *
+ * The backend re-reads the original ND2/TIFF on disk so the intensity
+ * numbers are derived from raw 16-bit signal (the per-channel PNGs are
+ * percentile-clipped 8-bit and unsuitable for absolute fluorescence).
+ */
+export const MicrotubuleMetricsSection: React.FC<
+  MicrotubuleMetricsSectionProps
+> = ({ value, onChange, availableChannels }) => {
+  const { t } = useLanguage();
+
+  const setEnabled = (enabled: boolean) =>
+    onChange({ ...value, enabled });
+
+  const setThickness = (raw: string) => {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 1 && n <= 100) {
+      onChange({ ...value, thicknessPx: n });
+    }
+  };
+
+  const setMargin = (raw: string) => {
+    const n = Number.parseFloat(raw);
+    if (Number.isFinite(n) && n >= 0 && n <= 10) {
+      onChange({ ...value, marginMultiplier: n });
+    }
+  };
+
+  const toggleChannel = (name: string, checked: boolean) => {
+    const set = new Set(value.channels);
+    if (checked) set.add(name);
+    else set.delete(name);
+    onChange({ ...value, channels: Array.from(set) });
+  };
+
+  const disabledInputs = !value.enabled;
+  const noChannels = availableChannels.length === 0;
+
+  return (
+    <Card className="p-3 sm:p-4">
+      <CardHeader className="p-0 pb-3 sm:pb-4">
+        <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+          <Wand2 className="h-4 w-4" />
+          {t('export.mt.sectionTitle')}
+        </CardTitle>
+        <CardDescription className="text-xs sm:text-sm">
+          {t('export.mt.sectionDescription')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-0">
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="mt-enabled"
+            checked={value.enabled}
+            onCheckedChange={c => setEnabled(c === true)}
+          />
+          <Label htmlFor="mt-enabled" className="text-sm">
+            {t('export.mt.enable')}
+          </Label>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <Label htmlFor="mt-thickness" className="text-sm">
+              {t('export.mt.thicknessLabel')}
+            </Label>
+            <Input
+              id="mt-thickness"
+              type="number"
+              min={1}
+              max={100}
+              step={1}
+              value={value.thicknessPx}
+              disabled={disabledInputs}
+              onChange={e => setThickness(e.target.value)}
+              className="mt-1 text-sm"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('export.mt.thicknessHelp')}
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="mt-margin" className="text-sm">
+              {t('export.mt.marginLabel')}
+            </Label>
+            <Input
+              id="mt-margin"
+              type="number"
+              min={0}
+              max={10}
+              step={0.1}
+              value={value.marginMultiplier}
+              disabled={disabledInputs}
+              onChange={e => setMargin(e.target.value)}
+              className="mt-1 text-sm"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('export.mt.marginHelp')}
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <Label className="text-sm">
+            {t('export.mt.channelsLabel')}
+          </Label>
+          {noChannels ? (
+            <p className="text-xs text-muted-foreground mt-2">
+              {t('export.mt.noChannels')}
+            </p>
+          ) : (
+            <div className="mt-2 space-y-2">
+              {availableChannels.map(ch => (
+                <div key={ch.name} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={`mt-channel-${ch.name}`}
+                    checked={value.channels.includes(ch.name)}
+                    disabled={disabledInputs}
+                    onCheckedChange={c => toggleChannel(ch.name, c === true)}
+                  />
+                  <Label
+                    htmlFor={`mt-channel-${ch.name}`}
+                    className="text-sm font-normal"
+                  >
+                    {ch.displayName ?? ch.name}
+                    {ch.displayName && ch.displayName !== ch.name ? (
+                      <span className="text-muted-foreground ml-1">
+                        ({ch.name})
+                      </span>
+                    ) : null}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -78,6 +78,19 @@ export interface ExportOptions {
   includeDocumentation?: boolean;
   selectedImageIds?: string[];
   pixelToMicrometerScale?: number;
+  /**
+   * Microtubule-only metrics. Sent to the backend on POST /export and
+   * consumed by the export pipeline only when the project type is
+   * ``microtubule``. Re-reads the original ND2/TIFF to compute raw
+   * intensity per band.
+   */
+  mtMetrics?: {
+    enabled: boolean;
+    thicknessPx: number;
+    marginMultiplier: number;
+    /** Channel names (machine-safe ``name`` field from container.channels). */
+    channels: string[];
+  };
 }
 
 export const useSharedAdvancedExport = (

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -7,7 +7,7 @@ import React, {
   startTransition,
 } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useAuth, useLanguage } from '@/contexts/exports';
+import { useAuth, useLanguage, useModel } from '@/contexts/exports';
 import { useProjectData } from '@/hooks/useProjectData';
 import { sortImagesBySettings } from '@/hooks/useImageFilter';
 import { useEnhancedSegmentationEditor } from './hooks/useEnhancedSegmentationEditor';
@@ -72,6 +72,7 @@ const SegmentationEditor = () => {
   }>();
   const { user } = useAuth();
   const { t } = useLanguage();
+  const { selectedModel, confidenceThreshold, detectHoles } = useModel();
   const navigate = useNavigate();
 
   // Track if this is the initial load (coming from Project Detail) vs internal navigation
@@ -137,6 +138,7 @@ const SegmentationEditor = () => {
   const [segmentationPolygons, setSegmentationPolygons] = useState<
     SegmentationPolygon[] | null
   >(null);
+  const [isResegmenting, setIsResegmenting] = useState(false);
   const [imageDimensions, setImageDimensions] = useState<{
     width: number;
     height: number;
@@ -1122,6 +1124,40 @@ const SegmentationEditor = () => {
     [handleUpdatePolygonField]
   );
 
+  // Re-run ML segmentation on the currently-open frame using the
+  // user-selected model + threshold. Overwrites the existing
+  // `Segmentation` row on the backend (upsert). After the batch
+  // endpoint returns, we reload polygons via the existing
+  // `reloadSegmentation` hook so the canvas reflects the new result.
+  const handleResegmentCurrentFrame = useCallback(async () => {
+    if (!imageId || isResegmenting) return;
+    setIsResegmenting(true);
+    try {
+      await apiClient.requestBatchSegmentation(
+        [imageId],
+        selectedModel,
+        confidenceThreshold,
+        detectHoles
+      );
+      await reloadSegmentation();
+      toast.success(t('segmentation.toolbar.resegmentSuccess'));
+    } catch (err) {
+      if (handleCancelledError(err, 'resegment current frame')) return;
+      logger.error('Resegment failed', err);
+      toast.error(t('segmentation.toolbar.resegmentFailed'));
+    } finally {
+      setIsResegmenting(false);
+    }
+  }, [
+    imageId,
+    isResegmenting,
+    selectedModel,
+    confidenceThreshold,
+    detectHoles,
+    reloadSegmentation,
+    t,
+  ]);
+
   // Convert new EditMode to legacy booleans for compatibility
   const legacyModes = useMemo(
     () => ({
@@ -1288,6 +1324,9 @@ const SegmentationEditor = () => {
               onZoomIn={editor.handleZoomIn}
               onZoomOut={editor.handleZoomOut}
               onResetView={editor.handleResetView}
+              onResegment={handleResegmentCurrentFrame}
+              isResegmenting={isResegmenting}
+              hasExistingPolygons={editor.getPolygons().length > 0}
             />
 
             {/* Center: Canvas and Top Toolbar */}

--- a/src/pages/segmentation/components/VerticalToolbar.tsx
+++ b/src/pages/segmentation/components/VerticalToolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   MousePointer,
@@ -11,8 +11,21 @@ import {
   ZoomIn,
   ZoomOut,
   Maximize2,
+  Wand2,
+  Loader2,
 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { useLanguage } from '@/contexts/useLanguage';
+import { useModel } from '@/contexts/exports';
 import { EditMode } from '../types';
 
 interface VerticalToolbarProps {
@@ -23,6 +36,9 @@ interface VerticalToolbarProps {
   onZoomIn?: () => void;
   onZoomOut?: () => void;
   onResetView?: () => void;
+  onResegment?: () => Promise<void> | void;
+  isResegmenting?: boolean;
+  hasExistingPolygons?: boolean;
 }
 
 /**
@@ -36,8 +52,32 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
   onZoomIn,
   onZoomOut,
   onResetView,
+  onResegment,
+  isResegmenting = false,
+  hasExistingPolygons = false,
 }) => {
   const { t } = useLanguage();
+  const { selectedModel, confidenceThreshold, getModelInfo } = useModel();
+  const [showResegmentDialog, setShowResegmentDialog] = useState(false);
+
+  const modelDisplayName = getModelInfo(selectedModel).displayName;
+  const thresholdFormatted = confidenceThreshold.toFixed(2);
+
+  const resegmentDisabled = disabled || isResegmenting || !onResegment;
+
+  const handleResegmentClick = () => {
+    if (resegmentDisabled || !onResegment) return;
+    if (hasExistingPolygons) {
+      setShowResegmentDialog(true);
+    } else {
+      void onResegment();
+    }
+  };
+
+  const handleConfirmResegment = () => {
+    setShowResegmentDialog(false);
+    if (onResegment) void onResegment();
+  };
 
   const getModeIcon = (mode: EditMode) => {
     switch (mode) {
@@ -209,9 +249,50 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
   };
 
   return (
-    <div className="w-14 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center py-4 gap-2 dark:bg-gray-900">
-      {/* Mode buttons */}
-      <ModeButton mode={EditMode.View} />
+    <>
+      <div className="w-14 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center py-4 gap-2 dark:bg-gray-900">
+        {/* Resegment current frame */}
+        {onResegment && (
+          <>
+            <div className="relative group">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleResegmentClick}
+                disabled={resegmentDisabled}
+                className={`
+                  w-12 h-12 rounded-lg transition-all duration-200
+                  hover:bg-indigo-100 dark:hover:bg-indigo-900/30
+                  ${resegmentDisabled ? 'opacity-50 cursor-not-allowed' : ''}
+                `}
+              >
+                {isResegmenting ? (
+                  <Loader2 size={20} className="animate-spin" />
+                ) : (
+                  <Wand2 size={20} />
+                )}
+              </Button>
+              <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+                <div className="font-medium">
+                  {t('segmentation.toolbar.resegment')}
+                </div>
+                <div className="text-xs text-gray-300 mt-1">
+                  {t('segmentation.toolbar.resegmentTooltipModel', {
+                    model: modelDisplayName,
+                    threshold: thresholdFormatted,
+                  })}
+                </div>
+                <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
+              </div>
+            </div>
+
+            {/* Separator below resegment */}
+            <div className="w-10 h-px bg-gray-300 dark:bg-gray-600 my-2" />
+          </>
+        )}
+
+        {/* Mode buttons */}
+        <ModeButton mode={EditMode.View} />
       <ModeButton mode={EditMode.EditVertices} />
       <ModeButton mode={EditMode.AddPoints} />
       <ModeButton mode={EditMode.CreatePolygon} />
@@ -276,6 +357,31 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
         </div>
       </div>
     </div>
+
+      <AlertDialog
+        open={showResegmentDialog}
+        onOpenChange={setShowResegmentDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('segmentation.toolbar.resegmentConfirmTitle')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('segmentation.toolbar.resegmentConfirmDescription')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t('common.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmResegment}>
+              {t('segmentation.toolbar.resegment')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };
 

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -613,6 +613,13 @@ export default {
       keyboard: 'Klávesa: {{key}}',
       requiresSelection: 'Vyžaduje výběr polygonu',
       requiresPolygonSelection: 'Vyžaduje výběr polygonu',
+      resegment: 'Znovu segmentovat snímek',
+      resegmentTooltipModel: 'Model: {{model}} · {{threshold}}',
+      resegmentSuccess: 'Snímek byl znovu segmentován',
+      resegmentFailed: 'Resegmentace selhala',
+      resegmentConfirmTitle: 'Nahradit existující polygony?',
+      resegmentConfirmDescription:
+        'Spuštění modelu přepíše současnou segmentaci. Ruční úpravy polygonů na tomto snímku budou ztraceny.',
       select: 'Vybrat',
       undoTooltip: 'Zpět (Ctrl+Z)',
       undo: 'Zpět',
@@ -1110,6 +1117,21 @@ export default {
     imagesDeleted_other: '{{count}} obrázky smazány',
   },
   export: {
+    mt: {
+      sectionTitle: 'Metriky mikrotubulů',
+      sectionDescription:
+        'Délka, plocha a intenzita signálu pro každý MT z původního ND2/TIFF souboru. Odečteno median pozadí (mimo dilatovanou masku MT).',
+      enable: 'Spočítat intenzitu signálu pro každý kanál',
+      thicknessLabel: 'Tloušťka MT (px)',
+      thicknessHelp:
+        'Šířka pásu podél polyline, ze kterého se sbírá signál. 5 px odpovídá běžnému průměru mikrotubulu při 100× widefield.',
+      marginLabel: 'Okraj pozadí (× tloušťka)',
+      marginHelp:
+        'Pixely v tomto poloměru (tloušťka × násobek) od libovolného MT se z pozadí vyloučí. Vyšší = konzervativnější.',
+      channelsLabel: 'Kanály ke zpracování',
+      noChannels:
+        'Tento projekt nemá metadata o kanálech. Pro získání metrik podle kanálů znovu nahrajte video.',
+    },
     advancedExport: 'Pokročilý export',
     advancedOptions: 'Pokročilé možnosti exportu',
     configureSettings:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -774,6 +774,13 @@ export default {
       keyboard: 'Taste: {{key}}',
       requiresSelection: 'Erfordert Polygon-Auswahl',
       requiresPolygonSelection: 'Erfordert Polygon-Auswahl',
+      resegment: 'Frame neu segmentieren',
+      resegmentTooltipModel: 'Modell: {{model}} · {{threshold}}',
+      resegmentSuccess: 'Frame neu segmentiert',
+      resegmentFailed: 'Neusegmentierung fehlgeschlagen',
+      resegmentConfirmTitle: 'Vorhandene Polygone ersetzen?',
+      resegmentConfirmDescription:
+        'Das Ausführen des Modells überschreibt die aktuelle Segmentierung. Manuelle Bearbeitungen der Polygone in diesem Frame gehen verloren.',
       select: 'Auswählen',
       undoTooltip: 'Rückgängig (Strg+Z)',
       undo: 'Rückgängig',
@@ -1121,6 +1128,21 @@ export default {
     imagesDeleted_other: '{{count}} Bilder gelöscht',
   },
   export: {
+    mt: {
+      sectionTitle: 'Mikrotubuli-Metriken',
+      sectionDescription:
+        'Pro-MT-Länge, -Fläche und kanalweise Intensität aus der rohen ND2/TIFF-Datei. Hintergrundkorrektur über den Median außerhalb der dilatierten MT-Maske.',
+      enable: 'Kanalweise Intensitätsmetriken berechnen',
+      thicknessLabel: 'MT-Dicke (px)',
+      thicknessHelp:
+        'Breite des Abtastbands entlang jeder Polyline. 5 px entspricht dem typischen Mikrotubulus-Durchmesser bei 100× Widefield.',
+      marginLabel: 'Hintergrundrand (× Dicke)',
+      marginHelp:
+        'Pixel innerhalb dieses Radius (Dicke × Multiplikator) von einem MT werden vom Hintergrund ausgeschlossen. Höher = konservativer.',
+      channelsLabel: 'Zu abtastende Kanäle',
+      noChannels:
+        'Dieses Projekt hat keine Kanal-Metadaten. Laden Sie das Video erneut hoch, um kanalspezifische Metriken zu erhalten.',
+    },
     advancedExport: 'Erweiterter Export',
     advancedOptions: 'Erweiterte Export-Optionen',
     configureSettings:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -698,6 +698,13 @@ export default {
       keyboard: 'Key: {{key}}',
       requiresSelection: 'Requires polygon selection',
       requiresPolygonSelection: 'Requires polygon selection',
+      resegment: 'Resegment frame',
+      resegmentTooltipModel: 'Model: {{model}} · {{threshold}}',
+      resegmentSuccess: 'Frame resegmented',
+      resegmentFailed: 'Resegmentation failed',
+      resegmentConfirmTitle: 'Replace existing polygons?',
+      resegmentConfirmDescription:
+        'Running the model will overwrite the current segmentation. Manual edits to polygons on this frame will be lost.',
       select: 'Select',
       undoTooltip: 'Undo (Ctrl+Z)',
       undo: 'Undo',
@@ -1100,6 +1107,22 @@ export default {
     imagesDeleted_other: '{{count}} images deleted',
   },
   export: {
+    // Microtubule-only metric controls.
+    mt: {
+      sectionTitle: 'Microtubule metrics',
+      sectionDescription:
+        'Per-MT length, area, and per-channel intensity from the raw ND2/TIFF file. Background-corrected using the median of pixels outside the dilated MT mask.',
+      enable: 'Compute per-channel intensity metrics',
+      thicknessLabel: 'MT thickness (px)',
+      thicknessHelp:
+        'Width of the sampling band along each polyline. 5 px matches typical microtubule diameter in 100x widefield.',
+      marginLabel: 'Background margin (× thickness)',
+      marginHelp:
+        'Excludes pixels within this radius (thickness × multiplier) of any MT from the background. Higher = more conservative.',
+      channelsLabel: 'Channels to sample',
+      noChannels:
+        'This project has no per-channel metadata. Re-upload the video to get channel-specific metrics.',
+    },
     // Dialog headers
     advancedExport: 'Advanced Export',
     advancedOptions: 'Advanced Export Options',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -766,6 +766,13 @@ export default {
       keyboard: 'Tecla: {{key}}',
       requiresSelection: 'Requiere selección de polígono',
       requiresPolygonSelection: 'Requiere selección de polígono',
+      resegment: 'Resegmentar fotograma',
+      resegmentTooltipModel: 'Modelo: {{model}} · {{threshold}}',
+      resegmentSuccess: 'Fotograma resegmentado',
+      resegmentFailed: 'Falló la resegmentación',
+      resegmentConfirmTitle: '¿Reemplazar polígonos existentes?',
+      resegmentConfirmDescription:
+        'Ejecutar el modelo sobrescribirá la segmentación actual. Las ediciones manuales de polígonos en este fotograma se perderán.',
       select: 'Seleccionar',
       undoTooltip: 'Deshacer (Ctrl+Z)',
       undo: 'Deshacer',
@@ -1105,6 +1112,21 @@ export default {
     imagesDeleted_other: '{{count}} imágenes eliminadas',
   },
   export: {
+    mt: {
+      sectionTitle: 'Métricas de microtúbulos',
+      sectionDescription:
+        'Longitud, área e intensidad por canal de cada MT desde el archivo ND2/TIFF original. Corregido con la mediana del fondo (fuera de la máscara MT dilatada).',
+      enable: 'Calcular métricas de intensidad por canal',
+      thicknessLabel: 'Grosor del MT (px)',
+      thicknessHelp:
+        'Ancho de la banda de muestreo a lo largo de cada polilínea. 5 px corresponde al diámetro típico del microtúbulo a 100× campo amplio.',
+      marginLabel: 'Margen del fondo (× grosor)',
+      marginHelp:
+        'Excluye píxeles dentro de este radio (grosor × multiplicador) de cualquier MT del fondo. Mayor = más conservador.',
+      channelsLabel: 'Canales a muestrear',
+      noChannels:
+        'Este proyecto no tiene metadatos de canales. Vuelva a subir el vídeo para obtener métricas por canal.',
+    },
     advancedExport: 'Exportación Avanzada',
     advancedOptions: 'Opciones Avanzadas de Exportación',
     configureSettings:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -767,6 +767,13 @@ export default {
       keyboard: 'Touche: {{key}}',
       requiresSelection: "Nécessite la sélection d'un polygone",
       requiresPolygonSelection: "Nécessite la sélection d'un polygone",
+      resegment: "Resegmenter l'image",
+      resegmentTooltipModel: 'Modèle: {{model}} · {{threshold}}',
+      resegmentSuccess: 'Image resegmentée',
+      resegmentFailed: 'Échec de la resegmentation',
+      resegmentConfirmTitle: 'Remplacer les polygones existants ?',
+      resegmentConfirmDescription:
+        "L'exécution du modèle écrasera la segmentation actuelle. Les modifications manuelles des polygones sur cette image seront perdues.",
       select: 'Sélectionner',
       undoTooltip: 'Annuler (Ctrl+Z)',
       undo: 'Annuler',
@@ -1110,6 +1117,21 @@ export default {
     imagesDeleted_other: '{{count}} images supprimées',
   },
   export: {
+    mt: {
+      sectionTitle: 'Métriques des microtubules',
+      sectionDescription:
+        "Longueur, aire et intensité par canal de chaque MT à partir du fichier ND2/TIFF d'origine. Corrigé par la médiane du fond (en dehors du masque MT dilaté).",
+      enable: 'Calculer les métriques d’intensité par canal',
+      thicknessLabel: 'Épaisseur du MT (px)',
+      thicknessHelp:
+        "Largeur de la bande d'échantillonnage le long de chaque polyligne. 5 px correspond au diamètre typique des microtubules en grand champ 100×.",
+      marginLabel: 'Marge du fond (× épaisseur)',
+      marginHelp:
+        "Exclut du fond les pixels situés dans ce rayon (épaisseur × multiplicateur) d'un MT. Plus élevé = plus conservateur.",
+      channelsLabel: 'Canaux à échantillonner',
+      noChannels:
+        'Ce projet ne contient pas de métadonnées de canaux. Téléversez à nouveau la vidéo pour obtenir des métriques par canal.',
+    },
     advancedExport: 'Export Avancé',
     advancedOptions: "Options d'Exportation Avancées",
     configureSettings:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -706,6 +706,13 @@ export default {
       keyboard: '按键: {{key}}',
       requiresSelection: '需要选择多边形',
       requiresPolygonSelection: '需要选择多边形',
+      resegment: '重新分割帧',
+      resegmentTooltipModel: '模型: {{model}} · {{threshold}}',
+      resegmentSuccess: '帧已重新分割',
+      resegmentFailed: '重新分割失败',
+      resegmentConfirmTitle: '替换现有的多边形？',
+      resegmentConfirmDescription:
+        '运行模型将覆盖当前的分割结果。该帧上对多边形所做的手动编辑将丢失。',
       select: '选择',
       undoTooltip: '撤销 (Ctrl+Z)',
       undo: '撤销',
@@ -1021,6 +1028,19 @@ export default {
     imagesDeleted_other: '已删除 {{count}} 张图片',
   },
   export: {
+    mt: {
+      sectionTitle: '微管指标',
+      sectionDescription:
+        '从原始 ND2/TIFF 文件计算每条微管的长度、面积及每通道强度。使用扩张 MT 掩码外的中位数进行背景校正。',
+      enable: '计算每通道强度指标',
+      thicknessLabel: '微管厚度 (px)',
+      thicknessHelp: '沿每条多边折线采样的带宽。100× 宽场下典型微管直径约为 5 px。',
+      marginLabel: '背景余量 (× 厚度)',
+      marginHelp:
+        '将距任意 MT 此半径范围内的像素 (厚度 × 倍率) 排除出背景。越大越保守。',
+      channelsLabel: '要采样的通道',
+      noChannels: '该项目没有通道元数据。请重新上传视频以获取按通道的指标。',
+    },
     advancedExport: '高级导出',
     advancedOptions: '高级导出选项',
     configureSettings: '配置您的导出设置以创建全面的数据包',


### PR DESCRIPTION
## Summary

- **MT intensity export**: new section in the export modal (MT projects only) emits per-(frame, polyline, channel) length, area, sum/mean/std intensity, median background, and signal-minus-background. Backend re-reads the original ND2/TIFF so values come from raw 16-bit signal, not the 8-bit display PNGs.
- **Editor resegment button**: Wand2 icon at the top of the left toolbar that re-runs the currently-selected ML model on the open frame. Confirms before overwriting existing polygons.
- New Python endpoint `POST /api/v1/mt-metrics` (cv2 polyline band raster + dilated background mask + per-channel stats over raw ND2/TIFF).
- 6 languages, 1442 keys each (parity verified).

## Test plan

- [ ] Production builds succeed: `make build-service SERVICE=frontend|backend|ml`
- [ ] `npx tsc --noEmit` clean on FE + BE
- [ ] `node scripts/check-i18n.cjs` reports complete parity across 6 languages
- [ ] MT project export with mtMetrics enabled produces `metrics/microtubule_metrics.csv` with correct columns
- [ ] Spheroid / sperm / wound exports unaffected (MT section hidden by `projectType` gate)
- [ ] Editor resegment button visible on every project type, confirm dialog only when polygons exist, POST `/api/segmentation/batch` fires with correct `{imageIds, model, threshold, detectHoles}` payload
- [ ] No new console errors during either flow

Smoke-tested against a real ND2 frame (TIRF_640 + TIRF_488 channels): signal-minus-background values are biologically meaningful (+57 in the targeted channel vs +0.94 in the off-target channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added microtubule metrics export for microtubule projects, computing per-channel intensity measurements with configurable thickness and background margin settings; results exportable to CSV, JSON, or Excel formats.
* Added frame resegmentation feature in the segmentation editor, allowing users to re-run ML model inference on the current frame with confirmation when existing polygons are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->