### PR TITLE
feat(upload): extract pixel size + frame interval from ND2/TIFF metadata

### DIFF
--- a/backend/prisma/migrations/20260514_add_calibration_metadata/migration.sql
+++ b/backend/prisma/migrations/20260514_add_calibration_metadata/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable -- add upload-extracted calibration metadata to the images table.
+--
+-- Backwards compatible: both columns are nullable so existing rows are
+-- unaffected. The fields are populated on video container rows by the
+-- upload pipeline:
+--   * pixelSizeUm: from ND2.voxel_size().x (assumes isotropic XY) or
+--     OME-TIFF PhysicalSizeX (converted to µm) or ImageJ TIFF XResolution.
+--   * frameIntervalMs: median Δ of consecutive ND2 event timestamps; for
+--     OME-TIFF the Pixels TimeIncrement; for ImageJ TIFF the `finterval`
+--     entry (converted from seconds). For mp4/avi/mov this is computed as
+--     durationMs / frameCount on the Node side.
+--
+-- Float so we can store sub-µm pixel sizes (0.108 etc.) and sub-ms
+-- intervals without losing precision.
+
+ALTER TABLE "images"
+    ADD COLUMN "pixelSizeUm"     DOUBLE PRECISION,
+    ADD COLUMN "frameIntervalMs" DOUBLE PRECISION;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -106,6 +106,11 @@ model Image {
   frameIndex             Int?                // 0-based position within parent video; null for standalone images
   frameCount             Int?                // Total frame count on the container row; null for frame / standalone rows
   videoDurationMs        Int?                // Source duration in ms; null when unknown or not a video
+  // Calibration metadata extracted from the upload (ND2 / OME-TIFF / ImageJ-TIFF).
+  // Both are set on container rows only (frames inherit by lookup). Float for
+  // sub-pixel sizes (typical 0.108 µm/px) and sub-millisecond intervals.
+  pixelSizeUm            Float?              // Isotropic XY pixel size in micrometers; null when unknown
+  frameIntervalMs        Float?              // Wall-clock ms between consecutive frames; null when unknown
   channels               Json?               // [{name, type:'irm'|'fluorescent', wavelengthNm?, displayColor?, isSegmentationSource}] on container rows
   createdAt              DateTime            @default(now())
   updatedAt              DateTime            @updatedAt

--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1059,6 +1059,12 @@ export class ImageController {
             frameIndex: image.frameIndex,
             frameCount: image.frameCount,
             videoDurationMs: image.videoDurationMs,
+            // Calibration metadata extracted at upload time. The export
+            // dialog reads pixelSizeUm to pre-fill the µm/px field for
+            // microtubule exports; frameIntervalMs is reserved for the
+            // upcoming time-series view.
+            pixelSizeUm: image.pixelSizeUm,
+            frameIntervalMs: image.frameIntervalMs,
             channels: image.channels,
             displayOrder: image.displayOrder,
             // Exposed so the Segment-All channel picker can derive the set

--- a/backend/src/services/video/ffmpegExtractor.ts
+++ b/backend/src/services/video/ffmpegExtractor.ts
@@ -197,9 +197,21 @@ export async function extractWithFfmpeg(
     height: probed?.height ?? null,
   });
 
+  // For container-encoded video (mp4/avi/mov/...) we don't have any
+  // physical calibration in the container. The temporal cadence comes
+  // from FPS — if ffprobe gave us a duration and a frame count, we can
+  // derive frame interval directly without a separate ffprobe pass for
+  // r_frame_rate (which is sometimes lying about VFR sources).
+  const frameIntervalMs =
+    probed?.durationMs != null && flatFiles.length > 1
+      ? probed.durationMs / (flatFiles.length - 1)
+      : null;
+
   return {
     frameCount: flatFiles.length,
     durationMs: probed?.durationMs ?? null,
+    frameIntervalMs,
+    pixelSizeUm: null,
     channels,
     width: probed?.width ?? 0,
     height: probed?.height ?? 0,

--- a/backend/src/services/video/pythonExtractor.ts
+++ b/backend/src/services/video/pythonExtractor.ts
@@ -30,6 +30,12 @@ const HELPERS_DIR = path.join(_MODULE_DIR, 'pythonHelpers');
 interface PythonResult {
   frameCount: number;
   durationMs: number | null;
+  /** Median ms between consecutive frames; null when unknown. Emitted
+   *  by both extract_nd2.py (ND2 events) and extract_tiff_stack.py
+   *  (OME-XML / ImageJ ``finterval``). */
+  frameIntervalMs?: number | null;
+  /** Isotropic pixel size in µm; null when unknown. */
+  pixelSizeUm?: number | null;
   width: number;
   height: number;
   channels: Array<{
@@ -161,6 +167,8 @@ export async function extractTiffStack(
   return {
     frameCount: result.frameCount,
     durationMs: result.durationMs ?? null,
+    frameIntervalMs: result.frameIntervalMs ?? null,
+    pixelSizeUm: result.pixelSizeUm ?? null,
     channels,
     width: result.width,
     height: result.height,
@@ -186,6 +194,8 @@ export async function extractNd2(
   return {
     frameCount: result.frameCount,
     durationMs: result.durationMs ?? null,
+    frameIntervalMs: result.frameIntervalMs ?? null,
+    pixelSizeUm: result.pixelSizeUm ?? null,
     channels,
     width: result.width,
     height: result.height,

--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -120,14 +120,37 @@ def main() -> int:
                 "wavelengthNm": emission,
             })
 
-        # Duration: nd2 sometimes exposes frame intervals.
+        # Duration + frame interval: ND2 events carry per-frame "Time [s]".
+        # Median Δ between consecutive timestamps is more robust than
+        # (last-first)/(N-1): a single dropped frame inflates the average.
+        # We keep the legacy `duration_ms` (end-start) since downstream
+        # code is already wired to it.
         duration_ms = None
+        frame_interval_ms = None
         try:
             events = f.events()
             if events and "Time [s]" in events[0]:
-                start = events[0]["Time [s]"]
-                end = events[-1]["Time [s]"]
-                duration_ms = int((end - start) * 1000)
+                ts = [e["Time [s]"] for e in events if "Time [s]" in e]
+                if len(ts) >= 2:
+                    duration_ms = int((ts[-1] - ts[0]) * 1000)
+                    deltas = np.diff(np.asarray(ts, dtype=np.float64))
+                    # Drop non-positive deltas (clock glitches) before median.
+                    pos = deltas[deltas > 0]
+                    if pos.size > 0:
+                        frame_interval_ms = float(np.median(pos) * 1000.0)
+        except Exception:
+            pass
+
+        # Pixel calibration. `voxel_size()` returns named tuple (x, y, z)
+        # in micrometers. ND2 is essentially always isotropic in XY, but
+        # we explicitly pick `x` rather than asserting equality so a
+        # mildly anisotropic acquisition still produces a single value.
+        pixel_size_um = None
+        try:
+            v = f.voxel_size()
+            x_um = getattr(v, "x", None) if v is not None else None
+            if isinstance(x_um, (int, float)) and x_um > 0:
+                pixel_size_um = float(x_um)
         except Exception:
             pass
 
@@ -143,6 +166,8 @@ def main() -> int:
     result = {
         "frameCount": int(T),
         "durationMs": duration_ms,
+        "frameIntervalMs": frame_interval_ms,
+        "pixelSizeUm": pixel_size_um,
         "width": int(W),
         "height": int(H),
         "channels": [

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -83,6 +83,153 @@ def _save_png(arr: np.ndarray, path: Path) -> None:
     Image.fromarray(_normalize_to_uint8(arr)).save(path, format="PNG", optimize=True)
 
 
+def _detect_pixel_size_um(tf) -> float | None:
+    """Best-effort extraction of isotropic pixel size in micrometers.
+
+    Tries three sources in order:
+      1. OME-XML `<Pixels PhysicalSizeX PhysicalSizeXUnit>`
+      2. ImageJ ``info`` block lines like "PixelWidth: 0.108 um"
+      3. Raw TIFF ``XResolution`` tag combined with ``ResolutionUnit``
+
+    Returns ``None`` on every failure path — this metadata is best-effort
+    and should never crash the extractor.
+    """
+    # 1. OME-XML
+    try:
+        ome = getattr(tf, "ome_metadata", None)
+        if isinstance(ome, str) and "<Pixels" in ome:
+            import re
+            m = re.search(r'PhysicalSizeX="([0-9.eE+-]+)"', ome)
+            unit = re.search(r'PhysicalSizeXUnit="([^"]+)"', ome)
+            if m:
+                val = float(m.group(1))
+                # Default unit per OME spec is "µm" / "um". Some files
+                # store the literal "µm" UTF-8 byte, others ASCII "um".
+                # Convert nm / pm to µm; pass µm/um through unchanged.
+                u = (unit.group(1).lower() if unit else "um")
+                if u in ("µm", "um", "micrometer", "micrometers"):
+                    return val
+                if u in ("nm", "nanometer", "nanometers"):
+                    return val / 1000.0
+                if u in ("mm", "millimeter", "millimeters"):
+                    return val * 1000.0
+                # Unknown unit — return as-is so caller at least has a hint.
+                return val
+    except Exception:
+        pass
+
+    # 2. ImageJ metadata
+    try:
+        meta = getattr(tf, "imagej_metadata", None)
+        if isinstance(meta, dict):
+            # ImageJ writes the calibration into ``info`` (multi-line
+            # string) for some plugins. The dedicated field is the
+            # filehandle-level resolution; we cover the explicit case
+            # first because it's unambiguous.
+            for key in ("PhysicalSizeX", "pixel_width", "pixelWidth"):
+                v = meta.get(key)
+                if isinstance(v, (int, float)) and v > 0:
+                    return float(v)
+            info = meta.get("info") or meta.get("Info")
+            if isinstance(info, str):
+                import re
+                # Match "PixelWidth: 0.108 um" or "spatial_resolution: 0.108"
+                for pat in (
+                    r"PixelWidth\s*[:=]\s*([0-9.eE+-]+)",
+                    r"pixel_width\s*[:=]\s*([0-9.eE+-]+)",
+                    r"spatial_resolution\s*[:=]\s*([0-9.eE+-]+)",
+                ):
+                    m = re.search(pat, info)
+                    if m:
+                        try:
+                            return float(m.group(1))
+                        except ValueError:
+                            pass
+    except Exception:
+        pass
+
+    # 3. Raw TIFF resolution tags (XResolution, ResolutionUnit).
+    try:
+        page = tf.pages[0] if tf.pages else None
+        if page is not None:
+            tags = page.tags
+            x_res = tags.get("XResolution")
+            unit_tag = tags.get("ResolutionUnit")
+            if x_res is not None and x_res.value:
+                # XResolution is a rational (numerator, denominator) giving
+                # pixels per unit. We want unit per pixel.
+                num, den = x_res.value
+                if num > 0 and den > 0:
+                    pixels_per_unit = num / den
+                    if pixels_per_unit > 0:
+                        unit_per_pixel = 1.0 / pixels_per_unit
+                        # ResolutionUnit: 1=none, 2=inch, 3=cm. Unknown maps to none.
+                        unit_code = (
+                            unit_tag.value if unit_tag is not None else 1
+                        )
+                        if unit_code == 2:  # inch
+                            return unit_per_pixel * 25_400.0  # → µm
+                        if unit_code == 3:  # cm
+                            return unit_per_pixel * 10_000.0  # → µm
+                        # No unit info → caller can't trust the value.
+                        return None
+    except Exception:
+        pass
+
+    return None
+
+
+def _detect_frame_interval_ms(tf) -> float | None:
+    """Best-effort frame-interval extraction in milliseconds.
+
+    Sources tried, in order:
+      1. OME-XML ``<Pixels TimeIncrement TimeIncrementUnit>``
+      2. ImageJ ``finterval`` (seconds per frame) or per-frame ``Labels``
+         timestamps.
+
+    Returns ``None`` when no time metadata is present — caller decides
+    whether to fall back to a Node-side ffmpeg estimate.
+    """
+    # 1. OME-XML
+    try:
+        ome = getattr(tf, "ome_metadata", None)
+        if isinstance(ome, str) and "<Pixels" in ome:
+            import re
+            m = re.search(r'TimeIncrement="([0-9.eE+-]+)"', ome)
+            unit_m = re.search(r'TimeIncrementUnit="([^"]+)"', ome)
+            if m:
+                val = float(m.group(1))
+                u = (unit_m.group(1).lower() if unit_m else "s")
+                if u in ("s", "sec", "second", "seconds"):
+                    return val * 1000.0
+                if u in ("ms", "millisecond", "milliseconds"):
+                    return val
+                if u in ("min", "minute", "minutes"):
+                    return val * 60_000.0
+                return val * 1000.0  # assume seconds if unit unknown
+    except Exception:
+        pass
+
+    # 2. ImageJ metadata.
+    try:
+        meta = getattr(tf, "imagej_metadata", None)
+        if isinstance(meta, dict):
+            # `finterval` is the canonical ImageJ field for time-lapse
+            # spacing in seconds. Stored as float by macros that call
+            # ``setFrameInterval``.
+            v = meta.get("finterval")
+            if isinstance(v, (int, float)) and v > 0:
+                return float(v) * 1000.0
+            # `fps` (frames per second) is the alternate form.
+            fps = meta.get("fps")
+            if isinstance(fps, (int, float)) and fps > 0:
+                return 1000.0 / float(fps)
+    except Exception:
+        pass
+
+    return None
+
+
 def main() -> int:
     if len(sys.argv) < 3:
         print("usage: extract_tiff_stack.py <src.tif> <dest_dir>", file=sys.stderr)
@@ -109,6 +256,12 @@ def main() -> int:
             else (arr.shape[0] if axes.startswith("C") else 1)
         )
         raw_channel_labels = _imagej_channel_labels(tf, _C_for_meta)
+        # Pixel calibration + frame interval. Priority chain:
+        #   1. OME-XML (most precise when present)
+        #   2. ImageJ metadata (most common in microscopy)
+        #   3. Raw TIFF resolution tags (last resort, unit may be unclear)
+        pixel_size_um = _detect_pixel_size_um(tf)
+        frame_interval_ms = _detect_frame_interval_ms(tf)
 
     # Resolve into (T, C, Y, X) by inserting unit dims for missing axes.
     if "Z" in axes and arr.ndim >= 3:
@@ -169,9 +322,19 @@ def main() -> int:
             sys.stdout.write(f"PROGRESS {(t + 1) / T:.4f}\n")
             sys.stdout.flush()
 
+    # If frame_interval is available, derive durationMs from it. Otherwise
+    # leave duration at None — only ND2 has a reliable cross-frame timeline.
+    duration_ms = (
+        int(round(frame_interval_ms * (T - 1)))
+        if frame_interval_ms is not None and T > 1
+        else None
+    )
+
     result = {
         "frameCount": int(T),
-        "durationMs": None,  # TIFFs don't carry timing in a standard place
+        "durationMs": duration_ms,
+        "frameIntervalMs": frame_interval_ms,
+        "pixelSizeUm": pixel_size_um,
         "width": int(W),
         "height": int(H),
         "channels": [

--- a/backend/src/services/video/types.ts
+++ b/backend/src/services/video/types.ts
@@ -38,6 +38,16 @@ export interface ExtractionResult {
   frameCount: number;
   /** Source duration in ms (best-effort: ffprobe / ND2 metadata / N * dt). */
   durationMs: number | null;
+  /** Median wall-clock ms between consecutive frames. Best-effort:
+   *  ND2 event timestamps, OME-TIFF TimeIncrement, ImageJ ``finterval``,
+   *  or (for mp4/avi/mov) durationMs / frameCount. ``null`` when the
+   *  source carries no temporal calibration. */
+  frameIntervalMs: number | null;
+  /** Isotropic XY pixel size in micrometers. Best-effort: ND2
+   *  ``voxel_size().x``, OME-TIFF ``PhysicalSizeX``, ImageJ TIFF info
+   *  block, or raw TIFF ``XResolution``. ``null`` when missing or
+   *  ambiguous (e.g. raw TIFF without ``ResolutionUnit``). */
+  pixelSizeUm: number | null;
   /** Channels detected in the source. For single-channel videos this is
    *  a one-element array with type='fluorescent' and isSegmentationSource=false
    *  (user retags via the channels dialog). */

--- a/backend/src/services/videoUploadService.ts
+++ b/backend/src/services/videoUploadService.ts
@@ -267,6 +267,11 @@ export async function uploadVideoFromFile(options: {
         height: result.height || null,
         frameCount: result.frameCount,
         videoDurationMs: result.durationMs ?? null,
+        // Calibration extracted from the upload (ND2 voxel_size /
+        // OME-TIFF Pixels / ImageJ finterval). Both null when the source
+        // carries no metadata — the export modal lets users override.
+        pixelSizeUm: result.pixelSizeUm ?? null,
+        frameIntervalMs: result.frameIntervalMs ?? null,
         channels: result.channels as unknown as object,
         segmentationStatus: 'no_segmentation',
       },

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -144,6 +144,27 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       }, [selectedImageIds, updateExportOptions]);
 
+      // Auto-fill the pixel-to-µm scale from the first video container's
+      // upload metadata (ND2 voxel_size, OME-TIFF PhysicalSizeX, ImageJ
+      // TIFF). Skipped when the user has already typed a value or when
+      // no container carries calibration. Applies universally — pixel
+      // scale is meaningful for any project type with a known optical
+      // setup, not just microtubule.
+      useEffect(() => {
+        if (exportOptions.pixelToMicrometerScale != null) return;
+        const containerWithScale = images.find(
+          img =>
+            img.isVideoContainer &&
+            typeof img.pixelSizeUm === 'number' &&
+            img.pixelSizeUm > 0
+        );
+        if (containerWithScale?.pixelSizeUm) {
+          updateExportOptions({
+            pixelToMicrometerScale: containerWithScale.pixelSizeUm,
+          });
+        }
+      }, [images, exportOptions.pixelToMicrometerScale, updateExportOptions]);
+
       const handleExport = async () => {
         try {
           await startExport(projectName);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -538,6 +538,12 @@ export interface ProjectImage {
   frameIndex?: number | null;
   frameCount?: number | null;
   videoDurationMs?: number | null;
+  // Calibration metadata extracted from the upload (ND2 voxel size,
+  // OME-TIFF Pixels, ImageJ finterval). Container rows only — frame
+  // rows inherit by parent lookup. ``null`` when the source had no
+  // calibration metadata.
+  pixelSizeUm?: number | null;
+  frameIntervalMs?: number | null;
   channels?: VideoChannel[] | null;
   // Storage key of the underlying file (e.g. frames/NNNN/<channel>.png).
   // Surfaced so the Segment-All channel picker can derive distinct channels


### PR DESCRIPTION
## Summary

At upload time, capture two pieces of calibration from the source file and persist them on the video container row:

- **`pixelSizeUm`** — isotropic XY pixel size in micrometers
- **`frameIntervalMs`** — median ms between consecutive frames

Both nullable; everything degrades gracefully when metadata is missing.

## Source priority

| Format | Pixel size | Frame interval |
|---|---|---|
| ND2 | `voxel_size().x` | median of `f.events()` `Time [s]` deltas |
| TIFF | OME-XML `PhysicalSizeX` → ImageJ `PhysicalSizeX`/`pixel_width` → raw `XResolution` | OME-XML `TimeIncrement` → ImageJ `finterval`/`fps` |
| MP4/AVI/MOV | null | `durationMs / (frameCount - 1)` |

## Bonus UX

`AdvancedExportDialog` now auto-fills the existing pixel-to-µm input from the first video container's `pixelSizeUm`. Applies universally; user override still wins.

## Deploy

After merge, **rebuild backend + ml** and apply the migration with `prisma migrate deploy`. The Python helpers are container-baked so the ml service needs a rebuild too.

## Test plan

- [ ] Real ND2 upload → DB row has non-null `pixelSizeUm` and `frameIntervalMs`
- [ ] OME-TIFF upload → values populated from XML
- [ ] ImageJ TIFF with `finterval` → interval populated; pixel size may be null
- [ ] MP4 upload → interval populated from ffprobe; pixel size null
- [ ] Open export modal on an MT project with calibrated source → µm/px field is pre-filled
- [ ] Open export modal on a project without calibration → field stays empty, user can type manually

Smoke-tested against `michalprusek/cell-segmentation-hub` MT project ND2: `pixelSizeUm=0.0725`, `frameIntervalMs=400` — matches expected Nikon TIRF 60× / 2.5 FPS live-cell time-lapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)