### PR TITLE
fix(editor): disable frame slider reverse-sync to stop oscillation

### DIFF
--- a/backend/src/services/__tests__/exportService.sperm.test.ts
+++ b/backend/src/services/__tests__/exportService.sperm.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  prisma: {
+    project: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock('../sharingService', () => ({
+  hasProjectAccess: vi.fn().mockResolvedValue({ hasAccess: true }),
+}));
+
+vi.mock('../websocketService', () => ({
+  WebSocketService: {
+    getInstance: vi.fn(() => ({ emitToUser: vi.fn() })),
+  },
+}));
+
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'job-sperm-orch') }));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('fs/promises', () => {
+  const noop = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    mkdir: noop,
+    writeFile: noop,
+    readFile: noop,
+    readdir: vi.fn().mockResolvedValue([]),
+    stat: vi.fn().mockResolvedValue({}),
+    unlink: noop,
+    copyFile: noop,
+    open: vi.fn(),
+  };
+  return { default: api, ...api };
+});
+
+vi.mock('archiver', () => ({
+  default: vi.fn(() => ({
+    directory: vi.fn(),
+    on: vi.fn(),
+    pipe: vi.fn(),
+    finalize: vi.fn(),
+  })),
+}));
+
+vi.mock('sharp', () => ({
+  default: vi.fn(() => ({
+    metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
+  })),
+}));
+
+vi.mock('../visualization/visualizationGenerator', () => ({
+  VisualizationGenerator: vi.fn(),
+}));
+
+vi.mock('../metrics/metricsCalculator', () => ({
+  MetricsCalculator: vi.fn(),
+}));
+
+vi.mock('../export/formatConverter', () => ({
+  FormatConverter: vi.fn(),
+  resolveImageDimensions: vi
+    .fn()
+    .mockResolvedValue({ width: 100, height: 100 }),
+}));
+
+vi.mock('../../utils/batchProcessor', () => ({
+  batchProcessor: {
+    processBatch: vi.fn(
+      async (
+        items: unknown[],
+        processor: (item: unknown) => Promise<unknown>
+      ) => Promise.all(items.map(processor))
+    ),
+  },
+}));
+
+import { ExportService } from '../exportService';
+import { MetricsCalculator } from '../metrics/metricsCalculator';
+import { VisualizationGenerator } from '../visualization/visualizationGenerator';
+import { FormatConverter } from '../export/formatConverter';
+import { logger } from '../../utils/logger';
+
+const MockMetricsCalculator = MetricsCalculator as unknown as ReturnType<
+  typeof vi.fn
+>;
+const MockVisualizationGenerator =
+  VisualizationGenerator as unknown as ReturnType<typeof vi.fn>;
+const MockFormatConverter = FormatConverter as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedLogger = logger as Mocked<typeof logger>;
+
+const resetSingleton = () => {
+  (ExportService as any).instance = undefined;
+};
+
+interface SpyHandles {
+  exportSpermToExcel: ReturnType<typeof vi.fn>;
+  exportPolygonMetricsToExcel: ReturnType<typeof vi.fn>;
+  exportToExcel: ReturnType<typeof vi.fn>;
+  calculateAllMetrics: ReturnType<typeof vi.fn>;
+  calculateAllImageMetrics: ReturnType<typeof vi.fn>;
+}
+
+const buildImage = (
+  id: string,
+  polygons: unknown[]
+): {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  segmentation: { polygons: string; model: string; threshold: number };
+} => ({
+  id,
+  name: `${id}.png`,
+  // width+height set so generateMetrics skips the disk-based BMP/sharp branch.
+  width: 100,
+  height: 100,
+  segmentation: {
+    polygons: JSON.stringify(polygons),
+    model: 'sperm',
+    threshold: 0.5,
+  },
+});
+
+const spermPolyline = (
+  partClass: 'head' | 'midpiece' | 'tail',
+  instanceId = 'sperm_1'
+) => ({
+  id: `pl-${partClass}`,
+  type: 'external',
+  geometry: 'polyline',
+  partClass,
+  instanceId,
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+  ],
+});
+
+describe('ExportService — sperm Excel orchestration (generateMetrics)', () => {
+  let service: ExportService;
+  let spies: SpyHandles;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSingleton();
+
+    spies = {
+      exportSpermToExcel: vi.fn(),
+      exportPolygonMetricsToExcel: vi.fn().mockResolvedValue(undefined),
+      exportToExcel: vi.fn().mockResolvedValue(undefined),
+      calculateAllMetrics: vi.fn().mockResolvedValue([]),
+      calculateAllImageMetrics: vi.fn().mockResolvedValue([]),
+    };
+
+    MockVisualizationGenerator.mockImplementation(function (this: any) {
+      this.generateVisualization = vi.fn().mockResolvedValue(undefined);
+    });
+    MockFormatConverter.mockImplementation(function (this: any) {
+      this.convertToCOCO = vi.fn().mockResolvedValue({});
+      this.convertToYOLO = vi.fn().mockResolvedValue({ content: '', warnings: [] });
+      this.convertToJSON = vi.fn().mockResolvedValue({});
+    });
+    MockMetricsCalculator.mockImplementation(function (this: any) {
+      this.calculateAllMetrics = spies.calculateAllMetrics;
+      this.calculateAllImageMetrics = spies.calculateAllImageMetrics;
+      this.exportToExcel = spies.exportToExcel;
+      this.exportToCSV = vi.fn().mockResolvedValue(undefined);
+      this.exportPolygonMetricsToExcel = spies.exportPolygonMetricsToExcel;
+      this.exportSpermToExcel = spies.exportSpermToExcel;
+    });
+
+    service = ExportService.getInstance();
+  });
+
+  afterEach(() => {
+    resetSingleton();
+  });
+
+  const callGenerateMetrics = (
+    projectType: string,
+    images: ReturnType<typeof buildImage>[],
+    options?: { pixelToMicrometerScale?: number }
+  ) =>
+    (service as any).generateMetrics(
+      images,
+      '/tmp/sperm-orch-test',
+      ['excel'],
+      'project-name',
+      projectType,
+      options,
+      'job-sperm-orch'
+    );
+
+  it('uses sperm Excel only when projectType is sperm and data exists', async () => {
+    spies.exportSpermToExcel.mockResolvedValue(true);
+
+    await callGenerateMetrics('sperm', [
+      buildImage('img1', [
+        spermPolyline('head'),
+        spermPolyline('midpiece'),
+        spermPolyline('tail'),
+      ]),
+    ]);
+
+    expect(spies.exportSpermToExcel).toHaveBeenCalledTimes(1);
+    expect(spies.exportPolygonMetricsToExcel).not.toHaveBeenCalled();
+    expect(spies.exportToExcel).not.toHaveBeenCalled();
+  });
+
+  it('falls back to polygon-metrics Excel and warns when sperm export returns false', async () => {
+    spies.exportSpermToExcel.mockResolvedValue(false);
+
+    await callGenerateMetrics('sperm', [
+      buildImage('img1', []),
+    ]);
+
+    expect(spies.exportSpermToExcel).toHaveBeenCalledTimes(1);
+    expect(spies.exportPolygonMetricsToExcel).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'flagged as sperm but no polyline data'
+      ),
+      'ExportService',
+      expect.objectContaining({ jobId: 'job-sperm-orch' })
+    );
+  });
+
+  it('propagates pixelToMicrometerScale to exportSpermToExcel', async () => {
+    spies.exportSpermToExcel.mockResolvedValue(true);
+
+    await callGenerateMetrics(
+      'sperm',
+      [buildImage('img1', [spermPolyline('head')])],
+      { pixelToMicrometerScale: 2.5 }
+    );
+
+    expect(spies.exportSpermToExcel).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.stringMatching(/metrics\.xlsx$/),
+      2.5
+    );
+  });
+
+  it('passes scale-undefined when no scale option is provided', async () => {
+    spies.exportSpermToExcel.mockResolvedValue(true);
+
+    await callGenerateMetrics('sperm', [
+      buildImage('img1', [spermPolyline('head')]),
+    ]);
+
+    expect(spies.exportSpermToExcel).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(String),
+      undefined
+    );
+  });
+
+  it('routes spheroid projects through polygon-metrics Excel, never sperm', async () => {
+    await callGenerateMetrics('spheroid', [
+      buildImage('img1', []),
+    ]);
+
+    expect(spies.exportSpermToExcel).not.toHaveBeenCalled();
+    expect(spies.exportPolygonMetricsToExcel).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes spheroid_invasive projects through DI-shaped Excel, never sperm', async () => {
+    await callGenerateMetrics('spheroid_invasive', [
+      buildImage('img1', []),
+    ]);
+
+    expect(spies.exportSpermToExcel).not.toHaveBeenCalled();
+    expect(spies.exportToExcel).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards image segmentation JSON unchanged to exportSpermToExcel', async () => {
+    spies.exportSpermToExcel.mockResolvedValue(true);
+
+    const polylines = [
+      spermPolyline('head'),
+      spermPolyline('tail'),
+    ];
+    await callGenerateMetrics('sperm', [buildImage('img-x', polylines)]);
+
+    const passedImages = spies.exportSpermToExcel.mock.calls[0]?.[0];
+    expect(passedImages).toHaveLength(1);
+    expect(passedImages[0].id).toBe('img-x');
+    expect(passedImages[0].segmentation.polygons).toBe(
+      JSON.stringify(polylines)
+    );
+  });
+});

