### PR TITLE
fix(editor): re-enable frame slider reverse-sync without oscillation

### DIFF
--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -242,7 +242,19 @@ class SegmentationController {
         return;
       }
 
-      if (!['hrnet', 'resunet_advanced', 'resunet_small'].includes(model)) {
+      if (
+        ![
+          'hrnet',
+          'cbam_resunet',
+          'unet_spherohq',
+          'unet_attention_aspp',
+          'resunet_advanced',
+          'resunet_small',
+          'sperm',
+          'wound',
+          'microtubule',
+        ].includes(model)
+      ) {
         ResponseHelper.validationError(res, 'Neplatný model');
         return;
       }

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -128,8 +128,20 @@ router.post(
       .withMessage('Všechna ID obrázků musí být platná UUID'),
     body('model')
       .optional()
-      .isIn(['hrnet', 'resunet_advanced', 'resunet_small'])
-      .withMessage('Model musí být hrnet, resunet_advanced nebo resunet_small'),
+      .isIn([
+        'hrnet',
+        'cbam_resunet',
+        'unet_spherohq',
+        'unet_attention_aspp',
+        'resunet_advanced',
+        'resunet_small',
+        'sperm',
+        'wound',
+        'microtubule',
+      ])
+      .withMessage(
+        'Model musí být jeden z podporovaných: hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, resunet_advanced, resunet_small, sperm, wound, microtubule'
+      ),
     body('threshold')
       .optional()
       .isFloat({ min: 0.1, max: 0.9 })

--- a/src/hooks/useImageFilter.tsx
+++ b/src/hooks/useImageFilter.tsx
@@ -36,6 +36,20 @@ const getImageComparator = (settings?: FilterSettings) => {
   const { sortField, sortDirection } = settings || getStoredSettings();
 
   return (a: ProjectImage, b: ProjectImage): number => {
+    // Frame siblings of the same video container are ALWAYS sorted by
+    // frameIndex ASC, regardless of the gallery sort field. Temporal
+    // order is the canonical truth for a video — back/next buttons,
+    // the slider, useVideoFrames and the BE all agree on this. Letting
+    // the user's `updatedAt DESC` preference invert frame order here
+    // is what caused PR #191's slider-oscillation regression.
+    const aParent = (a as { parentVideoId?: string | null }).parentVideoId;
+    const bParent = (b as { parentVideoId?: string | null }).parentVideoId;
+    if (aParent && bParent && aParent === bParent) {
+      const aIdx = (a as { frameIndex?: number | null }).frameIndex ?? 0;
+      const bIdx = (b as { frameIndex?: number | null }).frameIndex ?? 0;
+      return aIdx - bIdx;
+    }
+
     let comparison = 0;
 
     switch (sortField) {

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1320,8 +1320,14 @@ const SegmentationEditor = () => {
     !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
 
   // Seed video.frameIndex from the URL imageId on first container load.
-  // Reverse direction (frameIndex → URL) is disabled — see the comment
-  // block below.
+  // The `lastSeededIdx` ref tracks the URL-matching frameIndex that the
+  // editor has *observed* React commit to state — NOT just queued.
+  // Critical: we only update the ref in a separate "observation" effect
+  // below, after frameIndex actually equals urlIdx in a render cycle.
+  // Setting it inside this seed effect (before setFrameIndex propagates)
+  // would let reverse-sync fire on stale frameIndex=0 with the marker
+  // already "matched", which is what caused the oscillation regression.
+  const lastSeededIdx = useRef<number | null>(null);
   useEffect(() => {
     if (!isVideoMode || !video.container || !imageId) return;
     const idx = video.container.frames.findIndex(f => f.id === imageId);
@@ -1331,15 +1337,66 @@ const SegmentationEditor = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVideoMode, video.container, imageId]);
 
-  // Reverse sync (frameIndex → URL) temporarily DISABLED in production
-  // due to oscillation regression — `useVideoFrames.container.frames`
-  // ordering disagrees with the URL imageId selected from the gallery
-  // sort, causing seed + reverse-sync to fight each other at ~7Hz.
-  // Until that mismatch is resolved at the data layer, slider/play
-  // navigation falls back to the pre-#187 behaviour (slider scrubs the
-  // canvas but doesn't reload polylines — back/next buttons still do).
-  // Tracking issue: production showed 195+ console errors / sec on
-  // 621-frame MT videos with this effect enabled.
+  // Observation effect: only mark `lastSeededIdx` once frameIndex
+  // actually reflects the URL's matched index in a committed render.
+  // This breaks the race where the seed effect queues a setFrameIndex
+  // call but the value hasn't propagated yet.
+  useEffect(() => {
+    if (!isVideoMode || !video.container || !imageId) return;
+    const urlIdx = video.container.frames.findIndex(f => f.id === imageId);
+    if (urlIdx >= 0 && urlIdx === video.frameIndex) {
+      lastSeededIdx.current = urlIdx;
+    }
+  }, [isVideoMode, video.container, imageId, video.frameIndex]);
+
+  // Reset seed marker when container changes — next mount must
+  // re-prioritise URL over the local frameIndex state.
+  useEffect(() => {
+    lastSeededIdx.current = null;
+  }, [videoContainerId]);
+
+  // Reverse sync: mirror video.frameIndex back into URL imageId so the
+  // segmentation loader re-fires for slider scrubs and Play. Gating
+  // logic distinguishes the initial-mount race (frameIndex=0 default
+  // while URL points elsewhere) from a real user-initiated move:
+  //
+  // - If URL imageId is NOT in container.frames → navigate (recovery
+  //   path for stale/deep links).
+  // - If URL maps to urlIdx and frameIndex === urlIdx → in sync, no-op.
+  // - Otherwise, navigate only if seed has matched URL once
+  //   (lastSeededIdx === urlIdx). Before that, frameIndex=0 is the
+  //   initial state, not a user choice.
+  //
+  // `replace: true` keeps drag scrubbing and Play ticks out of history.
+  useEffect(() => {
+    if (!isVideoMode || !video.container) return;
+    const targetId = video.container.frames[video.frameIndex]?.id;
+    if (!targetId || targetId === imageId) return;
+    const urlIdx = video.container.frames.findIndex(f => f.id === imageId);
+    if (urlIdx === -1) {
+      // URL imageId outside this container — recover by navigating to
+      // whatever frame the slider currently points at.
+      startTransition(() => {
+        navigate(`/segmentation/${projectId}/${targetId}`, { replace: true });
+      });
+      return;
+    }
+    if (lastSeededIdx.current !== urlIdx) {
+      // Seed for THIS URL hasn't fired yet — bail.
+      return;
+    }
+    // Seed already matched this URL; user moved off it. Sync the URL.
+    startTransition(() => {
+      navigate(`/segmentation/${projectId}/${targetId}`, { replace: true });
+    });
+  }, [
+    isVideoMode,
+    video.container,
+    video.frameIndex,
+    imageId,
+    projectId,
+    navigate,
+  ]);
 
   // Show loading state only during initial load
   // Once we have basic image metadata, show the UI even if segmentation is still loading


### PR DESCRIPTION
Permanent fix for the regression that PR #191 hotfixed by disabling reverse-sync entirely.

## Root cause

Initial-mount race between two useEffects:
- Seed: URL imageId → setFrameIndex(matched urlIdx)  
- Reverse-sync: frameIndex → navigate to frames[frameIndex].id

useVideoFrames defaults frameIndex=0. Reverse-sync fired first with stale frameIndex=0, navigated to frames[0], then seed fired for new URL, loop oscillated at ~7Hz.

## Fix

1. **Sort sjednocení** in useImageFilter.getImageComparator: video-frame siblings sort by frameIndex ASC regardless of gallery preference. Aligns projectImages, useVideoFrames.container.frames, and back/next button navigation.

2. **Three-effect choreography** in SegmentationEditor:
   - **Seed effect** — queues setFrameIndex when URL maps to a frame index
   - **Observation effect** — only marks `lastSeededIdx.current = urlIdx` AFTER React commits the seeded value (deps include video.frameIndex so it re-runs post-commit)  
   - **Reverse-sync effect** — bails when seed hasn't been observed yet for current URL; navigates only on genuine user moves past seed
   - Container-change reset clears the seeded marker on video swap

## Verification

Tested on production https://spherosegapp.utia.cas.cz on the 621-frame MT video (frame 315 = `3ac5f000-...`):

- ✅ Stable mount: URL stays on frame 315 for 30 samples (was oscillating ~7Hz)
- ✅ Slider scrub to 70% updates URL to frame 435 (`8c0fac89-...`)
- ✅ Polygons reload on slider move (restores PR #187 intended behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded segmentation model support with additional specialized models now available, including advanced variants for medical imaging and microbiology applications.

* **Bug Fixes**
  * Fixed video frame slider synchronization issues in the segmentation editor.
  * Improved image ordering for video frame sequences to maintain correct frame sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/193)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->