### PR TITLE
fix(images): bubble pixel calibration from video container to frame rows

### DIFF
--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -962,6 +962,20 @@ export class ImageController {
             frameIntervalMs: p.frameIntervalMs,
           });
         }
+        // FK is ON DELETE CASCADE so a frame outliving its parent
+        // should be impossible. If we ever observe it here, the gallery
+        // looks calibration-less without explanation — log so Sentry
+        // surfaces the integrity drift instead of swallowing it.
+        if (parents.length !== parentIds.length) {
+          const missing = parentIds.filter(
+            id => !parentCalibrationById.has(id)
+          );
+          logger.warn(
+            'Frames reference missing video container — calibration bubble will fall through',
+            'ImageController',
+            { missingParentIds: missing, projectId }
+          );
+        }
       }
 
       // Get storage provider for URL generation
@@ -1093,8 +1107,8 @@ export class ImageController {
             frameCount: image.frameCount,
             videoDurationMs: image.videoDurationMs,
             // Calibration metadata extracted at upload time (µm/px and
-            // ms between frames). The bubble above lifts the parent
-            // container's values onto each frame row; standalone images
+            // ms between frames). Frame rows inherit from their parent
+            // container via `parentCalibrationById`; standalone images
             // (no parent) fall back to their own row, which may still
             // be null when the upload skipped extraction.
             pixelSizeUm:

--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -931,6 +931,39 @@ export class ImageController {
         where: galleryWhere,
       });
 
+      // Bubble calibration (pixelSizeUm / frameIntervalMs) from each
+      // video container down to its extracted frames. Calibration is
+      // stored only on the container row at upload time; downstream
+      // consumers (export dialog auto-fill, MT metrics scaling) need
+      // it on every frame row. Without this, the gallery filter
+      // (`isVideoContainer: false`) hides the only row carrying the
+      // value and every frame surfaces with null.
+      const parentIds = Array.from(
+        new Set(
+          images
+            .map(i => i.parentVideoId)
+            .filter(
+              (id): id is string => typeof id === 'string' && id.length > 0
+            )
+        )
+      );
+      const parentCalibrationById = new Map<
+        string,
+        { pixelSizeUm: number | null; frameIntervalMs: number | null }
+      >();
+      if (parentIds.length > 0) {
+        const parents = await prisma.image.findMany({
+          where: { id: { in: parentIds } },
+          select: { id: true, pixelSizeUm: true, frameIntervalMs: true },
+        });
+        for (const p of parents) {
+          parentCalibrationById.set(p.id, {
+            pixelSizeUm: p.pixelSizeUm,
+            frameIntervalMs: p.frameIntervalMs,
+          });
+        }
+      }
+
       // Get storage provider for URL generation
       const storage = getStorageProvider();
 
@@ -1060,10 +1093,19 @@ export class ImageController {
             frameCount: image.frameCount,
             videoDurationMs: image.videoDurationMs,
             // Calibration metadata extracted at upload time (µm/px and
-            // ms between frames). Populated on container rows only;
-            // null on frames + standalone images.
-            pixelSizeUm: image.pixelSizeUm,
-            frameIntervalMs: image.frameIntervalMs,
+            // ms between frames). The bubble above lifts the parent
+            // container's values onto each frame row; standalone images
+            // (no parent) fall back to their own row, which may still
+            // be null when the upload skipped extraction.
+            pixelSizeUm:
+              (image.parentVideoId
+                ? parentCalibrationById.get(image.parentVideoId)?.pixelSizeUm
+                : null) ?? image.pixelSizeUm,
+            frameIntervalMs:
+              (image.parentVideoId
+                ? parentCalibrationById.get(image.parentVideoId)
+                    ?.frameIntervalMs
+                : null) ?? image.frameIntervalMs,
             channels: image.channels,
             displayOrder: image.displayOrder,
             // Exposed so the Segment-All channel picker can derive the set

--- a/backend/src/services/imageService.ts
+++ b/backend/src/services/imageService.ts
@@ -616,6 +616,39 @@ export class ImageService {
       take: limit,
     });
 
