### PR TITLE
fix(review): post-review cleanup for calibration metadata pipeline

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -107,8 +107,7 @@ model Image {
   frameCount             Int?                // Total frame count on the container row; null for frame / standalone rows
   videoDurationMs        Int?                // Source duration in ms; null when unknown or not a video
   // Calibration metadata extracted from the upload (ND2 / OME-TIFF / ImageJ-TIFF).
-  // Both are set on container rows only (frames inherit by lookup). Float for
-  // sub-pixel sizes (typical 0.108 µm/px) and sub-millisecond intervals.
+  // Set on container rows only; frames + standalone images stay null.
   pixelSizeUm            Float?              // Isotropic XY pixel size in micrometers; null when unknown
   frameIntervalMs        Float?              // Wall-clock ms between consecutive frames; null when unknown
   channels               Json?               // [{name, type:'irm'|'fluorescent', wavelengthNm?, displayColor?, isSegmentationSource}] on container rows

--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -1059,10 +1059,9 @@ export class ImageController {
             frameIndex: image.frameIndex,
             frameCount: image.frameCount,
             videoDurationMs: image.videoDurationMs,
-            // Calibration metadata extracted at upload time. The export
-            // dialog reads pixelSizeUm to pre-fill the µm/px field for
-            // microtubule exports; frameIntervalMs is reserved for the
-            // upcoming time-series view.
+            // Calibration metadata extracted at upload time (µm/px and
+            // ms between frames). Populated on container rows only;
+            // null on frames + standalone images.
             pixelSizeUm: image.pixelSizeUm,
             frameIntervalMs: image.frameIntervalMs,
             channels: image.channels,

--- a/backend/src/services/video/ffmpegExtractor.ts
+++ b/backend/src/services/video/ffmpegExtractor.ts
@@ -198,12 +198,15 @@ export async function extractWithFfmpeg(
   });
 
   // For container-encoded video (mp4/avi/mov/...) we don't have any
-  // physical calibration in the container. The temporal cadence comes
-  // from FPS — if ffprobe gave us a duration and a frame count, we can
-  // derive frame interval directly without a separate ffprobe pass for
-  // r_frame_rate (which is sometimes lying about VFR sources).
+  // physical calibration. The temporal cadence comes from FPS — if
+  // ffprobe gave us a positive duration and ≥ 2 frames, we can derive
+  // frame interval directly without a separate ffprobe pass for
+  // r_frame_rate (which sometimes lies for VFR sources). Treat
+  // durationMs <= 0 as missing rather than emitting a misleading 0 ms.
   const frameIntervalMs =
-    probed?.durationMs != null && flatFiles.length > 1
+    probed?.durationMs != null &&
+    probed.durationMs > 0 &&
+    flatFiles.length > 1
       ? probed.durationMs / (flatFiles.length - 1)
       : null;
 

--- a/backend/src/services/video/pythonExtractor.ts
+++ b/backend/src/services/video/pythonExtractor.ts
@@ -30,12 +30,11 @@ const HELPERS_DIR = path.join(_MODULE_DIR, 'pythonHelpers');
 interface PythonResult {
   frameCount: number;
   durationMs: number | null;
-  /** Median ms between consecutive frames; null when unknown. Emitted
-   *  by both extract_nd2.py (ND2 events) and extract_tiff_stack.py
-   *  (OME-XML / ImageJ ``finterval``). */
-  frameIntervalMs?: number | null;
+  /** Median ms between consecutive frames; null when unknown. Both
+   *  helpers always emit the key. */
+  frameIntervalMs: number | null;
   /** Isotropic pixel size in µm; null when unknown. */
-  pixelSizeUm?: number | null;
+  pixelSizeUm: number | null;
   width: number;
   height: number;
   channels: Array<{
@@ -167,8 +166,8 @@ export async function extractTiffStack(
   return {
     frameCount: result.frameCount,
     durationMs: result.durationMs ?? null,
-    frameIntervalMs: result.frameIntervalMs ?? null,
-    pixelSizeUm: result.pixelSizeUm ?? null,
+    frameIntervalMs: result.frameIntervalMs,
+    pixelSizeUm: result.pixelSizeUm,
     channels,
     width: result.width,
     height: result.height,
@@ -194,8 +193,8 @@ export async function extractNd2(
   return {
     frameCount: result.frameCount,
     durationMs: result.durationMs ?? null,
-    frameIntervalMs: result.frameIntervalMs ?? null,
-    pixelSizeUm: result.pixelSizeUm ?? null,
+    frameIntervalMs: result.frameIntervalMs,
+    pixelSizeUm: result.pixelSizeUm,
     channels,
     width: result.width,
     height: result.height,

--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -137,11 +137,9 @@ def main() -> int:
                 "wavelengthNm": emission,
             })
 
-        # Duration + frame interval: ND2 events carry per-frame "Time [s]".
-        # Median Δ between consecutive timestamps is more robust than
-        # (last-first)/(N-1): a single dropped frame inflates the average.
-        # We keep the legacy `duration_ms` (end-start) since downstream
-        # code is already wired to it.
+        # Duration and frame interval. duration_ms = end−start span;
+        # frame_interval_ms = median Δ of consecutive timestamps (more
+        # robust to a single dropped frame than the simple average).
         duration_ms = None
         frame_interval_ms = None
         try:
@@ -151,25 +149,32 @@ def main() -> int:
                 if len(ts) >= 2:
                     duration_ms = int((ts[-1] - ts[0]) * 1000)
                     deltas = np.diff(np.asarray(ts, dtype=np.float64))
-                    # Drop non-positive deltas (clock glitches) before median.
-                    pos = deltas[deltas > 0]
+                    pos = deltas[deltas > 0]  # drop clock-glitch negatives
                     if pos.size > 0:
                         frame_interval_ms = float(np.median(pos) * 1000.0)
-        except Exception:
-            pass
+        except Exception as exc:
+            sys.stderr.write(f"ND2 events parse failed: {exc}\n")
 
-        # Pixel calibration. `voxel_size()` returns named tuple (x, y, z)
-        # in micrometers. ND2 is essentially always isotropic in XY, but
-        # we explicitly pick `x` rather than asserting equality so a
-        # mildly anisotropic acquisition still produces a single value.
+        # Pixel calibration. `voxel_size()` returns (x, y, z) in µm; we
+        # pick x. Log a stderr warning when y differs noticeably so an
+        # anisotropic acquisition doesn't silently get x-only treatment.
         pixel_size_um = None
         try:
             v = f.voxel_size()
             x_um = getattr(v, "x", None) if v is not None else None
+            y_um = getattr(v, "y", None) if v is not None else None
             if isinstance(x_um, (int, float)) and x_um > 0:
+                if (
+                    isinstance(y_um, (int, float))
+                    and y_um > 0
+                    and abs(x_um - y_um) / x_um > 0.01
+                ):
+                    sys.stderr.write(
+                        f"ND2 anisotropic XY: x={x_um} y={y_um}, using x\n"
+                    )
                 pixel_size_um = float(x_um)
-        except Exception:
-            pass
+        except Exception as exc:
+            sys.stderr.write(f"ND2 voxel_size read failed: {exc}\n")
 
     for t in range(T):
         frame_dir = dest / "frames" / f"{t:04d}"

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -96,67 +96,92 @@ def _save_png(arr: np.ndarray, path: Path) -> None:
 def _detect_pixel_size_um(tf) -> float | None:
     """Best-effort extraction of isotropic pixel size in micrometers.
 
-    Tries three sources in order:
-      1. OME-XML `<Pixels PhysicalSizeX PhysicalSizeXUnit>`
-      2. ImageJ ``info`` block lines like "PixelWidth: 0.108 um"
-      3. Raw TIFF ``XResolution`` tag combined with ``ResolutionUnit``
+    Tries three sources, each unit-checked before returning:
+      1. OME-XML ``<Pixels PhysicalSizeX PhysicalSizeXUnit>``
+      2. ImageJ ``imagej_metadata`` dedicated keys, then regex over the
+         multi-line ``info`` block — unit comes from ``unit`` / ``xunit``
+         on the metadata dict (or an inline unit captured from the regex).
+      3. Raw TIFF ``XResolution`` (rational pixels/unit) combined with
+         ``ResolutionUnit`` (1=none, 2=inch, 3=cm).
 
-    Returns ``None`` on every failure path — this metadata is best-effort
-    and should never crash the extractor.
+    Returns ``None`` whenever the unit is unknown or absent — the
+    µm-typed field downstream must never carry an ambiguous value.
+    Parse failures are non-fatal but emit a one-line stderr warning so
+    ops can spot regressions in tifffile metadata shapes.
     """
+    # Helper: convert a value in `unit` to micrometers. Returns None for
+    # unknown / unsupported units rather than letting an ambiguous value
+    # pollute the µm-typed field downstream.
+    def _to_um(value: float, unit: str | None) -> float | None:
+        u = (unit or "").strip().lower()
+        if u in ("", "µm", "um", "micron", "microns", "micrometer", "micrometers"):
+            return value  # OME default + microscopy convention
+        if u in ("nm", "nanometer", "nanometers"):
+            return value / 1000.0
+        if u in ("mm", "millimeter", "millimeters"):
+            return value * 1000.0
+        if u in ("cm", "centimeter", "centimeters"):
+            return value * 10_000.0
+        if u in ("inch", "inches", "in"):
+            return value * 25_400.0
+        return None  # unknown unit — caller can still ask user to override
+
     # 1. OME-XML
     try:
         ome = getattr(tf, "ome_metadata", None)
         if isinstance(ome, str) and "<Pixels" in ome:
             import re
             m = re.search(r'PhysicalSizeX="([0-9.eE+-]+)"', ome)
-            unit = re.search(r'PhysicalSizeXUnit="([^"]+)"', ome)
+            unit_m = re.search(r'PhysicalSizeXUnit="([^"]+)"', ome)
             if m:
                 val = float(m.group(1))
-                # Default unit per OME spec is "µm" / "um". Some files
-                # store the literal "µm" UTF-8 byte, others ASCII "um".
-                # Convert nm / pm to µm; pass µm/um through unchanged.
-                u = (unit.group(1).lower() if unit else "um")
-                if u in ("µm", "um", "micrometer", "micrometers"):
-                    return val
-                if u in ("nm", "nanometer", "nanometers"):
-                    return val / 1000.0
-                if u in ("mm", "millimeter", "millimeters"):
-                    return val * 1000.0
-                # Unknown unit — return as-is so caller at least has a hint.
-                return val
-    except Exception:
-        pass
+                # OME default unit is µm when PhysicalSizeXUnit is absent.
+                converted = _to_um(val, unit_m.group(1) if unit_m else None)
+                if converted is not None:
+                    return converted
+    except Exception as exc:
+        sys.stderr.write(f"OME-XML pixel-size parse failed: {exc}\n")
 
-    # 2. ImageJ metadata
+    # 2. ImageJ metadata. Prefer explicit numeric keys; fall back to
+    # regex over the multi-line "info" string. In all cases consult the
+    # unit metadata before returning so an nm-calibrated STORM TIFF
+    # isn't silently reported as µm (off by 1000×).
     try:
         meta = getattr(tf, "imagej_metadata", None)
         if isinstance(meta, dict):
-            # ImageJ writes the calibration into ``info`` (multi-line
-            # string) for some plugins. The dedicated field is the
-            # filehandle-level resolution; we cover the explicit case
-            # first because it's unambiguous.
+            ij_unit = (
+                meta.get("unit")
+                or meta.get("xunit")
+                or meta.get("Unit")
+                or meta.get("xUnit")
+            )
             for key in ("PhysicalSizeX", "pixel_width", "pixelWidth"):
                 v = meta.get(key)
                 if isinstance(v, (int, float)) and v > 0:
-                    return float(v)
+                    converted = _to_um(float(v), ij_unit)
+                    if converted is not None:
+                        return converted
             info = meta.get("info") or meta.get("Info")
             if isinstance(info, str):
                 import re
-                # Match "PixelWidth: 0.108 um" or "spatial_resolution: 0.108"
+                # Look for an inline unit on the same line as the value.
                 for pat in (
-                    r"PixelWidth\s*[:=]\s*([0-9.eE+-]+)",
-                    r"pixel_width\s*[:=]\s*([0-9.eE+-]+)",
-                    r"spatial_resolution\s*[:=]\s*([0-9.eE+-]+)",
+                    r"PixelWidth\s*[:=]\s*([0-9.eE+-]+)\s*([A-Za-zµ]*)",
+                    r"pixel_width\s*[:=]\s*([0-9.eE+-]+)\s*([A-Za-zµ]*)",
+                    r"spatial_resolution\s*[:=]\s*([0-9.eE+-]+)\s*([A-Za-zµ]*)",
                 ):
                     m = re.search(pat, info)
                     if m:
                         try:
-                            return float(m.group(1))
+                            val = float(m.group(1))
                         except ValueError:
-                            pass
-    except Exception:
-        pass
+                            continue
+                        inline_unit = m.group(2) if m.lastindex >= 2 else None
+                        converted = _to_um(val, inline_unit or ij_unit)
+                        if converted is not None:
+                            return converted
+    except Exception as exc:
+        sys.stderr.write(f"ImageJ pixel-size parse failed: {exc}\n")
 
     # 3. Raw TIFF resolution tags (XResolution, ResolutionUnit).
     try:
@@ -181,10 +206,11 @@ def _detect_pixel_size_um(tf) -> float | None:
                             return unit_per_pixel * 25_400.0  # → µm
                         if unit_code == 3:  # cm
                             return unit_per_pixel * 10_000.0  # → µm
-                        # No unit info → caller can't trust the value.
+                        # ResolutionUnit == 1 ("none") — value is in
+                        # arbitrary units; safer to surface as missing.
                         return None
-    except Exception:
-        pass
+    except Exception as exc:
+        sys.stderr.write(f"Raw-TIFF resolution parse failed: {exc}\n")
 
     return None
 
@@ -200,7 +226,7 @@ def _detect_frame_interval_ms(tf) -> float | None:
     Returns ``None`` when no time metadata is present — caller decides
     whether to fall back to a Node-side ffmpeg estimate.
     """
-    # 1. OME-XML
+    # 1. OME-XML — TimeIncrement default unit is seconds per the spec.
     try:
         ome = getattr(tf, "ome_metadata", None)
         if isinstance(ome, str) and "<Pixels" in ome:
@@ -216,26 +242,27 @@ def _detect_frame_interval_ms(tf) -> float | None:
                     return val
                 if u in ("min", "minute", "minutes"):
                     return val * 60_000.0
-                return val * 1000.0  # assume seconds if unit unknown
-    except Exception:
-        pass
+                # OME spec default for TimeIncrement is seconds, so we
+                # treat an unknown unit as seconds rather than dropping
+                # the value (different policy from pixel size because
+                # the unit space for time is much narrower).
+                return val * 1000.0
+    except Exception as exc:
+        sys.stderr.write(f"OME-XML time-increment parse failed: {exc}\n")
 
-    # 2. ImageJ metadata.
+    # 2. ImageJ metadata. `finterval` is seconds per frame; `fps` is the
+    # alternate form (frames per second).
     try:
         meta = getattr(tf, "imagej_metadata", None)
         if isinstance(meta, dict):
-            # `finterval` is the canonical ImageJ field for time-lapse
-            # spacing in seconds. Stored as float by macros that call
-            # ``setFrameInterval``.
             v = meta.get("finterval")
             if isinstance(v, (int, float)) and v > 0:
                 return float(v) * 1000.0
-            # `fps` (frames per second) is the alternate form.
             fps = meta.get("fps")
             if isinstance(fps, (int, float)) and fps > 0:
                 return 1000.0 / float(fps)
-    except Exception:
-        pass
+    except Exception as exc:
+        sys.stderr.write(f"ImageJ time-increment parse failed: {exc}\n")
 
     return None
 
@@ -332,8 +359,9 @@ def main() -> int:
             sys.stdout.write(f"PROGRESS {(t + 1) / T:.4f}\n")
             sys.stdout.flush()
 
-    # If frame_interval is available, derive durationMs from it. Otherwise
-    # leave duration at None — only ND2 has a reliable cross-frame timeline.
+    # Approximate duration from the (constant) frame interval when we
+    # have it. TIFFs don't carry per-frame timestamps, so this is an
+    # extrapolation, not a measurement.
     duration_ms = (
         int(round(frame_interval_ms * (T - 1)))
         if frame_interval_ms is not None and T > 1

--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -146,6 +146,8 @@ export const useProjectData = (
             frameIndex: img.frameIndex,
             frameCount: img.frameCount,
             videoDurationMs: img.videoDurationMs,
+            pixelSizeUm: img.pixelSizeUm,
+            frameIntervalMs: img.frameIntervalMs,
             channels: img.channels,
             // Surface originalPath for the Segment-All channel picker —
             // extractChannelsFromPaths derives distinct channels from the

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -79,8 +79,8 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
     }) => {
       const { t } = useLanguage();
       // ProjectType is `'microtubules'` (plural) — `'microtubule'`
-      // (singular) is the model id, not the project type. Mis-comparing
-      // them silently hides the MT section on every MT project.
+      // (singular) is the model id from MODEL_TYPE_COMPATIBILITY, not
+      // the project type.
       const isMTProject = projectType === 'microtubules';
 
       // Distinct channels across the project's video container rows.
@@ -145,20 +145,26 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       }, [selectedImageIds, updateExportOptions]);
 
       // Auto-fill the pixel-to-µm scale from the first video container's
-      // upload metadata (ND2 voxel_size, OME-TIFF PhysicalSizeX, ImageJ
-      // TIFF). Skipped when the user has already typed a value or when
-      // no container carries calibration. Applies universally — pixel
-      // scale is meaningful for any project type with a known optical
-      // setup, not just microtubule.
+      // upload metadata. The sentinel ref guarantees we only fill once
+      // per dialog open — if the user clears the field intentionally,
+      // we don't re-populate it on the next images update.
+      const autoFilledScaleRef = useRef(false);
       useEffect(() => {
-        if (exportOptions.pixelToMicrometerScale != null) return;
+        if (autoFilledScaleRef.current) return;
+        if (exportOptions.pixelToMicrometerScale != null) {
+          // User-supplied (or previously auto-filled) value — treat as
+          // done. Future clears are now respected.
+          autoFilledScaleRef.current = true;
+          return;
+        }
         const containerWithScale = images.find(
           img =>
             img.isVideoContainer &&
-            typeof img.pixelSizeUm === 'number' &&
+            img.pixelSizeUm != null &&
             img.pixelSizeUm > 0
         );
         if (containerWithScale?.pixelSizeUm) {
+          autoFilledScaleRef.current = true;
           updateExportOptions({
             pixelToMicrometerScale: containerWithScale.pixelSizeUm,
           });
@@ -369,9 +375,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                 {isMTProject && (
                   <MicrotubuleMetricsSection
                     value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
-                    onChange={next =>
-                      updateExportOptions({ mtMetrics: next })
-                    }
+                    onChange={next => updateExportOptions({ mtMetrics: next })}
                     availableChannels={availableChannels}
                   />
                 )}

--- a/src/pages/export/components/MicrotubuleMetricsSection.tsx
+++ b/src/pages/export/components/MicrotubuleMetricsSection.tsx
@@ -40,7 +40,7 @@ export interface MicrotubuleMetricsSectionProps {
 /**
  * MT-only export controls: band thickness, background margin
  * multiplier, channel multi-select. Renders inside the export dialog's
- * General tab when ``projectType === 'microtubule'``.
+ * General tab when ``projectType === 'microtubules'``.
  *
  * The backend re-reads the original ND2/TIFF on disk so the intensity
  * numbers are derived from raw 16-bit signal (the per-channel PNGs are
@@ -51,8 +51,7 @@ export const MicrotubuleMetricsSection: React.FC<
 > = ({ value, onChange, availableChannels }) => {
   const { t } = useLanguage();
 
-  const setEnabled = (enabled: boolean) =>
-    onChange({ ...value, enabled });
+  const setEnabled = (enabled: boolean) => onChange({ ...value, enabled });
 
   const setThickness = (raw: string) => {
     const n = Number.parseInt(raw, 10);
@@ -143,9 +142,7 @@ export const MicrotubuleMetricsSection: React.FC<
         </div>
 
         <div>
-          <Label className="text-sm">
-            {t('export.mt.channelsLabel')}
-          </Label>
+          <Label className="text-sm">{t('export.mt.channelsLabel')}</Label>
           {noChannels ? (
             <p className="text-xs text-muted-foreground mt-2">
               {t('export.mt.noChannels')}

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -148,8 +148,6 @@ const CanvasPolygon = React.memo(
         return isSelected ? '#16a34a' : '#22c55e'; // green
       }
       if (isPolyline) {
-        // Sperm body parts (head/midpiece/tail) use fixed colors so every
-        // sperm of the same part class reads as the same colour.
         switch (polygon.partClass) {
           case 'head':
             return isSelected ? '#16a34a' : '#22c55e'; // green
@@ -158,16 +156,9 @@ const CanvasPolygon = React.memo(
           case 'tail':
             return isSelected ? '#0891b2' : '#06b6d4'; // cyan
         }
-        // Everything else (microtubules, manually-drawn polylines):
-        // deterministic per-polyline HSL hash. Priority of seed:
-        //   1. `trackId` — cross-frame stable, set by the MT tracker; the
-        //      same microtubule keeps its colour across frames.
-        //   2. `instanceId` only when it has the `mt_` prefix (real MT
-        //      identity from the ML model). A sentinel like the historical
-        //      `'sperm_1'` default would otherwise collapse every manually-
-        //      drawn polyline to the same colour.
-        //   3. `polygon.id` — always a UUID, guarantees each polyline gets
-        //      a distinct colour even when no instanceId / trackId exists.
+        // Seed priority: cross-frame trackId, then MT-prefixed instanceId,
+        // then per-polygon UUID — guarantees a distinct colour per
+        // polyline even when ML identity is absent.
         const colorKey =
           polygon.trackId ||
           (isMicrotubuleInstance(polygon.instanceId)


### PR DESCRIPTION
## Summary

Addresses every critical + important finding from the multi-agent review of PRs #186 + #188.

### Critical fixes

- **`useProjectData.tsx`**: mapper now passes `pixelSizeUm` + `frameIntervalMs` through. Without this, every auto-fill access on the export modal was reading `undefined` — the bonus UX was dead code (classic FE-mapper enumerative-drop; TypeScript missed it because the fields are optional).
- **`AdvancedExportDialog.tsx`**: auto-fill effect uses a `useRef` sentinel so the user can clear the field without it being re-populated on the next render.
- **`extract_tiff_stack.py`**: ImageJ + OME-XML pixel-size branches now consult the unit before returning. An nm-calibrated STORM TIFF was being interpreted as µm — off by 1000×.
- **`ffmpegExtractor.ts`**: `durationMs <= 0` returns `null` for `frameIntervalMs` instead of emitting `0`.

### Important fixes

- **stderr surfacing**: bare `except Exception: pass` paths in both Python extractors now emit a one-line warning. Picked up by the existing stderr logger in `pythonExtractor` for ops visibility.
- **ND2 anisotropy detection**: logs to stderr when `voxel_size().x != voxel_size().y` instead of silently using x only.

### Types + comments

- `PythonResult`: dropped the optional `?` on the new fields (helpers always emit them).
- `MicrotubuleMetricsSection` docstring: `'microtubule'` → `'microtubules'`.
- Various PR-rationale comments trimmed to fact-only.

## Test plan

- [ ] Upload a fresh ND2 → DB row has populated `pixelSizeUm` + `frameIntervalMs`
- [ ] Open the export modal on that project → µm/px field is pre-filled
- [ ] Clear the field → value stays cleared (no re-fill on the next render)
- [ ] Upload a TIFF with `PhysicalSizeXUnit='nm'` → pixel size correctly converted to µm
- [ ] Upload a TIFF with no unit metadata → `pixelSizeUm` stays null, user can override
- [ ] No new console errors

## Deploy

Same migration as PR #188 (no new schema change). Rebuild FE + BE + ml, then deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed frame interval calculation to prevent invalid zero-millisecond values in video processing.
  * Corrected auto-fill behavior for pixel-to-micrometer scale in the export dialog to respect user input.
  * Improved error handling and reporting for video metadata extraction from ND2 and TIFF files.

* **Improvements**
  * Enhanced detection and handling of pixel size and frame interval metadata across video formats.
  * Better support for anisotropic pixel dimensions with appropriate warnings during metadata parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/190)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->