--- a/backend/src/services/__tests__/segmentationService.sperm.test.ts
+++ b/backend/src/services/__tests__/segmentationService.sperm.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { SegmentationService } from '../segmentationService';
+import { ImageService } from '../imageService';
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/config', () => ({
+  config: {
+    SEGMENTATION_SERVICE_URL: 'http://localhost:8000',
+    STORAGE_TYPE: 'local',
+    STORAGE_LOCAL_PATH: '/tmp/test-storage',
+  },
+}));
+
+vi.mock('../../storage');
+vi.mock('../segmentationThumbnailService');
+// Plain constructor inside factory: not a vi.fn(), so restoreMocks: true cannot
+// wipe the body between tests. metricsCalculator.sperm.test.ts has the same fix.
+vi.mock('../thumbnailManager', () => ({
+  ThumbnailManager: function MockThumbnailManager(this: any) {
+    this.generateAllThumbnails = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+vi.mock('../imageService');
+
+interface SpermPolygonInput {
+  id?: string;
+  points: { x: number; y: number }[];
+  type: 'external' | 'internal';
+  area?: number;
+  confidence?: number;
+  geometry?: 'polygon' | 'polyline';
+  partClass?: 'head' | 'midpiece' | 'tail' | 'core';
+  instanceId?: string;
+}
+
+const headPolyline: SpermPolygonInput = {
+  id: 'pl-head-1',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'head',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ],
+  area: 0,
+  confidence: 0.92,
+};
+
+const midpiecePolyline: SpermPolygonInput = {
+  id: 'pl-mid-1',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'midpiece',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 3, y: 0 },
+    { x: 3, y: 4 },
+  ],
+  area: 0,
+  confidence: 0.88,
+};
+
+const tailPolyline: SpermPolygonInput = {
+  id: 'pl-tail-1',
+  type: 'external',
+  geometry: 'polyline',
+  partClass: 'tail',
+  instanceId: 'sperm_1',
+  points: [
+    { x: 3, y: 4 },
+    { x: 3, y: 9 },
+  ],
+  area: 0,
+  confidence: 0.79,
+};
+
+describe('SegmentationService — sperm polyline roundtrip preservation', () => {
+  let segmentationService: SegmentationService;
+  let prismaMock: any;
+  let imageServiceMock: any;
+
+  // The simulated DB: keyed by imageId, holds the JSON string that
+  // upsert would have written. findMany serves it back unchanged.
+  const dbStore = new Map<string, string>();
+
+  beforeEach(() => {
+    dbStore.clear();
+
+    prismaMock = {
+      segmentation: {
+        findMany: vi.fn(async ({ where }: any) => {
+          const ids: string[] = where?.imageId?.in ?? [];
+          return ids
+            .filter(id => dbStore.has(id))
+            .map(id => ({
+              id: `seg-${id}`,
+              imageId: id,
+              polygons: dbStore.get(id),
+              model: 'sperm',
+              threshold: 0.5,
+              confidence: 0.85,
+              processingTime: 200,
+              imageWidth: 100,
+              imageHeight: 100,
+            }));
+        }),
+        findUnique: vi.fn(),
+        upsert: vi.fn(async ({ where, create }: any) => {
+          // Capture the JSON string the service tried to write so the round-trip
+          // can read it back. Both `update` and `create` carry the same JSON.
+          dbStore.set(where.imageId, create.polygons);
+          return { id: `seg-${where.imageId}`, ...create };
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        deleteMany: vi.fn(),
+      },
+      image: {
+        findMany: vi.fn(async ({ where }: any) => {
+          const ids: string[] = where?.id?.in ?? [];
+          return ids.map(id => ({ id }));
+        }),
+        findUnique: vi.fn(),
+        count: vi.fn(),
+      },
+      project: { findFirst: vi.fn() },
+    };
+
+    imageServiceMock = {
+      getImageById: vi.fn(),
+      updateSegmentationStatus: vi.fn().mockResolvedValue(undefined),
+    };
+
+    segmentationService = new SegmentationService(
+      prismaMock as PrismaClient,
+      imageServiceMock as ImageService
+    );
+  });
+
+  const saveSpermResults = async (
+    imageId: string,
+    polygons: SpermPolygonInput[]
+  ) =>
+    segmentationService.saveSegmentationResults(
+      imageId,
+      polygons as any,
+      'sperm',
+      0.5,
+      0.85,
+      200,
+      100,
+      100,
+      'user-1'
+    );
+
+  it('preserves geometry/partClass/instanceId on a single polyline through save→load', async () => {
+    await saveSpermResults('img-1', [headPolyline]);
+
+    const result = await segmentationService.getBatchSegmentationResults(
+      ['img-1'],
+      'user-1'
+    );
+
+    const loaded = (result['img-1'] as any).polygons;
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      geometry: 'polyline',
+      partClass: 'head',
+      instanceId: 'sperm_1',
+      type: 'external',
+    });
+    expect(loaded[0].points).toEqual(headPolyline.points);
+  });
+
+  it('preserves all three sperm parts with shared instanceId in a roundtrip', async () => {
+    await saveSpermResults('img-1', [
+      headPolyline,
+      midpiecePolyline,
+      tailPolyline,
+    ]);
+
+    const result = await segmentationService.getBatchSegmentationResults(
+      ['img-1'],
+      'user-1'
+    );
+
+    const loaded = (result['img-1'] as any).polygons;
+    expect(loaded).toHaveLength(3);
+
+    const byPart: Record<string, any> = {};
+    for (const p of loaded) {
+      byPart[p.partClass] = p;
+    }
+
+    expect(byPart.head?.instanceId).toBe('sperm_1');
+    expect(byPart.midpiece?.instanceId).toBe('sperm_1');
+    expect(byPart.tail?.instanceId).toBe('sperm_1');
+    expect(byPart.head?.geometry).toBe('polyline');
+    expect(byPart.midpiece?.geometry).toBe('polyline');
+    expect(byPart.tail?.geometry).toBe('polyline');
+  });
+
+  it('keeps multiple sperm instances distinguishable by instanceId', async () => {
+    const sperm1Head = { ...headPolyline, id: 'h1', instanceId: 'sperm_1' };
+    const sperm2Head = { ...headPolyline, id: 'h2', instanceId: 'sperm_2' };
+    const sperm2Tail = {
+      ...tailPolyline,
+      id: 't2',
+      instanceId: 'sperm_2',
+    };
+
+    await saveSpermResults('img-1', [sperm1Head, sperm2Head, sperm2Tail]);
+
+    const result = await segmentationService.getBatchSegmentationResults(
+      ['img-1'],
+      'user-1'
+    );
+
+    const loaded = (result['img-1'] as any).polygons;
+    const instanceIds = loaded.map((p: any) => p.instanceId).sort();
+    expect(instanceIds).toEqual(['sperm_1', 'sperm_2', 'sperm_2']);
+  });
+
+  it('does not add geometry/partClass/instanceId to closed polygons', async () => {
+    const closedPolygon: SpermPolygonInput = {
+      id: 'p1',
+      type: 'external',
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ],
+      area: 100,
+      confidence: 0.9,
+    };
+
+    await saveSpermResults('img-1', [closedPolygon]);
+
+    const result = await segmentationService.getBatchSegmentationResults(
+      ['img-1'],
+      'user-1'
+    );
+
+    const loaded = (result['img-1'] as any).polygons;
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].geometry).toBeUndefined();
+    expect(loaded[0].partClass).toBeUndefined();
+    expect(loaded[0].instanceId).toBeUndefined();
+  });
+
+  it('drops invalid partClass during validation but keeps the polyline geometry', async () => {
+    // PolygonValidator only preserves partClass if it's in the valid set.
+    // A typo like "haed" should be silently dropped on the read path.
+    const typoed: SpermPolygonInput = {
+      ...headPolyline,
+      partClass: 'haed' as any,
+    };
+
+    await saveSpermResults('img-1', [typoed]);
+
+    const result = await segmentationService.getBatchSegmentationResults(
+      ['img-1'],
+      'user-1'
+    );
+
+    const loaded = (result['img-1'] as any).polygons;
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].geometry).toBe('polyline');
+    expect(loaded[0].partClass).toBeUndefined();
+    expect(loaded[0].instanceId).toBe('sperm_1');
+  });
+
+  it('persists JSON exactly once per save (upsert is the only write path)', async () => {
+    await saveSpermResults('img-1', [headPolyline]);
+
+    expect(prismaMock.segmentation.upsert).toHaveBeenCalledTimes(1);
+
+    const upsertArg = prismaMock.segmentation.upsert.mock.calls[0]?.[0];
+    const writtenJson = upsertArg.create.polygons as string;
+    const parsed = JSON.parse(writtenJson);
+    expect(parsed[0]).toMatchObject({
+      geometry: 'polyline',
+      partClass: 'head',
+      instanceId: 'sperm_1',
+    });
+  });
+});