+    // Bubble calibration metadata from each frame's parent container
+    // down to the frame row. The DB only stores pixelSizeUm /
+    // frameIntervalMs on container rows (filled at upload-time by the
+    // ND2/TIFF extractor), but the gallery listing intentionally
+    // excludes containers (`isVideoContainer: false` filter above),
+    // so consumers downstream — most importantly the export dialog's
+    // pixel-scale auto-fill — never see the calibration. Fetch each
+    // distinct parent container once and overlay its calibration
+    // onto its frames in the response.
+    const parentIds = Array.from(
+      new Set(
+        images
+          .map(i => i.parentVideoId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      )
+    );
+    const parentCalibrationById = new Map<
+      string,
+      { pixelSizeUm: number | null; frameIntervalMs: number | null }
+    >();
+    if (parentIds.length > 0) {
+      const parents = await this.prisma.image.findMany({
+        where: { id: { in: parentIds } },
+        select: { id: true, pixelSizeUm: true, frameIntervalMs: true },
+      });
+      for (const p of parents) {
+        parentCalibrationById.set(p.id, {
+          pixelSizeUm: p.pixelSizeUm,
+          frameIntervalMs: p.frameIntervalMs,
+        });
+      }
+    }
+
     // Add URLs to images
     const storage = getStorageProvider();
     const imagesWithUrls: ImageWithUrls[] = await Promise.all(
@@ -630,8 +663,20 @@ export class ImageService {
           ? await storage.getUrl(image.segmentationThumbnailPath)
           : undefined;
 
+        // If this row is a video frame, prefer its parent container's
+        // calibration over the row's own (which is always null in
+        // current schema). Standalone images keep their own values.
+        const parentCal = image.parentVideoId
+          ? parentCalibrationById.get(image.parentVideoId)
+          : null;
+        const pixelSizeUm = parentCal?.pixelSizeUm ?? image.pixelSizeUm;
+        const frameIntervalMs =
+          parentCal?.frameIntervalMs ?? image.frameIntervalMs;
+
         return {
           ...image,
+          pixelSizeUm,
+          frameIntervalMs,
           originalUrl,
           thumbnailUrl,
           segmentationThumbnailUrl,

--- a/backend/src/services/imageService.ts
+++ b/backend/src/services/imageService.ts
@@ -647,6 +647,17 @@ export class ImageService {
           frameIntervalMs: p.frameIntervalMs,
         });
       }
+      // FK ON DELETE CASCADE should make this unreachable. If it
+      // fires, the gallery silently falls back to row-level nulls —
+      // log so the orphan drift gets investigated.
+      if (parents.length !== parentIds.length) {
+        const missing = parentIds.filter(id => !parentCalibrationById.has(id));
+        logger.warn(
+          'Frames reference missing video container — calibration bubble will fall through',
+          'ImageService',
+          { missingParentIds: missing, projectId }
+        );
+      }
     }
 
     // Add URLs to images
@@ -663,9 +674,10 @@ export class ImageService {
           ? await storage.getUrl(image.segmentationThumbnailPath)
           : undefined;
 
-        // If this row is a video frame, prefer its parent container's
-        // calibration over the row's own (which is always null in
-        // current schema). Standalone images keep their own values.
+        // Prefer parent container's calibration over the row's own
+        // (frames don't carry their own — `??` fallback also covers
+        // the future case where a per-frame override appears).
+        // Standalone images keep their own values.
         const parentCal = image.parentVideoId
           ? parentCalibrationById.get(image.parentVideoId)
           : null;

--- a/backend/src/services/video/pythonHelpers/extract_metadata_only.py
+++ b/backend/src/services/video/pythonHelpers/extract_metadata_only.py
@@ -4,8 +4,8 @@
 The full extractors (``extract_nd2.py``, ``extract_tiff_stack.py``) do
 the frame-writing pass AND the metadata pass in one shot. For
 backfilling calibration on already-extracted containers, we only need
-the metadata — re-writing every frame would be wasteful and could
-disturb the already-deployed frame paths.
+the metadata — re-writing every frame would rewrite existing PNGs
+and invalidate cached thumbnails for no benefit.
 
 This helper reuses the pure metadata helpers from the existing
 extractors via direct imports (no PNG output, no full array load).
@@ -74,7 +74,14 @@ def _extract_nd2(path: Path) -> dict:
 
 
 def _extract_tiff(path: Path) -> dict:
-    """TIFF metadata via the helpers in ``extract_tiff_stack.py``."""
+    """TIFF metadata via the helpers in ``extract_tiff_stack.py``.
+
+    Mirrors ``_extract_nd2``'s per-step exception isolation: a parser
+    raising on one of the two values should leave the other intact, so
+    a partially-readable TIFF still backfills what it can. Errors are
+    logged to stderr (the agreed logging channel for this script) and
+    the offending field is left as ``None``.
+    """
     import tifffile  # type: ignore
 
     from extract_tiff_stack import (
@@ -82,11 +89,23 @@ def _extract_tiff(path: Path) -> dict:
         _detect_frame_interval_ms,
     )
 
+    pixel_size_um: float | None = None
+    frame_interval_ms: float | None = None
+
     with tifffile.TiffFile(str(path)) as tf:
-        return {
-            "pixelSizeUm": _detect_pixel_size_um(tf),
-            "frameIntervalMs": _detect_frame_interval_ms(tf),
-        }
+        try:
+            pixel_size_um = _detect_pixel_size_um(tf)
+        except Exception as exc:
+            sys.stderr.write(f"TIFF pixel-size detect failed: {exc}\n")
+        try:
+            frame_interval_ms = _detect_frame_interval_ms(tf)
+        except Exception as exc:
+            sys.stderr.write(f"TIFF frame-interval detect failed: {exc}\n")
+
+    return {
+        "pixelSizeUm": pixel_size_um,
+        "frameIntervalMs": frame_interval_ms,
+    }
 
 
 def main() -> int:

--- a/backend/src/services/video/pythonHelpers/extract_metadata_only.py
+++ b/backend/src/services/video/pythonHelpers/extract_metadata_only.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Metadata-only extractor for an existing ND2 or multi-page TIFF on disk.
+
+The full extractors (``extract_nd2.py``, ``extract_tiff_stack.py``) do
+the frame-writing pass AND the metadata pass in one shot. For
+backfilling calibration on already-extracted containers, we only need
+the metadata — re-writing every frame would be wasteful and could
+disturb the already-deployed frame paths.
+
+This helper reuses the pure metadata helpers from the existing
+extractors via direct imports (no PNG output, no full array load).
+
+Stdout protocol (one JSON line on its own):
+  {"pixelSizeUm": <float|null>, "frameIntervalMs": <float|null>}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+
+def _extract_nd2(path: Path) -> dict:
+    """ND2 metadata via the `nd2` Python library. Mirrors the
+    `voxel_size().x` + median Δ over `Time [s]` events logic in
+    `extract_nd2.py` but skips the per-frame PNG pass entirely.
+    """
+    import nd2  # type: ignore
+    import numpy as np
+
+    pixel_size_um: float | None = None
+    frame_interval_ms: float | None = None
+
+    with nd2.ND2File(str(path)) as f:
+        # Pixel calibration — isotropic, X axis, with anisotropy warning.
+        try:
+            v = f.voxel_size()
+            x_um = getattr(v, "x", None) if v is not None else None
+            y_um = getattr(v, "y", None) if v is not None else None
+            if isinstance(x_um, (int, float)) and x_um > 0:
+                if (
+                    isinstance(y_um, (int, float))
+                    and y_um > 0
+                    and abs(x_um - y_um) / x_um > 0.01
+                ):
+                    sys.stderr.write(
+                        f"ND2 anisotropic XY: x={x_um} y={y_um}, using x\n"
+                    )
+                pixel_size_um = float(x_um)
+        except Exception as exc:
+            sys.stderr.write(f"ND2 voxel_size read failed: {exc}\n")
+
+        # Frame interval — median Δ over per-event Time [s].
+        try:
+            events = f.events()
+            if events and "Time [s]" in events[0]:
+                ts = [e["Time [s]"] for e in events if "Time [s]" in e]
+                if len(ts) >= 2:
+                    deltas = np.diff(np.asarray(ts, dtype=np.float64))
+                    pos = deltas[deltas > 0]
+                    if pos.size > 0:
+                        frame_interval_ms = float(np.median(pos) * 1000.0)
+        except Exception as exc:
+            sys.stderr.write(f"ND2 events parse failed: {exc}\n")
+
+    return {
+        "pixelSizeUm": pixel_size_um,
+        "frameIntervalMs": frame_interval_ms,
+    }
+
+
+def _extract_tiff(path: Path) -> dict:
+    """TIFF metadata via the helpers in ``extract_tiff_stack.py``."""
+    import tifffile  # type: ignore
+
+    from extract_tiff_stack import (
+        _detect_pixel_size_um,
+        _detect_frame_interval_ms,
+    )
+
+    with tifffile.TiffFile(str(path)) as tf:
+        return {
+            "pixelSizeUm": _detect_pixel_size_um(tf),
+            "frameIntervalMs": _detect_frame_interval_ms(tf),
+        }
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: extract_metadata_only.py <src>", file=sys.stderr)
+        return 2
+    src = Path(sys.argv[1])
+    if not src.is_file():
+        print(f"file not found: {src}", file=sys.stderr)
+        return 3
+
+    ext = src.suffix.lower()
+    try:
+        if ext == ".nd2":
+            result = _extract_nd2(src)
+        elif ext in (".tif", ".tiff"):
+            result = _extract_tiff(src)
+        else:
+            print(f"unsupported extension: {ext}", file=sys.stderr)
+            return 4
+    except Exception as exc:
+        # Surface the underlying error to stderr so the Node caller's
+        # backfill log shows WHY this container couldn't be calibrated.
+        print(f"extraction failed: {exc}", file=sys.stderr)
+        return 5
+
+    sys.stdout.write(json.dumps(result) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -144,23 +144,21 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       }, [selectedImageIds, updateExportOptions]);
 
-      // Auto-fill the pixel-to-µm scale from the first video container's
-      // upload metadata (ND2 voxel_size, OME-TIFF PhysicalSizeX, ImageJ
-      // TIFF). Skipped when the user has already typed a value or when
-      // no container carries calibration. Applies universally — pixel
-      // scale is meaningful for any project type with a known optical
-      // setup, not just microtubule.
+      // Auto-fill the pixel-to-µm scale from the first image carrying
+      // upload-time calibration (ND2 voxel_size, OME-TIFF
+      // PhysicalSizeX, ImageJ TIFF). The backend bubbles each frame
+      // row's calibration down from its parent video container, so any
+      // image — frame or standalone — with a positive pixelSizeUm is
+      // a valid source. Skipped when the user has already typed a
+      // value or when no image carries calibration.
       useEffect(() => {
         if (exportOptions.pixelToMicrometerScale != null) return;
-        const containerWithScale = images.find(
-          img =>
-            img.isVideoContainer &&
-            typeof img.pixelSizeUm === 'number' &&
-            img.pixelSizeUm > 0
+        const calibrated = images.find(
+          img => typeof img.pixelSizeUm === 'number' && img.pixelSizeUm > 0
         );
-        if (containerWithScale?.pixelSizeUm) {
+        if (calibrated?.pixelSizeUm) {
           updateExportOptions({
-            pixelToMicrometerScale: containerWithScale.pixelSizeUm,
+            pixelToMicrometerScale: calibrated.pixelSizeUm,
           });
         }
       }, [images, exportOptions.pixelToMicrometerScale, updateExportOptions]);

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -126,6 +126,12 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       } = useSharedAdvancedExport(projectId);
 
       const [activeTab, setActiveTab] = useState('general');
+      // `pixelToMicrometerScale != null` was the old auto-fill guard, but
+      // it collapses three distinct states (untouched, user-cleared,
+      // user-typed-zero-then-erased) into one. Tracking interaction
+      // explicitly keeps the auto-fill safe to re-run when `images`
+      // resolves after the dialog has already opened.
+      const hasUserTouchedScaleRef = useRef(false);
 
       // Notify parent component when export state changes
       useEffect(() => {
@@ -149,9 +155,10 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       // PhysicalSizeX, ImageJ TIFF). The backend bubbles each frame
       // row's calibration down from its parent video container, so any
       // image — frame or standalone — with a positive pixelSizeUm is
-      // a valid source. Skipped when the user has already typed a
-      // value or when no image carries calibration.
+      // a valid source. Skipped once the user has interacted with the
+      // input (see `hasUserTouchedScaleRef`).
       useEffect(() => {
+        if (hasUserTouchedScaleRef.current) return;
         if (exportOptions.pixelToMicrometerScale != null) return;
         const calibrated = images.find(
           img => typeof img.pixelSizeUm === 'number' && img.pixelSizeUm > 0
@@ -302,6 +309,11 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                         placeholder={t('export.scalePlaceholder')}
                         value={exportOptions.pixelToMicrometerScale || ''}
                         onChange={e => {
+                          // Any interaction disables further auto-fill —
+                          // including clearing the field, so a user who
+                          // wipes the auto-suggested value doesn't get it
+                          // silently re-applied on the next image refresh.
+                          hasUserTouchedScaleRef.current = true;
                           const value = e.target.value;
 
                           // Handle empty string


### PR DESCRIPTION
## Summary

Fixes the empty "Pixel Size (µm/pixel)" field in the Advanced Export dialog for projects with ND2 / OME-TIFF / ImageJ-TIFF videos. The calibration was extracted correctly at upload time but never reached the FE because the gallery listing surfaces filter out video containers — the only row that stores the value.

This was a **dual-surface enumerative-drop**: backend has two listing paths that share the gallery filter, only one of them is what the FE actually uses (`useProjectData` → `apiClient.getProjectImagesWithThumbnails`), and both needed the bubble fix.

## Changes

- **`imageController.getProjectImagesWithThumbnails`** — bubble `pixelSizeUm` + `frameIntervalMs` from each frame's parent container row. This is the path consumed by the project gallery + Advanced Export dialog.
- **`imageService.list()`** — same bubble in the admin/legacy listing path, so the wire response is consistent across surfaces.
- **`AdvancedExportDialog.tsx`** — relax the auto-fill `useEffect` to accept any image with `pixelSizeUm > 0`; previously required `img.isVideoContainer === true`, which was unreachable since containers are upstream-filtered out of the array.
- **`extract_metadata_only.py`** (new) — one-shot helper for backfilling calibration on pre-extractor uploads (re-reads ND2 `voxel_size` / TIFF OME XML without re-writing frame PNGs). Run via `docker exec spheroseg-backend python3 src/services/video/pythonHelpers/extract_metadata_only.py <container_file>` and patch the resulting JSON into the DB.

## Verification

End-to-end Playwright on production after deploy:
- ✅ MT project: dialog auto-fills `0.07245187878015268` on open (screenshot in branch).
- ✅ Sperm project: input stays empty (no calibration source — expected).
- ✅ Tab switching General/Visualization/Formats works.
- ✅ 0 console errors during the entire flow.

Direct API verification on the live endpoint the FE consumes:
```bash
curl ".../api/projects/<mt-id>/images-with-thumbnails?limit=3"
# every frame row now reports pixelSizeUm: 0.07245... (was null)
```

Comprehensive sweep (auth → 6 project types → editor → export → WebSocket → log scan): 99/117 200s, 18 ETag 304s, 0 5xx, 0 ML errors.

## Risk

- Low — adds one extra `findMany` (one query per page slice, ~3-5 ms typical), bounded by `parentIds` set size.
- The overlay falls back to `image.pixelSizeUm` if no parent (standalone images still get their own value).
- No DB schema change, no migration.

## Notes

- Pattern memorialized in [memory `project_image_listing_dual_surface_bubble`](https://github.com/) — next time someone adds a container-only field, grep both listing surfaces.
- Worktree deploy gotcha learned the hard way during this work (mounts resolve against cwd, not compose file) — separate memory `feedback_worktree_compose_cwd`.

## Test plan

- [x] Backend `npx tsc --noEmit` clean for changed files
- [x] Pre-commit hook passed (ESLint 0 warnings, TS, prettier)
- [x] Production curl: `pixelSizeUm` bubbled on `images-with-thumbnails` response
- [x] Playwright: MT auto-fills, sperm empty, 0 console errors
- [x] Backend log scan: 0 × 5xx, 0 × app 404s during 15-min Playwright sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata extraction tool for ND2 and TIFF video files.

* **Bug Fixes**
  * Video frame calibration metadata now properly inherited from parent containers when filtered.
  * Export dialog improved to find calibration data from frames and standalone images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->