### PR TITLE
fix(editor): distinct color per polyline + correct MT project-type gate

### DIFF
--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -568,9 +568,12 @@ export class ExportService {
       // the original ND2/TIFF for raw 16-bit signal (the per-channel PNGs
       // on disk are 8-bit display-mapped). MT-only and only when the
       // user enabled the section in the export modal.
+      // ProjectType is `'microtubules'` (plural) — `'microtubule'` is the
+      // model id, not the project type. Compare against the project-type
+      // string, otherwise the MT exporter is never invoked.
       if (
         options.mtMetrics?.enabled &&
-        (project.type ?? '') === 'microtubule' &&
+        (project.type ?? '') === 'microtubules' &&
         project.images?.length
       ) {
         exportTasks.push(

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -78,7 +78,10 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       onDownloadingChange,
     }) => {
       const { t } = useLanguage();
-      const isMTProject = projectType === 'microtubule';
+      // ProjectType is `'microtubules'` (plural) — `'microtubule'`
+      // (singular) is the model id, not the project type. Mis-comparing
+      // them silently hides the MT section on every MT project.
+      const isMTProject = projectType === 'microtubules';
 
       // Distinct channels across the project's video container rows.
       // De-dupe by machine name (the same channel might appear on

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -148,22 +148,8 @@ const CanvasPolygon = React.memo(
         return isSelected ? '#16a34a' : '#22c55e'; // green
       }
       if (isPolyline) {
-        // Microtubule polylines: deterministic per-instance HSL hash. The
-        // tracker (backend/src/services/tracking/trackerService.ts) writes
-        // a stable `trackId` across frames; `instanceId` is freshly
-        // generated per-inference and only differs within a single frame.
-        // Prefer `trackId` so the same microtubule keeps its color when
-        // scrubbing; fall back to `instanceId` before tracking has run.
-        // `class='microtubule'` is the authoritative ML signal; `mt_`
-        // instanceId prefix is the legacy fallback.
-        const isMt =
-          !polygon.partClass &&
-          (polygon.class === 'microtubule' ||
-            isMicrotubuleInstance(polygon.instanceId));
-        if (isMt) {
-          const colorKey = polygon.trackId ?? polygon.instanceId ?? '';
-          return colorFromInstanceId(colorKey, { selected: isSelected });
-        }
+        // Sperm body parts (head/midpiece/tail) use fixed colors so every
+        // sperm of the same part class reads as the same colour.
         switch (polygon.partClass) {
           case 'head':
             return isSelected ? '#16a34a' : '#22c55e'; // green
@@ -171,9 +157,24 @@ const CanvasPolygon = React.memo(
             return isSelected ? '#d97706' : '#f59e0b'; // orange
           case 'tail':
             return isSelected ? '#0891b2' : '#06b6d4'; // cyan
-          default:
-            return isSelected ? '#9333ea' : '#a855f7'; // purple (unclassified polyline)
         }
+        // Everything else (microtubules, manually-drawn polylines):
+        // deterministic per-polyline HSL hash. Priority of seed:
+        //   1. `trackId` — cross-frame stable, set by the MT tracker; the
+        //      same microtubule keeps its colour across frames.
+        //   2. `instanceId` only when it has the `mt_` prefix (real MT
+        //      identity from the ML model). A sentinel like the historical
+        //      `'sperm_1'` default would otherwise collapse every manually-
+        //      drawn polyline to the same colour.
+        //   3. `polygon.id` — always a UUID, guarantees each polyline gets
+        //      a distinct colour even when no instanceId / trackId exists.
+        const colorKey =
+          polygon.trackId ||
+          (isMicrotubuleInstance(polygon.instanceId)
+            ? polygon.instanceId
+            : null) ||
+          polygon.id;
+        return colorFromInstanceId(colorKey, { selected: isSelected });
       }
       if (isInternal) {
         return isSelected ? '#0b84da' : '#0ea5e9';
@@ -182,8 +183,8 @@ const CanvasPolygon = React.memo(
       }
     }, [
       isPolyline,
+      polygon.id,
       polygon.partClass,
-      polygon.class,
       polygon.instanceId,
       polygon.trackId,
       isSelected,


### PR DESCRIPTION
## Summary

- **Color collapse fix**: polylines without an `mt_`-prefixed `instanceId` (manually-drawn, malformed wire payload, or any other path where the MT signal is lost) now get a distinct colour via `polygon.id` UUID fallback. The hash priority is `trackId → mt_instanceId → polygon.id`.
- **Project-type gate fix**: my PR #185 used `'microtubule'` (model id) instead of `'microtubules'` (project type) on both the FE export-modal gate and the BE exporter gate. The MT export section was silently hidden on every MT project. Fixed.
- Sperm `partClass` polylines (head/midpiece/tail) keep their existing fixed colours — no behaviour change.

## Why

The previous color logic only treated a polyline as MT if `class === 'microtubule'` or `instanceId` started with `mt_`. The `class` field is stripped by both the polygon validator and the wire mapper, so the only surviving signal was the `mt_` prefix on instanceId. Anything that lost that prefix (manual drawing in MT projects inherits the sperm-static default `'sperm_1'`, partial wire-strip, etc.) collapsed to the default purple — visually one colour across every polyline.

## Test plan

- [ ] Open an MT project, scrub frames — ML-produced MT polylines still render in distinct colours and remain stable across frames (trackId)
- [ ] Manually draw multiple polylines in an MT project — each new polyline gets a distinct colour (via `polygon.id` fallback)
- [ ] Sperm project export modal — no MT section (unchanged)
- [ ] MT project export modal — "Microtubule metrics" card now appears in the General tab
- [ ] Enable MT metrics + export — backend writes `microtubule_metrics.csv` to the ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed microtubule project type detection to correctly identify microtubule projects for exports and related UI features.
* Updated polyline coloring to properly display colors for sperm cell parts, microtubules, and unclassified polylines based on their classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->