--- a/backend/src/services/metrics/__tests__/metricsCalculator.sperm.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.sperm.test.ts
@@ -1,0 +1,369 @@
+import {
+  MetricsCalculator,
+  ImageWithSegmentation,
+} from '../metricsCalculator';
+
+const mockWorksheet = {
+  columns: [] as Array<{ header?: string; key?: string; width?: number }>,
+  addRow: vi.fn(),
+  getRow: vi.fn(() => ({ font: undefined, fill: undefined })),
+};
+
+const mockAddWorksheet = vi.fn(() => mockWorksheet);
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+// Plain constructor inside the factory: not a vi.fn(), so `restoreMocks: true`
+// (vitest.config.ts) cannot wipe its body between tests. Top-level mock state
+// is captured by closure and accessed lazily when `new ExcelJS.Workbook()` runs.
+vi.mock('exceljs', () => ({
+  default: {
+    Workbook: function MockWorkbook(this: object) {
+      return {
+        addWorksheet: mockAddWorksheet,
+        xlsx: { writeFile: mockWriteFile },
+      };
+    },
+  },
+}));
+
+// Override the global fs/promises mock from src/test/setup.ts which lacks a
+// default export. metricsCalculator uses `import fs from 'fs/promises'`.
+vi.mock('fs/promises', () => {
+  const noop = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    mkdir: noop,
+    readFile: noop,
+    writeFile: noop,
+    unlink: noop,
+    access: noop,
+    stat: noop,
+  };
+  return { default: api, ...api };
+});
+
+vi.mock('axios', () => ({
+  default: { create: vi.fn(() => ({ post: vi.fn() })) },
+  create: vi.fn(() => ({ post: vi.fn() })),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../../utils/config', () => ({
+  config: {
+    SEGMENTATION_SERVICE_URL: 'http://ml-service:8000',
+  },
+}));
+
+import { logger } from '../../../utils/logger';
+const mockedLogger = logger as Mocked<typeof logger>;
+
+const buildImage = (
+  id: string,
+  name: string,
+  polygons: unknown
+): ImageWithSegmentation => ({
+  id,
+  name,
+  segmentation: {
+    polygons:
+      typeof polygons === 'string' ? polygons : JSON.stringify(polygons),
+    model: 'sperm',
+    threshold: 0.5,
+  },
+});
+
+const headPart = (instanceId = 'sperm_1') => ({
+  id: 'h',
+  type: 'external' as const,
+  geometry: 'polyline' as const,
+  partClass: 'head' as const,
+  instanceId,
+  points: [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ],
+});
+
+const midPart = (instanceId = 'sperm_1') => ({
+  id: 'm',
+  type: 'external' as const,
+  geometry: 'polyline' as const,
+  partClass: 'midpiece' as const,
+  instanceId,
+  points: [
+    { x: 3, y: 0 },
+    { x: 3, y: 4 },
+  ],
+});
+
+const tailPart = (instanceId = 'sperm_1') => ({
+  id: 't',
+  type: 'external' as const,
+  geometry: 'polyline' as const,
+  partClass: 'tail' as const,
+  instanceId,
+  points: [
+    { x: 3, y: 4 },
+    { x: 3, y: 9 },
+  ],
+});
+
+describe('MetricsCalculator.exportSpermToExcel', () => {
+  let calculator: MetricsCalculator;
+  const outputPath = '/tmp/sperm-test/sperm.xlsx';
+
+  beforeEach(() => {
+    // restoreMocks: true clears mockImplementation set after creation, so
+    // re-establish here; original impls passed to vi.fn(impl) DO survive.
+    mockWorksheet.columns = [];
+    mockWorksheet.addRow.mockReset();
+    mockWorksheet.getRow.mockReset();
+    mockWorksheet.getRow.mockImplementation(() => ({
+      font: undefined,
+      fill: undefined,
+    }));
+    mockAddWorksheet.mockClear();
+    mockWriteFile.mockClear();
+    mockedLogger.warn.mockClear();
+
+    calculator = new MetricsCalculator();
+  });
+
+  it('returns false and writes no file when no polylines exist', async () => {
+    const closedPolygon = {
+      id: 'p1',
+      type: 'external',
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ],
+    };
+    const result = await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [closedPolygon])],
+      outputPath
+    );
+
+    expect(result).toBe(false);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockWorksheet.addRow).not.toHaveBeenCalled();
+  });
+
+  it('returns true and writes one row per sperm instance with exact lengths', async () => {
+    const result = await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [headPart(), midPart(), tailPart()])],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockWriteFile).toHaveBeenCalledWith(outputPath);
+    expect(mockWorksheet.addRow).toHaveBeenCalledTimes(1);
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith({
+      imageName: 'a.png',
+      instanceId: 'sperm_1',
+      headLength: 3,
+      midpieceLength: 4,
+      tailLength: 5,
+      totalLength: 12,
+    });
+  });
+
+  it('uses px units in headers when no scale is provided', async () => {
+    await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [headPart(), midPart(), tailPart()])],
+      outputPath
+    );
+
+    const headers = mockWorksheet.columns.map(c => c.header);
+    expect(headers).toEqual([
+      'Image Name',
+      'Instance ID',
+      'Head Length (px)',
+      'Midpiece Length (px)',
+      'Tail Length (px)',
+      'Total Length (px)',
+    ]);
+  });
+
+  it('uses µm units and scales lengths when pixelToMicrometerScale > 0', async () => {
+    await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [headPart(), midPart(), tailPart()])],
+      outputPath,
+      2
+    );
+
+    const headers = mockWorksheet.columns.map(c => c.header);
+    expect(headers).toContain('Head Length (µm)');
+    expect(headers).toContain('Total Length (µm)');
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith({
+      imageName: 'a.png',
+      instanceId: 'sperm_1',
+      headLength: 6,
+      midpieceLength: 8,
+      tailLength: 10,
+      totalLength: 24,
+    });
+  });
+
+  it('treats scale = 0 and undefined as "no scale" (uses px)', async () => {
+    await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [headPart()])],
+      outputPath,
+      0
+    );
+
+    const headers = mockWorksheet.columns.map(c => c.header);
+    expect(headers).toContain('Head Length (px)');
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith(
+      expect.objectContaining({ headLength: 3 })
+    );
+  });
+
+  it('records 0 for missing parts (e.g. instance with only head)', async () => {
+    const result = await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [headPart('sperm_1')])],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith({
+      imageName: 'a.png',
+      instanceId: 'sperm_1',
+      headLength: 3,
+      midpieceLength: 0,
+      tailLength: 0,
+      totalLength: 3,
+    });
+  });
+
+  it('writes one row per instance when an image contains multiple sperm', async () => {
+    const result = await calculator.exportSpermToExcel(
+      [
+        buildImage('img1', 'a.png', [
+          headPart('sperm_1'),
+          midPart('sperm_1'),
+          tailPart('sperm_1'),
+          headPart('sperm_2'),
+          tailPart('sperm_2'),
+        ]),
+      ],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockWorksheet.addRow).toHaveBeenCalledTimes(2);
+    const rows = mockWorksheet.addRow.mock.calls.map(c => c[0]);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ instanceId: 'sperm_1', totalLength: 12 }),
+        expect.objectContaining({
+          instanceId: 'sperm_2',
+          totalLength: 8,
+          midpieceLength: 0,
+        }),
+      ])
+    );
+  });
+
+  it('skips images with malformed JSON without crashing and continues processing', async () => {
+    const result = await calculator.exportSpermToExcel(
+      [
+        buildImage('img1', 'broken.png', '{not-valid-json'),
+        buildImage('img2', 'good.png', [headPart(), midPart(), tailPart()]),
+      ],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse polygons'),
+      'MetricsCalculator',
+      expect.objectContaining({ imageId: 'img1' })
+    );
+    expect(mockWorksheet.addRow).toHaveBeenCalledTimes(1);
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith(
+      expect.objectContaining({ imageName: 'good.png' })
+    );
+  });
+
+  it('excludes orphan polylines (no instanceId) and warns', async () => {
+    const orphan = { ...headPart(), instanceId: undefined };
+    const result = await calculator.exportSpermToExcel(
+      [buildImage('img1', 'a.png', [orphan, midPart(), tailPart()])],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('without instanceId'),
+      'MetricsCalculator',
+      expect.objectContaining({ imageId: 'img1' })
+    );
+    const row = mockWorksheet.addRow.mock.calls[0]?.[0];
+    expect(row).toEqual(
+      expect.objectContaining({
+        instanceId: 'sperm_1',
+        headLength: 0,
+        midpieceLength: 4,
+        tailLength: 5,
+        totalLength: 9,
+      })
+    );
+  });
+
+  it('ignores polylines whose partClass is "core" (not a sperm part)', async () => {
+    const corePolyline = {
+      id: 'c',
+      type: 'external' as const,
+      geometry: 'polyline' as const,
+      partClass: 'core' as const,
+      instanceId: 'sperm_1',
+      points: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+    };
+    const result = await calculator.exportSpermToExcel(
+      [
+        buildImage('img1', 'a.png', [
+          corePolyline,
+          headPart(),
+          midPart(),
+          tailPart(),
+        ]),
+      ],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockWorksheet.addRow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'sperm_1',
+        headLength: 3,
+        midpieceLength: 4,
+        tailLength: 5,
+        totalLength: 12,
+      })
+    );
+  });
+
+  it('skips images with no segmentation data', async () => {
+    const result = await calculator.exportSpermToExcel(
+      [
+        { id: 'img1', name: 'no-seg.png' },
+        buildImage('img2', 'a.png', [headPart(), midPart(), tailPart()]),
+      ],
+      outputPath
+    );
+
+    expect(result).toBe(true);
+    expect(mockWorksheet.addRow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/sessionService.ts
+++ b/backend/src/services/sessionService.ts
@@ -105,9 +105,9 @@ class SessionService {
       );
     } catch (err) {
       logger.error(
-        'Refresh token rotation failed mid-write; attempting rollback',
+        `Refresh token rotation failed mid-write for user ${tokenData.userId}; attempting rollback`,
         err as Error,
-        { userId: tokenData.userId }
+        'SessionService'
       );
       // Best-effort: try to restore the original token so the user
       // isn't logged out by a transient Redis blip. If this also fails,

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1071,6 +1071,7 @@ const SegmentationEditor = () => {
         frameImageId: imageId,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     editor.polygons,
     persistedSelectionTrackId,
@@ -1319,44 +1320,26 @@ const SegmentationEditor = () => {
     !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
 
   // Seed video.frameIndex from the URL imageId on first container load.
-  // useVideoFrames defaults to frame 0 internally; without this sync,
-  // opening /segmentation/<pid>/<frame97Id> would show frame 0 in the
-  // canvas and "1 / 300" in the header. We seed once, when the
-  // container metadata arrives and the URL points at a known frame.
+  // Reverse direction (frameIndex → URL) is disabled — see the comment
+  // block below.
   useEffect(() => {
     if (!isVideoMode || !video.container || !imageId) return;
     const idx = video.container.frames.findIndex(f => f.id === imageId);
     if (idx >= 0 && idx !== video.frameIndex) {
       video.setFrameIndex(idx);
     }
-    // Intentionally NOT depending on video.frameIndex — that would
-    // fight Play / scrubber on every tick. Only re-run when the URL
-    // changes or the container is first loaded.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVideoMode, video.container, imageId]);
 
-  // Reverse sync: mirror video.frameIndex back into the URL imageId.
-  // The header slider and Play loop mutate frameIndex locally, but the
-  // segmentation loader (loadSegmentation useEffect) only re-fires when
-  // URL imageId changes — back/next buttons work because they navigate()
-  // directly, slider/play didn't. `replace: true` keeps drag scrubbing
-  // and play-loop ticks from polluting browser history.
-  useEffect(() => {
-    if (!isVideoMode || !video.container) return;
-    const targetId = video.container.frames[video.frameIndex]?.id;
-    if (targetId && targetId !== imageId) {
-      startTransition(() => {
-        navigate(`/segmentation/${projectId}/${targetId}`, { replace: true });
-      });
-    }
-  }, [
-    isVideoMode,
-    video.container,
-    video.frameIndex,
-    imageId,
-    projectId,
-    navigate,
-  ]);
+  // Reverse sync (frameIndex → URL) temporarily DISABLED in production
+  // due to oscillation regression — `useVideoFrames.container.frames`
+  // ordering disagrees with the URL imageId selected from the gallery
+  // sort, causing seed + reverse-sync to fight each other at ~7Hz.
+  // Until that mismatch is resolved at the data layer, slider/play
+  // navigation falls back to the pre-#187 behaviour (slider scrubs the
+  // canvas but doesn't reload polylines — back/next buttons still do).
+  // Tracking issue: production showed 195+ console errors / sec on
+  // 621-frame MT videos with this effect enabled.
 
   // Show loading state only during initial load
   // Once we have basic image metadata, show the UI even if segmentation is still loading

--- a/src/pages/segmentation/components/ChannelOverlayList.tsx
+++ b/src/pages/segmentation/components/ChannelOverlayList.tsx
@@ -181,8 +181,7 @@ export function ChannelOverlayList({
                     onChange={e => setRenameValue(e.target.value)}
                     onBlur={() => commitRename(ch.name, renameValue)}
                     onKeyDown={e => {
-                      if (e.key === 'Enter')
-                        commitRename(ch.name, renameValue);
+                      if (e.key === 'Enter') commitRename(ch.name, renameValue);
                       else if (e.key === 'Escape') setRenamingChannel(null);
                     }}
                     className="flex-1 min-w-0 bg-white dark:bg-gray-700 border border-blue-400 rounded px-1 py-0.5 text-sm text-gray-700 dark:text-gray-200"

--- a/src/pages/segmentation/components/VerticalToolbar.tsx
+++ b/src/pages/segmentation/components/VerticalToolbar.tsx
@@ -293,70 +293,74 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
 
         {/* Mode buttons */}
         <ModeButton mode={EditMode.View} />
-      <ModeButton mode={EditMode.EditVertices} />
-      <ModeButton mode={EditMode.AddPoints} />
-      <ModeButton mode={EditMode.CreatePolygon} />
-      <ModeButton mode={EditMode.CreatePolyline} />
-      <ModeButton mode={EditMode.Slice} />
-      <ModeButton mode={EditMode.DeletePolygon} />
+        <ModeButton mode={EditMode.EditVertices} />
+        <ModeButton mode={EditMode.AddPoints} />
+        <ModeButton mode={EditMode.CreatePolygon} />
+        <ModeButton mode={EditMode.CreatePolyline} />
+        <ModeButton mode={EditMode.Slice} />
+        <ModeButton mode={EditMode.DeletePolygon} />
 
-      {/* Separator */}
-      <div className="w-10 h-px bg-gray-300 dark:bg-gray-600 my-2" />
+        {/* Separator */}
+        <div className="w-10 h-px bg-gray-300 dark:bg-gray-600 my-2" />
 
-      {/* Zoom controls */}
-      <div className="relative group">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onZoomIn}
-          disabled={disabled}
-          className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
-        >
-          <ZoomIn size={20} />
-        </Button>
-        <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-          <div className="font-medium">{t('segmentation.toolbar.zoomIn')}</div>
-          <div className="text-xs text-gray-300 mt-1">+</div>
-          <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
-        </div>
-      </div>
-
-      <div className="relative group">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onZoomOut}
-          disabled={disabled}
-          className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
-        >
-          <ZoomOut size={20} />
-        </Button>
-        <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-          <div className="font-medium">{t('segmentation.toolbar.zoomOut')}</div>
-          <div className="text-xs text-gray-300 mt-1">-</div>
-          <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
-        </div>
-      </div>
-
-      <div className="relative group">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onResetView}
-          disabled={disabled}
-          className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
-        >
-          <Maximize2 size={20} />
-        </Button>
-        <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-          <div className="font-medium">
-            {t('segmentation.toolbar.resetView')}
+        {/* Zoom controls */}
+        <div className="relative group">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onZoomIn}
+            disabled={disabled}
+            className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
+          >
+            <ZoomIn size={20} />
+          </Button>
+          <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+            <div className="font-medium">
+              {t('segmentation.toolbar.zoomIn')}
+            </div>
+            <div className="text-xs text-gray-300 mt-1">+</div>
+            <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
           </div>
-          <div className="text-xs text-gray-300 mt-1">R</div>
-          <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
+        </div>
+
+        <div className="relative group">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onZoomOut}
+            disabled={disabled}
+            className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
+          >
+            <ZoomOut size={20} />
+          </Button>
+          <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+            <div className="font-medium">
+              {t('segmentation.toolbar.zoomOut')}
+            </div>
+            <div className="text-xs text-gray-300 mt-1">-</div>
+            <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
+          </div>
+        </div>
+
+        <div className="relative group">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onResetView}
+            disabled={disabled}
+            className="w-12 h-12 rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-gray-800 dark:bg-gray-800"
+          >
+            <Maximize2 size={20} />
+          </Button>
+          <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+            <div className="font-medium">
+              {t('segmentation.toolbar.resetView')}
+            </div>
+            <div className="text-xs text-gray-300 mt-1">R</div>
+            <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
+          </div>
         </div>
       </div>
-    </div>
 
       <AlertDialog
         open={showResegmentDialog}
@@ -372,9 +376,7 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>
-              {t('common.cancel')}
-            </AlertDialogCancel>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction onClick={handleConfirmResegment}>
               {t('segmentation.toolbar.resegment')}
             </AlertDialogAction>

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -132,7 +132,8 @@ function loadOpacityPrefs(userId: string | undefined): Record<string, number> {
     if (!parsed || typeof parsed !== 'object') return {};
     const clean: Record<string, number> = {};
     for (const [k, v] of Object.entries(parsed)) {
-      if (typeof v === 'number' && Number.isFinite(v)) clean[k] = clampOpacity(v);
+      if (typeof v === 'number' && Number.isFinite(v))
+        clean[k] = clampOpacity(v);
     }
     return clean;
   } catch {

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1034,7 +1034,8 @@ export default {
         '从原始 ND2/TIFF 文件计算每条微管的长度、面积及每通道强度。使用扩张 MT 掩码外的中位数进行背景校正。',
       enable: '计算每通道强度指标',
       thicknessLabel: '微管厚度 (px)',
-      thicknessHelp: '沿每条多边折线采样的带宽。100× 宽场下典型微管直径约为 5 px。',
+      thicknessHelp:
+        '沿每条多边折线采样的带宽。100× 宽场下典型微管直径约为 5 px。',
       marginLabel: '背景余量 (× 厚度)',
       marginHelp:
         '将距任意 MT 此半径范围内的像素 (厚度 × 倍率) 排除出背景。越大越保守。',


### PR DESCRIPTION
Hotfix for a production regression introduced in PR #187.

## Problem

Reverse-sync useEffect (frameIndex → URL with replace:true) causes URL oscillation at ~7Hz on 621-frame MT videos:

- useVideoFrames.container.frames ordering disagrees with URL imageId from gallery sort.
- Seed effect can never match the URL to a frame index → reverse-sync navigates to frames[0] → triggers re-seed → navigates back → etc.

**Symptom**: 195+ console errors / sec, retry storm against /api/segmentation/images/<id>/results, editor unusable on multi-frame videos.

## Fix

Disable reverse-sync; restore pre-#187 slider behaviour: slider still scrubs the canvas, polylines reload only via back/next buttons.

Verified on production after deploy: 0 console errors after hotfix.

## Permanent fix needed

Resolve the data-layer mismatch between useVideoFrames.container.frames and projectImages sort order. Until then, slider drags don't auto-reload polylines.

## Bundled clean-ups

- sessionService logger.error signature fix (3rd arg expects string context, not metadata object).
- Prettier reformat for 4 files touched by PR #189 (ChannelOverlayList, VerticalToolbar, ImageDisplayContext, zh.ts).
- eslint-disable for known-stable selection remap useEffect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)