### PR TITLE
fix(folders): polish error UX — whitespace, messages, Prisma codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ If the change is going to production, **build the production bundle locally and 
 
 ## Test Suite Reality
 
-**Treat the test suite as currently broken.** Honest numbers as of 2026-05-13:
+**Treat the test suite as currently broken.** Honest numbers as of 2026-05-15:
 
 | Suite                         | State                                                                                                                                                           |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -218,6 +218,10 @@ Each of these shipped to production at least once in 2026 despite green pre-comm
 
 10. **Queue worker stuck on `isProcessing=true`**. ML recreate during an in-flight axios POST leaves the backend in a deadlock state. Check: tail backend logs after deploy; if no progress, restart backend.
 
+11. **TDZ on useCallback referencing a later `const`**. New `useCallback` / `useMemo` / `useEffect` placed BEFORE a `const x = ...` it captures in its deps array (or body) throws `Cannot access '<single letter>' before initialization` at runtime — TS doesn't catch it because the component body looks like a flat scope. Production minified bundle shows the error as a single letter (`'A'`, `'b'`). Check: when reordering hooks in `SegmentationEditor.tsx`, ensure any hook that touches `video.*`, `editor.*`, `selectedImage.*` is placed AFTER the corresponding `const video = ...`, etc.
+
+12. **Frame slider seed/reverse-sync race**. `useVideoFrames` defaults `frameIndex=0`. If reverse-sync (frameIndex→URL) fires before seed (URL→frameIndex) propagates a `setFrameIndex(N)`, the URL flips to `frames[0]` and oscillates with seed at ~7 Hz on multi-hundred-frame videos. Check: tests on a 600+-frame video; the editor must converge within 1-2 render commits. Pattern: 3-effect choreography with ref-tracked seed marker — see memory `project_frame_slider_race_pattern`.
+
 ---
 
 ## Commands
@@ -260,14 +264,26 @@ make build-service SERVICE=frontend      # Build single service
 make build-clean                         # Full no-cache rebuild
 ```
 
-### Production
+### Production (single-stack, post-2026-05-15)
+
+Blue-green is gone (see memory `project_blue_green_removal_2026_05_15`). Deploy is just a rebuild + recreate of the affected services:
 
 ```bash
-make prod                                              # Build + deploy
+# 1. Build the changed services
+make build-service SERVICE=backend                     # or frontend / ml
+# 2. Recreate (no need to stop the others)
 docker compose -f docker-compose.production.yml \
-  --env-file .env.production up -d                     # Manual deploy (note --env-file!)
-curl https://spherosegapp.utia.cas.cz/health           # Verify
+  --env-file .env.production \
+  up -d --no-deps --force-recreate backend             # repeat with frontend / ml
+# 3. Flush nginx upstream DNS cache after a backend recreate
+docker restart spheroseg-nginx
+# 4. Verify
+curl https://spherosegapp.utia.cas.cz/health           # → "production-healthy"
 ```
+
+`make prod` rebuilds and recreates everything; useful for big changes but unnecessary for service-scoped updates.
+
+There are no longer `scripts/deploy-production.sh` / `rollback-deployment.sh` / `migrate-database.sh` etc. — those orchestrated blue↔green switching that doesn't exist now.
 
 | Service     | Production      | Dev  |
 | ----------- | --------------- | ---- |
@@ -310,8 +326,10 @@ Most complex feature in the repo (~51 KB orchestrator). Key files:
 - `useEnhancedSegmentationEditor` — core state (polygons, selection, undo/redo, transforms)
 - `useAdvancedInteractions` — mouse/keyboard, polygon creation, vertex editing
 - `EditMode` enum — state machine: `View | EditVertices | Slice | AddPoints | DeletePolygon | CreatePolygon | CreatePolyline`
-- `Polygon` model — closed polygons (`geometry: 'polygon'`) + open polylines (`geometry: 'polyline'`) with optional `partClass` + `instanceId` (sperm) or `trackId` + `_embedding` (microtubule cross-frame tracking)
+- `Polygon` model — closed polygons (`geometry: 'polygon'`) + open polylines (`geometry: 'polyline'`) with optional `partClass` + `instanceId` (sperm) or `trackId` + `_embedding` (microtubule cross-frame tracking). UI state (hide/select/rename) keys on `polygonKey(p) = p.trackId ?? p.id` so it survives frame scrubs — branded `PolygonKey` type for compile-time safety.
 - Canvas layers: `CanvasPolygon` (per-polygon, React.memo with custom comparator), `CanvasVertex`, `CanvasTemporaryGeometryLayer`
+- Toolbars: `TopToolbar` carries Undo / Redo / **Resegment** (multi-channel videos open `SegmentChannelDialog` first) / Save. `VerticalToolbar` is left rail with edit-mode buttons + zoom + reset only — no resegment there since PR #195.
+- Frame slider in `EditorHeader` uses 3-effect choreography in `SegmentationEditor` (seed + observation + reverse-sync with ref-tracked `lastSeededIdx`) — required on multi-hundred-frame videos to prevent oscillation. See memory `project_frame_slider_race_pattern`.
 
 ### Backend (`/backend/`)
 
@@ -393,6 +411,9 @@ The real PR gate is local: pre-commit hook + `make ci` + Playwright verification
 - **`HF_TOKEN`** required for first microtubule load (DINOv3 backbone, ~1.1 GB). Lives in `.env.production` (gitignored).
 - **Always `--env-file .env.production`** when running `docker compose` against production. Without it, env vars silently empty.
 - **After backend `--force-recreate`, restart nginx too** — DNS cache pins old container IP.
+- **Volume names still carry `_blue_data` suffix** (postgres_blue_data, redis_blue_data). Cosmetic-only — internal Docker identifiers, never user-facing. Renaming requires manual volume copy; not worth the downtime for "spheroseg_data" prettiness.
+- **Upload directory still mounted from `./backend/uploads/blue`** on host, but container sees neutral `/app/uploads`. 17 GB of production data lives there; renaming the host path would need `docker compose down` + `mv` + remount. Same trade-off as volume names.
+- **DB password literal `spheroseg_blue_2024`** is a fixed credential string (NOT a DB name reference). Database itself is `spheroseg` since 2026-05-15. Rotating the password means changing the live user's `PG_PASSWORD` first.
 
 ---
 

--- a/backend/prisma/migrations/20260516_add_project_folders/migration.sql
+++ b/backend/prisma/migrations/20260516_add_project_folders/migration.sql
@@ -1,0 +1,115 @@
+-- CreateTable -- per-user folder tree for organising the project gallery.
+--
+-- Data model: adjacency list with self-referential parentId. NULL parentId
+-- means the folder lives at the user's root level. Folder uniqueness is
+-- enforced *per parent* so two siblings cannot share a name; the same name
+-- in different parents (e.g. "Pictures" under two different folders) is
+-- allowed. We deliberately do NOT bound the depth — the application uses
+-- recursive CTEs to fetch the whole subtree and rejects cyclic moves.
+--
+-- Cascade behaviour:
+--   * Deleting a User cascades to every folder + placement they own.
+--   * Deleting a parent folder cascades to all descendants via the
+--     self-relation ON DELETE CASCADE, and the items inside them via the
+--     folder->item FK below. The service layer additionally invokes
+--     projectService.deleteProject for any *owned* projects in the subtree
+--     (file cleanup, queue purge, share revocation); shared-project
+--     placements are simply dropped, leaving the project intact for its
+--     real owner.
+
+CREATE TABLE "project_folders" (
+    "id"        TEXT         NOT NULL,
+    "name"      TEXT         NOT NULL,
+    "userId"    TEXT         NOT NULL,
+    "parentId"  TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_folders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable -- per-user placement of a project into one of their folders.
+--
+-- One row = "user U placed project P into folder F". The (userId, projectId)
+-- uniqueness means a user keeps each project in at most one folder; absence
+-- of a row means the project sits at the user's root level. userId is
+-- denormalised from folder.userId so the unique lookup is index-only.
+--
+-- Shared projects: when user A shares a project with user B, B can place
+-- the project into their own folder without touching A's view. The userId
+-- on the placement is B's id; the project's underlying userId is A's.
+
+CREATE TABLE "project_folder_items" (
+    "id"        TEXT         NOT NULL,
+    "userId"    TEXT         NOT NULL,
+    "projectId" TEXT         NOT NULL,
+    "folderId"  TEXT         NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "project_folder_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex -- siblings unique by name under the same parent (or root).
+-- NULL parentId is treated as a distinct group per Postgres NULL semantics:
+-- this still enforces uniqueness at root because (userId, NULL, name) only
+-- collides if another row has the *same* userId, NULL parent, and name.
+-- Actually Postgres treats NULLs as distinct in unique indexes, so we add
+-- a partial-index hardening below to lock down the root case.
+CREATE UNIQUE INDEX "uq_folder_sibling_name"
+    ON "project_folders" ("userId", "parentId", "name");
+
+CREATE UNIQUE INDEX "uq_folder_root_sibling_name"
+    ON "project_folders" ("userId", "name")
+    WHERE "parentId" IS NULL;
+
+-- CreateIndex -- fast lookup of a folder's direct children for tree builds.
+CREATE INDEX "idx_folder_user_parent"
+    ON "project_folders" ("userId", "parentId");
+
+-- CreateIndex -- each user keeps each project in at most one folder.
+CREATE UNIQUE INDEX "uq_folder_item_user_project"
+    ON "project_folder_items" ("userId", "projectId");
+
+-- CreateIndex -- fast "list everything inside this folder" query.
+CREATE INDEX "idx_folder_item_folder"
+    ON "project_folder_items" ("folderId");
+
+-- ForeignKey -- folder belongs to a user; cascade on user delete.
+ALTER TABLE "project_folders"
+    ADD CONSTRAINT "project_folders_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- ForeignKey -- self-relation for nested folders; cascade on parent delete
+-- sweeps the whole subtree in one statement.
+ALTER TABLE "project_folders"
+    ADD CONSTRAINT "project_folders_parentId_fkey"
+    FOREIGN KEY ("parentId") REFERENCES "project_folders"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- ForeignKey -- placement points at its folder; cascade removes placements
+-- when the containing folder is deleted.
+ALTER TABLE "project_folder_items"
+    ADD CONSTRAINT "project_folder_items_folderId_fkey"
+    FOREIGN KEY ("folderId") REFERENCES "project_folders"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- ForeignKey -- placement points at the project itself; cascade removes
+-- placements when the project is deleted (for owned projects this fires
+-- via projectService.deleteProject; for shared ones it never does, the
+-- owner's deletion is what triggers it).
+ALTER TABLE "project_folder_items"
+    ADD CONSTRAINT "project_folder_items_projectId_fkey"
+    FOREIGN KEY ("projectId") REFERENCES "projects"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- ForeignKey -- placement belongs to the placing user; cascade on user delete.
+ALTER TABLE "project_folder_items"
+    ADD CONSTRAINT "project_folder_items_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,8 @@ model User {
   sharedProjects    ProjectShare[]      @relation("SharedWith")
   projectsSharedByMe ProjectShare[]     @relation("SharedBy")
   feedbacks         Feedback[]
+  folders           ProjectFolder[]
+  folderItems       ProjectFolderItem[]
 
   @@map("users")
 }
@@ -74,6 +76,7 @@ model Project {
   user              User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   segmentationQueue SegmentationQueue[]
   shares            ProjectShare[]
+  folderItems       ProjectFolderItem[]
 
   @@index([userId, updatedAt], map: "idx_project_user_updated")
   @@map("projects")
@@ -238,4 +241,47 @@ model Feedback {
   @@index([userId, createdAt], map: "idx_feedback_user_created")
   @@index([status, createdAt], map: "idx_feedback_status_created")
   @@map("feedbacks")
+}
+
+// User-owned folder for organizing projects in a file-explorer-style hierarchy.
+// parentId is self-referential (adjacency list): NULL = root level under userId.
+// The unique [userId, parentId, name] prevents two siblings sharing a name.
+// onDelete: Cascade on the self-relation makes folder deletion sweep the subtree;
+// the API layer additionally deletes owned projects whose ProjectFolderItem rows
+// pointed inside the subtree (shared projects are merely unlinked).
+model ProjectFolder {
+  id        String              @id @default(uuid())
+  name      String
+  userId    String
+  parentId  String?
+  createdAt DateTime            @default(now())
+  updatedAt DateTime            @updatedAt
+  user      User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent    ProjectFolder?      @relation("FolderTree", fields: [parentId], references: [id], onDelete: Cascade)
+  children  ProjectFolder[]     @relation("FolderTree")
+  items     ProjectFolderItem[]
+
+  @@unique([userId, parentId, name], map: "uq_folder_sibling_name")
+  @@index([userId, parentId], map: "idx_folder_user_parent")
+  @@map("project_folders")
+}
+
+// Per-user placement of a project into one of that user's folders.
+// userId is denormalized from folder.userId to keep the [userId, projectId]
+// uniqueness lookup index-only (each user keeps each project in at most one
+// folder). Cascade from folder removes the placement row when the folder is
+// deleted; cascade from project removes it when the project itself is deleted.
+model ProjectFolderItem {
+  id        String        @id @default(uuid())
+  userId    String
+  projectId String
+  folderId  String
+  createdAt DateTime      @default(now())
+  folder    ProjectFolder @relation(fields: [folderId], references: [id], onDelete: Cascade)
+  project   Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, projectId], map: "uq_folder_item_user_project")
+  @@index([folderId], map: "idx_folder_item_folder")
+  @@map("project_folder_items")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -249,6 +249,13 @@ model Feedback {
 // onDelete: Cascade on the self-relation makes folder deletion sweep the subtree;
 // the API layer additionally deletes owned projects whose ProjectFolderItem rows
 // pointed inside the subtree (shared projects are merely unlinked).
+// NOTE on root-folder uniqueness: Postgres treats NULL as DISTINCT in
+// UNIQUE indexes, so `@@unique([userId, parentId, name])` does NOT prevent
+// two root folders (parentId IS NULL) with the same name from coexisting.
+// The migration `20260516_add_project_folders/migration.sql` adds a SECOND
+// partial unique index — `uq_folder_root_sibling_name (userId, name) WHERE
+// parentId IS NULL` — which Prisma's schema language cannot express. Keep
+// both indexes in sync if you ever rename or rebuild this model.
 model ProjectFolder {
   id        String              @id @default(uuid())
   name      String

--- a/backend/src/api/controllers/imageController.ts
+++ b/backend/src/api/controllers/imageController.ts
@@ -931,6 +931,53 @@ export class ImageController {
         where: galleryWhere,
       });
 
+      // Bubble calibration (pixelSizeUm / frameIntervalMs) from each
+      // video container down to its extracted frames. Calibration is
+      // stored only on the container row at upload time; downstream
+      // consumers (export dialog auto-fill, MT metrics scaling) need
+      // it on every frame row. Without this, the gallery filter
+      // (`isVideoContainer: false`) hides the only row carrying the
+      // value and every frame surfaces with null.
+      const parentIds = Array.from(
+        new Set(
+          images
+            .map(i => i.parentVideoId)
+            .filter(
+              (id): id is string => typeof id === 'string' && id.length > 0
+            )
+        )
+      );
+      const parentCalibrationById = new Map<
+        string,
+        { pixelSizeUm: number | null; frameIntervalMs: number | null }
+      >();
+      if (parentIds.length > 0) {
+        const parents = await prisma.image.findMany({
+          where: { id: { in: parentIds } },
+          select: { id: true, pixelSizeUm: true, frameIntervalMs: true },
+        });
+        for (const p of parents) {
+          parentCalibrationById.set(p.id, {
+            pixelSizeUm: p.pixelSizeUm,
+            frameIntervalMs: p.frameIntervalMs,
+          });
+        }
+        // FK is ON DELETE CASCADE so a frame outliving its parent
+        // should be impossible. If we ever observe it here, the gallery
+        // looks calibration-less without explanation — log so Sentry
+        // surfaces the integrity drift instead of swallowing it.
+        if (parents.length !== parentIds.length) {
+          const missing = parentIds.filter(
+            id => !parentCalibrationById.has(id)
+          );
+          logger.warn(
+            'Frames reference missing video container — calibration bubble will fall through',
+            'ImageController',
+            { missingParentIds: missing, projectId }
+          );
+        }
+      }
+
       // Get storage provider for URL generation
       const storage = getStorageProvider();
 
@@ -1060,10 +1107,19 @@ export class ImageController {
             frameCount: image.frameCount,
             videoDurationMs: image.videoDurationMs,
             // Calibration metadata extracted at upload time (µm/px and
-            // ms between frames). Populated on container rows only;
-            // null on frames + standalone images.
-            pixelSizeUm: image.pixelSizeUm,
-            frameIntervalMs: image.frameIntervalMs,
+            // ms between frames). Frame rows inherit from their parent
+            // container via `parentCalibrationById`; standalone images
+            // (no parent) fall back to their own row, which may still
+            // be null when the upload skipped extraction.
+            pixelSizeUm:
+              (image.parentVideoId
+                ? parentCalibrationById.get(image.parentVideoId)?.pixelSizeUm
+                : null) ?? image.pixelSizeUm,
+            frameIntervalMs:
+              (image.parentVideoId
+                ? parentCalibrationById.get(image.parentVideoId)
+                    ?.frameIntervalMs
+                : null) ?? image.frameIntervalMs,
             channels: image.channels,
             displayOrder: image.displayOrder,
             // Exposed so the Segment-All channel picker can derive the set

--- a/backend/src/api/controllers/projectController.ts
+++ b/backend/src/api/controllers/projectController.ts
@@ -99,6 +99,13 @@ export const getProjects = asyncHandler(
       return;
     }
 
+    // folderId is "root" | <uuid> | undefined. The schema validates it as
+    // optional; the controller forwards whatever the client sent without
+    // re-parsing (any string here would already have been rejected by
+    // validateQuery upstream).
+    const rawFolderId =
+      typeof req.query.folderId === 'string' ? req.query.folderId : undefined;
+
     const queryParams: ProjectQueryParams = {
       page: page || 1,
       limit: limit || 10,
@@ -108,6 +115,7 @@ export const getProjects = asyncHandler(
         ? req.query.sortBy
         : 'createdAt') as 'createdAt' | 'updatedAt' | 'title',
       sortOrder: (sortOrder || 'desc') as 'asc' | 'desc',
+      folderId: rawFolderId as ProjectQueryParams['folderId'],
     };
 
     try {

--- a/backend/src/api/controllers/projectFolderController.ts
+++ b/backend/src/api/controllers/projectFolderController.ts
@@ -1,0 +1,163 @@
+import { Request, Response } from 'express';
+import * as FolderService from '../../services/projectFolderService';
+import { FolderError } from '../../services/projectFolderService';
+import { ResponseHelper, asyncHandler } from '../../utils/response';
+import { logger } from '../../utils/logger';
+import type {
+  CreateFolderData,
+  UpdateFolderData,
+  FolderItemsData,
+} from '../../types/validation';
+
+/**
+ * Translates FolderError codes to HTTP responses. Keeps controller bodies
+ * uniform so each handler is just (validate → call service → translate).
+ */
+function handleFolderError(
+  res: Response,
+  error: unknown,
+  defaultMessage: string,
+  context: string
+): boolean {
+  if (error instanceof FolderError) {
+    switch (error.code) {
+      case 'NOT_FOUND':
+      case 'PARENT_NOT_FOUND':
+        ResponseHelper.notFound(res, error.message, context);
+        return true;
+      case 'DUPLICATE_NAME':
+        ResponseHelper.error(res, error.message, 409, undefined, context);
+        return true;
+      case 'CYCLE':
+      case 'PROJECT_NOT_ACCESSIBLE':
+      case 'INVALID_INPUT':
+        ResponseHelper.badRequest(res, error.message, context);
+        return true;
+    }
+  }
+  logger.error(defaultMessage, error as Error, context);
+  ResponseHelper.internalError(
+    res,
+    error as Error,
+    defaultMessage,
+    context
+  );
+  return false;
+}
+
+export const listFolders = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    try {
+      const folders = await FolderService.listUserFolders(req.user.id);
+      ResponseHelper.success(res, folders, 'Složky byly načteny');
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se načíst složky', 'FolderController');
+    }
+  }
+);
+
+export const createFolder = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    const data: CreateFolderData = req.body;
+    try {
+      const folder = await FolderService.createFolder(req.user.id, data);
+      ResponseHelper.success(res, folder, 'Složka byla vytvořena', 201);
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se vytvořit složku', 'FolderController');
+    }
+  }
+);
+
+export const updateFolder = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    const folderId = req.params.id;
+    if (!folderId) {
+      ResponseHelper.badRequest(res, 'Folder ID is required');
+      return;
+    }
+    const patch: UpdateFolderData = req.body;
+    try {
+      const folder = await FolderService.updateFolder(req.user.id, folderId, patch);
+      ResponseHelper.success(res, folder, 'Složka byla aktualizována');
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se aktualizovat složku', 'FolderController');
+    }
+  }
+);
+
+export const deleteFolder = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    const folderId = req.params.id;
+    if (!folderId) {
+      ResponseHelper.badRequest(res, 'Folder ID is required');
+      return;
+    }
+    try {
+      const result = await FolderService.deleteFolder(req.user.id, folderId);
+      ResponseHelper.success(res, result, 'Složka byla smazána');
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se smazat složku', 'FolderController');
+    }
+  }
+);
+
+export const previewFolder = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    const folderId = req.params.id;
+    if (!folderId) {
+      ResponseHelper.badRequest(res, 'Folder ID is required');
+      return;
+    }
+    try {
+      const preview = await FolderService.getFolderContentsPreview(req.user.id, folderId);
+      ResponseHelper.success(res, preview, 'Náhled obsahu složky');
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se načíst náhled složky', 'FolderController');
+    }
+  }
+);
+
+export const moveProjectsToFolder = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(res, 'Uživatel není autentizován', 'FolderController');
+      return;
+    }
+    // ":id" is the destination folder; the special string "root" moves to root
+    // (no folder placement). The router validates the param shape, so by this
+    // point we know it's either a uuid or the literal "root".
+    const rawId = req.params.id;
+    const folderId = rawId === 'root' ? null : rawId;
+    const { projectIds }: FolderItemsData = req.body;
+    try {
+      const result = await FolderService.moveProjectsToFolder(
+        req.user.id,
+        folderId,
+        projectIds
+      );
+      ResponseHelper.success(res, result, 'Projekty byly přesunuty');
+    } catch (error) {
+      handleFolderError(res, error, 'Nepodařilo se přesunout projekty', 'FolderController');
+    }
+  }
+);

--- a/backend/src/api/controllers/projectFolderController.ts
+++ b/backend/src/api/controllers/projectFolderController.ts
@@ -33,6 +33,17 @@ function handleFolderError(
       case 'INVALID_INPUT':
         ResponseHelper.badRequest(res, error.message, context);
         return true;
+      case 'PARTIAL_FAILURE':
+        // 207 Multi-Status: some operations succeeded, some failed.
+        // Reserved for any future handler that throws this; the canonical
+        // partial-success path for deleteFolder returns directly (below).
+        res.status(207).json({
+          success: false,
+          error: error.message,
+          code: 'PARTIAL_FAILURE',
+          details: error.details ?? {},
+        });
+        return true;
     }
   }
   logger.error(defaultMessage, error as Error, context);
@@ -110,6 +121,19 @@ export const deleteFolder = asyncHandler(
     }
     try {
       const result = await FolderService.deleteFolder(req.user.id, folderId);
+      // Partial-success path: at least one owned project failed to delete,
+      // so the folder was intentionally left in place. 207 Multi-Status
+      // signals "some succeeded, some didn't"; the body has the full
+      // breakdown so the frontend can render an actionable toast.
+      if (!result.folderDeleted) {
+        res.status(207).json({
+          success: false,
+          message: 'Některé projekty se nepodařilo smazat; složka zůstala zachována',
+          data: result,
+          code: 'PARTIAL_FAILURE',
+        });
+        return;
+      }
       ResponseHelper.success(res, result, 'Složka byla smazána');
     } catch (error) {
       handleFolderError(res, error, 'Nepodařilo se smazat složku', 'FolderController');

--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -4,6 +4,10 @@ import { ImageService } from '../../services/imageService';
 import { logger } from '../../utils/logger';
 import { ResponseHelper } from '../../utils/response';
 import { prisma } from '../../db';
+import {
+  SEGMENTATION_MODELS,
+  SEGMENTATION_MODEL_ERROR_MESSAGE,
+} from '../../constants/segmentationModels';
 
 class SegmentationController {
   private segmentationService: SegmentationService;
@@ -243,20 +247,13 @@ class SegmentationController {
         return;
       }
 
-      if (
-        ![
-          'hrnet',
-          'cbam_resunet',
-          'unet_spherohq',
-          'unet_attention_aspp',
-          'resunet_advanced',
-          'resunet_small',
-          'sperm',
-          'wound',
-          'microtubule',
-        ].includes(model)
-      ) {
-        ResponseHelper.validationError(res, 'Neplatný model');
+      // Defense-in-depth re-check. The express-validator on the route
+      // already rejects invalid models on the HTTP path, but if anyone
+      // later wires this method onto a different route without the
+      // same validator chain we still refuse. Single source of truth
+      // in constants/segmentationModels.ts.
+      if (!(SEGMENTATION_MODELS as readonly string[]).includes(model)) {
+        ResponseHelper.validationError(res, SEGMENTATION_MODEL_ERROR_MESSAGE);
         return;
       }
 
@@ -290,7 +287,11 @@ class SegmentationController {
         threshold,
         userId,
         detectHoles,
-        channel
+        // Channel override for multi-channel video frames (TIRF_640
+        // vs TIRF_488 etc). Validated by the route at body('channel').
+        typeof channel === 'string' && channel.length > 0
+          ? channel
+          : undefined
       );
 
       ResponseHelper.success(res, result, 'Dávkové zpracování dokončeno');

--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -225,6 +225,7 @@ class SegmentationController {
         model = 'hrnet',
         threshold = 0.5,
         detectHoles = true,
+        channel,
       } = req.body;
 
       // Validate user authentication
@@ -288,7 +289,8 @@ class SegmentationController {
         model,
         threshold,
         userId,
-        detectHoles
+        detectHoles,
+        channel
       );
 
       ResponseHelper.success(res, result, 'Dávkové zpracování dokončeno');

--- a/backend/src/api/routes/imageRoutes.ts
+++ b/backend/src/api/routes/imageRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { ImageController } from '../controllers/imageController';
 import { VideoController } from '../controllers/videoController';
 import { authenticate } from '../../middleware/auth';
+import { createCacheMiddleware } from '../../middleware/cache';
 import {
   validateParams,
   validateQuery,
@@ -21,6 +22,18 @@ import {
   imageReorderSchema,
 } from '../../types/validation';
 
+// Cache header preset for the per-frame PNG endpoints. The underlying
+// files are essentially static for a given frame (only re-extracted
+// manually), so a 30-minute browser cache lets a scrub-back replay the
+// same PNG without a round-trip. `stale-while-revalidate` keeps the
+// canvas painting during the silent background revalidation if the
+// max-age does expire mid-session.
+const framePngCache = createCacheMiddleware({
+  maxAge: 1800,
+  private: false,
+  staleWhileRevalidate: 300,
+});
+
 const router = Router();
 const imageController = new ImageController();
 
@@ -33,7 +46,7 @@ const imageController = new ImageController();
  * GET /images/:imageId/display
  * Note: No authentication required for image display
  */
-router.get('/:imageId/display', imageController.getImageForDisplay);
+router.get('/:imageId/display', framePngCache, imageController.getImageForDisplay);
 
 /**
  * Fetch the raw PNG for a specific channel of a video frame.
@@ -42,7 +55,7 @@ router.get('/:imageId/display', imageController.getImageForDisplay);
  * /display above. Browser `<img>` tags can't attach a JWT, so requiring
  * auth here would break the canvas image source in the editor.
  */
-router.get('/:imageId/frame-data', VideoController.getFrameData);
+router.get('/:imageId/frame-data', framePngCache, VideoController.getFrameData);
 
 // All other routes require authentication (email verification disabled for development)
 router.use(authenticate);

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -21,6 +21,7 @@ import cacheRoutes from './cacheRoutes';
 import databaseRoutes from './database';
 import rateLimitAdminRoutes from './rateLimitAdmin';
 import feedbackRoutes from './feedbackRoutes';
+import projectFolderRoutes from './projectFolderRoutes';
 
 interface RouteInfo {
   path: string;
@@ -85,6 +86,7 @@ export function setupRoutes(app: Express): void {
   app.use('/api/database', databaseRoutes); // Database management and monitoring routes
   app.use('/api/admin/rate-limits', rateLimitAdminRoutes); // Rate limiting administration routes
   app.use('/api/feedback', feedbackRoutes); // User-submitted bug reports + feature requests
+  app.use('/api/folders', projectFolderRoutes); // Per-user project folder hierarchy
 
   // Test email routes (enabled in all environments for debugging)
   app.use('/api/test-email', testEmailRoutes);
@@ -233,6 +235,50 @@ function registerKnownRoutes(): void {
     path: '/api/projects/:projectId',
     method: 'DELETE',
     description: 'Smazání projektu',
+    authenticated: true,
+  });
+
+  // Project folder endpoints
+  registerRoute({
+    path: '/api/folders',
+    method: 'GET',
+    description: 'Seznam složek uživatele (plochý strom)',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders',
+    method: 'POST',
+    description: 'Vytvoření nové složky',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders/:id',
+    method: 'PATCH',
+    description: 'Přejmenování nebo přesun složky',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders/:id',
+    method: 'DELETE',
+    description: 'Kaskádové smazání složky a obsahu',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders/:id/preview',
+    method: 'GET',
+    description: 'Náhled počtů obsahu složky pro potvrzení mazání',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders/:id/items',
+    method: 'POST',
+    description: 'Přesun projektů do složky',
+    authenticated: true,
+  });
+  registerRoute({
+    path: '/api/folders/root/items',
+    method: 'POST',
+    description: 'Přesun projektů zpět do rootu',
     authenticated: true,
   });
 

--- a/backend/src/api/routes/projectFolderRoutes.ts
+++ b/backend/src/api/routes/projectFolderRoutes.ts
@@ -1,0 +1,65 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  listFolders,
+  createFolder,
+  updateFolder,
+  deleteFolder,
+  previewFolder,
+  moveProjectsToFolder,
+} from '../controllers/projectFolderController';
+import { authenticate } from '../../middleware/auth';
+import {
+  validateBody,
+  validateParams,
+} from '../../middleware/validation';
+import {
+  createFolderSchema,
+  updateFolderSchema,
+  folderItemsSchema,
+  folderIdSchema,
+} from '../../types/validation';
+
+const router = Router();
+
+// All folder routes require authentication. The router is mounted at
+// /api/folders in setupRoutes() so paths below are relative to that.
+router.use(authenticate);
+
+router.get('/', listFolders);
+
+router.post('/', validateBody(createFolderSchema), createFolder);
+
+router.patch(
+  '/:id',
+  validateParams(folderIdSchema),
+  validateBody(updateFolderSchema),
+  updateFolder
+);
+
+router.delete('/:id', validateParams(folderIdSchema), deleteFolder);
+
+router.get('/:id/preview', validateParams(folderIdSchema), previewFolder);
+
+// Move projects into a folder. Two variants:
+//   POST /api/folders/root/items        — pull selection back to root (no placement row)
+//   POST /api/folders/:id/items         — push selection into a folder owned by the caller
+// They share a controller; the router decides which by branching the path so each
+// route's :id param is either a valid uuid or absent (no need for a uuid|"root" union schema).
+router.post(
+  '/root/items',
+  validateBody(folderItemsSchema),
+  (req: Request, _res: Response, next: NextFunction) => {
+    req.params.id = 'root';
+    next();
+  },
+  moveProjectsToFolder
+);
+
+router.post(
+  '/:id/items',
+  validateParams(folderIdSchema),
+  validateBody(folderItemsSchema),
+  moveProjectsToFolder
+);
+
+export default router;

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -150,6 +150,13 @@ router.post(
       .optional()
       .isBoolean()
       .withMessage('Detect holes musí být boolean hodnota'),
+    body('channel')
+      .optional()
+      .isString()
+      .matches(/^[A-Za-z0-9_-]{1,64}$/)
+      .withMessage(
+        'Channel musí být alnum/underscore/dash, max 64 znaků'
+      ),
   ],
   handleValidation,
   segmentationController.batchSegment

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -10,6 +10,10 @@ import {
 import { ResponseHelper } from '../../utils/response';
 import { buildKymograph } from '../../services/kymographService';
 import { logger } from '../../utils/logger';
+import {
+  SEGMENTATION_MODELS,
+  SEGMENTATION_MODEL_ERROR_MESSAGE,
+} from '../../constants/segmentationModels';
 
 // Middleware to handle express-validator results
 const handleValidation = (
@@ -128,20 +132,8 @@ router.post(
       .withMessage('Všechna ID obrázků musí být platná UUID'),
     body('model')
       .optional()
-      .isIn([
-        'hrnet',
-        'cbam_resunet',
-        'unet_spherohq',
-        'unet_attention_aspp',
-        'resunet_advanced',
-        'resunet_small',
-        'sperm',
-        'wound',
-        'microtubule',
-      ])
-      .withMessage(
-        'Model musí být jeden z podporovaných: hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, resunet_advanced, resunet_small, sperm, wound, microtubule'
-      ),
+      .isIn([...SEGMENTATION_MODELS])
+      .withMessage(SEGMENTATION_MODEL_ERROR_MESSAGE),
     body('threshold')
       .optional()
       .isFloat({ min: 0.1, max: 0.9 })
@@ -150,13 +142,15 @@ router.post(
       .optional()
       .isBoolean()
       .withMessage('Detect holes musí být boolean hodnota'),
+    // Channel override for multi-channel video frames. Same shape as
+    // batchQueueSchema.channel in validation.ts — alphanumeric + ._-
+    // bounded to 64 chars to prevent unbounded path-rewrite input.
     body('channel')
       .optional()
       .isString()
-      .matches(/^[A-Za-z0-9_-]{1,64}$/)
-      .withMessage(
-        'Channel musí být alnum/underscore/dash, max 64 znaků'
-      ),
+      .isLength({ max: 64 })
+      .matches(/^[A-Za-z0-9_.-]+$/)
+      .withMessage('Channel musí být alfanumerický řetězec do 64 znaků'),
   ],
   handleValidation,
   segmentationController.batchSegment

--- a/backend/src/constants/segmentationModels.ts
+++ b/backend/src/constants/segmentationModels.ts
@@ -1,0 +1,27 @@
+/**
+ * Single source of truth for the segmentation model whitelist.
+ *
+ * Three call sites used to maintain their own copies of this list and
+ * drifted apart (review pass-2 found 7 vs 9 vs 9 between Zod /
+ * express-validator route / controller). Extract once, import
+ * everywhere — a new model added in one place is a compile error
+ * (TS) if not added here.
+ */
+export const SEGMENTATION_MODELS = [
+  'hrnet',
+  'cbam_resunet',
+  'unet_spherohq',
+  'unet_attention_aspp',
+  'resunet_advanced',
+  'resunet_small',
+  'sperm',
+  'wound',
+  'microtubule',
+] as const;
+
+export type SegmentationModel = (typeof SEGMENTATION_MODELS)[number];
+
+/** Human-readable error message listing supported models. Mirrored
+ *  across the two validators so the message a client sees is the
+ *  same regardless of which path rejects them. */
+export const SEGMENTATION_MODEL_ERROR_MESSAGE = `Model musí být jeden z podporovaných: ${SEGMENTATION_MODELS.join(', ')}`;

--- a/backend/src/services/imageService.ts
+++ b/backend/src/services/imageService.ts
@@ -616,6 +616,50 @@ export class ImageService {
       take: limit,
     });
 
+    // Bubble calibration metadata from each frame's parent container
+    // down to the frame row. The DB only stores pixelSizeUm /
+    // frameIntervalMs on container rows (filled at upload-time by the
+    // ND2/TIFF extractor), but the gallery listing intentionally
+    // excludes containers (`isVideoContainer: false` filter above),
+    // so consumers downstream — most importantly the export dialog's
+    // pixel-scale auto-fill — never see the calibration. Fetch each
+    // distinct parent container once and overlay its calibration
+    // onto its frames in the response.
+    const parentIds = Array.from(
+      new Set(
+        images
+          .map(i => i.parentVideoId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      )
+    );
+    const parentCalibrationById = new Map<
+      string,
+      { pixelSizeUm: number | null; frameIntervalMs: number | null }
+    >();
+    if (parentIds.length > 0) {
+      const parents = await this.prisma.image.findMany({
+        where: { id: { in: parentIds } },
+        select: { id: true, pixelSizeUm: true, frameIntervalMs: true },
+      });
+      for (const p of parents) {
+        parentCalibrationById.set(p.id, {
+          pixelSizeUm: p.pixelSizeUm,
+          frameIntervalMs: p.frameIntervalMs,
+        });
+      }
+      // FK ON DELETE CASCADE should make this unreachable. If it
+      // fires, the gallery silently falls back to row-level nulls —
+      // log so the orphan drift gets investigated.
+      if (parents.length !== parentIds.length) {
+        const missing = parentIds.filter(id => !parentCalibrationById.has(id));
+        logger.warn(
+          'Frames reference missing video container — calibration bubble will fall through',
+          'ImageService',
+          { missingParentIds: missing, projectId }
+        );
+      }
+    }
+
     // Add URLs to images
     const storage = getStorageProvider();
     const imagesWithUrls: ImageWithUrls[] = await Promise.all(
@@ -630,8 +674,21 @@ export class ImageService {
           ? await storage.getUrl(image.segmentationThumbnailPath)
           : undefined;
 
+        // Prefer parent container's calibration over the row's own
+        // (frames don't carry their own — `??` fallback also covers
+        // the future case where a per-frame override appears).
+        // Standalone images keep their own values.
+        const parentCal = image.parentVideoId
+          ? parentCalibrationById.get(image.parentVideoId)
+          : null;
+        const pixelSizeUm = parentCal?.pixelSizeUm ?? image.pixelSizeUm;
+        const frameIntervalMs =
+          parentCal?.frameIntervalMs ?? image.frameIntervalMs;
+
         return {
           ...image,
+          pixelSizeUm,
+          frameIntervalMs,
           originalUrl,
           thumbnailUrl,
           segmentationThumbnailUrl,

--- a/backend/src/services/projectFolderService.ts
+++ b/backend/src/services/projectFolderService.ts
@@ -47,6 +47,44 @@ class FolderError extends Error {
 
 export { FolderError };
 
+/**
+ * Translates known Prisma error codes into user-friendly FolderError variants.
+ * Anything else passes through unchanged so the controller's default 500
+ * handler logs the full technical detail (we don't want to mask unknown
+ * Prisma failures — they're real bugs deserving a Sentry entry).
+ *
+ *   P2002 — unique constraint violated         → DUPLICATE_NAME
+ *   P2003 — foreign key constraint violated    → PARENT_NOT_FOUND
+ *                                                  (typically a parentId
+ *                                                  that no longer exists)
+ *   P2025 — record-not-found during update     → NOT_FOUND
+ *                                                  (race: deleted between
+ *                                                  our pre-flight check
+ *                                                  and the write)
+ */
+function translatePrismaError(error: unknown): Error {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    switch (error.code) {
+      case 'P2002':
+        return new FolderError(
+          'DUPLICATE_NAME',
+          'Složka se stejným názvem na této úrovni už existuje'
+        );
+      case 'P2003':
+        return new FolderError(
+          'PARENT_NOT_FOUND',
+          'Cílová nadřazená složka neexistuje'
+        );
+      case 'P2025':
+        return new FolderError(
+          'NOT_FOUND',
+          'Složka byla mezitím smazána; obnovte stránku'
+        );
+    }
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 // ---------------------------------------------------------------------------
 // Read paths
 // ---------------------------------------------------------------------------
@@ -173,16 +211,7 @@ export async function createFolder(
     logger.info('Folder created', 'FolderService', { userId, folderId: folder.id });
     return folder;
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === 'P2002'
-    ) {
-      throw new FolderError(
-        'DUPLICATE_NAME',
-        'Složka se stejným názvem na této úrovni už existuje'
-      );
-    }
-    throw error;
+    throw translatePrismaError(error);
   }
 }
 

--- a/backend/src/services/projectFolderService.ts
+++ b/backend/src/services/projectFolderService.ts
@@ -20,6 +20,13 @@ export interface FolderContentsPreview {
 }
 
 class FolderError extends Error {
+  /**
+   * Optional structured payload — used by PARTIAL_FAILURE in deleteFolder to
+   * report which projects were successfully deleted before the failure so the
+   * controller can echo it to the client (avoids silent data loss).
+   */
+  public details?: Record<string, unknown>;
+
   constructor(
     public readonly code:
       | 'NOT_FOUND'
@@ -27,11 +34,14 @@ class FolderError extends Error {
       | 'CYCLE'
       | 'PARENT_NOT_FOUND'
       | 'PROJECT_NOT_ACCESSIBLE'
-      | 'INVALID_INPUT',
-    message: string
+      | 'INVALID_INPUT'
+      | 'PARTIAL_FAILURE',
+    message: string,
+    details?: Record<string, unknown>
   ) {
     super(message);
     this.name = 'FolderError';
+    this.details = details;
   }
 }
 
@@ -41,11 +51,6 @@ export { FolderError };
 // Read paths
 // ---------------------------------------------------------------------------
 
-/**
- * Returns the user's entire folder tree as a flat list. The client side composes
- * the tree from parentId — keeping the wire format flat avoids deep JSON nesting
- * and makes optimistic updates trivial (insert/update by id, recompute children).
- */
 export async function listUserFolders(userId: string): Promise<FolderDTO[]> {
   const folders = await prisma.projectFolder.findMany({
     where: { userId },
@@ -58,45 +63,47 @@ export async function listUserFolders(userId: string): Promise<FolderDTO[]> {
     },
     orderBy: [{ parentId: 'asc' }, { name: 'asc' }],
   });
-
   return folders;
 }
 
 /**
  * Returns the full set of folder ids in the subtree rooted at `folderId`
- * (inclusive). Uses Postgres recursive CTE — adjacency-list traversal in a
- * single round trip. Caller is responsible for ownership validation; this
- * function does NOT enforce userId on the CTE to keep the query simple, so
- * never expose its result without filtering by userId beforehand.
+ * (inclusive). Uses Postgres recursive CTE with three layered safeguards:
+ *
+ *   1. `UNION` (distinct) — if a cycle ever exists in the data (race, restore
+ *      gone wrong, future bug), the second expansion adds no new ids and the
+ *      CTE terminates. `UNION ALL` would loop forever, burning a connection.
+ *   2. `depth < 50` — even with `UNION` a corrupted path between distinct
+ *      cyclic nodes can be long; capping depth bounds the worst case.
+ *   3. `userId` filter on both seed and recursive step — defense-in-depth so
+ *      a future caller that forgets the pre-flight ownership check cannot
+ *      enumerate another user's folder ids.
  */
 async function subtreeFolderIds(
   tx: Prisma.TransactionClient,
-  folderId: string
+  folderId: string,
+  userId: string
 ): Promise<string[]> {
   const rows = await tx.$queryRaw<{ id: string }[]>`
     WITH RECURSIVE descendants AS (
-      SELECT id FROM project_folders WHERE id = ${folderId}
-      UNION ALL
-      SELECT f.id
+      SELECT id, 1 AS depth
+        FROM project_folders
+        WHERE id = ${folderId} AND "userId" = ${userId}
+      UNION
+      SELECT f.id, d.depth + 1
         FROM project_folders f
         JOIN descendants d ON f."parentId" = d.id
+        WHERE f."userId" = ${userId} AND d.depth < 50
     )
-    SELECT id FROM descendants
+    SELECT DISTINCT id FROM descendants
   `;
   return rows.map(r => r.id);
 }
 
-/**
- * Counts what's *inside* a folder for the delete-confirmation dialog.
- * Walks the subtree; for each placement counts owned vs shared projects.
- * Shared = the user is in ProjectFolderItem but doesn't own the underlying
- * project — deleting the folder will unlink (not delete) those.
- */
 export async function getFolderContentsPreview(
   userId: string,
   folderId: string
 ): Promise<FolderContentsPreview> {
-  // Ownership check first so we never reveal counts of folders the user doesn't own.
   const folder = await prisma.projectFolder.findFirst({
     where: { id: folderId, userId },
     select: { id: true },
@@ -105,7 +112,7 @@ export async function getFolderContentsPreview(
     throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
   }
 
-  const subtreeIds = await subtreeFolderIds(prisma, folderId);
+  const subtreeIds = await subtreeFolderIds(prisma, folderId, userId);
   const subfolderCount = Math.max(0, subtreeIds.length - 1);
 
   const items = await prisma.projectFolderItem.findMany({
@@ -127,15 +134,6 @@ export async function getFolderContentsPreview(
 // Write paths
 // ---------------------------------------------------------------------------
 
-/**
- * Creates a folder. Parent (if provided) must belong to the same user.
- * Duplicate sibling names are rejected via the DB unique constraint —
- * Prisma surfaces P2002 which we translate to DUPLICATE_NAME.
- *
- * The Zod-inferred CreateFolderData widens `name` to `string | undefined`
- * because of `.trim()`; the route's validateBody guarantees the value is
- * present, so we re-narrow defensively at the boundary.
- */
 export async function createFolder(
   userId: string,
   data: { name?: string; parentId?: string | null }
@@ -190,100 +188,116 @@ export async function createFolder(
 
 /**
  * Renames a folder and/or moves it to a different parent.
- * Cycle check: a folder cannot become a descendant of itself — the recursive
- * CTE on the *current* state would still find the subtree before the move,
- * so we just verify the new parent is not in that set.
+ *
+ * The ownership lookup, cycle check, and update all run inside a single
+ * `$transaction` because otherwise two tabs could each see pre-move state
+ * and produce a cycle (tab A moves X under Y, tab B moves Y under X — both
+ * cycle checks pass, both updates commit). Holding a transaction takes a
+ * row-level lock on the inspected rows so the second tab serializes.
+ *
+ * Cycle check: a folder cannot become a descendant of itself. The recursive
+ * CTE on the pre-move state finds the subtree rooted at the moving folder;
+ * if the requested new parent is inside that set, reject.
  */
 export async function updateFolder(
   userId: string,
   folderId: string,
   patch: { name?: string; parentId?: string | null }
 ): Promise<FolderDTO> {
-  const folder = await prisma.projectFolder.findFirst({
-    where: { id: folderId, userId },
-    select: { id: true, parentId: true },
-  });
-  if (!folder) {
-    throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
-  }
-
-  if (patch.parentId !== undefined) {
-    if (patch.parentId === folderId) {
-      throw new FolderError('CYCLE', 'Složku nelze přesunout do sebe sama');
-    }
-    if (patch.parentId !== null) {
-      const parent = await prisma.projectFolder.findFirst({
-        where: { id: patch.parentId, userId },
-        select: { id: true },
-      });
-      if (!parent) {
-        throw new FolderError(
-          'PARENT_NOT_FOUND',
-          'Nadřazená složka nebyla nalezena'
-        );
-      }
-      const descendants = await subtreeFolderIds(prisma, folderId);
-      if (descendants.includes(patch.parentId)) {
-        throw new FolderError(
-          'CYCLE',
-          'Složku nelze přesunout do své vlastní podsložky'
-        );
-      }
-    }
-  }
-
-  try {
-    const updated = await prisma.projectFolder.update({
-      where: { id: folderId },
-      data: {
-        ...(patch.name !== undefined && { name: patch.name }),
-        ...(patch.parentId !== undefined && { parentId: patch.parentId }),
-      },
-      select: {
-        id: true,
-        name: true,
-        parentId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+  return prisma.$transaction(async tx => {
+    const folder = await tx.projectFolder.findFirst({
+      where: { id: folderId, userId },
+      select: { id: true, parentId: true },
     });
-    logger.info('Folder updated', 'FolderService', { userId, folderId, patch });
-    return updated;
-  } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === 'P2002'
-    ) {
-      throw new FolderError(
-        'DUPLICATE_NAME',
-        'Složka se stejným názvem na této úrovni už existuje'
-      );
+    if (!folder) {
+      throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
     }
-    throw error;
-  }
+
+    if (patch.parentId !== undefined) {
+      if (patch.parentId === folderId) {
+        throw new FolderError('CYCLE', 'Složku nelze přesunout do sebe sama');
+      }
+      if (patch.parentId !== null) {
+        const parent = await tx.projectFolder.findFirst({
+          where: { id: patch.parentId, userId },
+          select: { id: true },
+        });
+        if (!parent) {
+          throw new FolderError(
+            'PARENT_NOT_FOUND',
+            'Nadřazená složka nebyla nalezena'
+          );
+        }
+        const descendants = await subtreeFolderIds(tx, folderId, userId);
+        if (descendants.includes(patch.parentId)) {
+          throw new FolderError(
+            'CYCLE',
+            'Složku nelze přesunout do své vlastní podsložky'
+          );
+        }
+      }
+    }
+
+    try {
+      const updated = await tx.projectFolder.update({
+        where: { id: folderId },
+        data: {
+          ...(patch.name !== undefined && { name: patch.name }),
+          ...(patch.parentId !== undefined && { parentId: patch.parentId }),
+        },
+        select: {
+          id: true,
+          name: true,
+          parentId: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      logger.info('Folder updated', 'FolderService', { userId, folderId, patch });
+      return updated;
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new FolderError(
+          'DUPLICATE_NAME',
+          'Složka se stejným názvem na této úrovni už existuje'
+        );
+      }
+      throw error;
+    }
+  });
+}
+
+export interface DeleteFolderResult {
+  folderDeleted: boolean;
+  deletedProjectIds: string[];
+  unlinkedSharedProjectIds: string[];
+  failedProjectIds: { id: string; error: string }[];
 }
 
 /**
  * Deletes a folder and its entire subtree.
  *
  * Asymmetric semantics required by the file-explorer UX choice:
- *   - Owned projects placed inside the subtree → fully deleted (calls
- *     projectService.deleteProject so file storage, queue entries, shares
- *     are all cleaned up).
- *   - Shared projects placed inside the subtree → only their placements
- *     are dropped (we cannot delete projects owned by other users). The
- *     project itself stays intact for its real owner.
+ *   - Owned projects → fully deleted (calls projectService.deleteProject so
+ *     file storage, queue entries, shares are all cleaned up).
+ *   - Shared projects → only their placements are dropped (we cannot delete
+ *     projects owned by other users).
  *   - Subfolders → cascade-deleted via the FK.
  *
- * Project deletions happen sequentially because projectService.deleteProject
- * does file-system work outside the DB transaction; a Prisma $transaction
- * around it would not cover the FS operations anyway, and parallelism would
- * fight the same file paths. The final folder delete itself is fast.
+ * Partial-failure handling: project deletion does FS work outside any DB
+ * transaction. We run them through `Promise.allSettled` so a single failure
+ * doesn't strand the caller. If ANY owned-project deletion fails we DO NOT
+ * delete the folder — leaving it in place lets the user retry and see what
+ * still needs attention. The result always carries both lists; the
+ * controller maps `folderDeleted: false` to HTTP 207 Multi-Status.
  */
 export async function deleteFolder(
   userId: string,
   folderId: string
-): Promise<{ deletedProjectIds: string[]; unlinkedSharedProjectIds: string[] }> {
+): Promise<DeleteFolderResult> {
   const folder = await prisma.projectFolder.findFirst({
     where: { id: folderId, userId },
     select: { id: true },
@@ -292,7 +306,7 @@ export async function deleteFolder(
     throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
   }
 
-  const subtreeIds = await subtreeFolderIds(prisma, folderId);
+  const subtreeIds = await subtreeFolderIds(prisma, folderId, userId);
   const placements = await prisma.projectFolderItem.findMany({
     where: { userId, folderId: { in: subtreeIds } },
     select: { projectId: true, project: { select: { userId: true } } },
@@ -305,27 +319,48 @@ export async function deleteFolder(
     else unlinkedSharedProjectIds.push(p.projectId);
   }
 
+  const results = await Promise.allSettled(
+    ownedProjectIds.map(pid => ProjectService.deleteProject(pid, userId))
+  );
   const deletedProjectIds: string[] = [];
-  for (const projectId of ownedProjectIds) {
-    try {
-      const deleted = await ProjectService.deleteProject(projectId, userId);
-      if (deleted) deletedProjectIds.push(projectId);
-    } catch (err) {
+  const failedProjectIds: { id: string; error: string }[] = [];
+  results.forEach((r, i) => {
+    const pid = ownedProjectIds[i];
+    if (r.status === 'fulfilled' && r.value) {
+      deletedProjectIds.push(pid);
+    } else if (r.status === 'rejected') {
       logger.error(
         'Failed to delete project during folder cascade',
-        err as Error,
+        r.reason as Error,
         'FolderService',
-        { userId, folderId, projectId }
+        { userId, folderId, projectId: pid }
       );
-      throw err;
+      failedProjectIds.push({
+        id: pid,
+        error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+      });
     }
+  });
+
+  if (failedProjectIds.length > 0) {
+    logger.warn(
+      'Folder delete partial: kept folder due to failures',
+      'FolderService',
+      {
+        userId,
+        folderId,
+        deleted: deletedProjectIds.length,
+        failed: failedProjectIds.length,
+      }
+    );
+    return {
+      folderDeleted: false,
+      deletedProjectIds,
+      unlinkedSharedProjectIds,
+      failedProjectIds,
+    };
   }
 
-  // The folder delete cascades to:
-  //   * all subfolders (self-relation FK ON DELETE CASCADE)
-  //   * all remaining ProjectFolderItem placements inside the subtree
-  //     (folder→item FK ON DELETE CASCADE) — this is what handles the
-  //     "unlink shared projects" case.
   await prisma.projectFolder.delete({ where: { id: folderId } });
 
   logger.info('Folder deleted with subtree', 'FolderService', {
@@ -336,23 +371,14 @@ export async function deleteFolder(
     unlinkedSharedProjectIds: unlinkedSharedProjectIds.length,
   });
 
-  return { deletedProjectIds, unlinkedSharedProjectIds };
+  return {
+    folderDeleted: true,
+    deletedProjectIds,
+    unlinkedSharedProjectIds,
+    failedProjectIds: [],
+  };
 }
 
-/**
- * Moves a set of projects into a target folder, or to root when folderId === null.
- *
- * Pre-flight: every projectId must be either owned by the user or accepted-shared
- * with the user (`SharingService.hasProjectAccess`). Anything else is silently
- * dropped from the move — we report which ones moved so the caller can show a
- * partial-success message if needed.
- *
- * Storage:
- *   - Move to a folder: upsert ProjectFolderItem keyed on (userId, projectId).
- *     The unique index guarantees a project never sits in two folders for the
- *     same user; upsert replaces the previous placement atomically.
- *   - Move to root: delete the placement row (absence == root).
- */
 export async function moveProjectsToFolder(
   userId: string,
   folderId: string | null,

--- a/backend/src/services/projectFolderService.ts
+++ b/backend/src/services/projectFolderService.ts
@@ -1,0 +1,408 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db';
+import { logger } from '../utils/logger';
+import * as ProjectService from './projectService';
+import * as SharingService from './sharingService';
+
+export interface FolderDTO {
+  id: string;
+  name: string;
+  parentId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface FolderContentsPreview {
+  folderId: string;
+  ownedProjectCount: number;
+  sharedProjectCount: number;
+  subfolderCount: number;
+}
+
+class FolderError extends Error {
+  constructor(
+    public readonly code:
+      | 'NOT_FOUND'
+      | 'DUPLICATE_NAME'
+      | 'CYCLE'
+      | 'PARENT_NOT_FOUND'
+      | 'PROJECT_NOT_ACCESSIBLE'
+      | 'INVALID_INPUT',
+    message: string
+  ) {
+    super(message);
+    this.name = 'FolderError';
+  }
+}
+
+export { FolderError };
+
+// ---------------------------------------------------------------------------
+// Read paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the user's entire folder tree as a flat list. The client side composes
+ * the tree from parentId — keeping the wire format flat avoids deep JSON nesting
+ * and makes optimistic updates trivial (insert/update by id, recompute children).
+ */
+export async function listUserFolders(userId: string): Promise<FolderDTO[]> {
+  const folders = await prisma.projectFolder.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      name: true,
+      parentId: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: [{ parentId: 'asc' }, { name: 'asc' }],
+  });
+
+  return folders;
+}
+
+/**
+ * Returns the full set of folder ids in the subtree rooted at `folderId`
+ * (inclusive). Uses Postgres recursive CTE — adjacency-list traversal in a
+ * single round trip. Caller is responsible for ownership validation; this
+ * function does NOT enforce userId on the CTE to keep the query simple, so
+ * never expose its result without filtering by userId beforehand.
+ */
+async function subtreeFolderIds(
+  tx: Prisma.TransactionClient,
+  folderId: string
+): Promise<string[]> {
+  const rows = await tx.$queryRaw<{ id: string }[]>`
+    WITH RECURSIVE descendants AS (
+      SELECT id FROM project_folders WHERE id = ${folderId}
+      UNION ALL
+      SELECT f.id
+        FROM project_folders f
+        JOIN descendants d ON f."parentId" = d.id
+    )
+    SELECT id FROM descendants
+  `;
+  return rows.map(r => r.id);
+}
+
+/**
+ * Counts what's *inside* a folder for the delete-confirmation dialog.
+ * Walks the subtree; for each placement counts owned vs shared projects.
+ * Shared = the user is in ProjectFolderItem but doesn't own the underlying
+ * project — deleting the folder will unlink (not delete) those.
+ */
+export async function getFolderContentsPreview(
+  userId: string,
+  folderId: string
+): Promise<FolderContentsPreview> {
+  // Ownership check first so we never reveal counts of folders the user doesn't own.
+  const folder = await prisma.projectFolder.findFirst({
+    where: { id: folderId, userId },
+    select: { id: true },
+  });
+  if (!folder) {
+    throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
+  }
+
+  const subtreeIds = await subtreeFolderIds(prisma, folderId);
+  const subfolderCount = Math.max(0, subtreeIds.length - 1);
+
+  const items = await prisma.projectFolderItem.findMany({
+    where: { userId, folderId: { in: subtreeIds } },
+    select: { project: { select: { userId: true } } },
+  });
+
+  let ownedProjectCount = 0;
+  let sharedProjectCount = 0;
+  for (const item of items) {
+    if (item.project.userId === userId) ownedProjectCount += 1;
+    else sharedProjectCount += 1;
+  }
+
+  return { folderId, ownedProjectCount, sharedProjectCount, subfolderCount };
+}
+
+// ---------------------------------------------------------------------------
+// Write paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a folder. Parent (if provided) must belong to the same user.
+ * Duplicate sibling names are rejected via the DB unique constraint —
+ * Prisma surfaces P2002 which we translate to DUPLICATE_NAME.
+ *
+ * The Zod-inferred CreateFolderData widens `name` to `string | undefined`
+ * because of `.trim()`; the route's validateBody guarantees the value is
+ * present, so we re-narrow defensively at the boundary.
+ */
+export async function createFolder(
+  userId: string,
+  data: { name?: string; parentId?: string | null }
+): Promise<FolderDTO> {
+  if (!data.name || !data.name.trim()) {
+    throw new FolderError('INVALID_INPUT', 'Název složky je povinný');
+  }
+  if (data.parentId) {
+    const parent = await prisma.projectFolder.findFirst({
+      where: { id: data.parentId, userId },
+      select: { id: true },
+    });
+    if (!parent) {
+      throw new FolderError(
+        'PARENT_NOT_FOUND',
+        'Nadřazená složka nebyla nalezena'
+      );
+    }
+  }
+
+  const trimmedName = data.name.trim();
+  try {
+    const folder = await prisma.projectFolder.create({
+      data: {
+        userId,
+        name: trimmedName,
+        parentId: data.parentId ?? null,
+      },
+      select: {
+        id: true,
+        name: true,
+        parentId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    logger.info('Folder created', 'FolderService', { userId, folderId: folder.id });
+    return folder;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      throw new FolderError(
+        'DUPLICATE_NAME',
+        'Složka se stejným názvem na této úrovni už existuje'
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Renames a folder and/or moves it to a different parent.
+ * Cycle check: a folder cannot become a descendant of itself — the recursive
+ * CTE on the *current* state would still find the subtree before the move,
+ * so we just verify the new parent is not in that set.
+ */
+export async function updateFolder(
+  userId: string,
+  folderId: string,
+  patch: { name?: string; parentId?: string | null }
+): Promise<FolderDTO> {
+  const folder = await prisma.projectFolder.findFirst({
+    where: { id: folderId, userId },
+    select: { id: true, parentId: true },
+  });
+  if (!folder) {
+    throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
+  }
+
+  if (patch.parentId !== undefined) {
+    if (patch.parentId === folderId) {
+      throw new FolderError('CYCLE', 'Složku nelze přesunout do sebe sama');
+    }
+    if (patch.parentId !== null) {
+      const parent = await prisma.projectFolder.findFirst({
+        where: { id: patch.parentId, userId },
+        select: { id: true },
+      });
+      if (!parent) {
+        throw new FolderError(
+          'PARENT_NOT_FOUND',
+          'Nadřazená složka nebyla nalezena'
+        );
+      }
+      const descendants = await subtreeFolderIds(prisma, folderId);
+      if (descendants.includes(patch.parentId)) {
+        throw new FolderError(
+          'CYCLE',
+          'Složku nelze přesunout do své vlastní podsložky'
+        );
+      }
+    }
+  }
+
+  try {
+    const updated = await prisma.projectFolder.update({
+      where: { id: folderId },
+      data: {
+        ...(patch.name !== undefined && { name: patch.name }),
+        ...(patch.parentId !== undefined && { parentId: patch.parentId }),
+      },
+      select: {
+        id: true,
+        name: true,
+        parentId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    logger.info('Folder updated', 'FolderService', { userId, folderId, patch });
+    return updated;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      throw new FolderError(
+        'DUPLICATE_NAME',
+        'Složka se stejným názvem na této úrovni už existuje'
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Deletes a folder and its entire subtree.
+ *
+ * Asymmetric semantics required by the file-explorer UX choice:
+ *   - Owned projects placed inside the subtree → fully deleted (calls
+ *     projectService.deleteProject so file storage, queue entries, shares
+ *     are all cleaned up).
+ *   - Shared projects placed inside the subtree → only their placements
+ *     are dropped (we cannot delete projects owned by other users). The
+ *     project itself stays intact for its real owner.
+ *   - Subfolders → cascade-deleted via the FK.
+ *
+ * Project deletions happen sequentially because projectService.deleteProject
+ * does file-system work outside the DB transaction; a Prisma $transaction
+ * around it would not cover the FS operations anyway, and parallelism would
+ * fight the same file paths. The final folder delete itself is fast.
+ */
+export async function deleteFolder(
+  userId: string,
+  folderId: string
+): Promise<{ deletedProjectIds: string[]; unlinkedSharedProjectIds: string[] }> {
+  const folder = await prisma.projectFolder.findFirst({
+    where: { id: folderId, userId },
+    select: { id: true },
+  });
+  if (!folder) {
+    throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
+  }
+
+  const subtreeIds = await subtreeFolderIds(prisma, folderId);
+  const placements = await prisma.projectFolderItem.findMany({
+    where: { userId, folderId: { in: subtreeIds } },
+    select: { projectId: true, project: { select: { userId: true } } },
+  });
+
+  const ownedProjectIds: string[] = [];
+  const unlinkedSharedProjectIds: string[] = [];
+  for (const p of placements) {
+    if (p.project.userId === userId) ownedProjectIds.push(p.projectId);
+    else unlinkedSharedProjectIds.push(p.projectId);
+  }
+
+  const deletedProjectIds: string[] = [];
+  for (const projectId of ownedProjectIds) {
+    try {
+      const deleted = await ProjectService.deleteProject(projectId, userId);
+      if (deleted) deletedProjectIds.push(projectId);
+    } catch (err) {
+      logger.error(
+        'Failed to delete project during folder cascade',
+        err as Error,
+        'FolderService',
+        { userId, folderId, projectId }
+      );
+      throw err;
+    }
+  }
+
+  // The folder delete cascades to:
+  //   * all subfolders (self-relation FK ON DELETE CASCADE)
+  //   * all remaining ProjectFolderItem placements inside the subtree
+  //     (folder→item FK ON DELETE CASCADE) — this is what handles the
+  //     "unlink shared projects" case.
+  await prisma.projectFolder.delete({ where: { id: folderId } });
+
+  logger.info('Folder deleted with subtree', 'FolderService', {
+    userId,
+    folderId,
+    subtreeSize: subtreeIds.length,
+    deletedProjectIds: deletedProjectIds.length,
+    unlinkedSharedProjectIds: unlinkedSharedProjectIds.length,
+  });
+
+  return { deletedProjectIds, unlinkedSharedProjectIds };
+}
+
+/**
+ * Moves a set of projects into a target folder, or to root when folderId === null.
+ *
+ * Pre-flight: every projectId must be either owned by the user or accepted-shared
+ * with the user (`SharingService.hasProjectAccess`). Anything else is silently
+ * dropped from the move — we report which ones moved so the caller can show a
+ * partial-success message if needed.
+ *
+ * Storage:
+ *   - Move to a folder: upsert ProjectFolderItem keyed on (userId, projectId).
+ *     The unique index guarantees a project never sits in two folders for the
+ *     same user; upsert replaces the previous placement atomically.
+ *   - Move to root: delete the placement row (absence == root).
+ */
+export async function moveProjectsToFolder(
+  userId: string,
+  folderId: string | null,
+  projectIds: string[]
+): Promise<{ movedProjectIds: string[]; skippedProjectIds: string[] }> {
+  if (folderId) {
+    const folder = await prisma.projectFolder.findFirst({
+      where: { id: folderId, userId },
+      select: { id: true },
+    });
+    if (!folder) {
+      throw new FolderError('NOT_FOUND', 'Složka nebyla nalezena');
+    }
+  }
+
+  const accessChecks = await Promise.all(
+    projectIds.map(async pid => ({
+      pid,
+      ok: (await SharingService.hasProjectAccess(pid, userId)).hasAccess,
+    }))
+  );
+  const allowed = accessChecks.filter(c => c.ok).map(c => c.pid);
+  const skipped = accessChecks.filter(c => !c.ok).map(c => c.pid);
+
+  if (allowed.length === 0) {
+    return { movedProjectIds: [], skippedProjectIds: skipped };
+  }
+
+  await prisma.$transaction(async tx => {
+    if (folderId === null) {
+      await tx.projectFolderItem.deleteMany({
+        where: { userId, projectId: { in: allowed } },
+      });
+    } else {
+      for (const projectId of allowed) {
+        await tx.projectFolderItem.upsert({
+          where: { userId_projectId: { userId, projectId } },
+          create: { userId, projectId, folderId },
+          update: { folderId },
+        });
+      }
+    }
+  });
+
+  logger.info('Projects moved to folder', 'FolderService', {
+    userId,
+    folderId: folderId ?? 'root',
+    movedCount: allowed.length,
+    skippedCount: skipped.length,
+  });
+
+  return { movedProjectIds: allowed, skippedProjectIds: skipped };
+}

--- a/backend/src/services/projectService.ts
+++ b/backend/src/services/projectService.ts
@@ -14,6 +14,10 @@ export interface ProjectWithMeta extends Project {
   isOwned: boolean;
   isShared: boolean;
   owner: Pick<User, 'id' | 'email'>;
+  // The folder the calling user has placed this project in, or null if at
+  // their root level. Per-user — two users viewing the same shared project
+  // may see different folderId values.
+  folderId: string | null;
 }
 
 /**
@@ -82,7 +86,7 @@ export async function getUserProjects(
   };
 }> {
   try {
-    const { page, limit, search, sortBy, sortOrder } = options;
+    const { page, limit, search, sortBy, sortOrder, folderId } = options;
 
     // Get user for context
     const user = await prisma.user.findUnique({ where: { id: userId } });
@@ -114,6 +118,15 @@ export async function getUserProjects(
         ],
       };
       where.AND = [searchCondition];
+    }
+
+    // Folder placement filter (per-user). undefined = no filter;
+    // "root" = projects without a placement row for this user;
+    // <uuid> = projects with a placement row in this specific folder.
+    if (folderId === 'root') {
+      where.folderItems = { none: { userId } };
+    } else if (folderId) {
+      where.folderItems = { some: { userId, folderId } };
     }
 
     // Build order clause with type safety
@@ -174,6 +187,14 @@ export async function getUserProjects(
             status: true,
           },
         },
+        // Caller's placement for this project, if any. There can be at most
+        // one row per (userId, projectId) — enforced by the unique index on
+        // project_folder_items.
+        folderItems: {
+          where: { userId },
+          select: { folderId: true },
+          take: 1,
+        },
       },
     });
 
@@ -232,6 +253,7 @@ export async function getUserProjects(
         isOwned: project.userId === userId,
         isShared: project.userId !== userId && project.shares.length > 0,
         owner: project.user,
+        folderId: project.folderItems[0]?.folderId ?? null,
         // Enhanced project card metadata
         imageCount: totalImages,
         segmentedCount: segmentedImages,

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -1758,6 +1758,10 @@ export class SegmentationService {
     threshold = 0.5,
     userId: string,
     detectHoles?: boolean,
+    // Per-batch channel override for multi-channel video frames.
+    // When set, every per-image call inside this loop receives it so
+    // a multi-channel ND2 frame is segmented from the user-picked
+    // channel rather than the project's default `isSegmentationSource`.
     channel?: string
   ): Promise<{
     successful: number;

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -1757,7 +1757,8 @@ export class SegmentationService {
     model: 'hrnet' | 'resunet_advanced' | 'resunet_small' = 'hrnet',
     threshold = 0.5,
     userId: string,
-    detectHoles?: boolean
+    detectHoles?: boolean,
+    channel?: string
   ): Promise<{
     successful: number;
     failed: number;
@@ -1788,6 +1789,7 @@ export class SegmentationService {
           threshold,
           userId,
           detectHoles,
+          channel,
         });
 
         results.push({

--- a/backend/src/services/tracking/__tests__/trackerService.test.ts
+++ b/backend/src/services/tracking/__tests__/trackerService.test.ts
@@ -166,6 +166,91 @@ describe('trackerService.runTrackingForContainer (round-2 GAP-5)', () => {
     expect(errors).toMatch(/malformed polygons JSON/i);
   });
 
+  it('proceeds when a mix of segmented / no_segmentation / failed reaches final states', async () => {
+    // Regression: previously isBatchComplete required strict
+    // 'segmented' across all frames, so one no_segmentation or failed
+    // frame would block the tracker on the OTHER 600+ frames. The
+    // cross-frame color then went random (instanceId is per-inference
+    // UUID). The gate must accept any FINAL status — the tracker
+    // already skips empty-polyline contributions downstream.
+    prismaImageFindMany.mockImplementation(async ({ select }) => {
+      if (select?.segmentationStatus) {
+        return [
+          { segmentationStatus: 'segmented' },
+          { segmentationStatus: 'no_segmentation' },
+          { segmentationStatus: 'failed' },
+          { segmentationStatus: 'segmented' },
+        ];
+      }
+      return [
+        {
+          id: 'img-0',
+          frameIndex: 0,
+          segmentation: {
+            id: 'seg-0',
+            imageId: 'img-0',
+            polygons: JSON.stringify([
+              {
+                id: 'p0',
+                geometry: 'polyline',
+                points: [{ x: 1, y: 1 }, { x: 2, y: 2 }],
+              },
+            ]),
+          },
+        },
+        // No segmentation row at all for img-1 — the JOIN returns null.
+        { id: 'img-1', frameIndex: 1, segmentation: null },
+        { id: 'img-2', frameIndex: 2, segmentation: null },
+        {
+          id: 'img-3',
+          frameIndex: 3,
+          segmentation: {
+            id: 'seg-3',
+            imageId: 'img-3',
+            polygons: JSON.stringify([
+              {
+                id: 'p3',
+                geometry: 'polyline',
+                points: [{ x: 5, y: 5 }, { x: 6, y: 6 }],
+              },
+            ]),
+          },
+        },
+      ];
+    });
+
+    axiosPostMock.mockResolvedValue({
+      data: { assignments: { p0: 'track-X', p3: 'track-X' } },
+    });
+
+    await runTrackingForContainer('vid-mixed');
+
+    expect(axiosPostMock).toHaveBeenCalledOnce();
+    const updateCalls = prismaSegmentationUpdate.mock.calls.map(
+      c => (c[0] as { where: { id: string } }).where.id
+    );
+    expect(updateCalls).toContain('seg-0');
+    expect(updateCalls).toContain('seg-3');
+  });
+
+  it('still waits when any frame is in a pending state (queued / processing)', async () => {
+    // The complementary case: tracker MUST hold off while pending
+    // frames could still resolve into 'segmented' and contribute a
+    // polyline. The auto-trigger fires from each completed frame's
+    // 'segmented' webhook so a later trigger will catch the
+    // now-complete batch.
+    prismaImageFindMany.mockResolvedValue([
+      { segmentationStatus: 'segmented' },
+      { segmentationStatus: 'queued' },
+      { segmentationStatus: 'segmented' },
+    ]);
+
+    await runTrackingForContainer('vid-pending');
+
+    expect(axiosPostMock).not.toHaveBeenCalled();
+    expect(prismaSegmentationUpdate).not.toHaveBeenCalled();
+  });
+
   it('drops duplicate runs even when both callers race inside isBatchComplete', async () => {
     // Round-3 review caught: an in-flight guard that does
     //   has() -> await ... -> add()

--- a/backend/src/services/tracking/trackerService.ts
+++ b/backend/src/services/tracking/trackerService.ts
@@ -73,15 +73,35 @@ function asTrackerPolylines(
   return { frame: frameIndex, polylines };
 }
 
-/** Returns true once every frame of the container has segmentation
- *  status `'segmented'` (the per-frame model succeeded). */
+/** Returns true once every frame of the container has reached a FINAL
+ *  segmentation status: `'segmented'` (succeeded), `'no_segmentation'`
+ *  (model returned empty), or `'failed'`. Frames in pending states
+ *  (`'queued'`, `'processing'`) still need to resolve before tracking
+ *  can produce a stable cross-frame identity.
+ *
+ *  Previously the gate required strict `'segmented'`, which meant a
+ *  single failed/empty frame indefinitely blocked the tracker on the
+ *  other 600 frames — and the cross-frame color went random because
+ *  `instanceId` (the only fallback) re-randomises per inference. The
+ *  tracker itself already skips empty frames via the
+ *  `polylines.length === 0` early-return downstream, so admitting
+ *  no_segmentation / failed states here is safe. */
+const FINAL_SEGMENTATION_STATUSES = new Set([
+  'segmented',
+  'no_segmentation',
+  'failed',
+]);
 async function isBatchComplete(containerId: string): Promise<boolean> {
   const frames = await prisma.image.findMany({
     where: { parentVideoId: containerId },
     select: { segmentationStatus: true },
   });
   if (frames.length === 0) return false;
-  return frames.every(f => f.segmentationStatus === 'segmented');
+  return frames.every(
+    f =>
+      f.segmentationStatus != null &&
+      FINAL_SEGMENTATION_STATUSES.has(f.segmentationStatus)
+  );
 }
 
 /**

--- a/backend/src/services/video/pythonHelpers/extract_metadata_only.py
+++ b/backend/src/services/video/pythonHelpers/extract_metadata_only.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Metadata-only extractor for an existing ND2 or multi-page TIFF on disk.
+
+The full extractors (``extract_nd2.py``, ``extract_tiff_stack.py``) do
+the frame-writing pass AND the metadata pass in one shot. For
+backfilling calibration on already-extracted containers, we only need
+the metadata — re-writing every frame would rewrite existing PNGs
+and invalidate cached thumbnails for no benefit.
+
+This helper reuses the pure metadata helpers from the existing
+extractors via direct imports (no PNG output, no full array load).
+
+Stdout protocol (one JSON line on its own):
+  {"pixelSizeUm": <float|null>, "frameIntervalMs": <float|null>}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+
+def _extract_nd2(path: Path) -> dict:
+    """ND2 metadata via the `nd2` Python library. Mirrors the
+    `voxel_size().x` + median Δ over `Time [s]` events logic in
+    `extract_nd2.py` but skips the per-frame PNG pass entirely.
+    """
+    import nd2  # type: ignore
+    import numpy as np
+
+    pixel_size_um: float | None = None
+    frame_interval_ms: float | None = None
+
+    with nd2.ND2File(str(path)) as f:
+        # Pixel calibration — isotropic, X axis, with anisotropy warning.
+        try:
+            v = f.voxel_size()
+            x_um = getattr(v, "x", None) if v is not None else None
+            y_um = getattr(v, "y", None) if v is not None else None
+            if isinstance(x_um, (int, float)) and x_um > 0:
+                if (
+                    isinstance(y_um, (int, float))
+                    and y_um > 0
+                    and abs(x_um - y_um) / x_um > 0.01
+                ):
+                    sys.stderr.write(
+                        f"ND2 anisotropic XY: x={x_um} y={y_um}, using x\n"
+                    )
+                pixel_size_um = float(x_um)
+        except Exception as exc:
+            sys.stderr.write(f"ND2 voxel_size read failed: {exc}\n")
+
+        # Frame interval — median Δ over per-event Time [s].
+        try:
+            events = f.events()
+            if events and "Time [s]" in events[0]:
+                ts = [e["Time [s]"] for e in events if "Time [s]" in e]
+                if len(ts) >= 2:
+                    deltas = np.diff(np.asarray(ts, dtype=np.float64))
+                    pos = deltas[deltas > 0]
+                    if pos.size > 0:
+                        frame_interval_ms = float(np.median(pos) * 1000.0)
+        except Exception as exc:
+            sys.stderr.write(f"ND2 events parse failed: {exc}\n")
+
+    return {
+        "pixelSizeUm": pixel_size_um,
+        "frameIntervalMs": frame_interval_ms,
+    }
+
+
+def _extract_tiff(path: Path) -> dict:
+    """TIFF metadata via the helpers in ``extract_tiff_stack.py``.
+
+    Mirrors ``_extract_nd2``'s per-step exception isolation: a parser
+    raising on one of the two values should leave the other intact, so
+    a partially-readable TIFF still backfills what it can. Errors are
+    logged to stderr (the agreed logging channel for this script) and
+    the offending field is left as ``None``.
+    """
+    import tifffile  # type: ignore
+
+    from extract_tiff_stack import (
+        _detect_pixel_size_um,
+        _detect_frame_interval_ms,
+    )
+
+    pixel_size_um: float | None = None
+    frame_interval_ms: float | None = None
+
+    with tifffile.TiffFile(str(path)) as tf:
+        try:
+            pixel_size_um = _detect_pixel_size_um(tf)
+        except Exception as exc:
+            sys.stderr.write(f"TIFF pixel-size detect failed: {exc}\n")
+        try:
+            frame_interval_ms = _detect_frame_interval_ms(tf)
+        except Exception as exc:
+            sys.stderr.write(f"TIFF frame-interval detect failed: {exc}\n")
+
+    return {
+        "pixelSizeUm": pixel_size_um,
+        "frameIntervalMs": frame_interval_ms,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: extract_metadata_only.py <src>", file=sys.stderr)
+        return 2
+    src = Path(sys.argv[1])
+    if not src.is_file():
+        print(f"file not found: {src}", file=sys.stderr)
+        return 3
+
+    ext = src.suffix.lower()
+    try:
+        if ext == ".nd2":
+            result = _extract_nd2(src)
+        elif ext in (".tif", ".tiff"):
+            result = _extract_tiff(src)
+        else:
+            print(f"unsupported extension: {ext}", file=sys.stderr)
+            return 4
+    except Exception as exc:
+        # Surface the underlying error to stderr so the Node caller's
+        # backfill log shows WHY this container couldn't be calibrated.
+        print(f"extraction failed: {exc}", file=sys.stderr)
+        return 5
+
+    sys.stdout.write(json.dumps(result) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -215,46 +215,211 @@ def _detect_pixel_size_um(tf) -> float | None:
     return None
 
 
+def _imagej_label_to_seconds(label: str) -> float | None:
+    """Parse a single ImageJ slice ``Labels`` entry to a timestamp in
+    seconds. ImageJ stores annotations like:
+      ``"t=0.5s"``         (most common explicit)
+      ``"Time=0.5 s"``
+      ``"0.500"``           (bare seconds — common in MicroManager)
+      ``"0.5 min"`` / ``"1 h"``  (rare but legal)
+    Returns ``None`` when the label carries no time-like token. Keep the
+    parser conservative so unrelated metadata (channel names, Z indices)
+    doesn't accidentally produce a spurious timestamp.
+    """
+    if not isinstance(label, str):
+        return None
+    patterns = (
+        re.compile(r"\bt\s*=\s*([0-9.]+)\s*([smhSMH]?)", re.IGNORECASE),
+        re.compile(r"\btime\s*[:=]\s*([0-9.]+)\s*([smhSMH]?)", re.IGNORECASE),
+        # Bare numeric value (assume seconds) — only when the entire
+        # label is a number; rejects "z=2" / channel names.
+        re.compile(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*([smhSMH]?)\s*$"),
+    )
+    for pat in patterns:
+        m = pat.search(label)
+        if not m:
+            continue
+        try:
+            value = float(m.group(1))
+        except ValueError:
+            continue
+        unit = (m.group(2) if m.lastindex and m.lastindex >= 2 else "") or ""
+        u = unit.lower()
+        if u in ("", "s"):
+            return value
+        if u == "m":
+            return value * 60.0
+        if u == "h":
+            return value * 3600.0
+        # Unit captured but unrecognised (e.g. ms suffix on Labels which
+        # the rest of the parser doesn't support). Keep walking the
+        # remaining patterns — the next one may match cleanly.
+    return None
+
+
+def _median_interval_ms(timestamps_s: list[float]) -> float | None:
+    """Compute the median Δ (in milliseconds) between consecutive entries
+    of a per-frame timestamp list.
+
+    Robustness rules — these reflect concrete failure modes observed in
+    real microscopy files:
+      - Sort ascending so out-of-order entries don't poison the result.
+      - Dedupe **timestamps**, not deltas, via `np.unique` with a 1 µs
+        tolerance. Multichannel OME files emit one ``<Plane>`` per (T,C);
+        consecutive channels typically share a DeltaT-per-T and serialise
+        with float noise. Deduping after `np.diff` (the previous
+        implementation) would conflate "legitimate zero-Δ paused frame"
+        with "channel duplicate" and skew the median upward.
+      - Drop non-positive deltas after dedupe (paranoia — sort + unique
+        already guarantee strictly increasing).
+
+    Returns ``None`` if fewer than two distinct timestamps remain.
+    """
+    if len(timestamps_s) < 2:
+        return None
+    arr = np.asarray(sorted(timestamps_s), dtype=np.float64)
+    # Cluster near-duplicates using a relative tolerance proportional to
+    # the typical frame duration. 1 µs absolute is well below any plausible
+    # microscopy frame rate (10 kHz cameras are 100 µs/frame) and matches
+    # the float noise that tifffile / OME writers commonly introduce.
+    deduped = arr[np.concatenate(([True], np.diff(arr) > 1e-6))]
+    if deduped.size < 2:
+        return None
+    deltas = np.diff(deduped)
+    deltas = deltas[deltas > 0]
+    if deltas.size == 0:
+        return None
+    return float(np.median(deltas)) * 1000.0
+
+
 def _detect_frame_interval_ms(tf) -> float | None:
     """Best-effort frame-interval extraction in milliseconds.
 
     Sources tried, in order:
-      1. OME-XML ``<Pixels TimeIncrement TimeIncrementUnit>``
-      2. ImageJ ``finterval`` (seconds per frame) or per-frame ``Labels``
-         timestamps.
+      1. OME-XML ``<Plane DeltaT="..." DeltaTUnit="...">`` — per-frame
+         timestamps, median of consecutive Δs (robust to dropped frames,
+         mirrors the ND2 ``Time [s]`` events branch in ``extract_nd2``).
+      2. OME-XML ``<Pixels TimeIncrement TimeIncrementUnit>`` — single
+         declared interval (fallback when no per-frame planes carry DeltaT).
+      3. ImageJ per-slice ``Labels`` timestamps (``t=0.5s`` / ``0.5`` / …),
+         median Δ same as #1.
+      4. ImageJ ``finterval`` (seconds per frame) or ``fps``.
 
     Returns ``None`` when no time metadata is present — caller decides
     whether to fall back to a Node-side ffmpeg estimate.
     """
-    # 1. OME-XML — TimeIncrement default unit is seconds per the spec.
+    # Stage 1+2: OME-XML.
     try:
         ome = getattr(tf, "ome_metadata", None)
-        if isinstance(ome, str) and "<Pixels" in ome:
-            import re
-            m = re.search(r'TimeIncrement="([0-9.eE+-]+)"', ome)
-            unit_m = re.search(r'TimeIncrementUnit="([^"]+)"', ome)
-            if m:
-                val = float(m.group(1))
-                u = (unit_m.group(1).lower() if unit_m else "s")
+        if isinstance(ome, str):
+            # Per-frame Plane DeltaT first. Multichannel files emit one
+            # `<Plane>` per (T,C) — channel acquisitions for the same T
+            # share a DeltaT, so duplicates collapse via the dedupe in
+            # `_median_interval_ms`. Unknown unit attributes return None
+            # rather than silently defaulting to seconds (an off-by-1000
+            # nm→µm-style mistake has shipped in this repo before; same
+            # principle applies here).
+            # Two-stage match: locate each `<Plane>` tag, then search the
+            # tag's attribute substring for DeltaT and DeltaTUnit
+            # independently. The previous one-shot regex assumed
+            # `DeltaTUnit` precedes `DeltaT`, which is wrong for OME
+            # writers that emit attributes in canonical order (DeltaT,
+            # then DeltaTUnit) — exposed by regression tests.
+            plane_tag_re = re.compile(r"<Plane\b([^>]*)>", re.IGNORECASE)
+            delta_t_re = re.compile(
+                r'\bDeltaT="([0-9.eE+-]+)"', re.IGNORECASE
+            )
+            unit_re = re.compile(r'\bDeltaTUnit="([^"]+)"', re.IGNORECASE)
+            timestamps_s: list[float] = []
+            unknown_units_seen: set[str] = set()
+            for tag in plane_tag_re.finditer(ome):
+                attrs = tag.group(1)
+                dt = delta_t_re.search(attrs)
+                if dt is None:
+                    continue
+                try:
+                    value = float(dt.group(1))
+                except ValueError:
+                    continue
+                unit_m = unit_re.search(attrs)
+                if unit_m is None:
+                    # Attribute absent — OME spec defaults to seconds.
+                    timestamps_s.append(value)
+                    continue
+                u = unit_m.group(1).lower()
                 if u in ("s", "sec", "second", "seconds"):
-                    return val * 1000.0
-                if u in ("ms", "millisecond", "milliseconds"):
-                    return val
-                if u in ("min", "minute", "minutes"):
-                    return val * 60_000.0
-                # OME spec default for TimeIncrement is seconds, so we
-                # treat an unknown unit as seconds rather than dropping
-                # the value (different policy from pixel size because
-                # the unit space for time is much narrower).
-                return val * 1000.0
-    except Exception as exc:
-        sys.stderr.write(f"OME-XML time-increment parse failed: {exc}\n")
+                    timestamps_s.append(value)
+                elif u in ("ms", "millisecond", "milliseconds"):
+                    timestamps_s.append(value / 1000.0)
+                elif u in ("min", "minute", "minutes"):
+                    timestamps_s.append(value * 60.0)
+                else:
+                    # Explicit but unrecognised unit — refuse to guess.
+                    unknown_units_seen.add(u)
+            if unknown_units_seen:
+                sys.stderr.write(
+                    "OME-XML DeltaT carried unrecognised units "
+                    f"{sorted(unknown_units_seen)} — dropped those planes "
+                    "rather than guess seconds\n"
+                )
+            interval_ms = _median_interval_ms(timestamps_s)
+            if interval_ms is not None:
+                return interval_ms
 
-    # 2. ImageJ metadata. `finterval` is seconds per frame; `fps` is the
-    # alternate form (frames per second).
+            if "<Pixels" in ome:
+                m = re.search(r'TimeIncrement="([0-9.eE+-]+)"', ome)
+                unit_m = re.search(r'TimeIncrementUnit="([^"]+)"', ome)
+                if m:
+                    val = float(m.group(1))
+                    if unit_m is None:
+                        return val * 1000.0  # spec default: seconds
+                    u = unit_m.group(1).lower()
+                    if u in ("s", "sec", "second", "seconds"):
+                        return val * 1000.0
+                    if u in ("ms", "millisecond", "milliseconds"):
+                        return val
+                    if u in ("min", "minute", "minutes"):
+                        return val * 60_000.0
+                    sys.stderr.write(
+                        f"OME-XML TimeIncrement unrecognised unit '{u}' — "
+                        "dropping value rather than guessing seconds\n"
+                    )
+    except Exception as exc:
+        sys.stderr.write(f"OME-XML time parse failed: {exc}\n")
+
+    # Stage 3+4: ImageJ metadata.
     try:
         meta = getattr(tf, "imagej_metadata", None)
         if isinstance(meta, dict):
+            # ImageJ Labels carry per-slice annotations for time-series
+            # acquisitions. We require at least 75 % of the labels to
+            # parse as time AND a strictly increasing sequence; this
+            # rejects interleaved channel/time labels like
+            # `["DAPI", "0.5s", "GFP", "1.0s"]` which would otherwise
+            # yield a median Δ that's wrong by the channel-count
+            # multiplier.
+            labels = meta.get("Labels")
+            if isinstance(labels, (list, tuple)) and len(labels) >= 2:
+                parsed = [_imagej_label_to_seconds(label) for label in labels]
+                ts = [v for v in parsed if v is not None]
+                density = len(ts) / len(labels)
+                strictly_increasing = all(
+                    ts[i] < ts[i + 1] for i in range(len(ts) - 1)
+                )
+                if len(ts) >= 2 and density >= 0.75 and strictly_increasing:
+                    interval_ms = _median_interval_ms(ts)
+                    if interval_ms is not None:
+                        return interval_ms
+                elif len(ts) >= 2:
+                    # Some labels parsed but density too low / not
+                    # monotonic — refuse to guess.
+                    sys.stderr.write(
+                        f"ImageJ Labels: {len(ts)}/{len(labels)} parsed as time "
+                        f"(density {density:.2f}, increasing={strictly_increasing}); "
+                        "ignoring — likely interleaved with non-time labels\n"
+                    )
+
+            # `finterval` is seconds per frame; `fps` is the alternate.
             v = meta.get("finterval")
             if isinstance(v, (int, float)) and v > 0:
                 return float(v) * 1000.0

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
@@ -1,0 +1,226 @@
+"""Regression tests for the TIFF metadata parsers in
+``extract_tiff_stack.py``. These exercise pure helpers — no tifffile,
+no PIL, no real TIFF on disk — by stubbing the ``tf`` object's
+``ome_metadata`` / ``imagej_metadata`` attributes.
+
+The 4-stage priority chain (OME Plane → OME TimeIncrement → ImageJ
+Labels → ImageJ finterval/fps) is order-sensitive: a future refactor
+that flips two branches would silently change every downstream
+``frameIntervalMs`` value. The unit-normalisation maps are an equally
+common drift target (the repo has shipped 1000× errors before by
+flipping nm/µm — see memory ``project_video_bit_depth_preservation``).
+These tests pin both invariants.
+
+Run from repo root:
+  python3 -m pytest backend/src/services/video/pythonHelpers/tests/ -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# Allow direct import without depending on backend/segmentation's heavy
+# conftest (which pulls in torch / fastapi).
+HERE = os.path.dirname(__file__)
+HELPERS_DIR = os.path.abspath(os.path.join(HERE, ".."))
+sys.path.insert(0, HELPERS_DIR)
+
+# Stub tifffile so importing the module doesn't require it on the host.
+sys.modules.setdefault("tifffile", MagicMock())
+
+from extract_tiff_stack import (  # noqa: E402
+    _detect_frame_interval_ms,
+    _imagej_label_to_seconds,
+    _median_interval_ms,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _imagej_label_to_seconds
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("t=0.5s", 0.5),
+        ("T=2.0s", 2.0),
+        ("t = 0.5", 0.5),
+        ("Time=10", 10.0),
+        ("time = 5 s", 5.0),
+        ("0.5", 0.5),
+        ("0.500", 0.5),
+        ("1.0 m", 60.0),
+        ("1 h", 3600.0),
+        # Rejections — must return None so a misshaped Labels list
+        # can't poison the median.
+        ("Channel: DAPI", None),
+        ("DAPI", None),
+        ("z=2", None),
+        ("", None),
+        (None, None),
+        (12345, None),  # non-string
+    ],
+)
+def test_imagej_label_to_seconds(label, expected):
+    assert _imagej_label_to_seconds(label) == expected
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _median_interval_ms (the shared core)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_median_interval_one_dropped_frame():
+    # Five timestamps with one dropped → deltas 1, 1, 2.5, 1 → median 1 s.
+    assert _median_interval_ms([0.0, 1.0, 2.0, 4.5, 5.5]) == pytest.approx(1000.0)
+
+
+def test_median_interval_dedupes_multichannel_duplicates():
+    # Three timepoints × two channels share DeltaT per T. With tifffile
+    # float noise the duplicates serialise as near-equal values.
+    timestamps = [0.0, 0.0 + 1e-9, 1.0, 1.0 + 2e-9, 2.0, 2.0 - 3e-9]
+    assert _median_interval_ms(timestamps) == pytest.approx(1000.0)
+
+
+def test_median_interval_returns_none_below_two_samples():
+    assert _median_interval_ms([]) is None
+    assert _median_interval_ms([1.0]) is None
+
+
+def test_median_interval_handles_out_of_order():
+    # Caller may pass any iteration order; helper must sort before diff.
+    assert _median_interval_ms([2.0, 0.0, 1.0]) == pytest.approx(1000.0)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _detect_frame_interval_ms — 4-stage priority chain
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _tf(ome: str | None = None, ij: dict | None = None):
+    """Stub tifffile.TiffFile exposing only the metadata attrs used."""
+    return SimpleNamespace(ome_metadata=ome, imagej_metadata=ij)
+
+
+def test_ome_plane_delta_t_seconds_median():
+    ome = """<OME>
+<Plane DeltaT="0.0" DeltaTUnit="s"/>
+<Plane DeltaT="1.0" DeltaTUnit="s"/>
+<Plane DeltaT="2.0" DeltaTUnit="s"/>
+<Plane DeltaT="4.5" DeltaTUnit="s"/>
+<Plane DeltaT="5.5" DeltaTUnit="s"/>
+</OME>"""
+    # Deltas 1, 1, 2.5, 1 → median 1 s → 1000 ms.
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(1000.0)
+
+
+def test_ome_plane_unit_ms():
+    ome = '<OME><Plane DeltaT="100" DeltaTUnit="ms"/><Plane DeltaT="200" DeltaTUnit="ms"/></OME>'
+    # Two timestamps in ms → 0.1 s and 0.2 s → Δ 0.1 s → 100 ms.
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(100.0)
+
+
+def test_ome_plane_unit_minutes():
+    ome = '<OME><Plane DeltaT="1" DeltaTUnit="min"/><Plane DeltaT="2" DeltaTUnit="min"/></OME>'
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(60_000.0)
+
+
+def test_ome_plane_unit_missing_defaults_to_seconds():
+    ome = '<OME><Plane DeltaT="0.0"/><Plane DeltaT="0.5"/></OME>'
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(500.0)
+
+
+def test_ome_plane_unit_unknown_returns_none(capsys):
+    # Explicit but unrecognised unit must NOT default to seconds —
+    # consistent with pixel-size policy (unknown unit → return None).
+    ome = '<OME><Plane DeltaT="0.5" DeltaTUnit="fortnights"/><Plane DeltaT="1.0" DeltaTUnit="fortnights"/></OME>'
+    assert _detect_frame_interval_ms(_tf(ome=ome)) is None
+    # Should at least leave a stderr trace so ops can spot the regression.
+    captured = capsys.readouterr()
+    assert "fortnights" in captured.err
+
+
+def test_ome_time_increment_fallback_when_no_plane_delta_t():
+    ome = '<OME><Image><Pixels TimeIncrement="0.5" TimeIncrementUnit="s"/></Image></OME>'
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(500.0)
+
+
+def test_ome_plane_priority_over_time_increment():
+    # Both present — Plane DeltaT must win.
+    ome = """<OME><Image><Pixels TimeIncrement="0.5" TimeIncrementUnit="s">
+<Plane DeltaT="0.0" DeltaTUnit="s"/>
+<Plane DeltaT="2.0" DeltaTUnit="s"/>
+</Pixels></Image></OME>"""
+    assert _detect_frame_interval_ms(_tf(ome=ome)) == pytest.approx(2000.0)
+
+
+def test_imagej_labels_median():
+    labels = ["t=0.0s", "t=0.5s", "t=1.0s", "t=1.5s"]
+    assert _detect_frame_interval_ms(_tf(ij={"Labels": labels})) == pytest.approx(500.0)
+
+
+def test_imagej_labels_interleaved_with_channels_is_rejected(capsys):
+    # `["DAPI", "0.5", "GFP", "1.0"]` parses 2 timestamps with
+    # density 0.5 — below 0.75 threshold; result is None, NOT a
+    # confidently-wrong "0.5 s × channel_count" guess.
+    labels = ["DAPI", "0.5", "GFP", "1.0"]
+    assert _detect_frame_interval_ms(_tf(ij={"Labels": labels})) is None
+    captured = capsys.readouterr()
+    assert "density" in captured.err
+
+
+def test_imagej_labels_non_monotonic_is_rejected():
+    # All parse as time but not strictly increasing — refuse.
+    labels = ["t=1.0s", "t=0.5s", "t=2.0s"]
+    assert _detect_frame_interval_ms(_tf(ij={"Labels": labels})) is None
+
+
+def test_imagej_finterval_seconds_per_frame():
+    assert _detect_frame_interval_ms(_tf(ij={"finterval": 0.25})) == pytest.approx(250.0)
+
+
+def test_imagej_fps_alternate_form():
+    assert _detect_frame_interval_ms(_tf(ij={"fps": 10})) == pytest.approx(100.0)
+
+
+def test_imagej_finterval_wins_over_fps():
+    # finterval is the direct expression — prefer it when both are
+    # carried, otherwise rounding 1/fps could clash.
+    assert (
+        _detect_frame_interval_ms(_tf(ij={"finterval": 0.5, "fps": 10}))
+        == pytest.approx(500.0)
+    )
+
+
+def test_imagej_labels_priority_over_finterval():
+    # Per-slice timestamps are stronger evidence than the declared
+    # interval — prefer them when both are present.
+    assert (
+        _detect_frame_interval_ms(
+            _tf(ij={"Labels": ["t=0s", "t=1s", "t=2s"], "finterval": 99.0})
+        )
+        == pytest.approx(1000.0)
+    )
+
+
+def test_ome_priority_over_imagej():
+    # The full 4-stage chain: OME Plane > OME TimeIncrement > ImageJ.
+    ome = '<OME><Plane DeltaT="0" DeltaTUnit="s"/><Plane DeltaT="3" DeltaTUnit="s"/></OME>'
+    ij = {"Labels": ["t=0s", "t=99s"]}
+    assert _detect_frame_interval_ms(_tf(ome=ome, ij=ij)) == pytest.approx(3000.0)
+
+
+def test_malformed_ome_does_not_raise(capsys):
+    # Garbage in must not crash — the function must return None and log.
+    ome = '<OME><Plane DeltaT="not-a-number" DeltaTUnit="s"/></OME>'
+    assert _detect_frame_interval_ms(_tf(ome=ome)) is None
+
+
+def test_empty_metadata_returns_none():
+    assert _detect_frame_interval_ms(_tf()) is None
+    assert _detect_frame_interval_ms(_tf(ij={})) is None

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -459,11 +459,18 @@ export type CleanupQueueData = z.infer<typeof cleanupQueueSchema>;
 // Project folder schemas (file-explorer style hierarchy)
 // ============================================================================
 
+// `.trim()` runs LAST in Zod's pipeline, AFTER `.min(1)` — meaning a
+// whitespace-only input like " " would pass `.min(1)` validation and then
+// be trimmed to "" before reaching the service layer. Reorder so trim
+// happens first; the min(1) then catches the empty post-trim case.
+// (This bug shipped briefly with PR #202 and updateFolder accepted " " →
+// "" in the DB. createFolder had a defensive re-check; updateFolder did
+// not. Fixing at the schema level eliminates the divergence.)
 const folderNameSchema = z
   .string()
+  .trim()
   .min(1, 'Název složky je povinný')
-  .max(100, 'Název složky může mít maximálně 100 znaků')
-  .trim();
+  .max(100, 'Název složky může mít maximálně 100 znaků');
 
 export const createFolderSchema = z.object({
   name: folderNameSchema,

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import { JOB_STATUSES } from './index';
+import {
+  SEGMENTATION_MODELS,
+  SEGMENTATION_MODEL_ERROR_MESSAGE,
+} from '../constants/segmentationModels';
 
 // ============================================================================
 // Common validation schemas
@@ -17,23 +21,20 @@ export const uuidSchema = z.string().uuid('Musí být platné UUID');
  * (added 2026-05-12 with PR #142) so frontend Segment-All requests against
  * a Microtubules project send model='microtubule' and need to validate.
  */
-export const segmentationModelSchema = z.enum(
-  [
-    'hrnet',
-    'cbam_resunet',
-    'unet_spherohq',
-    'unet_attention_aspp',
-    'sperm',
-    'wound',
-    'microtubule',
-  ],
-  {
-    errorMap: () => ({
-      message:
-        'Model musí být hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, sperm, wound nebo microtubule',
-    }),
-  }
-);
+// Single source of truth is `constants/segmentationModels.ts`; the
+// Zod schema is derived from the same const so the route validator,
+// controller fallback, and any Zod-validated path stay in lock-step.
+// Previously these drifted (Zod had 7 models, route+controller had 9),
+// making a `resunet_advanced` request pass the route but fail Zod-aware
+// internal callers — silent acceptance / rejection asymmetry.
+const _SEG_MODELS_TUPLE = SEGMENTATION_MODELS as unknown as [
+  SegmentationModelLiteral,
+  ...SegmentationModelLiteral[],
+];
+type SegmentationModelLiteral = (typeof SEGMENTATION_MODELS)[number];
+export const segmentationModelSchema = z.enum(_SEG_MODELS_TUPLE, {
+  errorMap: () => ({ message: SEGMENTATION_MODEL_ERROR_MESSAGE }),
+});
 
 /**
  * Queue priority validation
@@ -233,6 +234,11 @@ export const updateProjectSchema = z.object({
 
 /**
  * Schema for project query parameters (pagination, search, sort)
+ *
+ * ``folderId`` filters by user-folder placement. Accepts:
+ *   - undefined / omitted: unfiltered (default — returns all projects the user can see).
+ *   - "root": projects that the user has NOT placed in any of their folders.
+ *   - <uuid>: projects placed inside the given folder (must belong to the caller).
  */
 export const projectQuerySchema = z.object({
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -256,6 +262,9 @@ export const projectQuerySchema = z.object({
     })
     .optional()
     .default('desc'),
+  folderId: z
+    .union([z.literal('root'), z.string().uuid('Neplatné ID složky')])
+    .optional(),
 });
 
 /**
@@ -445,6 +454,52 @@ export type AddImageToQueueData = z.infer<typeof addImageToQueueSchema>;
 export type BatchQueueData = z.infer<typeof batchQueueSchema>;
 export type ResetStuckItemsData = z.infer<typeof resetStuckItemsSchema>;
 export type CleanupQueueData = z.infer<typeof cleanupQueueSchema>;
+
+// ============================================================================
+// Project folder schemas (file-explorer style hierarchy)
+// ============================================================================
+
+const folderNameSchema = z
+  .string()
+  .min(1, 'Název složky je povinný')
+  .max(100, 'Název složky může mít maximálně 100 znaků')
+  .trim();
+
+export const createFolderSchema = z.object({
+  name: folderNameSchema,
+  parentId: z.string().uuid('Neplatné ID nadřazené složky').nullable().optional(),
+});
+
+// PATCH semantics: any subset of { name, parentId } may be supplied.
+// parentId === null  → move to root.
+// parentId === undefined → leave unchanged.
+export const updateFolderSchema = z
+  .object({
+    name: folderNameSchema.optional(),
+    parentId: z.string().uuid('Neplatné ID nadřazené složky').nullable().optional(),
+  })
+  .refine(v => v.name !== undefined || v.parentId !== undefined, {
+    message: 'Aktualizace musí obsahovat alespoň jedno pole (name nebo parentId)',
+  });
+
+export const folderItemsSchema = z.object({
+  projectIds: z
+    .array(uuidSchema)
+    .min(1, 'Je potřeba alespoň jedno UUID')
+    .max(100, 'Maximum 100 projektů na jeden přesun')
+    .refine(arr => new Set(arr).size === arr.length, {
+      message: 'projectIds obsahují duplicity',
+    }),
+});
+
+export const folderIdSchema = z.object({
+  id: z.string().uuid('Neplatné ID složky'),
+});
+
+export type CreateFolderData = z.infer<typeof createFolderSchema>;
+export type UpdateFolderData = z.infer<typeof updateFolderSchema>;
+export type FolderItemsData = z.infer<typeof folderItemsSchema>;
+export type FolderIdParams = z.infer<typeof folderIdSchema>;
 
 // ============================================================================
 // Feedback (bug reports + feature requests)

--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -119,6 +119,29 @@ server {
         }
     }
 
+    # Frame image endpoints - sliding-window prefetch in video editor
+    # fans out 30+ URLs per initial mount (15-frame window × 2 channels +
+    # polygons) which trivially overflowed the api zone's burst=80.
+    # Frame data is static file-serve with ETag/Cache-Control set by
+    # the backend mediumCache middleware, so we can afford the higher
+    # cap — file IO is the only real cost.
+    location ~ ^/api/images/[^/]+/(frame-data|display)$ {
+        limit_req zone=segmentation burst=100 nodelay;
+        limit_conn addr 50;
+
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Environment "production";
+
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+    }
+
     # Segmentation results endpoints - higher limits for bulk requests
     location ~ ^/api/segmentation/images/[^/]+/results$ {
         limit_req zone=segmentation burst=100 nodelay;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -1244,6 +1247,59 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "test:watch:focused": "vitest --watch --testNamePattern"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -6,6 +6,8 @@ import ProjectActions from '@/components/project/ProjectActions';
 import ProjectMetadata from '@/components/project/ProjectMetadata';
 import { Badge } from '@/components/ui/badge';
 import { Share2, Users, User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { dragSourceProps } from '@/utils/dashboardDrag';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useAuth } from '@/contexts/useAuth';
 
@@ -22,6 +24,10 @@ interface ProjectCardProps {
   owner?: { email: string; name?: string };
   shareId?: string;
   onProjectUpdate?: (projectId: string, action: string) => void;
+  /** When true, opens the move-to-folder dialog for this project. */
+  onRequestMove?: (projectId: string) => void;
+  /** Whether at least one folder exists — controls visibility of "Move to…". */
+  hasAnyFolder?: boolean;
 }
 
 const ProjectCard = React.memo(
@@ -38,10 +44,16 @@ const ProjectCard = React.memo(
     owner,
     shareId,
     onProjectUpdate,
+    onRequestMove,
+    hasAnyFolder,
   }: ProjectCardProps) => {
     const { t } = useLanguage();
     const { user: _user } = useAuth();
     const [isDialogOpen, setIsDialogOpen] = useState(false);
+    // HTML5 native DnD: clicking and dragging are decoupled by the browser,
+    // so onClick still fires reliably. dragSourceProps writes to a module-
+    // level ref that drop targets read on dragover/drop.
+    const drag = dragSourceProps({ type: 'project', id });
 
     const handleCardClick = (e: React.MouseEvent) => {
       // Don't navigate if any dialog is open
@@ -66,7 +78,10 @@ const ProjectCard = React.memo(
 
     return (
       <Card
-        className="overflow-hidden transition-all duration-300 hover:shadow-md cursor-pointer relative"
+        {...drag}
+        className={cn(
+          'overflow-hidden transition-all duration-300 hover:shadow-md cursor-pointer relative'
+        )}
         onClick={handleCardClick}
       >
         {isShared && (
@@ -96,6 +111,8 @@ const ProjectCard = React.memo(
                 isShared={isShared}
                 shareId={shareId}
                 onProjectUpdate={onProjectUpdate}
+                onRequestMove={onRequestMove}
+                hasAnyFolder={hasAnyFolder}
               />
             </div>
           </div>

--- a/src/components/ProjectListItem.tsx
+++ b/src/components/ProjectListItem.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowRight, Share2, User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { dragSourceProps } from '@/utils/dashboardDrag';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useAuth } from '@/contexts/useAuth';
 import ProjectThumbnail from '@/components/project/ProjectThumbnail';
@@ -21,6 +23,8 @@ interface ProjectListItemProps {
   owner?: { email: string; name?: string };
   shareId?: string;
   onProjectUpdate?: (projectId: string, action: string) => void;
+  onRequestMove?: (projectId: string) => void;
+  hasAnyFolder?: boolean;
 }
 
 const ProjectListItem = React.memo(
@@ -37,9 +41,13 @@ const ProjectListItem = React.memo(
     owner,
     shareId,
     onProjectUpdate,
+    onRequestMove,
+    hasAnyFolder,
   }: ProjectListItemProps) => {
     const { t: _t } = useLanguage();
     const { user: _user } = useAuth();
+    const drag = dragSourceProps({ type: 'project', id });
+
     const handleCardClick = () => {
       if (onClick) {
         onClick();
@@ -52,7 +60,10 @@ const ProjectListItem = React.memo(
 
     return (
       <Card
-        className="overflow-hidden transition-all duration-300 hover:shadow-md cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 w-full dark:hover:bg-gray-800 dark:bg-gray-900"
+        {...drag}
+        className={cn(
+          'overflow-hidden transition-all duration-300 hover:shadow-md cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 w-full dark:hover:bg-gray-800 dark:bg-gray-900'
+        )}
         onClick={handleCardClick}
       >
         <div className="flex items-center p-4">
@@ -91,9 +102,12 @@ const ProjectListItem = React.memo(
           <div className="flex items-center ml-4 space-x-2">
             <ProjectActions
               projectId={id}
+              projectTitle={title}
               isShared={isShared}
               shareId={shareId}
               onProjectUpdate={onProjectUpdate}
+              onRequestMove={onRequestMove}
+              hasAnyFolder={hasAnyFolder}
             />
             <Button variant="ghost" size="icon" className="h-8 w-8">
               <ArrowRight className="h-4 w-4" />

--- a/src/components/ProjectsList.tsx
+++ b/src/components/ProjectsList.tsx
@@ -3,10 +3,13 @@ import ProjectCard from '@/components/ProjectCard';
 import ProjectListItem from '@/components/ProjectListItem';
 import NewProjectCard from '@/components/NewProjectCard';
 import NewProjectListItem from '@/components/NewProjectListItem';
+import FolderCard from '@/components/project/FolderCard';
+import FolderListItem from '@/components/project/FolderListItem';
 import { useLanguage } from '@/contexts/useLanguage';
 import { SkeletonProjectCard } from '@/components/ui/skeleton-variants';
 import { cn } from '@/lib/utils';
 import { ProjectsGrid } from '@/components/layout';
+import type { DragItem } from '@/utils/dashboardDrag';
 
 export interface Project {
   id: string;
@@ -22,22 +25,52 @@ export interface Project {
   shareId?: string;
 }
 
+/**
+ * Minimal shape ProjectsList needs to render a folder tile. Defined locally
+ * rather than re-exporting hook types so the visual layer doesn't depend on
+ * React Query internals.
+ */
+export interface FolderViewItem {
+  id: string;
+  name: string;
+}
+
 export interface ProjectsListProps {
   projects: Project[];
+  /** Folders to render before projects (file-explorer convention). */
+  folders?: FolderViewItem[];
   viewMode: 'grid' | 'list';
   onOpenProject: (id: string) => void;
   loading: boolean;
   showCreateCard?: boolean;
   onProjectUpdate?: (projectId: string, action: string) => void;
+  /** Per-project move trigger. When undefined, project menu hides "Move to…". */
+  onRequestProjectMove?: (projectId: string) => void;
+  hasAnyFolder?: boolean;
+  /** Folder operations. When undefined, folder cards are not interactive. */
+  onOpenFolder?: (folderId: string) => void;
+  onRenameFolder?: (folderId: string, currentName: string) => void;
+  onMoveFolder?: (folderId: string) => void;
+  onDeleteFolder?: (folderId: string, name: string) => void;
+  /** Forwarded to FolderCard / FolderListItem so drops route up to Dashboard. */
+  onDropItem?: (item: DragItem, targetFolderId: string | null) => void;
 }
 
 const ProjectsList = ({
   projects,
+  folders = [],
   viewMode,
   onOpenProject,
   loading,
   showCreateCard = false,
   onProjectUpdate,
+  onRequestProjectMove,
+  hasAnyFolder,
+  onOpenFolder,
+  onRenameFolder,
+  onMoveFolder,
+  onDeleteFolder,
+  onDropItem,
 }: ProjectsListProps) => {
   const { t } = useLanguage();
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
@@ -76,7 +109,7 @@ const ProjectsList = ({
     );
   }
 
-  if (projects.length === 0 && !showCreateCard) {
+  if (projects.length === 0 && folders.length === 0 && !showCreateCard) {
     return (
       <div className="text-center py-12">
         <p className="text-gray-500 dark:text-gray-400">
@@ -87,6 +120,26 @@ const ProjectsList = ({
   }
 
   if (viewMode === 'list') {
+    const folderItems = folders.map(folder => (
+      <div
+        key={`folder-${folder.id}`}
+        className="animate-in fade-in slide-in-from-bottom-2 duration-500"
+      >
+        <FolderListItem
+          id={folder.id}
+          name={folder.name}
+          onOpen={() => onOpenFolder?.(folder.id)}
+          onRename={() => onRenameFolder?.(folder.id, folder.name)}
+          onMove={() => onMoveFolder?.(folder.id)}
+          onDelete={() => onDeleteFolder?.(folder.id, folder.name)}
+          onDropItem={
+            onDropItem
+              ? (item, targetId) => onDropItem(item, targetId)
+              : undefined
+          }
+        />
+      </div>
+    ));
     const projectItems = projects.map((project, index) => (
       <div
         key={project.id}
@@ -106,19 +159,22 @@ const ProjectsList = ({
           owner={project.owner}
           shareId={project.shareId}
           onProjectUpdate={onProjectUpdate}
+          onRequestMove={onRequestProjectMove}
+          hasAnyFolder={hasAnyFolder}
         />
       </div>
     ));
 
     const allItems = showCreateCard
       ? [
+          ...folderItems,
           ...projectItems,
           <NewProjectListItem
             key="new-project"
             onClick={() => setNewProjectDialogOpen(true)}
           />,
         ]
-      : projectItems;
+      : [...folderItems, ...projectItems];
 
     return (
       <div className="flex flex-col space-y-3 w-full">
@@ -133,7 +189,27 @@ const ProjectsList = ({
     );
   }
 
-  // Grid mode
+  // Grid mode — folders first, projects second; matches Windows / macOS Finder.
+  const folderCards = folders.map(folder => (
+    <div
+      key={`folder-${folder.id}`}
+      className="animate-in fade-in zoom-in-95 duration-500"
+    >
+      <FolderCard
+        id={folder.id}
+        name={folder.name}
+        onOpen={() => onOpenFolder?.(folder.id)}
+        onRename={() => onRenameFolder?.(folder.id, folder.name)}
+        onMove={() => onMoveFolder?.(folder.id)}
+        onDelete={() => onDeleteFolder?.(folder.id, folder.name)}
+        onDropItem={
+          onDropItem
+            ? (item, targetId) => onDropItem(item, targetId)
+            : undefined
+        }
+      />
+    </div>
+  ));
   const projectItems = projects.map((project, index) => (
     <div
       key={project.id}
@@ -153,13 +229,15 @@ const ProjectsList = ({
         owner={project.owner}
         shareId={project.shareId}
         onProjectUpdate={onProjectUpdate}
+        onRequestMove={onRequestProjectMove}
+        hasAnyFolder={hasAnyFolder}
       />
     </div>
   ));
 
   const allItems = showCreateCard
-    ? [...projectItems, <NewProjectCard key="new-project" />]
-    : projectItems;
+    ? [...folderCards, ...projectItems, <NewProjectCard key="new-project" />]
+    : [...folderCards, ...projectItems];
 
   return <ProjectsGrid>{allItems}</ProjectsGrid>;
 };

--- a/src/components/dashboard/ProjectsTab.tsx
+++ b/src/components/dashboard/ProjectsTab.tsx
@@ -1,29 +1,57 @@
 import React from 'react';
-import ProjectsList, { Project } from '@/components/ProjectsList';
+import ProjectsList, {
+  Project,
+  FolderViewItem,
+} from '@/components/ProjectsList';
+import type { DragItem } from '@/utils/dashboardDrag';
 
 interface ProjectsTabProps {
   projects: Project[];
+  folders?: FolderViewItem[];
   viewMode: 'grid' | 'list';
   loading: boolean;
   onOpenProject: (id: string) => void;
   onProjectUpdate?: (projectId: string, action: string) => void;
+  onRequestProjectMove?: (projectId: string) => void;
+  hasAnyFolder?: boolean;
+  onOpenFolder?: (folderId: string) => void;
+  onRenameFolder?: (folderId: string, currentName: string) => void;
+  onMoveFolder?: (folderId: string) => void;
+  onDeleteFolder?: (folderId: string, name: string) => void;
+  onDropItem?: (item: DragItem, targetFolderId: string | null) => void;
 }
 
 const ProjectsTab = ({
   projects,
+  folders,
   viewMode,
   loading,
   onOpenProject,
   onProjectUpdate,
+  onRequestProjectMove,
+  hasAnyFolder,
+  onOpenFolder,
+  onRenameFolder,
+  onMoveFolder,
+  onDeleteFolder,
+  onDropItem,
 }: ProjectsTabProps) => {
   return (
     <ProjectsList
       projects={projects}
+      folders={folders}
       viewMode={viewMode}
       onOpenProject={onOpenProject}
       loading={loading}
       showCreateCard={true}
       onProjectUpdate={onProjectUpdate}
+      onRequestProjectMove={onRequestProjectMove}
+      hasAnyFolder={hasAnyFolder}
+      onOpenFolder={onOpenFolder}
+      onRenameFolder={onRenameFolder}
+      onMoveFolder={onMoveFolder}
+      onDeleteFolder={onDeleteFolder}
+      onDropItem={onDropItem}
     />
   );
 };

--- a/src/components/project/CreateFolderDialog.tsx
+++ b/src/components/project/CreateFolderDialog.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { useCreateFolder } from '@/hooks/useFolders';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface CreateFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** parentId === null => create at root, else nest under the given folder. */
+  parentId: string | null;
+}
+
+/**
+ * Modal for creating a folder under the supplied parent. The dialog manages
+ * its own input state and resets on open so re-opening always starts blank.
+ * The submit handler awaits the mutation result so the toast and dismissal
+ * happen in the right order; rollback on failure is handled by the hook's
+ * onError (the optimistic insert is removed).
+ */
+const CreateFolderDialog: React.FC<CreateFolderDialogProps> = ({
+  open,
+  onOpenChange,
+  parentId,
+}) => {
+  const { t } = useLanguage();
+  const [name, setName] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const mutation = useCreateFolder();
+
+  useEffect(() => {
+    if (!open) return;
+    setName('');
+    // Focus the input on the next tick so the dialog's mount animation
+    // finishes before the field receives focus.
+    const tid = setTimeout(() => inputRef.current?.focus(), 30);
+    return () => clearTimeout(tid);
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      await mutation.mutateAsync({ name: trimmed, parentId });
+      toast.success(t('folders.created'));
+      onOpenChange(false);
+    } catch {
+      // hook's onError already surfaced toast + rolled back optimistic
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t('folders.createFolder')}</DialogTitle>
+          </DialogHeader>
+          <div className="py-4 space-y-2">
+            <Label htmlFor="folder-name">{t('folders.folderName')}</Label>
+            <Input
+              id="folder-name"
+              ref={inputRef}
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={100}
+              placeholder={String(t('folders.folderNamePlaceholder'))}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={!name.trim() || mutation.isPending}>
+              {t('folders.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateFolderDialog;

--- a/src/components/project/DeleteFolderDialog.tsx
+++ b/src/components/project/DeleteFolderDialog.tsx
@@ -47,10 +47,25 @@ const DeleteFolderDialog: React.FC<DeleteFolderDialogProps> = ({
   const handleConfirm = async () => {
     if (!folderId) return;
     try {
-      await mutation.mutateAsync(folderId);
-      toast.success(t('folders.deleted'));
-      onOpenChange(false);
-      onDeleted?.();
+      const result = await mutation.mutateAsync(folderId);
+      if (result.folderDeleted) {
+        toast.success(String(t('folders.deleted')));
+        onOpenChange(false);
+        onDeleted?.();
+      } else {
+        // Partial-failure path: some owned projects couldn't be deleted, so
+        // the folder was intentionally left in place. Surface what succeeded
+        // and what didn't; keep the dialog OPEN so the user can retry once
+        // the underlying problem is addressed.
+        toast.warning(
+          String(
+            t('folders.deletePartial', {
+              deleted: result.deletedProjectIds.length,
+              failed: result.failedProjectIds.length,
+            })
+          )
+        );
+      }
     } catch {
       // hook surfaces error toast
     }

--- a/src/components/project/DeleteFolderDialog.tsx
+++ b/src/components/project/DeleteFolderDialog.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+import { useDeleteFolder, useFolderPreview } from '@/hooks/useFolders';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface DeleteFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  folderId: string | null;
+  folderName: string;
+  /** Called with the navigation target after the delete completes. If we
+   *  deleted the folder the user was currently viewing, we navigate to the
+   *  parent. */
+  onDeleted?: () => void;
+}
+
+/**
+ * Two-step destructive dialog. While open, fetches a preview of what's
+ * inside the folder so the body text can show real counts:
+ *   "Smazat složku X? Smaže se N projektů, M podsložek a K sdílených připojení."
+ * This honours the user's "ask and delete everything (like Explorer)" choice
+ * by making the consequences explicit before the click.
+ */
+const DeleteFolderDialog: React.FC<DeleteFolderDialogProps> = ({
+  open,
+  onOpenChange,
+  folderId,
+  folderName,
+  onDeleted,
+}) => {
+  const { t } = useLanguage();
+  const { data: preview, isLoading: previewLoading } = useFolderPreview(
+    open ? folderId : null
+  );
+  const mutation = useDeleteFolder();
+
+  const handleConfirm = async () => {
+    if (!folderId) return;
+    try {
+      await mutation.mutateAsync(folderId);
+      toast.success(t('folders.deleted'));
+      onOpenChange(false);
+      onDeleted?.();
+    } catch {
+      // hook surfaces error toast
+    }
+  };
+
+  const owned = preview?.ownedProjectCount ?? 0;
+  const shared = preview?.sharedProjectCount ?? 0;
+  const subfolders = preview?.subfolderCount ?? 0;
+  const description = t('folders.deleteFolderConfirm', {
+    name: folderName,
+    projects: owned,
+    subfolders,
+    shared,
+  });
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('folders.deleteFolder')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {previewLoading ? t('common.loading') : description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={mutation.isPending}>
+            {t('common.cancel')}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-red-600 hover:bg-red-700 text-white"
+            disabled={mutation.isPending || previewLoading}
+            onClick={handleConfirm}
+          >
+            {t('common.delete')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default DeleteFolderDialog;

--- a/src/components/project/FolderActions.tsx
+++ b/src/components/project/FolderActions.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { MoreVertical, Pencil, Trash, FolderInput } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface FolderActionsProps {
+  onRename: () => void;
+  onMove: () => void;
+  onDelete: () => void;
+}
+
+/**
+ * Per-folder context menu shown in the top-right corner of FolderCard /
+ * FolderListItem. Mirrors ProjectActions in look-and-feel but exposes
+ * Rename / Move-to / Delete. "Move to…" is always available: even with
+ * a single folder, the user may still want to move it to root or pick
+ * a destination from the tree.
+ *
+ * All click handlers stop propagation so opening the menu doesn't also
+ * trigger the wrapping FolderCard's "open folder" navigation.
+ */
+const FolderActions: React.FC<FolderActionsProps> = ({
+  onRename,
+  onMove,
+  onDelete,
+}) => {
+  const { t } = useLanguage();
+
+  return (
+    <div onClick={e => e.stopPropagation()}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 rounded-full shadow-sm bg-white/80 hover:bg-white text-gray-700 dark:bg-gray-800/80 dark:hover:bg-gray-700 dark:text-gray-100 backdrop-blur-sm"
+            onClick={e => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-48"
+          onClick={e => e.stopPropagation()}
+        >
+          <DropdownMenuItem
+            onClick={e => {
+              e.stopPropagation();
+              onRename();
+            }}
+          >
+            <Pencil className="h-4 w-4 mr-2" />
+            {t('folders.rename')}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={e => {
+              e.stopPropagation();
+              onMove();
+            }}
+          >
+            <FolderInput className="h-4 w-4 mr-2" />
+            {t('folders.moveTo')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-red-600"
+            onClick={e => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash className="h-4 w-4 mr-2" />
+            {t('common.delete')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};
+
+export default FolderActions;

--- a/src/components/project/FolderBreadcrumb.tsx
+++ b/src/components/project/FolderBreadcrumb.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Home } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  readDragItem,
+  shouldAcceptOnBreadcrumb,
+  type DragItem,
+} from '@/utils/dashboardDrag';
+import { useLanguage } from '@/contexts/useLanguage';
+import type { ProjectFolder } from '@/types';
+
+export interface FolderBreadcrumbProps {
+  /** Empty array == at root; otherwise root → currentFolder, inclusive. */
+  path: ProjectFolder[];
+  onNavigate: (folderId: string | null) => void;
+  /** Drop a project/folder onto a breadcrumb segment to move it there.
+   *  `null` targetFolderId means "back to root". */
+  onDropToTarget?: (item: DragItem, targetFolderId: string | null) => void;
+}
+
+const BreadcrumbDropSpan: React.FC<{
+  targetFolderId: string | null;
+  ariaLabel: string;
+  onClick?: () => void;
+  isCurrent: boolean;
+  onDropToTarget?: (item: DragItem, targetFolderId: string | null) => void;
+  children: React.ReactNode;
+}> = ({
+  targetFolderId,
+  ariaLabel,
+  onClick,
+  isCurrent,
+  onDropToTarget,
+  children,
+}) => {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (shouldAcceptOnBreadcrumb(e.dataTransfer)) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      if (!isOver) setIsOver(true);
+    }
+  };
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsOver(false);
+    const item = readDragItem(e.dataTransfer);
+    if (!item) return;
+    // Skip move when the dragged folder is already exactly at this level —
+    // the drop would be a no-op and the toast would be misleading.
+    if (item.type === 'folder' && item.id === targetFolderId) return;
+    onDropToTarget?.(item, targetFolderId);
+  };
+
+  const className = cn(
+    'rounded px-1 transition-colors',
+    isOver && 'bg-blue-100 text-blue-800 dark:bg-blue-900/60 dark:text-blue-200'
+  );
+  const dropHandlers = {
+    onDragOver: handleDragOver,
+    onDragLeave: () => setIsOver(false),
+    onDrop: handleDrop,
+  };
+
+  if (isCurrent) {
+    return (
+      <BreadcrumbPage>
+        <span className={className} aria-label={ariaLabel} {...dropHandlers}>
+          {children}
+        </span>
+      </BreadcrumbPage>
+    );
+  }
+  return (
+    <BreadcrumbLink onClick={onClick}>
+      <span
+        className={cn(className, 'cursor-pointer')}
+        aria-label={ariaLabel}
+        {...dropHandlers}
+      >
+        {children}
+      </span>
+    </BreadcrumbLink>
+  );
+};
+
+const FolderBreadcrumb: React.FC<FolderBreadcrumbProps> = ({
+  path,
+  onNavigate,
+  onDropToTarget,
+}) => {
+  const { t } = useLanguage();
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbDropSpan
+            targetFolderId={null}
+            ariaLabel={String(t('folders.home'))}
+            isCurrent={path.length === 0}
+            onClick={() => onNavigate(null)}
+            onDropToTarget={onDropToTarget}
+          >
+            <span className="inline-flex items-center gap-1">
+              <Home className="h-3.5 w-3.5" />
+              {t('folders.home')}
+            </span>
+          </BreadcrumbDropSpan>
+        </BreadcrumbItem>
+        {path.map((node, idx) => {
+          const isLast = idx === path.length - 1;
+          return (
+            <React.Fragment key={node.id}>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbDropSpan
+                  targetFolderId={node.id}
+                  ariaLabel={node.name}
+                  isCurrent={isLast}
+                  onClick={() => onNavigate(node.id)}
+                  onDropToTarget={onDropToTarget}
+                >
+                  {node.name}
+                </BreadcrumbDropSpan>
+              </BreadcrumbItem>
+            </React.Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};
+
+export default FolderBreadcrumb;

--- a/src/components/project/FolderCard.tsx
+++ b/src/components/project/FolderCard.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Folder } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  dragSourceProps,
+  readDragItem,
+  shouldAcceptOnFolder,
+  type DragItem,
+} from '@/utils/dashboardDrag';
+import FolderActions from './FolderActions';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface FolderCardProps {
+  id: string;
+  name: string;
+  onOpen: () => void;
+  onRename: () => void;
+  onMove: () => void;
+  onDelete: () => void;
+  onDropItem?: (item: DragItem, targetFolderId: string) => void;
+}
+
+/**
+ * File-explorer style folder tile. Same aspect ratio as ProjectCard so the
+ * dashboard grid stays uniform when folders and projects are interleaved.
+ *
+ * HTML5 native DnD: the card is both a drag source (drag folder elsewhere)
+ * and a drop target (projects/other-folders land here). The drag-kind is
+ * communicated via custom MIME types in dataTransfer (see dashboardDrag.ts)
+ * so the dragover handler can preventDefault without needing access to the
+ * full payload (which the browser hides until drop for security reasons).
+ *
+ * Activation: single click opens the folder. FolderActions dropdown stops
+ * propagation on its own clicks so opening the menu doesn't also navigate
+ * into the folder.
+ */
+const FolderCard = React.memo(
+  ({
+    id,
+    name,
+    onOpen,
+    onRename,
+    onMove,
+    onDelete,
+    onDropItem,
+  }: FolderCardProps) => {
+    const { t } = useLanguage();
+    const drag = dragSourceProps({ type: 'folder', id });
+    const [isOver, setIsOver] = useState(false);
+
+    const handleDragOver = (e: React.DragEvent) => {
+      if (shouldAcceptOnFolder(id, e.dataTransfer)) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        if (!isOver) setIsOver(true);
+      }
+    };
+    const handleDragLeave = () => setIsOver(false);
+    const handleDrop = (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsOver(false);
+      const item = readDragItem(e.dataTransfer);
+      // Reject folder-into-itself at the FE so the user doesn't see a
+      // pointless round-trip toast for the no-op move.
+      if (item && !(item.type === 'folder' && item.id === id)) {
+        onDropItem?.(item, id);
+      }
+    };
+
+    return (
+      <div
+        {...drag}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={onOpen}
+        className="cursor-pointer"
+        data-folder-id={id}
+        role="button"
+        aria-label={name}
+      >
+        <Card
+          className={cn(
+            'overflow-hidden transition-all duration-200 hover:shadow-md relative',
+            isOver &&
+              'ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-gray-900'
+          )}
+        >
+          <div className="aspect-video flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/30 dark:to-blue-800/20">
+            <Folder
+              className="h-20 w-20 text-blue-500/80 dark:text-blue-400/80"
+              strokeWidth={1.2}
+            />
+            <div className="absolute top-4 right-4 z-10">
+              <FolderActions
+                onRename={onRename}
+                onMove={onMove}
+                onDelete={onDelete}
+              />
+            </div>
+          </div>
+          <CardContent className="p-5">
+            <h3 className="font-medium text-lg truncate" title={name}>
+              {name}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {t('folders.folder')}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+);
+
+FolderCard.displayName = 'FolderCard';
+
+export default FolderCard;

--- a/src/components/project/FolderListItem.tsx
+++ b/src/components/project/FolderListItem.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Folder } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  dragSourceProps,
+  readDragItem,
+  shouldAcceptOnFolder,
+  type DragItem,
+} from '@/utils/dashboardDrag';
+import FolderActions from './FolderActions';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface FolderListItemProps {
+  id: string;
+  name: string;
+  onOpen: () => void;
+  onRename: () => void;
+  onMove: () => void;
+  onDelete: () => void;
+  onDropItem?: (item: DragItem, targetFolderId: string) => void;
+}
+
+const FolderListItem = React.memo(
+  ({
+    id,
+    name,
+    onOpen,
+    onRename,
+    onMove,
+    onDelete,
+    onDropItem,
+  }: FolderListItemProps) => {
+    const { t } = useLanguage();
+    const drag = dragSourceProps({ type: 'folder', id });
+    const [isOver, setIsOver] = useState(false);
+
+    return (
+      <div
+        {...drag}
+        onDragOver={e => {
+          if (shouldAcceptOnFolder(id, e.dataTransfer)) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            if (!isOver) setIsOver(true);
+          }
+        }}
+        onDragLeave={() => setIsOver(false)}
+        onDrop={e => {
+          e.preventDefault();
+          setIsOver(false);
+          const item = readDragItem(e.dataTransfer);
+          if (item && !(item.type === 'folder' && item.id === id)) {
+            onDropItem?.(item, id);
+          }
+        }}
+        onClick={onOpen}
+        className="cursor-pointer"
+      >
+        <Card
+          className={cn(
+            'p-3 flex items-center gap-4 transition-all duration-200 hover:shadow-sm relative',
+            isOver &&
+              'ring-2 ring-blue-500 ring-offset-1 dark:ring-offset-gray-900'
+          )}
+        >
+          <div className="h-16 w-16 flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/30 dark:to-blue-800/20 rounded">
+            <Folder
+              className="h-10 w-10 text-blue-500/80 dark:text-blue-400/80"
+              strokeWidth={1.2}
+            />
+          </div>
+          <div className="flex-grow min-w-0">
+            <h3 className="font-medium truncate" title={name}>
+              {name}
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {t('folders.folder')}
+            </p>
+          </div>
+          <FolderActions
+            onRename={onRename}
+            onMove={onMove}
+            onDelete={onDelete}
+          />
+        </Card>
+      </div>
+    );
+  }
+);
+
+FolderListItem.displayName = 'FolderListItem';
+
+export default FolderListItem;

--- a/src/components/project/MoveToFolderDialog.tsx
+++ b/src/components/project/MoveToFolderDialog.tsx
@@ -77,17 +77,32 @@ const MoveToFolderDialog: React.FC<MoveToFolderDialogProps> = ({
     if (!subject) return;
     try {
       if (subject.kind === 'project') {
-        await moveProjects.mutateAsync({
+        const result = await moveProjects.mutateAsync({
           folderId: selected,
           projectIds: subject.ids,
         });
+        // Backend may silently drop projects the user can't access. Surface
+        // the partial outcome instead of pretending the whole move succeeded.
+        if (result.skippedProjectIds.length > 0) {
+          const moved = result.movedProjectIds.length;
+          const skipped = result.skippedProjectIds.length;
+          if (moved === 0) {
+            toast.warning(
+              String(t('folders.moveAllSkipped', { count: skipped }))
+            );
+          } else {
+            toast.warning(String(t('folders.movePartial', { moved, skipped })));
+          }
+        } else {
+          toast.success(String(t('folders.moved')));
+        }
       } else {
         await moveFolder.mutateAsync({
           id: subject.id,
           parentId: selected,
         });
+        toast.success(String(t('folders.moved')));
       }
-      toast.success(t('folders.moved'));
       onOpenChange(false);
     } catch {
       // hook handles error toast

--- a/src/components/project/MoveToFolderDialog.tsx
+++ b/src/components/project/MoveToFolderDialog.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Folder, Home } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+import {
+  useFolders,
+  useMoveFolder,
+  useMoveProjects,
+  type FolderNode,
+} from '@/hooks/useFolders';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export type MoveSubject =
+  | { kind: 'project'; ids: string[] }
+  | { kind: 'folder'; id: string };
+
+export interface MoveToFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  subject: MoveSubject | null;
+}
+
+/**
+ * Click-based "Move to…" picker. Shows the user's full folder tree as a
+ * nested list and lets them choose a destination (including the Root entry
+ * for "move out of any folder"). Used both from project context menus
+ * ("subject.kind === 'project'") and folder context menus ("kind === 'folder'").
+ *
+ * When subject is a folder, we hide that folder and its descendants from the
+ * picker — moving into oneself or a child is invalid and the backend would
+ * reject it anyway, so saving the user the round-trip is courtesy.
+ */
+const MoveToFolderDialog: React.FC<MoveToFolderDialogProps> = ({
+  open,
+  onOpenChange,
+  subject,
+}) => {
+  const { t } = useLanguage();
+  const { tree } = useFolders();
+  const [selected, setSelected] = useState<string | null>(null);
+  const moveProjects = useMoveProjects();
+  const moveFolder = useMoveFolder();
+
+  // Set of folder ids that should be disabled when subject is a folder
+  // (the folder itself and all its descendants — moving into oneself or a
+  // child is invalid). Walks the tree once, finds the subject, then DFSes
+  // its subtree to collect ids.
+  const disabled = useMemo(() => {
+    const out = new Set<string>();
+    if (!subject || subject.kind !== 'folder') return out;
+    const collectSubtree = (node: FolderNode) => {
+      out.add(node.id);
+      for (const c of node.children) collectSubtree(c);
+    };
+    const findSubject = (nodes: FolderNode[]): FolderNode | null => {
+      for (const n of nodes) {
+        if (n.id === subject.id) return n;
+        const inChild = findSubject(n.children);
+        if (inChild) return inChild;
+      }
+      return null;
+    };
+    const node = findSubject(tree);
+    if (node) collectSubtree(node);
+    return out;
+  }, [tree, subject]);
+
+  const handleConfirm = async () => {
+    if (!subject) return;
+    try {
+      if (subject.kind === 'project') {
+        await moveProjects.mutateAsync({
+          folderId: selected,
+          projectIds: subject.ids,
+        });
+      } else {
+        await moveFolder.mutateAsync({
+          id: subject.id,
+          parentId: selected,
+        });
+      }
+      toast.success(t('folders.moved'));
+      onOpenChange(false);
+    } catch {
+      // hook handles error toast
+    }
+  };
+
+  const pending = moveProjects.isPending || moveFolder.isPending;
+
+  const renderNode = (node: FolderNode, depth: number): React.ReactNode => {
+    const isDisabled = disabled.has(node.id);
+    return (
+      <li key={node.id}>
+        <button
+          type="button"
+          disabled={isDisabled}
+          className={cn(
+            'flex items-center gap-2 w-full px-2 py-1.5 rounded text-left',
+            'hover:bg-gray-100 dark:hover:bg-gray-800',
+            isDisabled && 'opacity-40 cursor-not-allowed',
+            selected === node.id &&
+              'bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200'
+          )}
+          style={{ paddingLeft: 8 + depth * 16 }}
+          onClick={() => !isDisabled && setSelected(node.id)}
+        >
+          <Folder className="h-4 w-4 flex-shrink-0 text-blue-500" />
+          <span className="truncate">{node.name}</span>
+        </button>
+        {node.children.length > 0 && (
+          <ul>{node.children.map(c => renderNode(c, depth + 1))}</ul>
+        )}
+      </li>
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('folders.moveTo')}</DialogTitle>
+        </DialogHeader>
+        <ul className="max-h-72 overflow-y-auto border rounded-md py-1 dark:border-gray-700">
+          <li>
+            <button
+              type="button"
+              className={cn(
+                'flex items-center gap-2 w-full px-2 py-1.5 rounded text-left',
+                'hover:bg-gray-100 dark:hover:bg-gray-800',
+                selected === null &&
+                  'bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200'
+              )}
+              onClick={() => setSelected(null)}
+            >
+              <Home className="h-4 w-4 flex-shrink-0 text-gray-500" />
+              <span>{t('folders.moveToRoot')}</span>
+            </button>
+          </li>
+          {tree.map(n => renderNode(n, 0))}
+        </ul>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleConfirm} disabled={pending}>
+            {t('common.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MoveToFolderDialog;

--- a/src/components/project/ProjectActions.tsx
+++ b/src/components/project/ProjectActions.tsx
@@ -1,7 +1,13 @@
 import { logger } from '@/lib/logger';
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { MoreVertical, Trash, Share, UserMinus } from 'lucide-react';
+import {
+  MoreVertical,
+  Trash,
+  Share,
+  UserMinus,
+  FolderInput,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -22,6 +28,13 @@ interface ProjectActionsProps {
   isShared?: boolean;
   shareId?: string;
   onProjectUpdate?: (projectId: string, action: 'delete' | 'unshare') => void;
+  /**
+   * Triggers the parent's move-to-folder dialog. When undefined or
+   * hasAnyFolder is false, the menu item is hidden (no folders to move into,
+   * so the action wouldn't make sense — file-explorer convention).
+   */
+  onRequestMove?: (projectId: string) => void;
+  hasAnyFolder?: boolean;
 }
 
 const ProjectActions = ({
@@ -31,6 +44,8 @@ const ProjectActions = ({
   isShared = false,
   shareId,
   onProjectUpdate,
+  onRequestMove,
+  hasAnyFolder = false,
 }: ProjectActionsProps) => {
   const { t } = useLanguage();
   const [loading, setLoading] = useState(false);
@@ -149,6 +164,21 @@ const ProjectActions = ({
             className="w-48"
             onClick={e => e.stopPropagation()}
           >
+            {hasAnyFolder && onRequestMove && (
+              <>
+                <DropdownMenuItem
+                  onClick={e => {
+                    e.stopPropagation();
+                    setDropdownOpen(false);
+                    onRequestMove(projectId);
+                  }}
+                >
+                  <FolderInput className="h-4 w-4 mr-2" />
+                  {t('folders.moveTo')}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
             {!isShared && (
               <>
                 <DropdownMenuItem onClick={handleShare}>

--- a/src/components/project/ProjectToolbar.tsx
+++ b/src/components/project/ProjectToolbar.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { SlidersHorizontal, Package, Trash2, Loader2 } from 'lucide-react';
+import {
+  SlidersHorizontal,
+  Package,
+  Trash2,
+  Loader2,
+  FolderPlus,
+  Plus,
+} from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -41,6 +48,13 @@ interface ProjectToolbarProps {
   // Export state callbacks
   onExportingChange?: (isExporting: boolean) => void;
   onDownloadingChange?: (isDownloading: boolean) => void;
+  /** Optional "New folder" affordance. Rendered only when provided — keeps
+   *  this toolbar reusable by the segmentation page where folders make no
+   *  sense. */
+  onCreateFolder?: () => void;
+  /** Optional "New project" trigger shown alongside the folder button.
+   *  Mirrors the dialog mode of NewProjectCard (controlled by Dashboard). */
+  onCreateProject?: () => void;
 }
 
 const ProjectToolbar = ({
@@ -67,6 +81,8 @@ const ProjectToolbar = ({
   showSelectAll = false,
   onExportingChange,
   onDownloadingChange,
+  onCreateFolder,
+  onCreateProject,
 }: ProjectToolbarProps) => {
   const { t } = useLanguage();
   const _navigate = useNavigate();
@@ -193,6 +209,30 @@ const ProjectToolbar = ({
               onChange={onSearchChange}
             />
           </div>
+        )}
+
+        {onCreateProject && (
+          <Button
+            variant="default"
+            size="sm"
+            className="flex items-center h-10 sm:h-9 justify-center"
+            onClick={onCreateProject}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            {t('common.newProject')}
+          </Button>
+        )}
+
+        {onCreateFolder && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex items-center h-10 sm:h-9 justify-center"
+            onClick={onCreateFolder}
+          >
+            <FolderPlus className="mr-1 h-4 w-4" />
+            {t('folders.newFolder')}
+          </Button>
         )}
 
         {/* Upload tlačítko zobrazit pouze pokud je požadováno */}

--- a/src/components/project/RenameFolderDialog.tsx
+++ b/src/components/project/RenameFolderDialog.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { useRenameFolder } from '@/hooks/useFolders';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface RenameFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  folderId: string;
+  currentName: string;
+}
+
+const RenameFolderDialog: React.FC<RenameFolderDialogProps> = ({
+  open,
+  onOpenChange,
+  folderId,
+  currentName,
+}) => {
+  const { t } = useLanguage();
+  const [name, setName] = useState(currentName);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const mutation = useRenameFolder();
+
+  useEffect(() => {
+    if (!open) return;
+    setName(currentName);
+    const tid = setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 30);
+    return () => clearTimeout(tid);
+  }, [open, currentName]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === currentName) {
+      onOpenChange(false);
+      return;
+    }
+    try {
+      await mutation.mutateAsync({ id: folderId, name: trimmed });
+      toast.success(t('folders.renamed'));
+      onOpenChange(false);
+    } catch {
+      // hook's onError handles toast + rollback
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t('folders.renameFolder')}</DialogTitle>
+          </DialogHeader>
+          <div className="py-4 space-y-2">
+            <Label htmlFor="folder-rename">{t('folders.folderName')}</Label>
+            <Input
+              id="folder-rename"
+              ref={inputRef}
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={100}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={!name.trim() || mutation.isPending}>
+              {t('common.save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RenameFolderDialog;

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import apiClient from '@/lib/api';
-import en from '@/translations/en';
-import cs from '@/translations/cs';
-import es from '@/translations/es';
-import fr from '@/translations/fr';
-import de from '@/translations/de';
-import zh from '@/translations/zh';
 import { useAuth } from '@/contexts/exports';
 import { getErrorMessage } from '@/types';
 import { logger } from '@/lib/logger';
@@ -14,82 +14,133 @@ import {
   LanguageContext,
   type Language,
   type Translations,
-  // type LanguageContextType,
 } from './LanguageContext.types';
 
-// Language and Translations types are exported from './exports' to avoid Fast Refresh warnings
-
-const translations = {
-  en,
-  cs,
-  es,
-  fr,
-  de,
-  zh,
+// Dynamic loaders — each language bundles into its own chunk via Vite's
+// import() splitting. The initial app bundle ships ONE language (the
+// user's preferred or browser default), not all six (which was ~150 KB
+// of unused JSON-shaped TypeScript before this change).
+const TRANSLATION_LOADERS: Record<Language, () => Promise<Translations>> = {
+  en: () => import('@/translations/en').then(m => m.default as Translations),
+  cs: () => import('@/translations/cs').then(m => m.default as Translations),
+  es: () => import('@/translations/es').then(m => m.default as Translations),
+  fr: () => import('@/translations/fr').then(m => m.default as Translations),
+  de: () => import('@/translations/de').then(m => m.default as Translations),
+  zh: () => import('@/translations/zh').then(m => m.default as Translations),
 };
+
+const SUPPORTED_LANGUAGES = Object.keys(TRANSLATION_LOADERS) as Language[];
+
+// Module-scope cache so a language re-selection across mount/unmount
+// doesn't re-fetch the chunk; the dynamic import is already cached by
+// the bundler but keeping the parsed module avoids re-instantiation.
+const _translationCache = new Map<Language, Translations>();
+
+async function loadTranslation(lang: Language): Promise<Translations> {
+  const cached = _translationCache.get(lang);
+  if (cached) return cached;
+  const mod = await TRANSLATION_LOADERS[lang]();
+  _translationCache.set(lang, mod);
+  return mod;
+}
+
+function resolveInitialLanguage(): Language {
+  const local = localStorage.getItem('language') as Language | null;
+  if (local && SUPPORTED_LANGUAGES.includes(local)) return local;
+  const browser = navigator.language.split('-')[0];
+  if (SUPPORTED_LANGUAGES.includes(browser as Language))
+    return browser as Language;
+  return 'en';
+}
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { user } = useAuth();
-  const [language, setLanguageState] = useState<Language>('en');
-  const [loaded, setLoaded] = useState<boolean>(false);
+  const [language, setLanguageState] = useState<Language>(
+    resolveInitialLanguage
+  );
+  const [currentTranslations, setCurrentTranslations] =
+    useState<Translations | null>(null);
 
-  // Po přihlášení zkusíme načíst jazyk z uživatelského profilu
+  // Tracks whether the user manually picked a language since the
+  // profile-fetch effect last started. Set by `setLanguage` below; the
+  // effect's onSuccess handler refuses to overwrite a manual choice
+  // (otherwise a slow server profile fetch resolving AFTER a user
+  // click would silently revert the click — review pass-3 #3).
+  const manualOverrideRef = useRef(false);
+
+  // Resolve preferred language from server profile (overrides localStorage)
+  // once authenticated. Keys on `user?.id` rather than the whole user
+  // object or `language`: including `language` would re-fire the fetch
+  // each time the user picks a different locale (the effect's own
+  // setLanguageState mutates `language`, so the deps array would loop
+  // — every UI language toggle would cost an extra getUserProfile()).
+  const userId = user?.id ?? null;
   useEffect(() => {
-    const fetchUserLanguage = async () => {
-      // Nejprve zkusíme načíst z localStorage
-      const localLanguage = localStorage.getItem('language') as Language | null;
-
-      // Pokud jsme přihlášeni, zkusíme získat jazyk z profilu
-      if (user) {
-        try {
-          const profileData = await apiClient.getUserProfile();
-
-          if (profileData && profileData.preferredLang) {
-            const dbLanguage = profileData.preferredLang as Language;
-            setLanguageState(dbLanguage);
-            localStorage.setItem('language', dbLanguage);
-            setLoaded(true);
-            return;
-          }
-        } catch (error) {
-          logger.error('Error loading language preference:', error);
-        }
+    if (!userId) return;
+    let cancelled = false;
+    manualOverrideRef.current = false;
+    (async () => {
+      try {
+        const profile = await apiClient.getUserProfile();
+        const pref = profile?.preferredLang as Language | undefined;
+        if (cancelled || !pref || !SUPPORTED_LANGUAGES.includes(pref)) return;
+        if (manualOverrideRef.current) return;
+        localStorage.setItem('language', pref);
+        setLanguageState(prev => (prev === pref ? prev : pref));
+      } catch (err) {
+        logger.error('Error loading language preference:', err);
       }
-
-      // Pokud nemáme jazyk z profilu, použijeme localStorage nebo výchozí hodnotu
-      if (localLanguage && Object.keys(translations).includes(localLanguage)) {
-        setLanguageState(localLanguage);
-      } else {
-        // Pokusíme se detekovat preferovaný jazyk prohlížeče
-        const browserLanguage = navigator.language.split('-')[0];
-        if (
-          browserLanguage &&
-          Object.keys(translations).includes(browserLanguage as Language)
-        ) {
-          setLanguageState(browserLanguage as Language);
-          localStorage.setItem('language', browserLanguage);
-        } else {
-          setLanguageState('en');
-          localStorage.setItem('language', 'en');
-        }
-      }
-
-      setLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
     };
+  }, [userId]);
 
-    fetchUserLanguage();
-  }, [user]);
+  // Load the chunk for the current language. The provider returns null
+  // until the first language is resolved, so consumers never see an
+  // empty `t()`. Subsequent language switches keep the previous strings
+  // visible until the new chunk arrives — no full-page flash.
+  useEffect(() => {
+    let cancelled = false;
+    loadTranslation(language)
+      .then(strings => {
+        if (!cancelled) setCurrentTranslations(strings);
+      })
+      .catch(err => {
+        logger.error(`Failed to load translations for '${language}':`, err);
+        // Fall back to English so the app doesn't dead-lock on a missing
+        // chunk (e.g. CDN hiccup or removed locale).
+        if (language !== 'en') {
+          loadTranslation('en')
+            .then(strings => {
+              if (!cancelled) setCurrentTranslations(strings);
+            })
+            .catch(enErr => {
+              // English fallback ALSO failed — without this log the app
+              // renders a blank page forever (`currentTranslations`
+              // stays null, provider returns null) with no diagnostic.
+              logger.error(
+                'CRITICAL: English fallback translation chunk failed to load — UI will be blank until a refresh',
+                enErr
+              );
+            });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [language]);
 
-  // Funkce pro nastavení jazyka
   const setLanguage = useCallback(
     async (newLanguage: Language) => {
-      // Aktualizujeme localStorage a stav
+      // Mark manual override so an in-flight profile fetch can't
+      // stomp the user's click (review pass-3 #3).
+      manualOverrideRef.current = true;
       localStorage.setItem('language', newLanguage);
       setLanguageState(newLanguage);
 
-      // Pokud jsme přihlášeni, aktualizujeme uživatelský profil
       if (user) {
         try {
           await apiClient.updateUserProfile({ preferredLang: newLanguage });
@@ -103,38 +154,35 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
     [user]
   );
 
-  // Funkce pro překlad
+  // Stable t() identity per (language, currentTranslations) — both are
+  // primitives or refs that only change when the dictionary really
+  // changes, so memoised consumers don't re-render on every render
+  // of the provider.
   const t = useCallback(
     (key: string, options?: Record<string, unknown>): string | string[] => {
-      // Rozdělení klíče podle teček pro přístup k vnořeným objektům
+      if (!currentTranslations) return key;
       const keys = key.split('.');
-
-      // Získání překladu
-      let translation: Record<string, unknown> = translations[language];
-
+      let translation: unknown = currentTranslations;
       for (const k of keys) {
         if (
           translation &&
           typeof translation === 'object' &&
-          translation[k] !== undefined
+          (translation as Record<string, unknown>)[k] !== undefined
         ) {
-          translation = translation[k] as Record<string, unknown>;
+          translation = (translation as Record<string, unknown>)[k];
         } else {
           i18nLogger.logMissingKey(key);
           return key;
         }
       }
 
-      if (Array.isArray(translation)) {
-        return translation;
-      }
+      if (Array.isArray(translation)) return translation as string[];
 
       if (typeof translation !== 'string') {
         i18nLogger.logMissingKey(key);
         return key;
       }
 
-      // Nahrazení placeholderů
       if (options) {
         return Object.entries(options).reduce((result, [optKey, optValue]) => {
           return result.replace(
@@ -143,10 +191,9 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
           );
         }, translation);
       }
-
       return translation;
     },
-    [language]
+    [currentTranslations]
   );
 
   const value = useMemo(
@@ -154,13 +201,16 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
       language,
       setLanguage,
       t,
-      translations: translations[language] as Translations,
+      translations: (currentTranslations ?? {}) as Translations,
     }),
-    [language, setLanguage, t]
+    [language, setLanguage, t, currentTranslations]
   );
 
-  // Čekáme, dokud se nenačte jazykové nastavení
-  if (!loaded) {
+  // First-paint gate: wait for at least one translation to resolve.
+  // Subsequent language switches keep the previous strings until the
+  // new chunk arrives (no flash) because `setCurrentTranslations` is
+  // only called on success.
+  if (!currentTranslations) {
     return null;
   }
 
@@ -170,5 +220,3 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
     </LanguageContext.Provider>
   );
 };
-
-// useLanguage is exported from './exports' to avoid Fast Refresh warnings

--- a/src/hooks/useDashboardProjects.ts
+++ b/src/hooks/useDashboardProjects.ts
@@ -16,6 +16,13 @@ export interface DashboardProjectsOptions {
   sortDirection: 'asc' | 'desc';
   userId: string | undefined;
   userEmail?: string;
+  // Filter to a specific folder's contents.
+  //   undefined → flat view: owned + shared in a single merged list (legacy).
+  //   "root"    → only projects without any placement row for this user.
+  //   <uuid>    → only projects placed inside this folder (owned + shared).
+  // When set, we skip the separate getSharedProjects call and trust the
+  // backend's combined OR (owned ∪ shared) gated by the folder placement.
+  folderId?: string | 'root';
 }
 
 // Interface for project data from API including optional images
@@ -28,6 +35,7 @@ export const useDashboardProjects = ({
   sortDirection,
   userId,
   userEmail,
+  folderId,
 }: DashboardProjectsOptions) => {
   const { t } = useLanguage();
   const { signOut } = useAuth();
@@ -69,30 +77,38 @@ export const useDashboardProjects = ({
         // Add cache-busting timestamp to prevent browser cache
         const timestamp = Date.now();
 
-        // Fetch owned projects first
-        const ownedResponse = await apiClient.getProjects({ _t: timestamp });
+        // Folder-scoped view: backend already merges owned+shared and gates
+        // on placement. We skip the separate /api/shared/projects call to
+        // avoid double-counting and to keep the URL the source of truth.
+        const ownedResponse = await apiClient.getProjects({
+          _t: timestamp,
+          ...(folderId !== undefined && { folderId }),
+        });
 
-        // Try to fetch shared projects, but don't fail if it errors
-        let sharedResponse = [];
-        try {
-          const response = await apiClient.getSharedProjects({ _t: timestamp });
-          // Handle both array and wrapped response formats
-          if (Array.isArray(response)) {
-            sharedResponse = response;
-          } else if (response && typeof response === 'object') {
-            // Check for data property or projects property
-            sharedResponse = response.data || response.projects || [];
-          } else {
+        let sharedResponse: unknown[] = [];
+        if (folderId === undefined) {
+          try {
+            const response = await apiClient.getSharedProjects({
+              _t: timestamp,
+            });
+            if (Array.isArray(response)) {
+              sharedResponse = response;
+            } else if (response && typeof response === 'object') {
+              sharedResponse =
+                (response as { data?: unknown[] }).data ||
+                (response as { projects?: unknown[] }).projects ||
+                [];
+            } else {
+              sharedResponse = [];
+            }
+            logger.debug('Shared projects response loaded', 'Dashboard', {
+              count: Array.isArray(sharedResponse) ? sharedResponse.length : 0,
+            });
+          } catch (shareError) {
+            logger.error('Failed to fetch shared projects', shareError);
+            logger.warn('Failed to fetch shared projects:', shareError);
             sharedResponse = [];
           }
-          logger.debug('Shared projects response loaded', 'Dashboard', {
-            count: Array.isArray(sharedResponse) ? sharedResponse.length : 0,
-          });
-        } catch (shareError) {
-          logger.error('Failed to fetch shared projects', shareError);
-          logger.warn('Failed to fetch shared projects:', shareError);
-          sharedResponse = [];
-          // Continue with just owned projects
         }
 
         const ownedProjects = ownedResponse.projects || [];
@@ -354,7 +370,16 @@ export const useDashboardProjects = ({
         }
       }
     },
-    [userId, userEmail, sortField, sortDirection, t, navigate, signOut]
+    [
+      userId,
+      userEmail,
+      sortField,
+      sortDirection,
+      folderId,
+      t,
+      navigate,
+      signOut,
+    ]
   );
 
   // Use debounced values to prevent excessive API calls
@@ -366,6 +391,7 @@ export const useDashboardProjects = ({
     debouncedUserId,
     debouncedSortField,
     debouncedSortDirection,
+    folderId,
     fetchProjects,
   ]);
 

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -1,0 +1,242 @@
+import { useMemo } from 'react';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { toast } from 'sonner';
+import apiClient from '@/lib/api';
+import { logger } from '@/lib/logger';
+import type { ProjectFolder } from '@/types';
+
+const FOLDERS_KEY: QueryKey = ['folders'];
+
+export interface FolderNode extends ProjectFolder {
+  /** Direct children, sorted by name. Empty array for leaf folders. */
+  children: FolderNode[];
+}
+
+/**
+ * Builds a tree of FolderNodes from the flat list returned by the API.
+ *
+ * The flat shape (id + parentId) is what the wire format ships; building the
+ * tree is a pure function so it lives in a memo and re-runs only when the
+ * underlying array reference changes. Orphans (parentId pointing at a deleted
+ * folder we somehow have in cache) get re-parented to root rather than dropped,
+ * so the user never loses sight of their data.
+ */
+function buildTree(flat: ProjectFolder[]): FolderNode[] {
+  const byId = new Map<string, FolderNode>();
+  for (const f of flat) {
+    byId.set(f.id, { ...f, children: [] });
+  }
+  const roots: FolderNode[] = [];
+  for (const node of Array.from(byId.values())) {
+    if (node.parentId && byId.has(node.parentId)) {
+      byId.get(node.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  const sortByName = (a: FolderNode, b: FolderNode) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  const sortRec = (nodes: FolderNode[]) => {
+    nodes.sort(sortByName);
+    for (const n of nodes) sortRec(n.children);
+  };
+  sortRec(roots);
+  return roots;
+}
+
+/** Flat list query + memoised tree derivation. */
+export function useFolders() {
+  const query = useQuery({
+    queryKey: FOLDERS_KEY,
+    queryFn: () => apiClient.getFolders(),
+    staleTime: 60_000,
+  });
+  const tree = useMemo(
+    () => (query.data ? buildTree(query.data) : []),
+    [query.data]
+  );
+  const byId = useMemo(() => {
+    const map = new Map<string, ProjectFolder>();
+    for (const f of query.data ?? []) map.set(f.id, f);
+    return map;
+  }, [query.data]);
+  return { ...query, tree, byId };
+}
+
+/**
+ * Returns the breadcrumb chain from root → folderId, inclusive.
+ * Empty array when folderId is null (at root). Each entry is a `ProjectFolder`
+ * so callers can render with `name` and link with `id`.
+ */
+export function useFolderPath(
+  folderId: string | null,
+  byId: Map<string, ProjectFolder>
+): ProjectFolder[] {
+  return useMemo(() => {
+    if (!folderId) return [];
+    const path: ProjectFolder[] = [];
+    let cursor: string | null | undefined = folderId;
+    const seen = new Set<string>(); // defensive: stop on accidental cycle
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      const node = byId.get(cursor);
+      if (!node) break;
+      path.unshift(node);
+      cursor = node.parentId;
+    }
+    return path;
+  }, [folderId, byId]);
+}
+
+// ----- Mutations -----------------------------------------------------------
+//
+// All folder mutations invalidate ['folders'] AND any cached project list,
+// because moving a folder/project changes both. The `projects` invalidation
+// is a prefix wildcard — useDashboardProjects manages its own state, so the
+// invalidation is mostly useful for future React-Query-based callers.
+
+function invalidateAll(qc: ReturnType<typeof useQueryClient>) {
+  // Notify the (non-React-Query) useDashboardProjects state manager that
+  // its in-memory project list is stale and a refetch is needed. The
+  // listener lives in useDashboardProjects.ts and was originally wired
+  // for failed mutations; we reuse it as the universal post-move signal
+  // so the dashboard refreshes immediately after any folder operation,
+  // without forcing the user to hit F5.
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('project-refetch-needed'));
+  }
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: FOLDERS_KEY }),
+    qc.invalidateQueries({ queryKey: ['projects'] }),
+  ]);
+}
+
+export function useCreateFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { name: string; parentId?: string | null }) =>
+      apiClient.createFolder(vars),
+    onMutate: async vars => {
+      await qc.cancelQueries({ queryKey: FOLDERS_KEY });
+      const previous = qc.getQueryData<ProjectFolder[]>(FOLDERS_KEY);
+      // Optimistic insert with a temporary id; the real id replaces it on
+      // settlement when the server response arrives. Using a "tmp-" prefix
+      // makes it trivial to identify and skip in any later code that
+      // distinguishes server-persisted folders.
+      const optimistic: ProjectFolder = {
+        id: `tmp-${Date.now()}`,
+        name: vars.name,
+        parentId: vars.parentId ?? null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      qc.setQueryData<ProjectFolder[]>(FOLDERS_KEY, [
+        ...(previous ?? []),
+        optimistic,
+      ]);
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
+      logger.error('Failed to create folder', err);
+      toast.error((err as Error).message ?? 'Failed to create folder');
+    },
+    onSettled: () => invalidateAll(qc),
+  });
+}
+
+export function useRenameFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; name: string }) =>
+      apiClient.updateFolder(vars.id, { name: vars.name }),
+    onMutate: async vars => {
+      await qc.cancelQueries({ queryKey: FOLDERS_KEY });
+      const previous = qc.getQueryData<ProjectFolder[]>(FOLDERS_KEY);
+      if (previous) {
+        qc.setQueryData<ProjectFolder[]>(
+          FOLDERS_KEY,
+          previous.map(f => (f.id === vars.id ? { ...f, name: vars.name } : f))
+        );
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
+      logger.error('Failed to rename folder', err);
+      toast.error((err as Error).message ?? 'Failed to rename folder');
+    },
+    onSettled: () => invalidateAll(qc),
+  });
+}
+
+export function useMoveFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; parentId: string | null }) =>
+      apiClient.updateFolder(vars.id, { parentId: vars.parentId }),
+    onMutate: async vars => {
+      await qc.cancelQueries({ queryKey: FOLDERS_KEY });
+      const previous = qc.getQueryData<ProjectFolder[]>(FOLDERS_KEY);
+      if (previous) {
+        qc.setQueryData<ProjectFolder[]>(
+          FOLDERS_KEY,
+          previous.map(f =>
+            f.id === vars.id ? { ...f, parentId: vars.parentId } : f
+          )
+        );
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
+      logger.error('Failed to move folder', err);
+      toast.error((err as Error).message ?? 'Failed to move folder');
+    },
+    onSettled: () => invalidateAll(qc),
+  });
+}
+
+export function useDeleteFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiClient.deleteFolder(id),
+    // No optimistic removal — the cascade may affect many projects; we'd
+    // rather wait for the server's verdict than show partial UI. Errors
+    // here are user-facing (cycle, permission), not "stale optimistic state".
+    onError: err => {
+      logger.error('Failed to delete folder', err);
+      toast.error((err as Error).message ?? 'Failed to delete folder');
+    },
+    onSettled: () => invalidateAll(qc),
+  });
+}
+
+export function useMoveProjects() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { folderId: string | null; projectIds: string[] }) =>
+      apiClient.moveProjectsToFolder(vars.folderId, vars.projectIds),
+    onError: err => {
+      logger.error('Failed to move projects', err);
+      toast.error((err as Error).message ?? 'Failed to move projects');
+    },
+    onSettled: () => invalidateAll(qc),
+  });
+}
+
+/** Pre-flight count of folder contents for the delete-confirmation dialog. */
+export function useFolderPreview(folderId: string | null) {
+  return useQuery({
+    queryKey: ['folder-preview', folderId],
+    queryFn: () =>
+      folderId ? apiClient.previewFolder(folderId) : Promise.resolve(null),
+    enabled: !!folderId,
+    staleTime: 5_000,
+  });
+}

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -93,6 +93,33 @@ export function useFolderPath(
   }, [folderId, byId]);
 }
 
+/**
+ * Pulls the user-facing message out of an axios error. Backend errors come
+ * through axios as `err.response.data = { success: false, error, code, ... }`
+ * — the `error` field is the localized server message (Czech text from
+ * `FolderError`). Falling back to `err.message` alone shows
+ * "Request failed with status code 409" which is meaningless to users.
+ * Order of preference:
+ *   1. response.data.error    (FolderError envelope from backend)
+ *   2. response.data.message  (legacy success/info envelope)
+ *   3. native err.message     (network errors, no response body)
+ *   4. supplied fallback
+ */
+function extractServerMessage(err: unknown, fallback: string): string {
+  const axiosErr = err as
+    | {
+        response?: { data?: { error?: string; message?: string } };
+        message?: string;
+      }
+    | undefined;
+  return (
+    axiosErr?.response?.data?.error ??
+    axiosErr?.response?.data?.message ??
+    axiosErr?.message ??
+    fallback
+  );
+}
+
 // ----- Mutations -----------------------------------------------------------
 //
 // All folder mutations invalidate ['folders'] AND any cached project list,
@@ -144,7 +171,7 @@ export function useCreateFolder() {
     onError: (err, _vars, ctx) => {
       if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
       logger.error('Failed to create folder', err);
-      toast.error((err as Error).message ?? 'Failed to create folder');
+      toast.error(extractServerMessage(err, 'Failed to create folder'));
     },
     onSettled: () => invalidateAll(qc),
   });
@@ -169,7 +196,7 @@ export function useRenameFolder() {
     onError: (err, _vars, ctx) => {
       if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
       logger.error('Failed to rename folder', err);
-      toast.error((err as Error).message ?? 'Failed to rename folder');
+      toast.error(extractServerMessage(err, 'Failed to rename folder'));
     },
     onSettled: () => invalidateAll(qc),
   });
@@ -196,7 +223,7 @@ export function useMoveFolder() {
     onError: (err, _vars, ctx) => {
       if (ctx?.previous) qc.setQueryData(FOLDERS_KEY, ctx.previous);
       logger.error('Failed to move folder', err);
-      toast.error((err as Error).message ?? 'Failed to move folder');
+      toast.error(extractServerMessage(err, 'Failed to move folder'));
     },
     onSettled: () => invalidateAll(qc),
   });
@@ -211,7 +238,7 @@ export function useDeleteFolder() {
     // here are user-facing (cycle, permission), not "stale optimistic state".
     onError: err => {
       logger.error('Failed to delete folder', err);
-      toast.error((err as Error).message ?? 'Failed to delete folder');
+      toast.error(extractServerMessage(err, 'Failed to delete folder'));
     },
     onSettled: () => invalidateAll(qc),
   });
@@ -224,7 +251,7 @@ export function useMoveProjects() {
       apiClient.moveProjectsToFolder(vars.folderId, vars.projectIds),
     onError: err => {
       logger.error('Failed to move projects', err);
-      toast.error((err as Error).message ?? 'Failed to move projects');
+      toast.error(extractServerMessage(err, 'Failed to move projects'));
     },
     onSettled: () => invalidateAll(qc),
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1450,13 +1450,15 @@ class ApiClient {
     imageIds: string[],
     model?: string,
     threshold?: number,
-    detectHoles?: boolean
+    detectHoles?: boolean,
+    channel?: string
   ): Promise<SegmentationResult> {
     const response = await this.instance.post(`/segmentation/batch`, {
       imageIds,
       model: model || 'hrnet',
       threshold: threshold || 0.5,
       detectHoles: detectHoles,
+      ...(channel ? { channel } : {}),
     });
     return this.extractData(response);
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -145,6 +145,22 @@ export interface SegmentationResult {
   updatedAt: string;
 }
 
+/** Actual shape returned by POST /api/segmentation/batch — the
+ *  controller wraps each image's outcome in this envelope and returns
+ *  HTTP 200 even when EVERY image failed. The previous typing claimed
+ *  `SegmentationResult` (a single result) which let the FE silently
+ *  treat all-failed batches as successes (false-green toast). */
+export interface BatchSegmentationResult {
+  successful: number;
+  failed: number;
+  results: Array<{
+    imageId: string;
+    success: boolean;
+    error?: string;
+    result?: SegmentationResult;
+  }>;
+}
+
 export interface QueueItem {
   id: string;
   imageId: string;
@@ -676,6 +692,15 @@ class ApiClient {
       result.image_count = imageCount;
     }
 
+    // Per-user folder placement. Backend returns `folderId: string | null`
+    // on each project; the FE always reads the canonical camelCase name. We
+    // explicitly copy `null` (not just truthy values) so callers can
+    // distinguish "at root" (folderId === null) from "not loaded yet"
+    // (folderId === undefined).
+    if (project.folderId !== undefined) {
+      result.folderId = (project.folderId as string | null) ?? null;
+    }
+
     return result;
   }
 
@@ -783,6 +808,9 @@ class ApiClient {
     page?: number;
     limit?: number;
     search?: string;
+    // "root" filters to projects without any folder placement; a uuid filters
+    // to a specific folder owned by the caller; undefined means no filter.
+    folderId?: string | 'root';
     _t?: number; // Cache-busting timestamp
   }): Promise<{
     projects: Project[];
@@ -898,6 +926,65 @@ class ApiClient {
   async deleteProject(id: string): Promise<void> {
     await this.instance.delete(`/projects/${id}`);
   }
+
+  // ---- Project folders --------------------------------------------------
+  //
+  // Folder tree is per-user (a placement of A's project in B's folder is B's
+  // organisation only and never visible to A). All endpoints require auth.
+
+  async getFolders(): Promise<import('@/types').ProjectFolder[]> {
+    const response = await this.instance.get('/folders');
+    const folders = this.extractData<unknown>(response);
+    return Array.isArray(folders)
+      ? (folders as import('@/types').ProjectFolder[])
+      : [];
+  }
+
+  async createFolder(data: {
+    name: string;
+    parentId?: string | null;
+  }): Promise<import('@/types').ProjectFolder> {
+    const response = await this.instance.post('/folders', data);
+    return this.extractData<import('@/types').ProjectFolder>(response);
+  }
+
+  async updateFolder(
+    id: string,
+    patch: { name?: string; parentId?: string | null }
+  ): Promise<import('@/types').ProjectFolder> {
+    const response = await this.instance.patch(`/folders/${id}`, patch);
+    return this.extractData<import('@/types').ProjectFolder>(response);
+  }
+
+  async deleteFolder(id: string): Promise<{
+    deletedProjectIds: string[];
+    unlinkedSharedProjectIds: string[];
+  }> {
+    const response = await this.instance.delete(`/folders/${id}`);
+    return this.extractData(response);
+  }
+
+  async previewFolder(id: string): Promise<{
+    folderId: string;
+    ownedProjectCount: number;
+    sharedProjectCount: number;
+    subfolderCount: number;
+  }> {
+    const response = await this.instance.get(`/folders/${id}/preview`);
+    return this.extractData(response);
+  }
+
+  /** Move a set of projects into `folderId` (or `null` to send back to root). */
+  async moveProjectsToFolder(
+    folderId: string | null,
+    projectIds: string[]
+  ): Promise<{ movedProjectIds: string[]; skippedProjectIds: string[] }> {
+    const path =
+      folderId === null ? '/folders/root/items' : `/folders/${folderId}/items`;
+    const response = await this.instance.post(path, { projectIds });
+    return this.extractData(response);
+  }
+  // ----------------------------------------------------------------------
 
   // Sharing methods
   async shareProjectByEmail(
@@ -1451,8 +1538,12 @@ class ApiClient {
     model?: string,
     threshold?: number,
     detectHoles?: boolean,
+    // Channel override for multi-channel video frames. Forwarded to
+    // backend's `resolveChannelPath` so a TIRF_640 / TIRF_488 ND2
+    // frame gets segmented on the user-picked channel instead of the
+    // project's default `isSegmentationSource`.
     channel?: string
-  ): Promise<SegmentationResult> {
+  ): Promise<BatchSegmentationResult> {
     const response = await this.instance.post(`/segmentation/batch`, {
       imageIds,
       model: model || 'hrnet',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -957,10 +957,23 @@ class ApiClient {
   }
 
   async deleteFolder(id: string): Promise<{
+    folderDeleted: boolean;
     deletedProjectIds: string[];
     unlinkedSharedProjectIds: string[];
+    failedProjectIds: { id: string; error: string }[];
   }> {
-    const response = await this.instance.delete(`/folders/${id}`);
+    // Server returns 200 on full success and 207 on partial (some projects
+    // failed to delete; folder kept in place). axios accepts both as
+    // success by default. Either way the wire payload carries the
+    // structured DeleteFolderResult; we extract from `data` (200) or read
+    // directly from response.data (207 wraps it differently).
+    const response = await this.instance.delete(`/folders/${id}`, {
+      validateStatus: s => (s >= 200 && s < 300) || s === 207,
+    });
+    if (response.status === 207) {
+      // 207 envelope: { success: false, message, data: DeleteFolderResult }
+      return response.data?.data ?? response.data;
+    }
     return this.extractData(response);
   }
 

--- a/src/lib/rendering/FrameImageCache.ts
+++ b/src/lib/rendering/FrameImageCache.ts
@@ -1,0 +1,219 @@
+/**
+ * URL-keyed LRU cache of warm HTMLImageElement instances for video
+ * frames in the segmentation editor.
+ *
+ * Backs sliding-window prefetch around the current frame index so
+ * scrubbing the slider or playing the timeline reads from RAM instead
+ * of hitting the network. The `<img>` swap in CanvasImage /
+ * MultiChannelCanvas can mount the cached element directly and skip
+ * the HTTP roundtrip.
+ *
+ * Modeled on BoundingBoxCache (Map insertion-order LRU + hit/miss
+ * stats). Key is the canonical frame URL — channel + frameId already
+ * collapse into that, so a flat string keeps the API simple.
+ */
+const DEFAULT_MAX_ENTRIES = 200;
+/** Backoff schedule for transient prefetch failures (e.g. nginx
+ *  rate-limit 503 during initial mount burst). The schedule's length
+ *  determines `MAX_RETRIES`; bumping the tuple grows the recovery
+ *  window without touching the state machine. */
+const RETRY_DELAYS_MS = [300, 600, 1200] as const;
+type RetryCount = 0 | 1 | 2 | 3;
+
+/** Tri-state cache entry status as a discriminated union — makes
+ *  `loaded && errored` unrepresentable. `retriesUsed` only exists
+ *  while pending, since it has no meaning post-resolution. */
+type CacheStatus =
+  | { kind: 'pending'; retriesUsed: RetryCount }
+  | { kind: 'loaded' }
+  | { kind: 'errored' };
+
+interface CacheEntry {
+  image: HTMLImageElement;
+  /** Resolves once the image fully loads. Lets prefetchers `await`
+   *  the warm-up so a Play button can gate on "X frames ready". */
+  ready: Promise<HTMLImageElement>;
+  status: CacheStatus;
+}
+
+export class FrameImageCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private hits = 0;
+  private misses = 0;
+
+  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {
+    if (!Number.isFinite(maxEntries) || maxEntries < 1) {
+      throw new Error(
+        `FrameImageCache: maxEntries must be a finite number >= 1 (got ${maxEntries})`
+      );
+    }
+  }
+
+  has(url: string): boolean {
+    return this.entries.has(url);
+  }
+
+  /** True only when the image element has loaded successfully and is
+   *  safe to swap into an `<img>` or `drawImage` source. */
+  isReady(url: string): boolean {
+    return this.entries.get(url)?.status.kind === 'loaded';
+  }
+
+  /** Returns the warm image element if present, promoting it to MRU.
+   *  Use `isReady(url)` first if you need to know whether the element
+   *  has finished loading. */
+  get(url: string): HTMLImageElement | undefined {
+    const entry = this.entries.get(url);
+    if (!entry) {
+      this.misses++;
+      return undefined;
+    }
+    this.hits++;
+    // Promote to most-recently-used.
+    this.entries.delete(url);
+    this.entries.set(url, entry);
+    return entry.image;
+  }
+
+  /** Kick off a load for `url` if not already cached and return the
+   *  ready-promise. Idempotent: existing entries return their stored
+   *  promise unchanged so concurrent prefetch calls dedupe. */
+  prefetch(url: string): Promise<HTMLImageElement> {
+    const existing = this.entries.get(url);
+    if (existing) {
+      // Promote and reuse.
+      this.entries.delete(url);
+      this.entries.set(url, existing);
+      return existing.ready;
+    }
+
+    this.misses++;
+    const image = new Image();
+    image.decoding = 'async';
+    image.loading = 'eager';
+    const entry: CacheEntry = {
+      image,
+      status: { kind: 'pending', retriesUsed: 0 },
+      ready: new Promise<HTMLImageElement>((resolve, reject) => {
+        image.onload = () => {
+          entry.status = { kind: 'loaded' };
+          resolve(image);
+        };
+        image.onerror = () => {
+          // Only retry while pending; if we've already settled into
+          // loaded/errored, ignore (defensive — the browser shouldn't
+          // re-fire onerror post-onload, but better safe).
+          if (entry.status.kind !== 'pending') return;
+          const used = entry.status.retriesUsed;
+          if (used < RETRY_DELAYS_MS.length) {
+            const delay = RETRY_DELAYS_MS[used];
+            entry.status = {
+              kind: 'pending',
+              retriesUsed: (used + 1) as RetryCount,
+            };
+            window.setTimeout(() => {
+              // The entry may have been aborted/evicted while we slept;
+              // never re-fire a load against a stale element.
+              if (this.entries.get(url) !== entry) return;
+              // Setting src='' then re-assigning the same URL forces
+              // the browser to retrigger the request; assigning the
+              // same value without the reset would be a no-op.
+              entry.image.src = '';
+              entry.image.src = url;
+            }, delay);
+            return;
+          }
+          entry.status = { kind: 'errored' };
+          reject(
+            new Error(
+              `FrameImageCache: failed to load ${url} after ${RETRY_DELAYS_MS.length} retries`
+            )
+          );
+        };
+      }),
+    };
+    // Swallow unhandled rejections — consumers that care `await`
+    // the promise; consumers that just warm the cache don't.
+    entry.ready.catch(() => {});
+    image.src = url;
+    this.entries.set(url, entry);
+    this.evictIfOverflow();
+    return entry.ready;
+  }
+
+  /** Abort an in-flight load by clearing the element's src. Used by
+   *  prefetch hooks during cleanup so a fast scrub doesn't keep N
+   *  zombie HTTP connections open. */
+  abort(url: string): void {
+    const entry = this.entries.get(url);
+    if (!entry || entry.status.kind !== 'pending') return;
+    // Setting src='' is the documented way to cancel a pending HTTP
+    // request issued by `new Image()`. We drop the entry so the next
+    // prefetch starts fresh.
+    entry.image.src = '';
+    this.entries.delete(url);
+  }
+
+  invalidate(url: string): void {
+    this.entries.delete(url);
+  }
+
+  clear(): void {
+    for (const entry of this.entries.values()) {
+      if (entry.status.kind === 'pending') {
+        entry.image.src = '';
+      }
+    }
+    this.entries.clear();
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  getStats() {
+    const total = this.hits + this.misses;
+    let readyCount = 0;
+    let pendingCount = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.status.kind === 'loaded') readyCount++;
+      else if (entry.status.kind === 'pending') pendingCount++;
+    }
+    return {
+      size: this.entries.size,
+      ready: readyCount,
+      pending: pendingCount,
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: total === 0 ? 0 : this.hits / total,
+    };
+  }
+
+  /** How many of the given URLs are loaded and ready right now.
+   *  Used by the play-gate to decide whether the buffer is warm
+   *  enough to start playback. */
+  readyCount(urls: readonly string[]): number {
+    let count = 0;
+    for (const url of urls) {
+      if (this.isReady(url)) count++;
+    }
+    return count;
+  }
+
+  private evictIfOverflow(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) break;
+      const url = oldest.value;
+      const entry = this.entries.get(url);
+      if (entry?.status.kind === 'pending') {
+        // Cancel in-flight before evicting so we don't leak connections.
+        entry.image.src = '';
+      }
+      this.entries.delete(url);
+    }
+  }
+}
+
+/** Shared singleton — one cache for the whole editor session. The
+ *  segmentation editor lives in a single route, so a single instance
+ *  is enough; tests that need isolation can `new FrameImageCache()`. */
+export const frameImageCache = new FrameImageCache();

--- a/src/lib/rendering/__tests__/FrameImageCache.test.ts
+++ b/src/lib/rendering/__tests__/FrameImageCache.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FrameImageCache } from '../FrameImageCache';
+
+// jsdom provides a working `Image` constructor but onload doesn't fire
+// because no real network is involved. Override it so tests can drive
+// load/error transitions deterministically.
+class FakeImage {
+  src = '';
+  decoding = 'auto';
+  loading = 'auto';
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  /** Manually resolve the pending load — simulates HTTP success. */
+  _fireLoad() {
+    this.onload?.();
+  }
+  /** Manually reject the pending load — simulates HTTP error. */
+  _fireError() {
+    this.onerror?.();
+  }
+}
+
+const originalImage = global.Image;
+beforeEach(() => {
+  (global as unknown as { Image: typeof FakeImage }).Image = FakeImage;
+});
+
+afterEach(() => {
+  (global as unknown as { Image: typeof Image }).Image = originalImage;
+});
+
+describe('FrameImageCache', () => {
+  it('returns undefined and miss-stats for an unknown url', () => {
+    const cache = new FrameImageCache();
+    expect(cache.get('/missing')).toBeUndefined();
+    expect(cache.has('/missing')).toBe(false);
+    expect(cache.isReady('/missing')).toBe(false);
+    expect(cache.getStats()).toMatchObject({
+      size: 0,
+      ready: 0,
+      hits: 0,
+      misses: 1,
+    });
+  });
+
+  it('prefetch dedupes concurrent requests for the same url', () => {
+    const cache = new FrameImageCache();
+    const p1 = cache.prefetch('/a.png');
+    const p2 = cache.prefetch('/a.png');
+    expect(p1).toBe(p2);
+    expect(cache.getStats().size).toBe(1);
+  });
+
+  it('isReady flips true once onload fires', async () => {
+    const cache = new FrameImageCache();
+    const promise = cache.prefetch('/a.png');
+    expect(cache.isReady('/a.png')).toBe(false);
+
+    const img = cache.get('/a.png')! as unknown as FakeImage;
+    img._fireLoad();
+    await promise;
+
+    expect(cache.isReady('/a.png')).toBe(true);
+  });
+
+  it('rejects only after retries are exhausted', async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new FrameImageCache();
+      const promise = cache.prefetch('/broken.png');
+      // Swallow the eventual rejection so unhandled-rejection
+      // diagnostics in the test runner don't blow up — we assert
+      // on it via the wrapped promise below.
+      const settled = expect(promise).rejects.toThrow(/after 3 retries/);
+      // Each error fire schedules the next attempt via setTimeout;
+      // we need 1 initial + 3 retries = 4 onerror events. The retry
+      // body re-assigns `image.src`, which on the fake harness does
+      // NOT auto-fire — so we keep grabbing the entry's image and
+      // firing manually.
+      let img = cache.get('/broken.png')! as unknown as FakeImage;
+      img._fireError();
+      await vi.advanceTimersByTimeAsync(300);
+      img = cache.get('/broken.png')! as unknown as FakeImage;
+      img._fireError();
+      await vi.advanceTimersByTimeAsync(600);
+      img = cache.get('/broken.png')! as unknown as FakeImage;
+      img._fireError();
+      await vi.advanceTimersByTimeAsync(1200);
+      img = cache.get('/broken.png')! as unknown as FakeImage;
+      img._fireError();
+      await settled;
+      expect(cache.isReady('/broken.png')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('recovers after a transient error via automatic retry', async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new FrameImageCache();
+      const promise = cache.prefetch('/flaky.png');
+      // First attempt fails — cache should schedule retry, not reject.
+      const img1 = cache.get('/flaky.png')! as unknown as FakeImage;
+      img1._fireError();
+      // Promise must still be pending: race a sentinel that resolves
+      // immediately on the next microtask.
+      const racer = await Promise.race([
+        promise
+          .then(() => 'resolved' as const)
+          .catch(() => 'rejected' as const),
+        Promise.resolve('pending' as const),
+      ]);
+      expect(racer).toBe('pending');
+      // Advance past the first backoff and let the second attempt
+      // succeed. The same Image element is reused, so the onload
+      // handler is still attached.
+      await vi.advanceTimersByTimeAsync(300);
+      const img2 = cache.get('/flaky.png')! as unknown as FakeImage;
+      img2._fireLoad();
+      await expect(promise).resolves.toBeTruthy();
+      expect(cache.isReady('/flaky.png')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('evicts oldest entries past maxEntries', () => {
+    const cache = new FrameImageCache(2);
+    cache.prefetch('/a');
+    cache.prefetch('/b');
+    cache.prefetch('/c');
+    expect(cache.has('/a')).toBe(false);
+    expect(cache.has('/b')).toBe(true);
+    expect(cache.has('/c')).toBe(true);
+  });
+
+  it('get() promotes the entry so it survives the next eviction', () => {
+    const cache = new FrameImageCache(2);
+    cache.prefetch('/a');
+    cache.prefetch('/b');
+    // Touch /a — promotes it to MRU. /b should now evict first.
+    cache.get('/a');
+    cache.prefetch('/c');
+    expect(cache.has('/a')).toBe(true);
+    expect(cache.has('/b')).toBe(false);
+    expect(cache.has('/c')).toBe(true);
+  });
+
+  it('abort cancels pending loads and removes the entry', () => {
+    const cache = new FrameImageCache();
+    cache.prefetch('/slow.png');
+    const img = cache.get('/slow.png')! as unknown as FakeImage;
+    expect(img.src).toBe('/slow.png');
+    cache.abort('/slow.png');
+    expect(cache.has('/slow.png')).toBe(false);
+  });
+
+  it('readyCount reports loaded URLs only', async () => {
+    const cache = new FrameImageCache();
+    const a = cache.prefetch('/a');
+    cache.prefetch('/b'); // never loaded
+    (cache.get('/a')! as unknown as FakeImage)._fireLoad();
+    await a;
+    expect(cache.readyCount(['/a', '/b', '/c'])).toBe(1);
+  });
+
+  it('clear cancels pending entries and resets stats', () => {
+    const cache = new FrameImageCache();
+    cache.prefetch('/a');
+    cache.prefetch('/b');
+    cache.clear();
+    expect(cache.getStats()).toMatchObject({ size: 0, hits: 0, misses: 0 });
+  });
+});

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -147,15 +147,24 @@ const Dashboard = () => {
     async (item: DragItem, destFolderId: string | null) => {
       try {
         if (item.type === 'project') {
-          await moveProjectsMutation.mutateAsync({
+          // mutateAsync returns the backend's structured result: which
+          // projects actually moved vs which were dropped (no access).
+          // We optimistically remove BEFORE the success toast so a slow
+          // mutation doesn't show "Moved" with the card still visible.
+          if (destFolderId !== currentFolderId) {
+            removeProjectOptimistically(item.id);
+          }
+          const result = await moveProjectsMutation.mutateAsync({
             folderId: destFolderId,
             projectIds: [item.id],
           });
-          toast.success(String(t('folders.moved')));
-          // Current view is folder-scoped — drop a project out of it and the
-          // project should immediately disappear from the grid.
-          if (destFolderId !== currentFolderId) {
-            removeProjectOptimistically(item.id);
+          if (result.skippedProjectIds.length > 0) {
+            // Single-project DnD where the project was skipped means
+            // access was denied — the optimistic remove is wrong; the
+            // ['projects'] invalidation will restore it on next refetch.
+            toast.warning(String(t('folders.moveSkipped')));
+          } else {
+            toast.success(String(t('folders.moved')));
           }
         } else if (item.type === 'folder') {
           if (item.id === destFolderId) return;
@@ -166,6 +175,9 @@ const Dashboard = () => {
           toast.success(String(t('folders.moved')));
         }
       } catch (err) {
+        // The hook's onError already toasted; this only catches errors
+        // outside the mutation (e.g. removeProjectOptimistically failure)
+        // so they don't propagate as unhandled rejections.
         logger.error('DnD move failed', err);
       }
     },

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,13 +1,28 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import type { DragItem } from '@/utils/dashboardDrag';
 
 import DashboardHeader from '@/components/DashboardHeader';
 import StatsOverview from '@/components/StatsOverview';
 import { useAuth, useLanguage } from '@/contexts/exports';
 import ProjectToolbar from '@/components/project/ProjectToolbar';
 import ProjectsTab from '@/components/dashboard/ProjectsTab';
+import FolderBreadcrumb from '@/components/project/FolderBreadcrumb';
+import CreateFolderDialog from '@/components/project/CreateFolderDialog';
+import RenameFolderDialog from '@/components/project/RenameFolderDialog';
+import DeleteFolderDialog from '@/components/project/DeleteFolderDialog';
+import MoveToFolderDialog, {
+  type MoveSubject,
+} from '@/components/project/MoveToFolderDialog';
+import NewProjectCard from '@/components/NewProjectCard';
 import { useDashboardProjects } from '@/hooks/useDashboardProjects';
+import {
+  useFolders,
+  useFolderPath,
+  useMoveProjects,
+  useMoveFolder,
+} from '@/hooks/useFolders';
 import { apiClient } from '@/lib/api';
 import { logger } from '@/lib/logger';
 import { useSegmentationQueue } from '@/hooks/useSegmentationQueue';
@@ -33,6 +48,16 @@ const Dashboard = () => {
   const { user } = useAuth();
   const { t } = useLanguage();
 
+  // Folder navigation lives in the URL so reloads and shareable links keep
+  // their position. `?folder=<uuid>` => inside that folder; no query => root.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentFolderId = searchParams.get('folder');
+
+  // Effective folderId passed to the project list query. The backend accepts
+  // "root" as the literal "show projects with no placement"; mapping null →
+  // "root" makes that contract explicit in one place.
+  const projectFolderQuery: string | 'root' = currentFolderId ?? 'root';
+
   const {
     projects,
     loading,
@@ -45,7 +70,113 @@ const Dashboard = () => {
     sortDirection,
     userId: user?.id,
     userEmail: user?.email,
+    folderId: projectFolderQuery,
   });
+
+  const {
+    data: flatFolders = [],
+    tree: folderTree,
+    byId: folderById,
+    isSuccess: foldersLoaded,
+  } = useFolders();
+  const path = useFolderPath(currentFolderId, folderById);
+
+  // Folders shown in the current view = direct children of currentFolderId.
+  const visibleFolders = useMemo(() => {
+    if (currentFolderId === null) {
+      return folderTree.map(n => ({ id: n.id, name: n.name }));
+    }
+    const node = (function findNode(
+      nodes: typeof folderTree
+    ): (typeof folderTree)[number] | null {
+      for (const n of nodes) {
+        if (n.id === currentFolderId) return n;
+        const found = findNode(n.children);
+        if (found) return found;
+      }
+      return null;
+    })(folderTree);
+    return (node?.children ?? []).map(n => ({ id: n.id, name: n.name }));
+  }, [folderTree, currentFolderId]);
+
+  const hasAnyFolder = flatFolders.length > 0;
+
+  // Fallback: if the URL points at a folder that no longer exists in our
+  // tree (someone deleted it, bookmarked URL, etc.) we'd otherwise filter
+  // projects to an empty set and confuse the user with a blank gallery.
+  // Wait until the folders query *successfully resolves* (foldersLoaded =
+  // useQuery.isSuccess) before deciding — checking `flatFolders.length`
+  // alone false-positives during the initial loading phase AND when the
+  // user simply has zero folders.
+  useEffect(() => {
+    if (currentFolderId && foldersLoaded && !folderById.has(currentFolderId)) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('folder');
+      setSearchParams(next, { replace: true });
+    }
+  }, [
+    currentFolderId,
+    foldersLoaded,
+    folderById,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  // ----- Dialog state -----------------------------------------------------
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [moveSubject, setMoveSubject] = useState<MoveSubject | null>(null);
+
+  // ----- DnD: HTML5 native ------------------------------------------------
+  // We use plain draggable + onDragOver/onDrop because @dnd-kit's sensors
+  // call preventDefault on pointerdown, which silently breaks click events
+  // on the same element. Native HTML5 drag and click are separate event
+  // chains, so cards stay clickable AND draggable.
+  const moveProjectsMutation = useMoveProjects();
+  const moveFolderMutation = useMoveFolder();
+
+  const handleDropOnTarget = useCallback(
+    async (item: DragItem, destFolderId: string | null) => {
+      try {
+        if (item.type === 'project') {
+          await moveProjectsMutation.mutateAsync({
+            folderId: destFolderId,
+            projectIds: [item.id],
+          });
+          toast.success(String(t('folders.moved')));
+          // Current view is folder-scoped — drop a project out of it and the
+          // project should immediately disappear from the grid.
+          if (destFolderId !== currentFolderId) {
+            removeProjectOptimistically(item.id);
+          }
+        } else if (item.type === 'folder') {
+          if (item.id === destFolderId) return;
+          await moveFolderMutation.mutateAsync({
+            id: item.id,
+            parentId: destFolderId,
+          });
+          toast.success(String(t('folders.moved')));
+        }
+      } catch (err) {
+        logger.error('DnD move failed', err);
+      }
+    },
+    [
+      moveProjectsMutation,
+      moveFolderMutation,
+      removeProjectOptimistically,
+      currentFolderId,
+      t,
+    ]
+  );
 
   // Listen for WebSocket segmentation updates to refresh project cards
   const { lastUpdate } = useSegmentationQueue('DISABLE_GLOBAL');
@@ -55,7 +186,6 @@ const Dashboard = () => {
     const pendingToken = localStorage.getItem('pendingShareToken');
     if (!pendingToken || !user) return;
 
-    // Prevent duplicate processing by immediately removing the token
     localStorage.removeItem('pendingShareToken');
 
     let loadingToastId: string | number | undefined;
@@ -66,12 +196,10 @@ const Dashboard = () => {
         pendingToken
       );
 
-      // Show loading toast
       loadingToastId = toast.loading(t('sharing.processingInvitation'));
 
       const result = await apiClient.acceptShareInvitation(pendingToken);
 
-      // Dismiss loading toast on success
       if (loadingToastId) toast.dismiss(loadingToastId);
 
       if (!result.needsLogin) {
@@ -81,28 +209,21 @@ const Dashboard = () => {
             : undefined,
         });
 
-        // Delay to ensure database propagation and API cache refresh
-        // This prevents race conditions where shared projects are fetched before
-        // the database has fully propagated the new share relationship
         await new Promise(resolve =>
           setTimeout(resolve, SHARE_PROPAGATION_DELAY)
         );
 
-        // Refresh projects list to show the newly shared project
         await fetchProjects();
       }
     } catch (error: any) {
-      // Always dismiss loading toast on error
       if (loadingToastId) toast.dismiss(loadingToastId);
 
       logger.error('Failed to process pending share invitation:', error);
 
-      // Check if the error is because invitation was already accepted
       if (
         error?.response?.status === 409 ||
         error?.response?.data?.message?.includes('already')
       ) {
-        // Invitation was already accepted, wait for propagation and refresh
         logger.debug(
           'Share invitation was already accepted, refreshing projects'
         );
@@ -117,10 +238,8 @@ const Dashboard = () => {
         );
         await fetchProjects();
       } else if (error?.response?.status === 404) {
-        // Invalid or expired invitation
         toast.error(t('sharing.invitationInvalid'));
       } else {
-        // Show generic error for other cases
         toast.error(
           t('sharing.invitationError', 'Failed to process share invitation')
         );
@@ -129,32 +248,28 @@ const Dashboard = () => {
   }, [user, t, fetchProjects]);
 
   useEffect(() => {
-    // Process pending share invitation when user is authenticated
     if (user) {
       processPendingShareInvitation();
     }
   }, [user, processPendingShareInvitation]);
 
   useEffect(() => {
-    // Create a single debounced fetch handler to prevent rapid multiple calls
     const debouncedFetchProjects = (() => {
       let timeoutId: NodeJS.Timeout;
       return () => {
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => {
           fetchProjects();
-        }, 300); // Wait 300ms after last event before fetching
+        }, 300);
       };
     })();
 
-    // Handle image updates with optimistic UI updates
     const handleImageUpdate = (event: Event) => {
       const customEvent = event as CustomEvent;
       const detail = customEvent.detail;
 
       if (!detail?.projectId) return;
 
-      // Update project immediately with new image count and thumbnail
       const updates: Record<string, any> = {};
 
       if (detail.imageCount !== undefined) {
@@ -175,7 +290,6 @@ const Dashboard = () => {
       }
     };
 
-    // Listen for project-created events (not delete/unshare - those use direct callback)
     window.addEventListener('project-created', debouncedFetchProjects);
     window.addEventListener('project-images-updated', handleImageUpdate);
     window.addEventListener('project-image-deleted', handleImageUpdate);
@@ -187,14 +301,12 @@ const Dashboard = () => {
     };
   }, [fetchProjects, updateProjectOptimistically]);
 
-  // Refresh projects when WebSocket reports segmentation completion
   useEffect(() => {
     if (
       lastUpdate &&
       (lastUpdate.status === 'segmented' ||
         lastUpdate.status === 'no_segmentation')
     ) {
-      // Delay slightly to ensure backend has updated the image count
       const timer = setTimeout(() => {
         fetchProjects();
       }, 500);
@@ -209,16 +321,35 @@ const Dashboard = () => {
     [navigate]
   );
 
+  const handleNavigateToFolder = useCallback(
+    (folderId: string | null) => {
+      // Manipulate the query string in place so we keep any unrelated params
+      // the rest of the app may have set.
+      const next = new URLSearchParams(searchParams);
+      if (folderId === null) next.delete('folder');
+      else next.set('folder', folderId);
+      setSearchParams(next, { replace: false });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  // If the user just deleted the folder they were standing in, jump back to
+  // its parent (or root). Wired via DeleteFolderDialog's onDeleted callback.
+  const handleAfterDeleteCurrent = useCallback(() => {
+    if (!deleteTarget) return;
+    if (deleteTarget.id === currentFolderId) {
+      const me = folderById.get(currentFolderId);
+      handleNavigateToFolder(me?.parentId ?? null);
+    }
+  }, [deleteTarget, currentFolderId, folderById, handleNavigateToFolder]);
+
   const handleSort = useCallback(
     (field: 'name' | 'updatedAt' | 'segmentationStatus') => {
       let frontendField = field;
 
-      // Map field names to frontend fields (API client already handles backend mapping)
-      if (field === 'name')
-        frontendField = 'name'; // Now sort by 'name' directly
+      if (field === 'name') frontendField = 'name';
       else if (field === 'updatedAt') frontendField = 'updated_at';
 
-      // Toggle direction if same field
       const newDirection =
         frontendField === sortField
           ? sortDirection === 'asc'
@@ -234,7 +365,6 @@ const Dashboard = () => {
 
   const handleProjectUpdate = useCallback(
     (projectId: string, action: string) => {
-      // Remove project from UI immediately for delete, unshare, and access-denied actions
       if (
         action === 'delete' ||
         action === 'unshare' ||
@@ -246,10 +376,16 @@ const Dashboard = () => {
     [removeProjectOptimistically]
   );
 
-  // Memoize the StatsOverview component to prevent unnecessary re-renders
+  const handleRequestProjectMove = useCallback((projectId: string) => {
+    setMoveSubject({ kind: 'project', ids: [projectId] });
+  }, []);
+
+  const handleRequestFolderMove = useCallback((folderId: string) => {
+    setMoveSubject({ kind: 'folder', id: folderId });
+  }, []);
+
   const statsOverview = useMemo(() => <StatsOverview />, []);
 
-  // Memoize the toolbar component
   const projectToolbar = useMemo(
     () => (
       <ProjectToolbar
@@ -261,6 +397,8 @@ const Dashboard = () => {
         showSearchBar={false}
         showUploadButton={false}
         showExportButton={false}
+        onCreateProject={() => setNewProjectOpen(true)}
+        onCreateFolder={() => setCreateOpen(true)}
       />
     ),
     [sortField, sortDirection, handleSort, viewMode]
@@ -323,16 +461,62 @@ const Dashboard = () => {
                 {projectToolbar}
               </FlexBetween>
 
+              <div className="mb-4">
+                <FolderBreadcrumb
+                  path={path}
+                  onNavigate={handleNavigateToFolder}
+                  onDropToTarget={handleDropOnTarget}
+                />
+              </div>
+
               <ProjectsTab
                 projects={projects}
+                folders={visibleFolders}
                 viewMode={viewMode}
                 loading={loading}
                 onOpenProject={handleOpenProject}
                 onProjectUpdate={handleProjectUpdate}
+                onRequestProjectMove={handleRequestProjectMove}
+                hasAnyFolder={hasAnyFolder}
+                onOpenFolder={handleNavigateToFolder}
+                onRenameFolder={(id, name) => setRenameTarget({ id, name })}
+                onMoveFolder={handleRequestFolderMove}
+                onDeleteFolder={(id, name) => setDeleteTarget({ id, name })}
+                onDropItem={handleDropOnTarget}
               />
             </ContentCard>
           </div>
         </PageContainer>
+
+        {/* Folder dialogs are mounted at Dashboard level so opening one
+         *  from a nested grid card doesn't fight the card's own state. */}
+        <CreateFolderDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          parentId={currentFolderId}
+        />
+        <RenameFolderDialog
+          open={renameTarget !== null}
+          onOpenChange={open => !open && setRenameTarget(null)}
+          folderId={renameTarget?.id ?? ''}
+          currentName={renameTarget?.name ?? ''}
+        />
+        <DeleteFolderDialog
+          open={deleteTarget !== null}
+          onOpenChange={open => !open && setDeleteTarget(null)}
+          folderId={deleteTarget?.id ?? null}
+          folderName={deleteTarget?.name ?? ''}
+          onDeleted={handleAfterDeleteCurrent}
+        />
+        <MoveToFolderDialog
+          open={moveSubject !== null}
+          onOpenChange={open => !open && setMoveSubject(null)}
+          subject={moveSubject}
+        />
+        <NewProjectCard
+          isOpen={newProjectOpen}
+          onOpenChange={setNewProjectOpen}
+        />
       </div>
     </PageTransition>
   );

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -79,8 +79,8 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
     }) => {
       const { t } = useLanguage();
       // ProjectType is `'microtubules'` (plural) — `'microtubule'`
-      // (singular) is the model id from MODEL_TYPE_COMPATIBILITY, not
-      // the project type.
+      // (singular) is the model id, not the project type. Mis-comparing
+      // them silently hides the MT section on every MT project.
       const isMTProject = projectType === 'microtubules';
 
       // Distinct channels across the project's video container rows.
@@ -126,6 +126,12 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       } = useSharedAdvancedExport(projectId);
 
       const [activeTab, setActiveTab] = useState('general');
+      // `pixelToMicrometerScale != null` was the old auto-fill guard, but
+      // it collapses three distinct states (untouched, user-cleared,
+      // user-typed-zero-then-erased) into one. Tracking interaction
+      // explicitly keeps the auto-fill safe to re-run when `images`
+      // resolves after the dialog has already opened.
+      const hasUserTouchedScaleRef = useRef(false);
 
       // Notify parent component when export state changes
       useEffect(() => {
@@ -144,29 +150,22 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       }, [selectedImageIds, updateExportOptions]);
 
-      // Auto-fill the pixel-to-µm scale from the first video container's
-      // upload metadata. The sentinel ref guarantees we only fill once
-      // per dialog open — if the user clears the field intentionally,
-      // we don't re-populate it on the next images update.
-      const autoFilledScaleRef = useRef(false);
+      // Auto-fill the pixel-to-µm scale from the first image carrying
+      // upload-time calibration (ND2 voxel_size, OME-TIFF
+      // PhysicalSizeX, ImageJ TIFF). The backend bubbles each frame
+      // row's calibration down from its parent video container, so any
+      // image — frame or standalone — with a positive pixelSizeUm is
+      // a valid source. Skipped once the user has interacted with the
+      // input (see `hasUserTouchedScaleRef`).
       useEffect(() => {
-        if (autoFilledScaleRef.current) return;
-        if (exportOptions.pixelToMicrometerScale != null) {
-          // User-supplied (or previously auto-filled) value — treat as
-          // done. Future clears are now respected.
-          autoFilledScaleRef.current = true;
-          return;
-        }
-        const containerWithScale = images.find(
-          img =>
-            img.isVideoContainer &&
-            img.pixelSizeUm != null &&
-            img.pixelSizeUm > 0
+        if (hasUserTouchedScaleRef.current) return;
+        if (exportOptions.pixelToMicrometerScale != null) return;
+        const calibrated = images.find(
+          img => typeof img.pixelSizeUm === 'number' && img.pixelSizeUm > 0
         );
-        if (containerWithScale?.pixelSizeUm) {
-          autoFilledScaleRef.current = true;
+        if (calibrated?.pixelSizeUm) {
           updateExportOptions({
-            pixelToMicrometerScale: containerWithScale.pixelSizeUm,
+            pixelToMicrometerScale: calibrated.pixelSizeUm,
           });
         }
       }, [images, exportOptions.pixelToMicrometerScale, updateExportOptions]);
@@ -310,6 +309,11 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                         placeholder={t('export.scalePlaceholder')}
                         value={exportOptions.pixelToMicrometerScale || ''}
                         onChange={e => {
+                          // Any interaction disables further auto-fill —
+                          // including clearing the field, so a user who
+                          // wipes the auto-suggested value doesn't get it
+                          // silently re-applied on the next image refresh.
+                          hasUserTouchedScaleRef.current = true;
                           const value = e.target.value;
 
                           // Handle empty string
@@ -344,6 +348,21 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                   </CardContent>
                 </Card>
 
+                {/* Microtubule-only section. Rendered ABOVE the image
+                    grid because for MT projects the per-channel +
+                    band-width choices change which images make sense
+                    to export — deciding the metrics first feels more
+                    natural than scrolling past the image picker.
+                    Only mounted when projectType === 'microtubules'
+                    (intensity sampling needs the raw ND2/TIFF on disk). */}
+                {isMTProject && (
+                  <MicrotubuleMetricsSection
+                    value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
+                    onChange={next => updateExportOptions({ mtMetrics: next })}
+                    availableChannels={availableChannels}
+                  />
+                )}
+
                 <Card className="p-3 sm:p-4">
                   <CardHeader className="p-0 pb-3 sm:pb-4">
                     <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
@@ -367,18 +386,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                     />
                   </CardContent>
                 </Card>
-
-                {/* Microtubule-only section. Rendered only when the
-                    project type is `microtubule` because intensity
-                    sampling requires multi-channel video data + raw
-                    ND2/TIFF on disk. */}
-                {isMTProject && (
-                  <MicrotubuleMetricsSection
-                    value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
-                    onChange={next => updateExportOptions({ mtMetrics: next })}
-                    availableChannels={availableChannels}
-                  />
-                )}
               </TabsContent>
 
               <TabsContent

--- a/src/pages/export/components/MicrotubuleMetricsSection.tsx
+++ b/src/pages/export/components/MicrotubuleMetricsSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Wand2 } from 'lucide-react';
 import {
   Card,
@@ -40,7 +40,7 @@ export interface MicrotubuleMetricsSectionProps {
 /**
  * MT-only export controls: band thickness, background margin
  * multiplier, channel multi-select. Renders inside the export dialog's
- * General tab when ``projectType === 'microtubules'``.
+ * General tab when ``projectType === 'microtubule'``.
  *
  * The backend re-reads the original ND2/TIFF on disk so the intensity
  * numbers are derived from raw 16-bit signal (the per-channel PNGs are
@@ -51,19 +51,77 @@ export const MicrotubuleMetricsSection: React.FC<
 > = ({ value, onChange, availableChannels }) => {
   const { t } = useLanguage();
 
+  // Local text mirrors of the two numeric inputs. We need this because
+  // the previous implementation only updated the parent state when the
+  // typed value parsed AND fell in range — so a backspace (which goes
+  // through `''` → NaN → skip-update) left the input visually empty
+  // for one tick and then snapped back to the previous value, making
+  // it impossible to erase a digit. With a local string the user can
+  // freely type / delete; we propagate to the parent only when the
+  // current text is a valid integer in range, and snap back on blur
+  // if they leave the field invalid.
+  const [thicknessText, setThicknessText] = useState(String(value.thicknessPx));
+  const [marginText, setMarginText] = useState(String(value.marginMultiplier));
+
+  // Re-sync local state when the parent value changes externally
+  // (preset switch, dialog re-open). Skip when the local text already
+  // matches a clean serialisation so an in-progress edit isn't stomped
+  // by a parent re-render.
+  useEffect(() => {
+    setThicknessText(prev =>
+      prev !== '' && Number.parseInt(prev, 10) === value.thicknessPx
+        ? prev
+        : String(value.thicknessPx)
+    );
+  }, [value.thicknessPx]);
+  useEffect(() => {
+    setMarginText(prev =>
+      prev !== '' && Number.parseInt(prev, 10) === value.marginMultiplier
+        ? prev
+        : String(value.marginMultiplier)
+    );
+  }, [value.marginMultiplier]);
+
   const setEnabled = (enabled: boolean) => onChange({ ...value, enabled });
 
-  const setThickness = (raw: string) => {
+  // Integer-only validators. User explicitly asked for integers in both
+  // fields, so the margin step changed from 0.1 (float) to 1 (integer).
+  const onThicknessChange = (raw: string) => {
+    setThicknessText(raw);
+    if (raw === '') return; // allow empty intermediate state for editing
     const n = Number.parseInt(raw, 10);
-    if (Number.isFinite(n) && n >= 1 && n <= 100) {
+    if (
+      Number.isFinite(n) &&
+      n >= 1 &&
+      n <= 100 &&
+      String(n) === raw // reject decimal / leading-zero / sign noise
+    ) {
       onChange({ ...value, thicknessPx: n });
     }
   };
 
-  const setMargin = (raw: string) => {
-    const n = Number.parseFloat(raw);
-    if (Number.isFinite(n) && n >= 0 && n <= 10) {
+  const onMarginChange = (raw: string) => {
+    setMarginText(raw);
+    if (raw === '') return;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 0 && n <= 10 && String(n) === raw) {
       onChange({ ...value, marginMultiplier: n });
+    }
+  };
+
+  // On blur, if the field is empty or invalid, snap back to the last
+  // committed value so the user never leaves the form in an invalid
+  // state (the submit button would otherwise read NaN through props).
+  const onThicknessBlur = () => {
+    const n = Number.parseInt(thicknessText, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 100) {
+      setThicknessText(String(value.thicknessPx));
+    }
+  };
+  const onMarginBlur = () => {
+    const n = Number.parseInt(marginText, 10);
+    if (!Number.isFinite(n) || n < 0 || n > 10) {
+      setMarginText(String(value.marginMultiplier));
     }
   };
 
@@ -108,12 +166,14 @@ export const MicrotubuleMetricsSection: React.FC<
             <Input
               id="mt-thickness"
               type="number"
+              inputMode="numeric"
               min={1}
               max={100}
               step={1}
-              value={value.thicknessPx}
+              value={thicknessText}
               disabled={disabledInputs}
-              onChange={e => setThickness(e.target.value)}
+              onChange={e => onThicknessChange(e.target.value)}
+              onBlur={onThicknessBlur}
               className="mt-1 text-sm"
             />
             <p className="text-xs text-muted-foreground mt-1">
@@ -127,12 +187,14 @@ export const MicrotubuleMetricsSection: React.FC<
             <Input
               id="mt-margin"
               type="number"
+              inputMode="numeric"
               min={0}
               max={10}
-              step={0.1}
-              value={value.marginMultiplier}
+              step={1}
+              value={marginText}
               disabled={disabledInputs}
-              onChange={e => setMargin(e.target.value)}
+              onChange={e => onMarginChange(e.target.value)}
+              onBlur={onMarginBlur}
               className="mt-1 text-sm"
             />
             <p className="text-xs text-muted-foreground mt-1">

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -7,6 +7,7 @@ import React, {
   startTransition,
 } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuth, useLanguage, useModel } from '@/contexts/exports';
 import { useProjectData } from '@/hooks/useProjectData';
 import { sortImagesBySettings } from '@/hooks/useImageFilter';
@@ -40,13 +41,16 @@ import { isMicrotubuleInstance } from './utils/instanceColors';
 import ChannelsSection from './components/sidebar/ChannelsSection';
 import DisplaySection from './components/sidebar/DisplaySection';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
-import { SegmentChannelDialog } from '@/components/project/SegmentChannelDialog';
 import SegmentationErrorBoundary from './components/SegmentationErrorBoundary';
 
 // Canvas components
 import CanvasContainer from './components/canvas/CanvasContainer';
 import CanvasContent from './components/canvas/CanvasContent';
 import VideoFrameImage from './components/canvas/VideoFrameImage';
+import FrameWindowPrefetcher from './components/canvas/FrameWindowPrefetcher';
+import FrameLoadingGate from './components/canvas/FrameLoadingGate';
+import { polygonVisibilityManager } from '@/lib/rendering/PolygonVisibilityManager';
+import { SegmentChannelDialog } from '@/components/project/SegmentChannelDialog';
 import CanvasPolygon from './components/canvas/CanvasPolygon';
 import CanvasSvgFilters from './components/canvas/CanvasSvgFilters';
 import ModeInstructions from './components/canvas/ModeInstructions';
@@ -63,6 +67,10 @@ import EditorLayout from './components/layout/EditorLayout';
 import { VideoModeOverlay } from './components/VideoModeOverlay';
 import { ImageDisplayProvider } from './contexts/ImageDisplayContext';
 import { useVideoFrames } from './hooks/useVideoFrames';
+import {
+  getCachedSegmentationPolygons,
+  setCachedSegmentationPolygons,
+} from './hooks/segmentationPolygonCache';
 
 const EMPTY_HOVERED_VERTEX = { polygonId: null, vertexIndex: null } as const;
 
@@ -75,6 +83,11 @@ const SegmentationEditor = () => {
   const { t } = useLanguage();
   const { selectedModel, confidenceThreshold, detectHoles } = useModel();
   const navigate = useNavigate();
+  // Shared cache between the editor's primary load and the
+  // sliding-window prefetch hook. Both write/read under the
+  // canonical segmentation-results query key so a scrub-back or a
+  // pre-warmed frame paints without a network round-trip.
+  const queryClient = useQueryClient();
 
   // Track if this is the initial load (coming from Project Detail) vs internal navigation
   const isInitialLoadRef = useRef(true);
@@ -162,6 +175,14 @@ const SegmentationEditor = () => {
     width: 800,
     height: 600,
   });
+  // `loadedFrameKey` is `${imageId}::${channelsKey}` — both axes
+  // need to match before the Skeleton overlay can step aside.
+  // Tracking just `imageId` would let a channel toggle keep a stale
+  // composite painted while the new channel still decodes.
+  // The debounce that latches "show overlay" lives inside
+  // `FrameLoadingGate`, which is rendered under ImageDisplayProvider
+  // (it needs `visibleChannels` to construct the target key).
+  const [loadedFrameKey, setLoadedFrameKey] = useState<string | null>(null);
 
   // Use custom hook for segmentation reload logic
   const { isReloading, reloadSegmentation, cleanupReloadOperations } =
@@ -609,6 +630,29 @@ const SegmentationEditor = () => {
         return;
       }
 
+      // Cache hit: serve a previously-fetched / prefetched result
+      // without going to the network. The shared React Query cache
+      // is populated by the editor's own success path below and by
+      // the `useFrameWindowPrefetch` sliding window, so scrub-back
+      // and pre-warmed frames paint instantly.
+      const cached = getCachedSegmentationPolygons(queryClient, imageId);
+      if (cached !== undefined) {
+        if (!isMounted || imageId !== currentImageIdRef.current) return;
+        if (cached.imageWidth && cached.imageHeight) {
+          setImageDimensions({
+            width: cached.imageWidth,
+            height: cached.imageHeight,
+          });
+        } else if (selectedImage?.width && selectedImage?.height) {
+          setImageDimensions({
+            width: selectedImage.width,
+            height: selectedImage.height,
+          });
+        }
+        setSegmentationPolygons(cached.polygons);
+        return;
+      }
+
       try {
         const segmentationData = await apiClient.getSegmentationResults(
           imageId,
@@ -628,6 +672,27 @@ const SegmentationEditor = () => {
           );
           return;
         }
+
+        // Populate the shared cache with the *normalised* result so
+        // a future scrub-back or window-prefetch read can serve from
+        // RAM. Empty / 404 frames are cached as `polygons: null` to
+        // avoid retry storms on a fast scrub across non-segmented
+        // frames.
+        if (segmentationData && !segmentationData.polygons) {
+          // Backend returned a non-null payload without a polygons
+          // field — distinguishes a misshaped 200 from a legitimate
+          // "no segmentation yet" so a misconfigured response doesn't
+          // silently masquerade as empty for 60 s of staleTime.
+          logger.warn(
+            'Segmentation response present but missing polygons field — caching as empty',
+            { imageId }
+          );
+        }
+        setCachedSegmentationPolygons(queryClient, imageId, {
+          polygons: segmentationData?.polygons ?? null,
+          imageWidth: segmentationData?.imageWidth,
+          imageHeight: segmentationData?.imageHeight,
+        });
 
         // Handle empty or null segmentation gracefully
         if (!segmentationData || !segmentationData.polygons) {
@@ -748,6 +813,7 @@ const SegmentationEditor = () => {
     selectedImage?.height,
     selectedImage?.segmentationStatus,
     getSignal,
+    queryClient,
   ]);
 
   useEffect(() => {
@@ -921,7 +987,15 @@ const SegmentationEditor = () => {
   }, [abortAll]);
 
   // Handle image load to get dimensions (only if not already set from segmentation data)
-  const handleImageLoad = (width: number, height: number) => {
+  const handleImageLoad = (
+    width: number,
+    height: number,
+    channelsKey: string
+  ) => {
+    // Mark this `(imageId, channels)` pair as visible so the Skeleton
+    // overlay can step aside. The channelsKey comes from the canvas
+    // that just finished compositing — see `MultiChannelCanvas.onLoad`.
+    if (imageId) setLoadedFrameKey(`${imageId}::${channelsKey}`);
     setImageDimensions(current => {
       // Only update if dimensions are not already set from segmentation data
       if (!current) {
@@ -1072,6 +1146,10 @@ const SegmentationEditor = () => {
         frameImageId: imageId,
       });
     }
+    // Intentionally narrow deps: passing the whole `editor` object
+    // would re-fire on every render of useEnhancedSegmentationEditor
+    // (cursor moves, hovers). The destructured fields capture
+    // exactly the state this effect needs to react to.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     editor.polygons,
@@ -1198,48 +1276,17 @@ const SegmentationEditor = () => {
     [handleUpdatePolygonField]
   );
 
-  // Channel picker state for the resegment action on multi-channel
-  // video frames. `pendingResegment=true` means the user clicked
-  // Resegment in the toolbar and we're awaiting their channel choice
-  // (or running the request if only one channel exists).
-  const [showResegmentChannelDialog, setShowResegmentChannelDialog] =
-    useState(false);
-
   // Re-run ML segmentation on the currently-open frame using the
-  // user-selected model + threshold. For multi-channel video frames
-  // the parent decides which channel to feed by passing `channel`.
-  const runResegment = useCallback(
-    async (channel?: string) => {
-      if (!imageId || isResegmenting) return;
-      setIsResegmenting(true);
-      try {
-        await apiClient.requestBatchSegmentation(
-          [imageId],
-          selectedModel,
-          confidenceThreshold,
-          detectHoles,
-          channel
-        );
-        await reloadSegmentation();
-        toast.success(t('segmentation.toolbar.resegmentSuccess'));
-      } catch (err) {
-        if (handleCancelledError(err, 'resegment current frame')) return;
-        logger.error('Resegment failed', err);
-        toast.error(t('segmentation.toolbar.resegmentFailed'));
-      } finally {
-        setIsResegmenting(false);
-      }
-    },
-    [
-      imageId,
-      isResegmenting,
-      selectedModel,
-      confidenceThreshold,
-      detectHoles,
-      reloadSegmentation,
-      t,
-    ]
-  );
+  // user-selected model + threshold. Overwrites the existing
+  // `Segmentation` row on the backend (upsert). After the batch
+  // endpoint returns, we reload polygons via the existing
+  // `reloadSegmentation` hook so the canvas reflects the new result.
+  // The resegment hook chain MUST be declared after `const video = useVideoFrames(...)`
+  // because `handleResegmentCurrentFrame` captures `video.container`. Per
+  // CLAUDE.md production bug #11 + memory `feedback_react_hook_tdz_after_data_source`:
+  // useCallback/useMemo placed BEFORE the `const` they capture in deps
+  // throws "Cannot access 'X' before initialization" at runtime. Moved
+  // ~100 lines down to live next to `const video = useVideoFrames(...)`.
 
   // Convert new EditMode to legacy booleans for compatibility
   const legacyModes = useMemo(
@@ -1281,7 +1328,8 @@ const SegmentationEditor = () => {
 
   const currentImageIndex = navContext.index;
 
-  const visiblePolygons = useMemo(
+  // Stage 1: filter hidden / degenerate polygons.
+  const renderablePolygons = useMemo(
     () =>
       editor.polygons.filter(polygon => {
         if (hiddenPolygonIds.has(polygonKey(polygon)) || !polygon.points)
@@ -1291,6 +1339,39 @@ const SegmentationEditor = () => {
       }),
     [editor.polygons, hiddenPolygonIds]
   );
+
+  // Stage 2: frustum-cull off-viewport polygons via the visibility manager.
+  // The manager's internal threshold guards small counts (< 10 polygons
+  // → no culling), so MT/single-polyline cases pay zero overhead. Sperm
+  // projects with 50+ polylines at high zoom typically halve the SVG
+  // node count under this filter. We pass through `selectedPolygonId`
+  // so the manager never culls the focused polygon even if it scrolls
+  // off-screen briefly during a drag.
+  const visiblePolygons = useMemo(() => {
+    if (renderablePolygons.length < 10) return renderablePolygons;
+    const containerWidth = imageDimensions?.width || canvasWidth;
+    const containerHeight = imageDimensions?.height || canvasHeight;
+    return polygonVisibilityManager.getVisiblePolygons(renderablePolygons, {
+      zoom: editor.transform.zoom,
+      offset: {
+        x: editor.transform.translateX,
+        y: editor.transform.translateY,
+      },
+      containerWidth,
+      containerHeight,
+      selectedPolygonId: editor.selectedPolygonId,
+      forceRenderSelected: true,
+    }).visiblePolygons;
+  }, [
+    renderablePolygons,
+    editor.transform.zoom,
+    editor.transform.translateX,
+    editor.transform.translateY,
+    editor.selectedPolygonId,
+    imageDimensions,
+    canvasWidth,
+    canvasHeight,
+  ]);
 
   // Panels still consume polygon.id, so project the stable-key set
   // down per frame.
@@ -1329,94 +1410,174 @@ const SegmentationEditor = () => {
   const isVideoMode =
     !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
 
-  // Top-toolbar Resegment button entry-point. Declared here (after
-  // `video`) so React doesn't hit a TDZ on the video.container access.
-  // If the video container has more than one channel, open the picker
-  // so the user can pick which one ML should see; otherwise run.
-  const handleResegmentClick = useCallback(() => {
+  // ───────────────── Resegment chain ─────────────────
+  // Re-runs ML segmentation on the currently-open frame. Lives HERE
+  // (after `const video = useVideoFrames`) because
+  // `handleResegmentCurrentFrame` captures `video.container`; placing
+  // the useCallback above the const triggers a TDZ at runtime that
+  // the minifier surfaces as "Cannot access 'X' before initialization"
+  // (CLAUDE.md production bug #11).
+
+  // The backend enforces a per-project-type model whitelist. The
+  // user-chosen `selectedModel` is meaningful only for the generic
+  // spheroid project — typed projects must use their matching model
+  // (`spheroid_invasive` → `unet_attention_aspp` per backend's
+  // MODEL_TYPE_COMPATIBILITY) or the request gets rejected.
+  const effectiveResegmentModel = useMemo(() => {
+    if (projectType === 'microtubules') return 'microtubule';
+    if (projectType === 'sperm') return 'sperm';
+    if (projectType === 'wound') return 'wound';
+    if (projectType === 'spheroid_invasive') return 'unet_attention_aspp';
+    return selectedModel;
+  }, [projectType, selectedModel]);
+
+  // Channel picker state for multi-channel video frames.
+  const [showResegmentChannelDialog, setShowResegmentChannelDialog] =
+    useState(false);
+
+  // Pure request helper — shared by the direct (single-channel) path
+  // and the dialog's onConfirm callback.
+  const runResegment = useCallback(
+    async (channel?: string) => {
+      if (!imageId || isResegmenting) return;
+      setIsResegmenting(true);
+      try {
+        const result = await apiClient.requestBatchSegmentation(
+          [imageId],
+          effectiveResegmentModel,
+          confidenceThreshold,
+          detectHoles,
+          channel
+        );
+        // Batch endpoint returns HTTP 200 even when every image failed;
+        // surface the per-image outcome (review pass-2 silent-failure #5).
+        if (result.successful === 0) {
+          const firstError = result.results?.[0]?.error;
+          logger.error('Resegment returned 0 successes', { firstError });
+          toast.error(
+            firstError
+              ? `${t('segmentation.toolbar.resegmentFailed')}: ${firstError}`
+              : t('segmentation.toolbar.resegmentFailed')
+          );
+          return;
+        }
+        // Defense-in-depth: a 1-image call is always all-or-nothing,
+        // but if the helper is ever reused with >1 imageIds a partial
+        // failure must not be hidden by the success toast.
+        if (result.failed > 0) {
+          const firstError = result.results?.find(r => !r.success)?.error;
+          logger.warn('Resegment partial failure', { result });
+          toast.warning(
+            firstError
+              ? `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed: ${firstError})`
+              : `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed)`
+          );
+        } else {
+          toast.success(t('segmentation.toolbar.resegmentSuccess'));
+        }
+        await reloadSegmentation();
+      } catch (err) {
+        if (handleCancelledError(err, 'resegment current frame')) return;
+        logger.error('Resegment failed', err);
+        toast.error(t('segmentation.toolbar.resegmentFailed'));
+      } finally {
+        setIsResegmenting(false);
+      }
+    },
+    [
+      imageId,
+      isResegmenting,
+      effectiveResegmentModel,
+      confidenceThreshold,
+      detectHoles,
+      reloadSegmentation,
+      t,
+    ]
+  );
+
+  // Top-toolbar Resegment entry point. Multichannel videos open the
+  // channel picker first (per CLAUDE.md spec); single-channel cases
+  // commit immediately.
+  const handleResegmentCurrentFrame = useCallback(() => {
     if (!imageId || isResegmenting) return;
     const channels = video.container?.channels ?? [];
     if (channels.length > 1) {
       setShowResegmentChannelDialog(true);
-    } else {
-      void runResegment();
+      return;
     }
+    void runResegment();
   }, [imageId, isResegmenting, video.container, runResegment]);
 
+  // ─────────────── End resegment chain ───────────────
+
+  // The overlay debounce moved into `FrameLoadingGate` — it needs
+  // `visibleChannels` from ImageDisplayContext which is only mounted
+  // inside the provider subtree below.
+
   // Seed video.frameIndex from the URL imageId on first container load.
-  // The `lastSeededIdx` ref tracks the URL-matching frameIndex that the
-  // editor has *observed* React commit to state — NOT just queued.
-  // Critical: we only update the ref in a separate "observation" effect
-  // below, after frameIndex actually equals urlIdx in a render cycle.
-  // Setting it inside this seed effect (before setFrameIndex propagates)
-  // would let reverse-sync fire on stale frameIndex=0 with the marker
-  // already "matched", which is what caused the oscillation regression.
-  const lastSeededIdx = useRef<number | null>(null);
+  // useVideoFrames defaults to frame 0 internally; without this sync,
+  // opening /segmentation/<pid>/<frame97Id> would show frame 0 in the
+  // canvas and "1 / 300" in the header. We seed once, when the
+  // container metadata arrives and the URL points at a known frame.
   useEffect(() => {
     if (!isVideoMode || !video.container || !imageId) return;
     const idx = video.container.frames.findIndex(f => f.id === imageId);
     if (idx >= 0 && idx !== video.frameIndex) {
       video.setFrameIndex(idx);
     }
+    // Intentionally NOT depending on video.frameIndex — that would
+    // fight Play / scrubber on every tick. Only re-run when the URL
+    // changes or the container is first loaded.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVideoMode, video.container, imageId]);
 
-  // Observation effect: only mark `lastSeededIdx` once frameIndex
-  // actually reflects the URL's matched index in a committed render.
-  // This breaks the race where the seed effect queues a setFrameIndex
-  // call but the value hasn't propagated yet.
-  useEffect(() => {
-    if (!isVideoMode || !video.container || !imageId) return;
-    const urlIdx = video.container.frames.findIndex(f => f.id === imageId);
-    if (urlIdx >= 0 && urlIdx === video.frameIndex) {
-      lastSeededIdx.current = urlIdx;
-    }
-  }, [isVideoMode, video.container, imageId, video.frameIndex]);
-
-  // Reset seed marker when container changes — next mount must
-  // re-prioritise URL over the local frameIndex state.
-  useEffect(() => {
-    lastSeededIdx.current = null;
-  }, [videoContainerId]);
-
-  // Reverse sync: mirror video.frameIndex back into URL imageId so the
-  // segmentation loader re-fires for slider scrubs and Play. Gating
-  // logic distinguishes the initial-mount race (frameIndex=0 default
-  // while URL points elsewhere) from a real user-initiated move:
+  // Reverse sync: mirror video.frameIndex back into the URL imageId.
+  // The header slider and Play loop mutate frameIndex locally, but the
+  // segmentation loader (loadSegmentation useEffect) only re-fires when
+  // URL imageId changes — back/next buttons work because they navigate()
+  // directly, slider/play didn't. `replace: true` keeps drag scrubbing
+  // and play-loop ticks from polluting browser history.
   //
-  // - If URL imageId is NOT in container.frames → navigate (recovery
-  //   path for stale/deep links).
-  // - If URL maps to urlIdx and frameIndex === urlIdx → in sync, no-op.
-  // - Otherwise, navigate only if seed has matched URL once
-  //   (lastSeededIdx === urlIdx). Before that, frameIndex=0 is the
-  //   initial state, not a user choice.
-  //
-  // `replace: true` keeps drag scrubbing and Play ticks out of history.
+  // Playback ticks at 10 FPS need IMMEDIATE sync so each tick triggers
+  // its fetch. Manual scrubs (slider drag, arrow-key mash) are
+  // DEBOUNCED — a 40 key/s mash would otherwise fan out 40 redundant
+  // navigate() + fetch cycles per second; the slider thumb already
+  // moves locally without waiting for this sync, so we can wait
+  // until the user pauses before committing the URL.
+  // Tracks the previous render's `isPlaying` so we can detect the
+  // playback→pause transition and FLUSH any pending mismatch right
+  // away. Without this, a user pausing mid-tick would leave the URL
+  // 100-200 ms behind the slider thumb until the debounce fires.
+  const wasPlayingRef = useRef(video.isPlaying);
   useEffect(() => {
+    const justPaused = wasPlayingRef.current && !video.isPlaying;
+    wasPlayingRef.current = video.isPlaying;
+
     if (!isVideoMode || !video.container) return;
     const targetId = video.container.frames[video.frameIndex]?.id;
     if (!targetId || targetId === imageId) return;
-    const urlIdx = video.container.frames.findIndex(f => f.id === imageId);
-    if (urlIdx === -1) {
-      // URL imageId outside this container — recover by navigating to
-      // whatever frame the slider currently points at.
+
+    const commit = () => {
       startTransition(() => {
         navigate(`/segmentation/${projectId}/${targetId}`, { replace: true });
       });
+    };
+
+    if (video.isPlaying || justPaused) {
+      commit();
       return;
     }
-    if (lastSeededIdx.current !== urlIdx) {
-      // Seed for THIS URL hasn't fired yet — bail.
-      return;
-    }
-    // Seed already matched this URL; user moved off it. Sync the URL.
-    startTransition(() => {
-      navigate(`/segmentation/${projectId}/${targetId}`, { replace: true });
-    });
+
+    // Debounce window: 120 ms is short enough that a paused user
+    // pressing → once feels instant (UI thumb already moved), long
+    // enough that a held-key burst at >8/s collapses to one commit.
+    const timer = window.setTimeout(commit, 120);
+    return () => window.clearTimeout(timer);
   }, [
     isVideoMode,
     video.container,
     video.frameIndex,
+    video.isPlaying,
     imageId,
     projectId,
     navigate,
@@ -1450,6 +1611,20 @@ const SegmentationEditor = () => {
           sections, future PR), and the canvas (brightness/contrast
           CSS filter) can all read/write the same display state. */}
       <ImageDisplayProvider userId={user?.id}>
+        {/* Headless sliding-window prefetcher: warms the FrameImageCache
+            for the per-channel PNGs around `video.frameIndex` and seeds
+            the React Query cache with polygon JSON for the same window.
+            Lives inside the provider so it can consume `visibleChannels`
+            + `channel` from useImageDisplay. Disabled outside video
+            mode — standalone images don't have an upcoming-frame
+            concept. */}
+        {isVideoMode && video.container && (
+          <FrameWindowPrefetcher
+            frames={video.container.frames}
+            currentIndex={video.frameIndex}
+            enabled={isVideoMode}
+          />
+        )}
         <EditorLayout>
           {/* Header */}
           <EditorHeader
@@ -1500,7 +1675,12 @@ const SegmentationEditor = () => {
 
             {/* Center: Canvas and Top Toolbar */}
             <div className="flex-1 flex flex-col">
-              {/* Top Toolbar */}
+              {/* Top Toolbar — Resegment lives here (next to Undo/Redo)
+                  per PR #195. The button is disabled with a spinner
+                  while the batch runs; once the batch returns,
+                  `handleResegmentCurrentFrame` calls `reloadSegmentation`
+                  so the new polyline drops into the canvas without a
+                  full reload. */}
               <TopToolbar
                 canUndo={editor.canUndo}
                 canRedo={editor.canRedo}
@@ -1508,7 +1688,7 @@ const SegmentationEditor = () => {
                 handleUndo={editor.handleUndo}
                 handleRedo={editor.handleRedo}
                 handleSave={editor.handleSave}
-                onResegment={imageId ? handleResegmentClick : undefined}
+                onResegment={handleResegmentCurrentFrame}
                 isResegmenting={isResegmenting}
                 disabled={projectLoading}
                 isSaving={editor.isSaving}
@@ -1535,24 +1715,15 @@ const SegmentationEditor = () => {
                           head (useVideoFrames.currentFrame.id) and the
                           active channel (useImageDisplay.channel), so
                           scrubbing / Play / channel-switch actually
-                          swap the canvas image. Prefetch warms the
-                          next ten frames during playback so the swap
-                          is instant rather than a roundtrip per frame.
+                          swap the canvas image. The sliding-window
+                          prefetch (FrameWindowPrefetcher above) keeps
+                          the cache warm symmetrically around the
+                          current index for both scrub and playback.
                           Standalone images keep the static URL. */}
                       {selectedImage && (
                         <VideoFrameImage
                           isVideoMode={isVideoMode}
                           currentFrameId={video.currentFrame?.id ?? null}
-                          upcomingFrameIds={
-                            isVideoMode && video.isPlaying && video.container
-                              ? video.container.frames
-                                  .slice(
-                                    video.frameIndex + 1,
-                                    video.frameIndex + 11
-                                  )
-                                  .map(f => f.id)
-                              : undefined
-                          }
                           fallbackSrc={ensureBrowserCompatibleUrl(
                             selectedImage.id,
                             selectedImage.url,
@@ -1660,6 +1831,20 @@ const SegmentationEditor = () => {
                           polygons={editor.polygons}
                         />
                       </svg>
+
+                      {/* Skeleton-first loading overlay: hides the canvas
+                          while the new frame's image hasn't decoded yet.
+                          Sits *inside* CanvasContent so the pan/zoom
+                          transform aligns the overlay with the image
+                          area, not the surrounding viewport chrome. */}
+                      <FrameLoadingGate
+                        imageId={imageId ?? null}
+                        loadedFrameKey={loadedFrameKey}
+                        isVideoMode={isVideoMode}
+                        width={imageDimensions?.width || canvasWidth}
+                        height={imageDimensions?.height || canvasHeight}
+                        label={t('segmentationEditor.loadingFrame')}
+                      />
                     </CanvasContent>
 
                     {/* Mode Instructions Overlay */}
@@ -1751,27 +1936,34 @@ const SegmentationEditor = () => {
             />
           </div>
         </EditorLayout>
-        {/* Channel picker for resegment on multi-channel video frames.
-            Reuses the same dialog as project-level Segment All. */}
-        {video.container?.channels && video.container.channels.length > 1 && (
-          <SegmentChannelDialog
-            open={showResegmentChannelDialog}
-            channels={video.container.channels.map(c => c.name)}
-            defaultChannel={
-              video.container.channels.find(c => c.isSegmentationSource)
-                ?.name ?? video.container.channels[0].name
-            }
-            onConfirm={channel => {
-              setShowResegmentChannelDialog(false);
-              void runResegment(channel);
-            }}
-            onCancel={() => setShowResegmentChannelDialog(false)}
-          />
-        )}
         {/* Opt-in dev overlay: append ?perf=1 to the URL or set
             localStorage.segPerfOverlay='1'. Renders null in production
             by default — no bundle cost beyond the module itself. */}
         <FpsMeter />
+
+        {/* Channel picker for resegment on multi-channel video frames.
+            Opens when the user clicks Resegment on a video whose
+            container exposes more than one channel. The picker forwards
+            the chosen channel to `runResegment` which threads it through
+            apiClient → /segmentation/batch → segmentationService. */}
+        <SegmentChannelDialog
+          open={showResegmentChannelDialog}
+          channels={video.container?.channels?.map(c => c.name) ?? []}
+          defaultChannel={
+            // Prefer the channel currently picked as the segmentation
+            // source (so the user's first click typically just confirms);
+            // fall back to the first channel in the container.
+            video.container?.channels?.find(c => c.isSegmentationSource)
+              ?.name ??
+            video.container?.channels?.[0]?.name ??
+            ''
+          }
+          onConfirm={channel => {
+            setShowResegmentChannelDialog(false);
+            void runResegment(channel);
+          }}
+          onCancel={() => setShowResegmentChannelDialog(false)}
+        />
       </ImageDisplayProvider>
     </SegmentationErrorBoundary>
   );

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -40,6 +40,7 @@ import { isMicrotubuleInstance } from './utils/instanceColors';
 import ChannelsSection from './components/sidebar/ChannelsSection';
 import DisplaySection from './components/sidebar/DisplaySection';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
+import { SegmentChannelDialog } from '@/components/project/SegmentChannelDialog';
 import SegmentationErrorBoundary from './components/SegmentationErrorBoundary';
 
 // Canvas components
@@ -1197,39 +1198,48 @@ const SegmentationEditor = () => {
     [handleUpdatePolygonField]
   );
 
+  // Channel picker state for the resegment action on multi-channel
+  // video frames. `pendingResegment=true` means the user clicked
+  // Resegment in the toolbar and we're awaiting their channel choice
+  // (or running the request if only one channel exists).
+  const [showResegmentChannelDialog, setShowResegmentChannelDialog] =
+    useState(false);
+
   // Re-run ML segmentation on the currently-open frame using the
-  // user-selected model + threshold. Overwrites the existing
-  // `Segmentation` row on the backend (upsert). After the batch
-  // endpoint returns, we reload polygons via the existing
-  // `reloadSegmentation` hook so the canvas reflects the new result.
-  const handleResegmentCurrentFrame = useCallback(async () => {
-    if (!imageId || isResegmenting) return;
-    setIsResegmenting(true);
-    try {
-      await apiClient.requestBatchSegmentation(
-        [imageId],
-        selectedModel,
-        confidenceThreshold,
-        detectHoles
-      );
-      await reloadSegmentation();
-      toast.success(t('segmentation.toolbar.resegmentSuccess'));
-    } catch (err) {
-      if (handleCancelledError(err, 'resegment current frame')) return;
-      logger.error('Resegment failed', err);
-      toast.error(t('segmentation.toolbar.resegmentFailed'));
-    } finally {
-      setIsResegmenting(false);
-    }
-  }, [
-    imageId,
-    isResegmenting,
-    selectedModel,
-    confidenceThreshold,
-    detectHoles,
-    reloadSegmentation,
-    t,
-  ]);
+  // user-selected model + threshold. For multi-channel video frames
+  // the parent decides which channel to feed by passing `channel`.
+  const runResegment = useCallback(
+    async (channel?: string) => {
+      if (!imageId || isResegmenting) return;
+      setIsResegmenting(true);
+      try {
+        await apiClient.requestBatchSegmentation(
+          [imageId],
+          selectedModel,
+          confidenceThreshold,
+          detectHoles,
+          channel
+        );
+        await reloadSegmentation();
+        toast.success(t('segmentation.toolbar.resegmentSuccess'));
+      } catch (err) {
+        if (handleCancelledError(err, 'resegment current frame')) return;
+        logger.error('Resegment failed', err);
+        toast.error(t('segmentation.toolbar.resegmentFailed'));
+      } finally {
+        setIsResegmenting(false);
+      }
+    },
+    [
+      imageId,
+      isResegmenting,
+      selectedModel,
+      confidenceThreshold,
+      detectHoles,
+      reloadSegmentation,
+      t,
+    ]
+  );
 
   // Convert new EditMode to legacy booleans for compatibility
   const legacyModes = useMemo(
@@ -1318,6 +1328,20 @@ const SegmentationEditor = () => {
   const video = useVideoFrames(videoContainerId);
   const isVideoMode =
     !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
+
+  // Top-toolbar Resegment button entry-point. Declared here (after
+  // `video`) so React doesn't hit a TDZ on the video.container access.
+  // If the video container has more than one channel, open the picker
+  // so the user can pick which one ML should see; otherwise run.
+  const handleResegmentClick = useCallback(() => {
+    if (!imageId || isResegmenting) return;
+    const channels = video.container?.channels ?? [];
+    if (channels.length > 1) {
+      setShowResegmentChannelDialog(true);
+    } else {
+      void runResegment();
+    }
+  }, [imageId, isResegmenting, video.container, runResegment]);
 
   // Seed video.frameIndex from the URL imageId on first container load.
   // The `lastSeededIdx` ref tracks the URL-matching frameIndex that the
@@ -1471,8 +1495,6 @@ const SegmentationEditor = () => {
               onZoomIn={editor.handleZoomIn}
               onZoomOut={editor.handleZoomOut}
               onResetView={editor.handleResetView}
-              onResegment={handleResegmentCurrentFrame}
-              isResegmenting={isResegmenting}
               hasExistingPolygons={editor.getPolygons().length > 0}
             />
 
@@ -1486,6 +1508,8 @@ const SegmentationEditor = () => {
                 handleUndo={editor.handleUndo}
                 handleRedo={editor.handleRedo}
                 handleSave={editor.handleSave}
+                onResegment={imageId ? handleResegmentClick : undefined}
+                isResegmenting={isResegmenting}
                 disabled={projectLoading}
                 isSaving={editor.isSaving}
               />
@@ -1727,6 +1751,23 @@ const SegmentationEditor = () => {
             />
           </div>
         </EditorLayout>
+        {/* Channel picker for resegment on multi-channel video frames.
+            Reuses the same dialog as project-level Segment All. */}
+        {video.container?.channels && video.container.channels.length > 1 && (
+          <SegmentChannelDialog
+            open={showResegmentChannelDialog}
+            channels={video.container.channels.map(c => c.name)}
+            defaultChannel={
+              video.container.channels.find(c => c.isSegmentationSource)
+                ?.name ?? video.container.channels[0].name
+            }
+            onConfirm={channel => {
+              setShowResegmentChannelDialog(false);
+              void runResegment(channel);
+            }}
+            onCancel={() => setShowResegmentChannelDialog(false)}
+          />
+        )}
         {/* Opt-in dev overlay: append ?perf=1 to the URL or set
             localStorage.segPerfOverlay='1'. Renders null in production
             by default — no bundle cost beyond the module itself. */}

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useDeferredValue, useMemo } from 'react';
 import { Spline, Eye, EyeOff } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import { Polygon } from '@/lib/segmentation';
@@ -28,19 +28,26 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
 }) => {
   const { t } = useLanguage();
 
+  // Defer the (filter + sort) re-derivation when polygons update
+  // rapidly (e.g. during playback ticking at 10 FPS). The canvas
+  // uses the live `polygons` reference; this panel can lag a frame
+  // or two without the user noticing, but unblocks the main thread
+  // for the canvas to commit on time.
+  const deferredPolygons = useDeferredValue(polygons);
+
   // A polyline belongs in the MT panel when:
   //   (a) the ML model stamped class='microtubule' on it, OR
   //   (b) it has no partClass (i.e. not sperm) AND an mt_ instanceId
   //       (covers legacy data from before `class` was added).
   const microtubules = useMemo(
     () =>
-      polygons.filter(
+      deferredPolygons.filter(
         p =>
           p.geometry === 'polyline' &&
           !p.partClass &&
           (p.class === 'microtubule' || isMicrotubuleInstance(p.instanceId))
       ),
-    [polygons]
+    [deferredPolygons]
   );
 
   // Stable identity for sort + color: prefer trackId (preserved across

--- a/src/pages/segmentation/components/PolygonListPanel.tsx
+++ b/src/pages/segmentation/components/PolygonListPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useDeferredValue } from 'react';
 import {
   Eye,
   EyeOff,
@@ -49,6 +49,13 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
   const [editingPolygonId, setEditingPolygonId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState<string>('');
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+
+  // Defer the heavy row mapping when polygons change rapidly (playback
+  // ticks at 10 FPS, undo/redo bursts). The counter + nav handlers below
+  // still use the live `polygons` ref so the "(N)" header and Prev/Next
+  // buttons stay snappy. Only the list body lags one render — invisible
+  // during fast updates.
+  const deferredPolygons = useDeferredValue(polygons);
 
   const handleStartRename = (polygon: Polygon) => {
     setEditingPolygonId(polygon.id);
@@ -226,7 +233,7 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
         data-scroll-area="true"
       >
         <div className="p-2 space-y-1">
-          {polygons.map((polygon, index) => {
+          {deferredPolygons.map((polygon, index) => {
             const isSelected = selectedPolygonId === polygon.id;
             const isHidden = hiddenPolygonIds.has(polygon.id);
             const isEditing = editingPolygonId === polygon.id;

--- a/src/pages/segmentation/components/SpermInstancePanel.tsx
+++ b/src/pages/segmentation/components/SpermInstancePanel.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useDeferredValue,
+} from 'react';
 import { ChevronDown, ChevronRight, Plus, Spline } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import { Button } from '@/components/ui/button';
@@ -52,10 +58,16 @@ const SpermInstancePanel: React.FC<SpermInstancePanelProps> = ({
     new Set()
   );
 
+  // Defer panel re-derivation under rapid `polygons` updates (playback
+  // ticks at 10 FPS, multi-frame undo). The canvas reads live polygons;
+  // the panel can lag a render or two without user noticing — and React
+  // gets a free hand to prioritise canvas commits.
+  const deferredPolygons = useDeferredValue(polygons);
+
   // Get only polylines from polygons
   const polylines = useMemo(
-    () => polygons.filter(p => p.geometry === 'polyline'),
-    [polygons]
+    () => deferredPolygons.filter(p => p.geometry === 'polyline'),
+    [deferredPolygons]
   );
 
   // Group polylines by instanceId

--- a/src/pages/segmentation/components/TopToolbar.tsx
+++ b/src/pages/segmentation/components/TopToolbar.tsx
@@ -15,9 +15,10 @@ interface TopToolbarProps {
   handleRedo: () => void;
   handleSave: () => Promise<void>;
 
-  // Resegment action — optional; rendered to the right of Undo/Redo
-  // when provided. Parent decides whether to open a channel picker
-  // first (for multi-channel video frames) before invoking.
+  // Resegment action — rendered to the right of Undo/Redo when
+  // provided. While `isResegmenting` is true the button is disabled
+  // and shows a spinner; the polyline result re-flows through the
+  // parent's `reloadSegmentation` once the batch returns.
   onResegment?: () => void;
   isResegmenting?: boolean;
 
@@ -27,7 +28,7 @@ interface TopToolbarProps {
 }
 
 /**
- * Horizontální toolbar s ovládacími prvky (bez mode selection)
+ * Horizontální toolbar s ovládacími prvky (bez mode selection).
  */
 const TopToolbar: React.FC<TopToolbarProps> = ({
   canUndo,

--- a/src/pages/segmentation/components/TopToolbar.tsx
+++ b/src/pages/segmentation/components/TopToolbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Undo, Redo, Save } from 'lucide-react';
+import { Undo, Redo, Save, RotateCw, Loader2 } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 
 interface TopToolbarProps {
@@ -14,6 +14,12 @@ interface TopToolbarProps {
   handleUndo: () => void;
   handleRedo: () => void;
   handleSave: () => Promise<void>;
+
+  // Resegment action — optional; rendered to the right of Undo/Redo
+  // when provided. Parent decides whether to open a channel picker
+  // first (for multi-channel video frames) before invoking.
+  onResegment?: () => void;
+  isResegmenting?: boolean;
 
   // Optional props
   disabled?: boolean;
@@ -30,6 +36,8 @@ const TopToolbar: React.FC<TopToolbarProps> = ({
   handleUndo,
   handleRedo,
   handleSave,
+  onResegment,
+  isResegmenting = false,
   disabled = false,
   isSaving = false,
 }) => {
@@ -65,6 +73,25 @@ const TopToolbar: React.FC<TopToolbarProps> = ({
             {t('segmentation.toolbar.redo')}
           </span>
         </Button>
+        {onResegment && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={disabled || isResegmenting}
+            onClick={onResegment}
+            title={t('segmentation.toolbar.resegment')}
+            className="flex items-center gap-2"
+          >
+            {isResegmenting ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <RotateCw size={16} />
+            )}
+            <span className="hidden sm:inline">
+              {t('segmentation.toolbar.resegment')}
+            </span>
+          </Button>
+        )}
       </div>
 
       {/* Right side - Save Button */}

--- a/src/pages/segmentation/components/VerticalToolbar.tsx
+++ b/src/pages/segmentation/components/VerticalToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button } from '@/components/ui/button';
 import {
   MousePointer,
@@ -11,21 +11,8 @@ import {
   ZoomIn,
   ZoomOut,
   Maximize2,
-  Wand2,
-  Loader2,
 } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useLanguage } from '@/contexts/useLanguage';
-import { useModel } from '@/contexts/exports';
 import { EditMode } from '../types';
 
 interface VerticalToolbarProps {
@@ -36,8 +23,6 @@ interface VerticalToolbarProps {
   onZoomIn?: () => void;
   onZoomOut?: () => void;
   onResetView?: () => void;
-  onResegment?: () => Promise<void> | void;
-  isResegmenting?: boolean;
   hasExistingPolygons?: boolean;
 }
 
@@ -52,32 +37,9 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
   onZoomIn,
   onZoomOut,
   onResetView,
-  onResegment,
-  isResegmenting = false,
-  hasExistingPolygons = false,
+  hasExistingPolygons: _hasExistingPolygons = false,
 }) => {
   const { t } = useLanguage();
-  const { selectedModel, confidenceThreshold, getModelInfo } = useModel();
-  const [showResegmentDialog, setShowResegmentDialog] = useState(false);
-
-  const modelDisplayName = getModelInfo(selectedModel).displayName;
-  const thresholdFormatted = confidenceThreshold.toFixed(2);
-
-  const resegmentDisabled = disabled || isResegmenting || !onResegment;
-
-  const handleResegmentClick = () => {
-    if (resegmentDisabled || !onResegment) return;
-    if (hasExistingPolygons) {
-      setShowResegmentDialog(true);
-    } else {
-      void onResegment();
-    }
-  };
-
-  const handleConfirmResegment = () => {
-    setShowResegmentDialog(false);
-    if (onResegment) void onResegment();
-  };
 
   const getModeIcon = (mode: EditMode) => {
     switch (mode) {
@@ -251,45 +213,7 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
   return (
     <>
       <div className="w-14 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center py-4 gap-2 dark:bg-gray-900">
-        {/* Resegment current frame */}
-        {onResegment && (
-          <>
-            <div className="relative group">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleResegmentClick}
-                disabled={resegmentDisabled}
-                className={`
-                  w-12 h-12 rounded-lg transition-all duration-200
-                  hover:bg-indigo-100 dark:hover:bg-indigo-900/30
-                  ${resegmentDisabled ? 'opacity-50 cursor-not-allowed' : ''}
-                `}
-              >
-                {isResegmenting ? (
-                  <Loader2 size={20} className="animate-spin" />
-                ) : (
-                  <Wand2 size={20} />
-                )}
-              </Button>
-              <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 px-3 py-2 bg-black text-white text-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                <div className="font-medium">
-                  {t('segmentation.toolbar.resegment')}
-                </div>
-                <div className="text-xs text-gray-300 mt-1">
-                  {t('segmentation.toolbar.resegmentTooltipModel', {
-                    model: modelDisplayName,
-                    threshold: thresholdFormatted,
-                  })}
-                </div>
-                <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-black" />
-              </div>
-            </div>
-
-            {/* Separator below resegment */}
-            <div className="w-10 h-px bg-gray-300 dark:bg-gray-600 my-2" />
-          </>
-        )}
+        {/* Resegment lives in TopToolbar now (next to Undo/Redo). */}
 
         {/* Mode buttons */}
         <ModeButton mode={EditMode.View} />
@@ -361,28 +285,6 @@ const VerticalToolbar: React.FC<VerticalToolbarProps> = ({
           </div>
         </div>
       </div>
-
-      <AlertDialog
-        open={showResegmentDialog}
-        onOpenChange={setShowResegmentDialog}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t('segmentation.toolbar.resegmentConfirmTitle')}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('segmentation.toolbar.resegmentConfirmDescription')}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmResegment}>
-              {t('segmentation.toolbar.resegment')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 };

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -344,17 +344,18 @@ const CanvasPolygon = React.memo(
             pointerEvents={isPolyline ? 'stroke' : 'all'}
           />
 
-          {/* Polyline endpoint markers.
-              - Microtubule projects: only render when selected — the
-                MT visual identity is "plain curve on the image",
-                clutter-free in the default state.
-              - Sperm (and any other future polyline-bearing project):
-                always render the start + end dots. Sperm artwork has
-                always shown them and biologists expect that affordance
-                to mark head / tail orientation. */}
+          {/* Polyline endpoint markers — render ONLY when no draggable
+              vertices are on top (i.e. polyline not selected). When
+              selected, the `PolygonVertices` layer below paints the
+              draggable circles AT the same coordinates, and a fixed
+              marker underneath surfaces as a coloured dot when the
+              user drags the vertex — visual noise. MT projects stay
+              clutter-free in the unselected state too (no markers);
+              sperm keeps the head/tail orientation cue when idle. */}
           {isPolyline &&
+            !isSelected &&
             validPoints.length >= 2 &&
-            (projectType === 'microtubules' ? isSelected : true) && (
+            projectType !== 'microtubules' && (
               <>
                 <circle
                   cx={validPoints[0].x}

--- a/src/pages/segmentation/components/canvas/EditorFrameLoadingOverlay.tsx
+++ b/src/pages/segmentation/components/canvas/EditorFrameLoadingOverlay.tsx
@@ -1,0 +1,56 @@
+/**
+ * Full-canvas loading overlay shown while the current video frame is
+ * not yet warm in cache. Skeleton-first behaviour: the editor hides
+ * the old frame + polygons whenever the new frame is still in flight,
+ * so the canvas never flickers between two unrelated frames.
+ *
+ * The overlay disappears the moment both (a) the image is loaded in
+ * `frameImageCache` and (b) the polygon query has settled. Cache hits
+ * from `useFrameWindowPrefetch` skip the overlay entirely — a scrub
+ * inside the prefetch window paints instantly.
+ */
+
+import { Loader2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface EditorFrameLoadingOverlayProps {
+  visible: boolean;
+  width?: number;
+  height?: number;
+  label?: string;
+}
+
+export default function EditorFrameLoadingOverlay({
+  visible,
+  width,
+  height,
+  label,
+}: EditorFrameLoadingOverlayProps) {
+  if (!visible) return null;
+  return (
+    <div
+      className={cn(
+        'absolute inset-0 z-30 pointer-events-none flex items-center justify-center',
+        // The overlay sits ABOVE the image and SVG polygon layers so a
+        // partially-rendered frame doesn't bleed through.
+        'bg-background/40'
+      )}
+      style={{
+        width: width ? `${width}px` : undefined,
+        height: height ? `${height}px` : undefined,
+      }}
+      data-testid="editor-frame-loading-overlay"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <Skeleton className="absolute inset-0 rounded-none opacity-60" />
+      <div className="relative flex flex-col items-center gap-2">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        {label ? (
+          <span className="text-sm text-muted-foreground">{label}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/segmentation/components/canvas/FrameLoadingGate.tsx
+++ b/src/pages/segmentation/components/canvas/FrameLoadingGate.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { useImageDisplay } from '../../contexts/ImageDisplayContext';
+import EditorFrameLoadingOverlay from './EditorFrameLoadingOverlay';
+
+interface FrameLoadingGateProps {
+  imageId: string | null;
+  loadedFrameKey: string | null;
+  isVideoMode: boolean;
+  width?: number;
+  height?: number;
+  label?: string;
+}
+
+// Lives inside ImageDisplayProvider so it can read visibleChannels —
+// the overlay must track BOTH frame id and channel set, otherwise a
+// channel toggle on the same frame would never re-arm the overlay
+// even while the new channel PNG is still decoding.
+export default function FrameLoadingGate({
+  imageId,
+  loadedFrameKey,
+  isVideoMode,
+  width,
+  height,
+  label,
+}: FrameLoadingGateProps) {
+  const { visibleChannels, channel } = useImageDisplay();
+  const channelsKey =
+    visibleChannels.length > 0 ? visibleChannels.join('|') : (channel ?? '');
+  const targetFrameKey = imageId ? `${imageId}::${channelsKey}` : null;
+
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const mismatched =
+      isVideoMode && !!targetFrameKey && loadedFrameKey !== targetFrameKey;
+    if (!mismatched) {
+      setShow(false);
+      return;
+    }
+    // 150 ms grace — cache hits and warm-network loads finish first.
+    const timer = window.setTimeout(() => setShow(true), 150);
+    return () => window.clearTimeout(timer);
+  }, [isVideoMode, targetFrameKey, loadedFrameKey]);
+
+  return (
+    <EditorFrameLoadingOverlay
+      visible={show}
+      width={width}
+      height={height}
+      label={label}
+    />
+  );
+}

--- a/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
+++ b/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
@@ -1,0 +1,47 @@
+/**
+ * Headless component that drives the sliding-window frame prefetch
+ * from inside the `ImageDisplayProvider` subtree.
+ *
+ * Reads `visibleChannels` from `useImageDisplay()` (only available
+ * under the provider) and forwards everything else from props. The
+ * editor mounts this once next to the canvas so the prefetch hook
+ * fires whenever the container, frame index, or channel set changes.
+ *
+ * Returns null — all side effects live inside `useFrameWindowPrefetch`.
+ */
+
+import { useImageDisplay } from '../../contexts/ImageDisplayContext';
+import {
+  useFrameWindowPrefetch,
+  type FrameMinimal,
+} from '../../hooks/useFrameWindowPrefetch';
+
+interface FrameWindowPrefetcherProps {
+  frames: readonly FrameMinimal[];
+  currentIndex: number;
+  enabled: boolean;
+}
+
+export default function FrameWindowPrefetcher({
+  frames,
+  currentIndex,
+  enabled,
+}: FrameWindowPrefetcherProps) {
+  const { visibleChannels, channel } = useImageDisplay();
+
+  // The single-channel fallback uses `/display` (encoded as `null`
+  // channel in `buildFrameImageUrl`). Multi-channel mode prefetches
+  // every visible channel so MultiChannelCanvas's `fetch()` calls
+  // hit the browser HTTP cache populated by `frameImageCache`.
+  const channels =
+    visibleChannels.length > 0 ? visibleChannels : channel ? [channel] : [];
+
+  useFrameWindowPrefetch({
+    frames,
+    currentIndex,
+    channels,
+    enabled,
+  });
+
+  return null;
+}

--- a/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
+++ b/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
@@ -51,9 +51,11 @@ interface MultiChannelCanvasProps {
   height?: number;
   loading?: boolean;
   /** Notified once the first channel image has loaded with its natural
-   *  dimensions — the rest of the editor wires zoom + polygons against
-   *  the image-space coordinate system. */
-  onLoad?: (width: number, height: number) => void;
+   *  dimensions + the channelsKey that produced this load. The
+   *  channelsKey lets the editor distinguish "same frame, different
+   *  channel mix" — without it, a channel toggle on the current frame
+   *  would never re-arm the loading overlay. */
+  onLoad?: (width: number, height: number, channelsKey: string) => void;
 }
 
 /** Parse `#RRGGBB` (or `#rgb`) into a 3-element [r, g, b] tuple. White
@@ -164,7 +166,7 @@ export default function MultiChannelCanvas({
       const h = firstBmp.height;
       canvas.width = w;
       canvas.height = h;
-      onLoad?.(w, h);
+      onLoad?.(w, h, channelsKey);
 
       // Per-channel tint pipeline. We could colour-mix natively via
       // canvas blend modes (multiply→lighter), but the manual pixel
@@ -222,6 +224,12 @@ export default function MultiChannelCanvas({
       cancelled = true;
       controller.abort();
     };
+    // `channelOpacities` is intentionally absent — `opacitiesKey` is
+    // its primitive fingerprint; listing the object would re-fire on
+    // every parent render because Context spreads a fresh reference.
+    // Same trick already applies to visibleChannels (channelsKey) and
+    // channelColors (colorsKey).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     frameId,
     channelsKey,
@@ -230,10 +238,6 @@ export default function MultiChannelCanvas({
     windowMin,
     windowMax,
     onLoad,
-    // visibleChannels + channelColors purposefully excluded — `channelsKey`
-    // + `colorsKey` are their content fingerprints, primitive-safe for the
-    // dep array. Listing the arrays directly would re-fire on every
-    // parent render because they're freshly-spread objects.
     visibleChannels,
     channelColors,
   ]);

--- a/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
+++ b/src/pages/segmentation/components/canvas/VideoFrameImage.tsx
@@ -1,27 +1,28 @@
 /**
  * Canvas image source resolver for video-mode editing.
  *
- * Two jobs:
- *   1. Compute the right URL for the canvas <img>:
- *      - Video mode: /api/images/<currentFrameId>/frame-data?channel=<channel>
- *        so flipping the channel in the sidebar swaps PNG to the right
- *        per-channel file, and so changing frameIndex (Play / scrubber /
- *        Next / Back) follows the play head instead of staying on the
- *        URL imageId.
- *      - Otherwise: pass through the static URL the parent computed.
- *   2. Prefetch the next N frames while playback is live so when the
- *      timer ticks, the browser already has the PNG cached and the
- *      <img> swap is instant rather than a full HTTP roundtrip per
- *      frame.
+ * Resolves the right URL for the canvas `<img>`:
+ *   - Video mode: /api/images/<currentFrameId>/frame-data?channel=<channel>
+ *     so flipping the channel in the sidebar swaps PNG to the right
+ *     per-channel file, and so changing frameIndex (Play / scrubber /
+ *     Next / Back) follows the play head instead of staying on the
+ *     URL imageId.
+ *   - Otherwise: pass through the static URL the parent computed.
+ *
+ * The playback-time prefetch loop that used to live here has been
+ * promoted into `useFrameWindowPrefetch` (driven by
+ * `FrameWindowPrefetcher`), which now warms the cache symmetrically
+ * around the current frame for both scrub and playback.
  *
  * Lives in the JSX subtree wrapped by ImageDisplayProvider so it can
  * read the current channel via useImageDisplay().
  */
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import CanvasImage from './CanvasImage';
 import MultiChannelCanvas from './MultiChannelCanvas';
 import { useImageDisplay } from '../../contexts/ImageDisplayContext';
+import { buildFrameImageUrl } from '../../hooks/segmentationPolygonCache';
 
 interface VideoFrameImageProps {
   /** True when the row is part of a video container. Off → fallback. */
@@ -29,36 +30,22 @@ interface VideoFrameImageProps {
   /** Frame id from useVideoFrames.currentFrame.id — drives playback,
    *  scrubber, prev/next. */
   currentFrameId: string | null;
-  /** Frame ids to warm in the browser HTTP cache. Caller supplies the
-   *  ones it expects the user to hit next (e.g. the next 10 forward
-   *  frames during playback). */
-  upcomingFrameIds?: string[];
   /** Static image URL used when not in video mode (standalone image). */
   fallbackSrc: string;
   /** Forwarded to <CanvasImage>. */
   width?: number;
   height?: number;
   alt?: string;
-  onLoad?: (width: number, height: number) => void;
-}
-
-const PREFETCH_FRAME_COUNT = 10;
-
-/** Build the per-channel display URL for one video frame. The channel
- *  query is omitted when there is no active channel (single-channel
- *  videos / channel-context not initialised yet); the backend resolver
- *  falls back to the segmentation-source channel in that case. */
-function buildFrameSrc(frameId: string, channel: string | null): string {
-  if (channel) {
-    return `/api/images/${frameId}/frame-data?channel=${encodeURIComponent(channel)}`;
-  }
-  return `/api/images/${frameId}/display`;
+  /** `channelsKey` identifies which channel set produced the load,
+   *  letting the parent invalidate "loaded" state when the channel
+   *  mix changes on the same frame. Single-channel fallback emits
+   *  the single `channel` name (or '' when none is selected). */
+  onLoad?: (width: number, height: number, channelsKey: string) => void;
 }
 
 export default function VideoFrameImage({
   isVideoMode,
   currentFrameId,
-  upcomingFrameIds,
   fallbackSrc,
   width,
   height,
@@ -73,36 +60,10 @@ export default function VideoFrameImage({
   // takes over the moment the user picks any channels.
   const src = useMemo(() => {
     if (isVideoMode && currentFrameId) {
-      return buildFrameSrc(currentFrameId, channel);
+      return buildFrameImageUrl(currentFrameId, channel);
     }
     return fallbackSrc;
   }, [isVideoMode, currentFrameId, channel, fallbackSrc]);
-
-  // Prefetch warm-up: kick off HTTP requests for the upcoming frames so
-  // the browser has them cached when the <img> src swap happens. We
-  // never read the resulting Image objects — they exist only to populate
-  // the disk/memory cache. Cleanup via .src = '' aborts in-flight
-  // requests when the dependency changes (e.g. user pauses).
-  useEffect(() => {
-    if (!isVideoMode || !upcomingFrameIds || upcomingFrameIds.length === 0) {
-      return;
-    }
-    const slice = upcomingFrameIds.slice(0, PREFETCH_FRAME_COUNT);
-    const handles: HTMLImageElement[] = [];
-    for (const frameId of slice) {
-      const img = new Image();
-      img.src = buildFrameSrc(frameId, channel);
-      handles.push(img);
-    }
-    return () => {
-      for (const img of handles) {
-        // Setting src='' is the documented way to cancel a pending
-        // HTTP request issued by `new Image()`. Browsers ignore the
-        // partial response and the connection is reused.
-        img.src = '';
-      }
-    };
-  }, [isVideoMode, upcomingFrameIds, channel]);
 
   // Multi-channel overlay mode: composite each visible channel via
   // canvas with per-channel colour + min/max LUT remap. Falls through
@@ -122,13 +83,20 @@ export default function VideoFrameImage({
     );
   }
 
+  // CanvasImage doesn't know about channels; we synthesise the
+  // channelsKey here so the parent contract is uniform.
+  const fallbackChannelsKey = channel ?? '';
+  const handleFallbackLoad = onLoad
+    ? (w: number, h: number) => onLoad(w, h, fallbackChannelsKey)
+    : undefined;
+
   return (
     <CanvasImage
       src={src}
       width={width}
       height={height}
       alt={alt}
-      onLoad={onLoad}
+      onLoad={handleFallbackLoad}
     />
   );
 }

--- a/src/pages/segmentation/components/canvas/__tests__/FrameLoadingGate.test.tsx
+++ b/src/pages/segmentation/components/canvas/__tests__/FrameLoadingGate.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import FrameLoadingGate from '../FrameLoadingGate';
+import { ImageDisplayProvider } from '../../../contexts/ImageDisplayContext';
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+function renderWithProvider(
+  props: React.ComponentProps<typeof FrameLoadingGate>
+) {
+  return render(
+    <ImageDisplayProvider userId="u1">
+      <FrameLoadingGate {...props} />
+    </ImageDisplayProvider>
+  );
+}
+
+describe('FrameLoadingGate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not render the overlay when frame key matches loaded key (cache hit)', () => {
+    renderWithProvider({
+      imageId: 'frame-1',
+      loadedFrameKey: 'frame-1::',
+      isVideoMode: true,
+    });
+    expect(
+      screen.queryByTestId('editor-frame-loading-overlay')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the overlay when video mode is off', () => {
+    renderWithProvider({
+      imageId: 'frame-1',
+      loadedFrameKey: 'something-else::',
+      isVideoMode: false,
+    });
+    expect(
+      screen.queryByTestId('editor-frame-loading-overlay')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders overlay only after 150 ms grace period of mismatch', () => {
+    renderWithProvider({
+      imageId: 'frame-1',
+      loadedFrameKey: null,
+      isVideoMode: true,
+    });
+    // Just before grace expires — overlay still hidden.
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(
+      screen.queryByTestId('editor-frame-loading-overlay')
+    ).not.toBeInTheDocument();
+    // Cross the threshold — overlay appears.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(
+      screen.getByTestId('editor-frame-loading-overlay')
+    ).toBeInTheDocument();
+  });
+
+  it('cancels the grace timer when the mismatch resolves mid-grace', () => {
+    const { rerender } = render(
+      <ImageDisplayProvider userId="u1">
+        <FrameLoadingGate imageId="frame-1" loadedFrameKey={null} isVideoMode />
+      </ImageDisplayProvider>
+    );
+    // Wait 100 ms — still mismatched.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // Frame load completes before the grace expires; cancel the timer.
+    rerender(
+      <ImageDisplayProvider userId="u1">
+        <FrameLoadingGate
+          imageId="frame-1"
+          loadedFrameKey="frame-1::"
+          isVideoMode
+        />
+      </ImageDisplayProvider>
+    );
+    // Even after the original 150 ms would have elapsed, no overlay.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(
+      screen.queryByTestId('editor-frame-loading-overlay')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/segmentationPolygonCache.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/segmentationPolygonCache.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  buildFrameImageUrl,
+  fetchSegmentationPolygonsForCache,
+  getCachedSegmentationPolygons,
+  segmentationPolygonsQueryKey,
+  setCachedSegmentationPolygons,
+} from '../segmentationPolygonCache';
+import apiClient from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    getSegmentationResults: vi.fn(),
+  },
+}));
+
+const mockGet = apiClient.getSegmentationResults as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+describe('segmentationPolygonCache', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  describe('fetchSegmentationPolygonsForCache', () => {
+    it('returns { polygons: null } when apiClient returns null (404 case)', async () => {
+      mockGet.mockResolvedValue(null);
+      const result = await fetchSegmentationPolygonsForCache('frame-1');
+      expect(result).toEqual({ polygons: null });
+    });
+
+    it('returns { polygons: null } when payload has no polygons field', async () => {
+      // Backend returns 200 but the polygons field is missing — must
+      // normalise to null so consumers don't crash on undefined.
+      mockGet.mockResolvedValue({ imageWidth: 1024, imageHeight: 768 });
+      const result = await fetchSegmentationPolygonsForCache('frame-1');
+      expect(result).toEqual({ polygons: null });
+    });
+
+    it('returns the polygons + dimensions when payload is well-formed', async () => {
+      const polygons = [{ id: 'p1', points: [] }];
+      mockGet.mockResolvedValue({
+        polygons,
+        imageWidth: 320,
+        imageHeight: 240,
+      });
+      const result = await fetchSegmentationPolygonsForCache('frame-1');
+      expect(result).toEqual({
+        polygons,
+        imageWidth: 320,
+        imageHeight: 240,
+      });
+    });
+
+    it('re-throws real network/5xx errors so React Query can retry', async () => {
+      const err = new Error('upstream down');
+      mockGet.mockRejectedValue(err);
+      await expect(fetchSegmentationPolygonsForCache('frame-1')).rejects.toBe(
+        err
+      );
+    });
+
+    it('forwards the abort signal to apiClient', async () => {
+      mockGet.mockResolvedValue(null);
+      const controller = new AbortController();
+      await fetchSegmentationPolygonsForCache('frame-1', controller.signal);
+      expect(mockGet).toHaveBeenCalledWith('frame-1', {
+        signal: controller.signal,
+      });
+    });
+  });
+
+  describe('cache helpers', () => {
+    it('round-trips polygons through React Query cache by canonical key', () => {
+      const qc = new QueryClient();
+      const data = { polygons: [], imageWidth: 100, imageHeight: 100 };
+      setCachedSegmentationPolygons(qc, 'frame-9', data);
+      expect(getCachedSegmentationPolygons(qc, 'frame-9')).toEqual(data);
+    });
+
+    it('returns undefined for unknown imageIds', () => {
+      const qc = new QueryClient();
+      expect(getCachedSegmentationPolygons(qc, 'nope')).toBeUndefined();
+    });
+
+    it('uses a stable query key shape', () => {
+      expect(segmentationPolygonsQueryKey('frame-x')).toEqual([
+        'segmentation-results',
+        'frame-x',
+      ]);
+    });
+  });
+
+  describe('buildFrameImageUrl', () => {
+    it('omits channel param when null', () => {
+      expect(buildFrameImageUrl('frame-1', null)).toBe(
+        '/api/images/frame-1/display'
+      );
+    });
+
+    it('encodes channel name in the query string', () => {
+      expect(buildFrameImageUrl('frame-1', 'TIRF 640')).toBe(
+        '/api/images/frame-1/frame-data?channel=TIRF%20640'
+      );
+    });
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/useFrameWindowPrefetch.test.tsx
+++ b/src/pages/segmentation/hooks/__tests__/useFrameWindowPrefetch.test.tsx
@@ -1,0 +1,220 @@
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { useFrameWindowPrefetch } from '../useFrameWindowPrefetch';
+
+const prefetchMock = vi.fn();
+const isReadyMock = vi.fn().mockReturnValue(false);
+const abortMock = vi.fn();
+const readyCountMock = vi.fn().mockReturnValue(0);
+
+vi.mock('@/lib/rendering/FrameImageCache', () => ({
+  frameImageCache: {
+    prefetch: (url: string) => prefetchMock(url),
+    isReady: (url: string) => isReadyMock(url),
+    abort: (url: string) => abortMock(url),
+    readyCount: (urls: readonly string[]) => readyCountMock(urls),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    getSegmentationResults: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+function makeFrames(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `frame-${i}`,
+    segmentationStatus: 'segmented',
+  }));
+}
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+describe('useFrameWindowPrefetch', () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    prefetchMock.mockReset();
+    prefetchMock.mockReturnValue(Promise.resolve(new Image()));
+    // Simulate the production case: cached/browser-HTTP fetches return
+    // ready synchronously, so the cleanup branch that aborts pending
+    // URLs is a no-op. The hook's dedup semantics depend on this.
+    isReadyMock.mockReset().mockReturnValue(true);
+    abortMock.mockReset();
+    readyCountMock.mockReset().mockReturnValue(0);
+    qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+  });
+
+  it('prefetches every URL in the window on first render', () => {
+    const frames = makeFrames(100);
+    renderHook(
+      () =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex: 20,
+          channels: ['ch1', 'ch2'],
+          enabled: true,
+        }),
+      { wrapper: wrapper(qc) }
+    );
+    // Window = 5 back + 10 ahead + current = 16 frames × 2 channels = 32
+    expect(prefetchMock).toHaveBeenCalledTimes(32);
+  });
+
+  it('window-shift fires prefetch ONLY for new leading-edge URLs', () => {
+    const frames = makeFrames(100);
+    const { rerender } = renderHook(
+      ({ currentIndex }: { currentIndex: number }) =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex,
+          channels: ['ch1', 'ch2'],
+          enabled: true,
+        }),
+      {
+        wrapper: wrapper(qc),
+        initialProps: { currentIndex: 20 },
+      }
+    );
+    expect(prefetchMock).toHaveBeenCalledTimes(32);
+    prefetchMock.mockClear();
+
+    // Slide window by 1: only the new leading-edge frame (index 31)
+    // contributes its 2 channels — the trailing edge (index 14) is
+    // dropped silently, and every other URL is already in prefetchedRef.
+    rerender({ currentIndex: 21 });
+    expect(prefetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT re-prefetch when window content unchanged (clamped at edge)', () => {
+    const frames = makeFrames(20);
+    const { rerender } = renderHook(
+      ({ currentIndex }: { currentIndex: number }) =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex,
+          channels: ['ch1'],
+          enabled: true,
+        }),
+      {
+        wrapper: wrapper(qc),
+        initialProps: { currentIndex: 18 },
+      }
+    );
+    // Window clamped at frames.length - 1 = 19, so frames 13..19 = 7
+    expect(prefetchMock).toHaveBeenCalledTimes(7);
+    prefetchMock.mockClear();
+
+    // Advance currentIndex but window stays clamped at the end of the
+    // frames array — no new URLs to prefetch.
+    rerender({ currentIndex: 19 });
+    expect(prefetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('clears dedup state and re-fires on channelsKey change', () => {
+    const frames = makeFrames(50);
+    const { rerender } = renderHook(
+      ({ channels }: { channels: string[] }) =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex: 20,
+          channels,
+          enabled: true,
+        }),
+      {
+        wrapper: wrapper(qc),
+        initialProps: { channels: ['ch1'] },
+      }
+    );
+    expect(prefetchMock).toHaveBeenCalledTimes(16);
+    prefetchMock.mockClear();
+
+    // Switching channel set must re-prefetch the whole window for the
+    // new URLs (channel name is part of the URL).
+    rerender({ channels: ['ch2'] });
+    expect(prefetchMock).toHaveBeenCalledTimes(16);
+  });
+
+  it('skips polygon prefetch when frame status is not segmented', () => {
+    const frames = [
+      { id: 'a', segmentationStatus: 'segmented' },
+      { id: 'b', segmentationStatus: 'queued' },
+      { id: 'c', segmentationStatus: 'failed' },
+    ];
+    // Polygon prefetch goes through React Query; we don't have a direct
+    // assertion on it without instrumenting the client. Image prefetch
+    // for all 3 still fires (status only gates polygon, not image).
+    renderHook(
+      () =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex: 1,
+          channels: ['ch1'],
+          enabled: true,
+        }),
+      { wrapper: wrapper(qc) }
+    );
+    expect(prefetchMock).toHaveBeenCalledTimes(3);
+    // Polygon side: only 'a' should have been queried; b/c skipped.
+    // React Query exposes this through cache state.
+    const aData = qc.getQueryState(['segmentation-results', 'a']);
+    const bData = qc.getQueryState(['segmentation-results', 'b']);
+    expect(aData).toBeDefined();
+    expect(bData).toBeUndefined();
+  });
+
+  it('aborts pending URLs from the previous window and unmarks them', () => {
+    // Pending URLs (isReady=false) get cancelled on window-shift so a
+    // user mashing the slider doesn't keep N HTTP connections open.
+    isReadyMock.mockReturnValue(false);
+    const frames = makeFrames(100);
+    const { rerender } = renderHook(
+      ({ currentIndex }: { currentIndex: number }) =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex,
+          channels: ['ch1'],
+          enabled: true,
+        }),
+      {
+        wrapper: wrapper(qc),
+        initialProps: { currentIndex: 20 },
+      }
+    );
+    prefetchMock.mockClear();
+    abortMock.mockClear();
+
+    rerender({ currentIndex: 40 });
+    // 16 NEW URLs in the new window get prefetched; 16 OLD URLs from
+    // the previous run are aborted because they never settled.
+    expect(prefetchMock).toHaveBeenCalledTimes(16);
+    expect(abortMock).toHaveBeenCalledTimes(16);
+  });
+
+  it('does nothing when enabled=false', () => {
+    const frames = makeFrames(50);
+    renderHook(
+      () =>
+        useFrameWindowPrefetch({
+          frames,
+          currentIndex: 20,
+          channels: ['ch1'],
+          enabled: false,
+        }),
+      { wrapper: wrapper(qc) }
+    );
+    expect(prefetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/segmentation/hooks/segmentationPolygonCache.ts
+++ b/src/pages/segmentation/hooks/segmentationPolygonCache.ts
@@ -1,0 +1,106 @@
+/**
+ * Single source of truth for the segmentation-polygon React Query
+ * cache used by the segmentation editor.
+ *
+ * Both the editor's primary load path (`SegmentationEditor.tsx`'s
+ * effect that hydrates the canvas on imageId change) and the
+ * sliding-window prefetch hook (`useFrameWindowPrefetch`) share the
+ * same query key + queryFn + cache config so a scrub-back is served
+ * from RAM and a prefetched frame surfaces instantly when the user
+ * lands on it.
+ *
+ * The exported `buildFrameImageUrl` helper also lives here so the
+ * prefetch hook and the canvas image components agree on URL shape
+ * (channel encoding + fallback to `/display`).
+ */
+
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import apiClient, { SegmentationPolygon } from '@/lib/api';
+
+export interface CachedSegmentationData {
+  polygons: SegmentationPolygon[] | null;
+  imageWidth?: number;
+  imageHeight?: number;
+}
+
+/** Canonical React Query key. Keep co-located with the queryFn so a
+ *  rename can't drift between call sites. */
+export function segmentationPolygonsQueryKey(imageId: string): QueryKey {
+  return ['segmentation-results', imageId];
+}
+
+/** Fetcher used by both the prefetch hook and the editor's primary
+ *  load. `apiClient.getSegmentationResults` already returns `null`
+ *  for 404 ("no segmentation yet") so we only have to normalise the
+ *  empty-result shape — no catch needed for the "missing data is not
+ *  an error" path. Real network/5xx errors still propagate so React
+ *  Query's `retry: 1` kicks in. */
+export async function fetchSegmentationPolygonsForCache(
+  imageId: string,
+  signal?: AbortSignal
+): Promise<CachedSegmentationData> {
+  const data = await apiClient.getSegmentationResults(imageId, { signal });
+  if (!data || !data.polygons) {
+    return { polygons: null };
+  }
+  return {
+    polygons: data.polygons,
+    imageWidth: data.imageWidth,
+    imageHeight: data.imageHeight,
+  };
+}
+
+/** Per-query options applied to both prefetch and main fetch. The
+ *  60 s staleTime + 5 min gcTime is tuned so a user can scrub away
+ *  and back without a refetch but a stale-after-resegmentation case
+ *  still resolves within a minute. ETag-based invalidation from the
+ *  backend is the longer-lived correctness story; this is just the
+ *  client-side default. */
+export const SEGMENTATION_POLYGON_QUERY_OPTIONS = {
+  staleTime: 60_000,
+  gcTime: 5 * 60_000,
+  // Only one retry — the network-error case is usually transient
+  // and the prefetch path swallows failures anyway.
+  retry: 1,
+} as const;
+
+/** Synchronous cache read used by the editor's primary load path so
+ *  a scrub-back or a freshly-prefetched frame paints without a
+ *  network round-trip. Returns `undefined` when there's no entry —
+ *  callers fall back to the existing apiClient call and then write
+ *  the result back via `setCachedSegmentationPolygons`. */
+export function getCachedSegmentationPolygons(
+  queryClient: QueryClient,
+  imageId: string
+): CachedSegmentationData | undefined {
+  return queryClient.getQueryData<CachedSegmentationData>(
+    segmentationPolygonsQueryKey(imageId)
+  );
+}
+
+/** Companion to `getCachedSegmentationPolygons`. Called by the
+ *  editor's primary load path after a successful fetch so subsequent
+ *  cache hits (scrub-back, late prefetch arrival) can short-circuit
+ *  the network call. */
+export function setCachedSegmentationPolygons(
+  queryClient: QueryClient,
+  imageId: string,
+  data: CachedSegmentationData
+): void {
+  queryClient.setQueryData(segmentationPolygonsQueryKey(imageId), data);
+}
+
+/** Build the per-channel display URL for one video frame. Mirrors
+ *  the helper in `VideoFrameImage.tsx` — duplicated there for
+ *  locality; this re-export is the canonical version the prefetch
+ *  hook uses so both sides agree on URL shape (including channel
+ *  encoding). */
+export function buildFrameImageUrl(
+  frameId: string,
+  channel: string | null
+): string {
+  if (channel) {
+    return `/api/images/${frameId}/frame-data?channel=${encodeURIComponent(channel)}`;
+  }
+  return `/api/images/${frameId}/display`;
+}

--- a/src/pages/segmentation/hooks/useFrameWindowPrefetch.ts
+++ b/src/pages/segmentation/hooks/useFrameWindowPrefetch.ts
@@ -1,0 +1,228 @@
+/**
+ * Sliding-window prefetch around the current frame in video-mode editor.
+ *
+ * Walks a window of frames spanning `windowBack` slots before the
+ * current index and `windowAhead` slots after it. For each frame in the
+ * window the hook (a) warms a per-channel image element via
+ * `frameImageCache` so the `<img>` swap is RAM-only on scrub or
+ * playback tick, and (b) seeds React Query with the polygon JSON via
+ * `queryClient.prefetchQuery` keyed by the canonical query key. Both
+ * paths are idempotent — re-running with the same window short-circuits
+ * to cached entries, and a window shift evicts only the off-window
+ * tails by virtue of `FrameImageCache`'s LRU + React Query's
+ * stale-while-revalidate.
+ *
+ * Replaces two ad-hoc prefetch sites that previously diverged:
+ *   - `SegmentationEditor.tsx`'s `prefetchWithPriority` (±1 image,
+ *     non-video, polygon JSON only, 500 ms-delayed adjacent).
+ *   - `VideoFrameImage.tsx`'s 10-frame lookahead (playback only, single
+ *     channel only, image only).
+ *
+ * Window choice is intentionally asymmetric (5 back / 10 ahead) — a
+ * paused user is more likely to step forward than backward and
+ * playback is forward-only. See `FRAME_PREFETCH_WINDOW`.
+ */
+
+import { useEffect, useMemo, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { frameImageCache } from '@/lib/rendering/FrameImageCache';
+import {
+  buildFrameImageUrl,
+  getCachedSegmentationPolygons,
+  segmentationPolygonsQueryKey,
+  fetchSegmentationPolygonsForCache,
+  SEGMENTATION_POLYGON_QUERY_OPTIONS,
+} from './segmentationPolygonCache';
+
+export const FRAME_PREFETCH_WINDOW = {
+  back: 5,
+  ahead: 10,
+} as const;
+
+export interface FrameMinimal {
+  id: string;
+  /** Segmentation status drives whether we waste a prefetch slot on a
+   *  frame that the backend will refuse to return polygons for. */
+  segmentationStatus?: string;
+}
+
+export interface UseFrameWindowPrefetchOptions {
+  /** Ordered list of frames (the container's `frames` array). */
+  frames: readonly FrameMinimal[];
+  /** Index of the frame currently visible in the editor. */
+  currentIndex: number;
+  /** Channels to prefetch per frame. Empty array means single-channel
+   *  fallback URL only. The hook calls
+   *  `frameImageCache.prefetch(url)` for each. */
+  channels: readonly string[];
+  /** Only run when we're in video mode — for standalone images the
+   *  prefetch concept doesn't apply. */
+  enabled: boolean;
+  /** Override window. Default is 5 back / 10 ahead. */
+  windowBack?: number;
+  windowAhead?: number;
+}
+
+export interface UseFrameWindowPrefetchResult {
+  /** All image URLs the hook is currently warming. Useful for the
+   *  buffer indicator + play-gate to compute ready-count. */
+  windowImageUrls: string[];
+  /** How many of the warmed URLs have finished loading. */
+  readyCount: number;
+  /** True when every URL in the window has loaded. */
+  isWindowReady: boolean;
+}
+
+export function useFrameWindowPrefetch({
+  frames,
+  currentIndex,
+  channels,
+  enabled,
+  windowBack = FRAME_PREFETCH_WINDOW.back,
+  windowAhead = FRAME_PREFETCH_WINDOW.ahead,
+}: UseFrameWindowPrefetchOptions): UseFrameWindowPrefetchResult {
+  const queryClient = useQueryClient();
+
+  // Stable fingerprint of channels — joining is cheap and gives the
+  // effect a primitive dependency so a fresh `channels` array from the
+  // parent doesn't re-fire the work.
+  const channelsKey = channels.join('|');
+
+  const windowFrames = useMemo(() => {
+    if (!enabled || frames.length === 0) return [];
+    const start = Math.max(0, currentIndex - windowBack);
+    const end = Math.min(frames.length - 1, currentIndex + windowAhead);
+    const slice: FrameMinimal[] = [];
+    for (let i = start; i <= end; i++) slice.push(frames[i]);
+    return slice;
+    // `frames` is referentially stable inside one container fetch so
+    // listing it here is safe; the explicit guard above handles the
+    // not-yet-loaded case.
+  }, [enabled, frames, currentIndex, windowBack, windowAhead]);
+
+  // Compute the per-channel URL set for the window. Used both to
+  // drive prefetch and to report `readyCount` back to consumers.
+  // `channelsKey` (primitive) is the fingerprint that drives the
+  // memo: parent renders that hand us a fresh `channels` array with
+  // identical content won't recompute the URLs.
+  const windowImageUrls = useMemo(() => {
+    if (!windowFrames.length) return [];
+    const channelList = channels.length > 0 ? channels : [null];
+    const urls: string[] = [];
+    for (const frame of windowFrames) {
+      for (const channel of channelList) {
+        urls.push(buildFrameImageUrl(frame.id, channel));
+      }
+    }
+    return urls;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowFrames, channelsKey]);
+
+  // Track the set of URLs we've already kicked off so a window
+  // shift fires `prefetch()` only for the NEW URLs at the leading
+  // edge, not the 30+ already-warmed URLs at the trailing edge.
+  // During playback the slider advances by 1 frame at a time, so
+  // each tick should add just `channels.length` new URLs to this
+  // set — orders of magnitude below the nginx api-zone rate limit
+  // (30 r/s burst 80). Without this guard the prefetch fanout
+  // generated 50+ 503 responses per second during playback.
+  const prefetchedRef = useRef<Set<string>>(new Set());
+  const prefetchedPolygonsRef = useRef<Set<string>>(new Set());
+
+  // Reset the ref-tracked sets when the channel set or enable flag
+  // changes — a different channel needs its own URLs prefetched
+  // fresh, and disabling/re-enabling video mode should not leak
+  // stale "already prefetched" markers into the new session.
+  //
+  // MUST be declared BEFORE the main prefetch effect: React fires
+  // effects in source order, so putting reset after would clear the
+  // ref *after* the main effect populated it on mount, defeating the
+  // dedup on every subsequent window-shift.
+  useEffect(() => {
+    prefetchedRef.current.clear();
+    prefetchedPolygonsRef.current.clear();
+  }, [channelsKey, enabled]);
+
+  // Effect: kick off image + polygon prefetch for each window frame.
+  // Idempotent at the URL level — only NEW URLs trigger network calls.
+  useEffect(() => {
+    if (!enabled || windowFrames.length === 0) return;
+
+    const startedImageUrls: string[] = [];
+
+    // Image prefetch — fire and forget for URLs we haven't seen.
+    // The ref-tracked set is more aggressive than FrameImageCache.has
+    // because evicted entries (rare, only past the 200-LRU cap)
+    // shouldn't trigger redundant re-fetches mid-playback — the
+    // browser HTTP cache (30 min) will serve them on real mount.
+    const channelList = channels.length > 0 ? channels : [null];
+    for (const frame of windowFrames) {
+      for (const channel of channelList) {
+        const url = buildFrameImageUrl(frame.id, channel);
+        if (prefetchedRef.current.has(url)) continue;
+        prefetchedRef.current.add(url);
+        startedImageUrls.push(url);
+        frameImageCache.prefetch(url).catch(() => {
+          /* silent — surfaced by the actual mount */
+        });
+      }
+    }
+
+    // Polygon prefetch — only call prefetchQuery for frames we
+    // haven't seen AND that aren't already in the React Query
+    // cache. Otherwise React Query will short-circuit cheaply, but
+    // the call still costs a microtask + an observer touch which at
+    // 10 FPS × 16 frames adds up.
+    for (const frame of windowFrames) {
+      const status = frame.segmentationStatus;
+      if (status && status !== 'segmented' && status !== 'completed') continue;
+      if (prefetchedPolygonsRef.current.has(frame.id)) continue;
+      if (getCachedSegmentationPolygons(queryClient, frame.id) !== undefined) {
+        prefetchedPolygonsRef.current.add(frame.id);
+        continue;
+      }
+      prefetchedPolygonsRef.current.add(frame.id);
+      queryClient
+        .prefetchQuery({
+          queryKey: segmentationPolygonsQueryKey(frame.id),
+          queryFn: ({ signal }) =>
+            fetchSegmentationPolygonsForCache(frame.id, signal),
+          ...SEGMENTATION_POLYGON_QUERY_OPTIONS,
+        })
+        .catch(() => {
+          /* prefetch is best-effort; main fetch path retries on real visit */
+        });
+    }
+
+    // Snapshot the ref so the cleanup closure uses the same set that
+    // the effect body wrote to (silences exhaustive-deps stale-ref
+    // warning; the ref is intentionally reset elsewhere on channel
+    // changes, not here).
+    const prefetchedSet = prefetchedRef.current;
+    return () => {
+      // Cancel only image entries that started in *this* effect run
+      // and have not finished loading yet. Already-loaded entries
+      // are LRU candidates managed by the cache itself.
+      for (const url of startedImageUrls) {
+        if (!frameImageCache.isReady(url)) {
+          frameImageCache.abort(url);
+          // Allow a future window-shift to retry this URL — the
+          // abort means we never saw the response.
+          prefetchedSet.delete(url);
+        }
+      }
+      // React Query handles its own cancellation when the queryClient
+      // detects the cache entry's signal observer count drops.
+    };
+    // `channels` is fingerprinted by `channelsKey`; including only
+    // the primitive prevents re-fires on parent-provided fresh
+    // arrays with identical content.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, windowFrames, channelsKey, queryClient]);
+
+  const readyCount = frameImageCache.readyCount(windowImageUrls);
+  const isWindowReady =
+    windowImageUrls.length > 0 && readyCount === windowImageUrls.length;
+
+  return { windowImageUrls, readyCount, isWindowReady };
+}

--- a/src/pages/segmentation/hooks/useVideoFrames.ts
+++ b/src/pages/segmentation/hooks/useVideoFrames.ts
@@ -9,7 +9,7 @@
  * owns the frame-list metadata + playback loop.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import apiClient from '@/lib/api';
 import type { VideoChannel, ProjectImage } from '@/types';
@@ -88,11 +88,30 @@ export function useVideoFrames(
     queryFn: () => fetchVideoContainer(videoContainerId as string),
     enabled: !!videoContainerId,
     staleTime: 60_000,
+    // Keep the previous container's frame metadata visible while a
+    // background refetch is in flight (token refresh, network blip).
+    // Without this the slider snaps to 0/0 and the canvas dims during
+    // the brief window before fresh data arrives — same trade-off as
+    // the editor's overlay debounce: stale-then-correct is smoother
+    // than empty-then-correct.
+    placeholderData: keepPreviousData,
   });
-  const container = data ?? null;
+  // `placeholderData: keepPreviousData` means `data` can still be the
+  // PREVIOUS container's frames briefly while a new container loads
+  // — guard so the consumer never derives `currentFrame` from a
+  // mismatched container (see review pass-2 #1).
+  const container = data && data.id === videoContainerId ? data : null;
 
   const [frameIndex, setFrameIndexState] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
+
+  // Reset frameIndex when the container itself changes — without
+  // this, navigating from a 600-frame video at index 250 to a
+  // 50-frame video would derive a stale frame for one render.
+  useEffect(() => {
+    setFrameIndexState(0);
+    setIsPlaying(false);
+  }, [videoContainerId]);
 
   // Clamp index whenever the frame list changes (e.g., on first load).
   useEffect(() => {

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2148,6 +2148,12 @@ export default {
     renamed: 'Složka přejmenována',
     deleted: 'Složka smazána',
     moved: 'Úspěšně přesunuto',
+    moveSkipped: 'Přesun přeskočen — žádný přístup k projektu',
+    movePartial:
+      'Přesunuto {{moved}} projektů; {{skipped}} přeskočeno (bez přístupu)',
+    moveAllSkipped: '{{count}} projektů přeskočeno — bez přístupu',
+    deletePartial:
+      'Smazáno {{deleted}} projektů; {{failed}} selhalo. Složka zůstala; zkuste znovu.',
     duplicateName: 'Složka se stejným názvem zde už existuje',
     cannotMoveIntoSelf: 'Složku nelze přesunout do sebe nebo do své podsložky',
   },

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2008,6 +2008,7 @@ export default {
   error: 'Chyba',
   segmentationEditor: {
     reloadingSegmentation: 'Obnovování segmentace...',
+    loadingFrame: 'Načítání snímku...',
     segmenting: 'Segmentování...',
     waitingInQueue: 'Čekání ve frontě...',
     retryingLoad: 'Načítání se nedaří. Zkouším znovu...',
@@ -2124,5 +2125,30 @@ export default {
       play: 'Přehrát',
       pause: 'Pauza',
     },
+  },
+
+  folders: {
+    folder: 'Složka',
+    home: 'Domů',
+    newFolder: 'Nová složka',
+    createFolder: 'Vytvořit složku',
+    create: 'Vytvořit',
+    folderName: 'Název složky',
+    folderNamePlaceholder: 'např. Experiment A',
+    rename: 'Přejmenovat',
+    renameFolder: 'Přejmenovat složku',
+    deleteFolder: 'Smazat složku',
+    deleteFolderConfirm:
+      'Smazat složku „{{name}}"? Tato akce trvale smaže {{projects}} projektů a {{subfolders}} podsložek. {{shared}} sdílených projektů se vrátí do rootu.',
+    moveTo: 'Přesunout do…',
+    moveToRoot: 'Root (bez složky)',
+    openFolder: 'Otevřít složku {{name}}',
+    empty: 'Prázdná složka',
+    created: 'Složka vytvořena',
+    renamed: 'Složka přejmenována',
+    deleted: 'Složka smazána',
+    moved: 'Úspěšně přesunuto',
+    duplicateName: 'Složka se stejným názvem zde už existuje',
+    cannotMoveIntoSelf: 'Složku nelze přesunout do sebe nebo do své podsložky',
   },
 };

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1978,6 +1978,7 @@ export default {
   error: 'Fehler',
   segmentationEditor: {
     reloadingSegmentation: 'Segmentierung wird neu geladen...',
+    loadingFrame: 'Frame wird geladen...',
     segmenting: 'Segmentierung läuft...',
     waitingInQueue: 'Warten in der Warteschlange...',
     retryingLoad: 'Ladeprobleme. Neuer Versuch...',
@@ -2115,5 +2116,31 @@ export default {
       play: 'Abspielen',
       pause: 'Pause',
     },
+  },
+
+  folders: {
+    folder: 'Ordner',
+    home: 'Start',
+    newFolder: 'Neuer Ordner',
+    createFolder: 'Ordner erstellen',
+    create: 'Erstellen',
+    folderName: 'Ordnername',
+    folderNamePlaceholder: 'z. B. Experiment A',
+    rename: 'Umbenennen',
+    renameFolder: 'Ordner umbenennen',
+    deleteFolder: 'Ordner löschen',
+    deleteFolderConfirm:
+      'Ordner „{{name}}" löschen? {{projects}} Projekt(e) und {{subfolders}} Unterordner werden dauerhaft entfernt. {{shared}} geteilte Projekte kehren ins Stammverzeichnis zurück.',
+    moveTo: 'Verschieben nach…',
+    moveToRoot: 'Stamm (kein Ordner)',
+    openFolder: 'Ordner {{name}} öffnen',
+    empty: 'Leerer Ordner',
+    created: 'Ordner erstellt',
+    renamed: 'Ordner umbenannt',
+    deleted: 'Ordner gelöscht',
+    moved: 'Erfolgreich verschoben',
+    duplicateName: 'Ein Ordner mit diesem Namen existiert hier bereits',
+    cannotMoveIntoSelf:
+      'Ein Ordner kann nicht in sich selbst oder einen eigenen Unterordner verschoben werden',
   },
 };

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2139,6 +2139,12 @@ export default {
     renamed: 'Ordner umbenannt',
     deleted: 'Ordner gelöscht',
     moved: 'Erfolgreich verschoben',
+    moveSkipped: 'Verschieben übersprungen — kein Zugriff auf das Projekt',
+    movePartial:
+      '{{moved}} Projekt(e) verschoben; {{skipped}} übersprungen (kein Zugriff)',
+    moveAllSkipped: '{{count}} Projekt(e) übersprungen — kein Zugriff',
+    deletePartial:
+      '{{deleted}} Projekt(e) gelöscht; {{failed}} fehlgeschlagen. Ordner behalten; bitte erneut versuchen.',
     duplicateName: 'Ein Ordner mit diesem Namen existiert hier bereits',
     cannotMoveIntoSelf:
       'Ein Ordner kann nicht in sich selbst oder einen eigenen Unterordner verschoben werden',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2072,6 +2072,7 @@ export default {
   error: 'Error',
   segmentationEditor: {
     reloadingSegmentation: 'Reloading segmentation...',
+    loadingFrame: 'Loading frame...',
     segmenting: 'Segmenting...',
     waitingInQueue: 'Waiting in queue...',
     retryingLoad: 'Having trouble loading. Retrying...',
@@ -2186,5 +2187,32 @@ export default {
       play: 'Play',
       pause: 'Pause',
     },
+  },
+
+  // Project folder hierarchy (file-explorer-style organisation of the gallery)
+  folders: {
+    folder: 'Folder',
+    home: 'Home',
+    newFolder: 'New folder',
+    createFolder: 'Create folder',
+    create: 'Create',
+    folderName: 'Folder name',
+    folderNamePlaceholder: 'e.g. Experiment A',
+    rename: 'Rename',
+    renameFolder: 'Rename folder',
+    deleteFolder: 'Delete folder',
+    deleteFolderConfirm:
+      'Delete folder "{{name}}"? This will permanently delete {{projects}} project(s) and {{subfolders}} subfolder(s). {{shared}} shared project(s) will return to root.',
+    moveTo: 'Move to…',
+    moveToRoot: 'Root (no folder)',
+    openFolder: 'Open folder {{name}}',
+    empty: 'Empty folder',
+    created: 'Folder created',
+    renamed: 'Folder renamed',
+    deleted: 'Folder deleted',
+    moved: 'Moved successfully',
+    duplicateName: 'A folder with this name already exists here',
+    cannotMoveIntoSelf:
+      'A folder cannot be moved into itself or its own subfolder',
   },
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2211,6 +2211,11 @@ export default {
     renamed: 'Folder renamed',
     deleted: 'Folder deleted',
     moved: 'Moved successfully',
+    moveSkipped: 'Move skipped — no access to that project',
+    movePartial: 'Moved {{moved}} project(s); {{skipped}} skipped (no access)',
+    moveAllSkipped: '{{count}} project(s) skipped — no access',
+    deletePartial:
+      'Deleted {{deleted}} project(s); {{failed}} failed. Folder kept; retry the failures.',
     duplicateName: 'A folder with this name already exists here',
     cannotMoveIntoSelf:
       'A folder cannot be moved into itself or its own subfolder',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2177,6 +2177,12 @@ export default {
     renamed: 'Carpeta renombrada',
     deleted: 'Carpeta eliminada',
     moved: 'Movido correctamente',
+    moveSkipped: 'Movimiento omitido — sin acceso al proyecto',
+    movePartial:
+      'Movidos {{moved}} proyecto(s); {{skipped}} omitido(s) (sin acceso)',
+    moveAllSkipped: '{{count}} proyecto(s) omitido(s) — sin acceso',
+    deletePartial:
+      '{{deleted}} proyecto(s) eliminado(s); {{failed}} falló/fallaron. Carpeta conservada; inténtelo de nuevo.',
     duplicateName: 'Ya existe una carpeta con este nombre aquí',
     cannotMoveIntoSelf:
       'Una carpeta no se puede mover dentro de sí misma o de su propia subcarpeta',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2037,6 +2037,7 @@ export default {
   error: 'Error',
   segmentationEditor: {
     reloadingSegmentation: 'Recargando segmentación...',
+    loadingFrame: 'Cargando fotograma...',
     segmenting: 'Segmentando...',
     waitingInQueue: 'Esperando en cola...',
     retryingLoad: 'Problemas al cargar. Reintentando...',
@@ -2153,5 +2154,31 @@ export default {
       play: 'Reproducir',
       pause: 'Pausar',
     },
+  },
+
+  folders: {
+    folder: 'Carpeta',
+    home: 'Inicio',
+    newFolder: 'Nueva carpeta',
+    createFolder: 'Crear carpeta',
+    create: 'Crear',
+    folderName: 'Nombre de la carpeta',
+    folderNamePlaceholder: 'p. ej. Experimento A',
+    rename: 'Renombrar',
+    renameFolder: 'Renombrar carpeta',
+    deleteFolder: 'Eliminar carpeta',
+    deleteFolderConfirm:
+      '¿Eliminar la carpeta «{{name}}»? Esto eliminará permanentemente {{projects}} proyecto(s) y {{subfolders}} subcarpeta(s). {{shared}} proyecto(s) compartido(s) volverán a la raíz.',
+    moveTo: 'Mover a…',
+    moveToRoot: 'Raíz (sin carpeta)',
+    openFolder: 'Abrir carpeta {{name}}',
+    empty: 'Carpeta vacía',
+    created: 'Carpeta creada',
+    renamed: 'Carpeta renombrada',
+    deleted: 'Carpeta eliminada',
+    moved: 'Movido correctamente',
+    duplicateName: 'Ya existe una carpeta con este nombre aquí',
+    cannotMoveIntoSelf:
+      'Una carpeta no se puede mover dentro de sí misma o de su propia subcarpeta',
   },
 };

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1965,6 +1965,7 @@ export default {
   error: 'Erreur',
   segmentationEditor: {
     reloadingSegmentation: 'Rechargement de la segmentation...',
+    loadingFrame: 'Chargement de la trame...',
     segmenting: 'Segmentation en cours...',
     waitingInQueue: 'En attente dans la file...',
     retryingLoad: 'Problème de chargement. Nouvelle tentative...',
@@ -2102,5 +2103,31 @@ export default {
       play: 'Lecture',
       pause: 'Pause',
     },
+  },
+
+  folders: {
+    folder: 'Dossier',
+    home: 'Accueil',
+    newFolder: 'Nouveau dossier',
+    createFolder: 'Créer un dossier',
+    create: 'Créer',
+    folderName: 'Nom du dossier',
+    folderNamePlaceholder: 'ex. Expérience A',
+    rename: 'Renommer',
+    renameFolder: 'Renommer le dossier',
+    deleteFolder: 'Supprimer le dossier',
+    deleteFolderConfirm:
+      'Supprimer le dossier « {{name}} » ? Cette action supprimera définitivement {{projects}} projet(s) et {{subfolders}} sous-dossier(s). {{shared}} projet(s) partagé(s) retourneront à la racine.',
+    moveTo: 'Déplacer vers…',
+    moveToRoot: 'Racine (sans dossier)',
+    openFolder: 'Ouvrir le dossier {{name}}',
+    empty: 'Dossier vide',
+    created: 'Dossier créé',
+    renamed: 'Dossier renommé',
+    deleted: 'Dossier supprimé',
+    moved: 'Déplacé avec succès',
+    duplicateName: 'Un dossier portant ce nom existe déjà ici',
+    cannotMoveIntoSelf:
+      'Un dossier ne peut pas être déplacé dans lui-même ou dans son propre sous-dossier',
   },
 };

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2126,6 +2126,12 @@ export default {
     renamed: 'Dossier renommé',
     deleted: 'Dossier supprimé',
     moved: 'Déplacé avec succès',
+    moveSkipped: "Déplacement ignoré — pas d'accès au projet",
+    movePartial:
+      "{{moved}} projet(s) déplacé(s) ; {{skipped}} ignoré(s) (pas d'accès)",
+    moveAllSkipped: "{{count}} projet(s) ignoré(s) — pas d'accès",
+    deletePartial:
+      '{{deleted}} projet(s) supprimé(s) ; {{failed}} échoué(s). Dossier conservé ; réessayez.',
     duplicateName: 'Un dossier portant ce nom existe déjà ici',
     cannotMoveIntoSelf:
       'Un dossier ne peut pas être déplacé dans lui-même ou dans son propre sous-dossier',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -2002,6 +2002,11 @@ export default {
     renamed: '文件夹已重命名',
     deleted: '文件夹已删除',
     moved: '已成功移动',
+    moveSkipped: '已跳过移动 — 无该项目访问权限',
+    movePartial: '已移动 {{moved}} 个项目;{{skipped}} 个已跳过(无访问权限)',
+    moveAllSkipped: '{{count}} 个项目已跳过 — 无访问权限',
+    deletePartial:
+      '已删除 {{deleted}} 个项目;{{failed}} 个失败。文件夹已保留,请重试。',
     duplicateName: '此处已存在同名文件夹',
     cannotMoveIntoSelf: '无法将文件夹移动到自身或其子文件夹中',
   },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1848,6 +1848,7 @@ export default {
   error: '错误',
   segmentationEditor: {
     reloadingSegmentation: '重新加载分割...',
+    loadingFrame: '正在加载帧...',
     segmenting: '分割中...',
     waitingInQueue: '队列中等待...',
     retryingLoad: '加载遇到问题，正在重试...',
@@ -1978,5 +1979,30 @@ export default {
       play: '播放',
       pause: '暂停',
     },
+  },
+
+  folders: {
+    folder: '文件夹',
+    home: '主页',
+    newFolder: '新建文件夹',
+    createFolder: '创建文件夹',
+    create: '创建',
+    folderName: '文件夹名称',
+    folderNamePlaceholder: '例如：实验 A',
+    rename: '重命名',
+    renameFolder: '重命名文件夹',
+    deleteFolder: '删除文件夹',
+    deleteFolderConfirm:
+      '删除文件夹"{{name}}"?将永久删除 {{projects}} 个项目和 {{subfolders}} 个子文件夹。{{shared}} 个共享项目将返回根目录。',
+    moveTo: '移动到…',
+    moveToRoot: '根目录(无文件夹)',
+    openFolder: '打开文件夹 {{name}}',
+    empty: '空文件夹',
+    created: '文件夹已创建',
+    renamed: '文件夹已重命名',
+    deleted: '文件夹已删除',
+    moved: '已成功移动',
+    duplicateName: '此处已存在同名文件夹',
+    cannotMoveIntoSelf: '无法将文件夹移动到自身或其子文件夹中',
   },
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -400,6 +400,18 @@ export interface Project {
   user_id: string;
   imageCount?: number;
   thumbnail?: string;
+  // Per-user folder placement. `null` (or absent) means the project sits at
+  // the caller's root level. Two users can see different folderId values for
+  // the same shared project — see backend ProjectFolderItem model.
+  folderId?: string | null;
+}
+
+export interface ProjectFolder {
+  id: string;
+  name: string;
+  parentId: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface NewProject {

--- a/src/utils/dashboardDrag.ts
+++ b/src/utils/dashboardDrag.ts
@@ -1,0 +1,82 @@
+// HTML5 native DnD helpers for the dashboard's file-explorer drag-and-drop.
+//
+// Why not @dnd-kit? Its sensors call event.preventDefault() on pointerdown
+// to block native drag selection. That preventDefault also suppresses the
+// browser's subsequent click event — so cards using @dnd-kit listeners
+// stop being clickable. HTML5 native drag and click are independent event
+// chains, so cards stay both clickable AND draggable.
+//
+// Why dataTransfer-based and not a shared module-level ref?
+// During the dragover phase the browser hides dataTransfer.getData() return
+// values for security (the receiver shouldn't be able to peek at payload
+// before the user commits to the drop). However the *list* of MIME types
+// IS exposed during dragover via dataTransfer.types — so we encode the
+// dragged item's *type* in the MIME and read the *id* only at drop time.
+//
+// MIME conventions:
+//   application/x-spheroseg-project   payload: project uuid
+//   application/x-spheroseg-folder    payload: folder uuid
+// The `x-spheroseg-` prefix prevents accidental matches with files dragged
+// in from the desktop (e.g. text/plain, Files).
+
+export type DragItem =
+  | { type: 'project'; id: string }
+  | { type: 'folder'; id: string };
+
+export const PROJECT_MIME = 'application/x-spheroseg-project';
+export const FOLDER_MIME = 'application/x-spheroseg-folder';
+
+/** Props for a drag source. Spread onto the draggable element. */
+export function dragSourceProps(item: DragItem): {
+  draggable: true;
+  onDragStart: (e: React.DragEvent) => void;
+} {
+  const mime = item.type === 'project' ? PROJECT_MIME : FOLDER_MIME;
+  return {
+    draggable: true,
+    onDragStart: (e: React.DragEvent) => {
+      e.dataTransfer.effectAllowed = 'move';
+      // Set BOTH a structured MIME (read on drop) and text/plain
+      // (some browsers — Firefox in particular — refuse to initiate a
+      // drag without a text/plain payload).
+      e.dataTransfer.setData(mime, item.id);
+      e.dataTransfer.setData('text/plain', `${item.type}:${item.id}`);
+    },
+  };
+}
+
+/** What type of item is currently being dragged, derived from dataTransfer
+ *  types? Available even during dragover (when getData itself returns ""). */
+export function dragKindFromTypes(
+  types: ReadonlyArray<string>
+): DragItem['type'] | null {
+  if (types.includes(PROJECT_MIME)) return 'project';
+  if (types.includes(FOLDER_MIME)) return 'folder';
+  return null;
+}
+
+/** Read the actual payload at drop time (getData() works now). */
+export function readDragItem(dataTransfer: DataTransfer): DragItem | null {
+  const project = dataTransfer.getData(PROJECT_MIME);
+  if (project) return { type: 'project', id: project };
+  const folder = dataTransfer.getData(FOLDER_MIME);
+  if (folder) return { type: 'folder', id: folder };
+  return null;
+}
+
+/** Should the current dragover be accepted onto a folder target? */
+export function shouldAcceptOnFolder(
+  targetFolderId: string,
+  dataTransfer: DataTransfer
+): boolean {
+  const kind = dragKindFromTypes(Array.from(dataTransfer.types));
+  if (!kind) return false;
+  // We cannot peek the source id during dragover, so we'd allow a
+  // self-drop here; the drop handler filters it (folder !== self).
+  return true;
+}
+
+/** Should the current dragover be accepted onto a breadcrumb segment? */
+export function shouldAcceptOnBreadcrumb(dataTransfer: DataTransfer): boolean {
+  return dragKindFromTypes(Array.from(dataTransfer.types)) !== null;
+}


### PR DESCRIPTION
Follow-up to #202 — addresses the three "important" findings from the multi-agent review that didn't block merge but improve user-facing error UX.

## Summary

- **Whitespace-only folder name validation** — Zod `.trim().min(1)` order fix; was previously accepted by updateFolder
- **Server-side messages in toasts** — extract localized Czech from `err.response.data.error` instead of axios "Request failed with status code 409"
- **Broader Prisma error mapping** — P2003 (FK) → PARENT_NOT_FOUND, P2025 (record-not-found race) → NOT_FOUND

## Implementation notes

**Fix #6** (`backend/src/types/validation.ts`) — `folderNameSchema` was `.string().min(1).max(100).trim()`. Zod evaluates `.min(1)` BEFORE `.trim()`, so `" "` passed validation, was trimmed to `""`, and stored. `createFolder` had a defensive re-check but `updateFolder` did not. The fix moves `.trim()` first.

**Fix #9** (`src/hooks/useFolders.ts`) — All five mutation `onError` handlers toasted `(err as Error).message` which axios sets to literal "Request failed with status code 409". New `extractServerMessage(err, fallback)` helper checks: response.data.error → response.data.message → err.message → fallback. Users now see "Složka se stejným názvem na této úrovni už existuje" instead of HTTP jargon.

**Fix #11** (`backend/src/services/projectFolderService.ts`) — All `try/catch` around Prisma writes used a single P2002 check then re-threw. New `translatePrismaError()` helper covers P2002 → DUPLICATE_NAME (409), P2003 → PARENT_NOT_FOUND (404), P2025 → NOT_FOUND (404). Unknown Prisma codes still bubble up to the controller's generic 500 handler so genuine bugs reach Sentry.

## Test plan
- [x] Smoke test: `PATCH /api/folders/:id {"name":"   "}` → 400 VALIDATION_ERROR (previously 200)
- [x] Smoke test: `POST /api/folders {"name":"   "}` → 400 VALIDATION_ERROR
- [x] Race condition: rename a folder that was just deleted → 404 "Složka nebyla nalezena"
- [ ] Manual UI: rename folder to duplicate name → localized toast instead of "Request failed..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project folder organization with hierarchical folder structure and drag-and-drop support to move projects between folders.
  * Implemented frame image caching and sliding-window prefetching for smoother video playback navigation.
  * Added channel selection for batch segmentation on multi-channel videos.
  * Added visual loading indicator when switching between video frames.

* **Bug Fixes**
  * Tracker now correctly handles frames with failed segmentations without indefinitely blocking batch completion.
  * Enhanced frame interval detection from microscopy TIFF and ND2 files with improved timestamp parsing and unit normalization.

* **Improvements**
  * Added nginx caching for frame image endpoints to reduce load.
  * Updated segmentation model allowlist validation across controllers and routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->