### PR TITLE
fix(api): widen batch segmentation model whitelist

### DIFF
--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -242,7 +242,19 @@ class SegmentationController {
         return;
       }
 
-      if (!['hrnet', 'resunet_advanced', 'resunet_small'].includes(model)) {
+      if (
+        ![
+          'hrnet',
+          'cbam_resunet',
+          'unet_spherohq',
+          'unet_attention_aspp',
+          'resunet_advanced',
+          'resunet_small',
+          'sperm',
+          'wound',
+          'microtubule',
+        ].includes(model)
+      ) {
         ResponseHelper.validationError(res, 'Neplatný model');
         return;
       }

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -128,8 +128,20 @@ router.post(
       .withMessage('Všechna ID obrázků musí být platná UUID'),
     body('model')
       .optional()
-      .isIn(['hrnet', 'resunet_advanced', 'resunet_small'])
-      .withMessage('Model musí být hrnet, resunet_advanced nebo resunet_small'),
+      .isIn([
+        'hrnet',
+        'cbam_resunet',
+        'unet_spherohq',
+        'unet_attention_aspp',
+        'resunet_advanced',
+        'resunet_small',
+        'sperm',
+        'wound',
+        'microtubule',
+      ])
+      .withMessage(
+        'Model musí být jeden z podporovaných: hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, resunet_advanced, resunet_small, sperm, wound, microtubule'
+      ),
     body('threshold')
       .optional()
       .isFloat({ min: 0.1, max: 0.9 })


### PR DESCRIPTION
POST /api/segmentation/batch rejected microtubule/sperm/wound models with 400 'Neplatný model'. PR #185 added a resegment button to the MT editor that posts model: 'microtubule' — endpoint returned 400 → users couldn't resegment.

Whitelist now matches the full BE SegmentationRequest model type:
hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, resunet_advanced, resunet_small, sperm, wound, microtubule.

Verified on production via curl after deploy: microtubule batch returns success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)