### PR TITLE
feat(editor): MT add-points UX + kymograph fidelity + zoom perf

### DIFF
--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -317,11 +317,8 @@ class KymographResponse(BaseModel):
 def _resample_profile(profile: np.ndarray, target_width: int) -> np.ndarray:
     """Nearest-neighbour resample of a 1D intensity profile to ``target_width``.
 
-    Linear interpolation (np.interp) was smoothing the data — averaging
-    adjacent pixel intensities — which hides genuine intensity steps along
-    the microtubule. We pick the source index nearest to each destination
-    position so every value in the kymograph row is a real, unaltered pixel
-    intensity sampled along the polyline.
+    Each output value is a real source pixel — no interpolation — so the
+    kymograph faithfully reports the raw intensity sampled along the polyline.
     """
     if profile.size == 0:
         return np.zeros(target_width, dtype=np.float32)
@@ -431,12 +428,14 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
         H, W = img.shape
         pts = np.asarray(frame.polyline_rc, dtype=np.float32)
         if pts.ndim != 2 or pts.shape[1] != 2 or pts.shape[0] < 2:
+            logger.warning(
+                "kymograph: frame %s polyline has <2 points; row filled with zeros",
+                frame.frame,
+            )
             rows.append(np.zeros(req.target_width, dtype=np.float32))
             continue
-        # scipy.ndimage.map_coordinates expects (channel, point) layout for
-        # row & column samplers. order=0 picks the nearest pixel rather
-        # than blending neighbours — required so the kymograph shows raw
-        # intensities along the polyline, not smoothed averages.
+        # map_coordinates: coords shape (2, N) — row 0 = row indices,
+        # row 1 = column indices. order=0 = nearest pixel (no blending).
         rows_idx = np.clip(pts[:, 0], 0, H - 1)
         cols_idx = np.clip(pts[:, 1], 0, W - 1)
         profile = map_coordinates(

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -315,14 +315,23 @@ class KymographResponse(BaseModel):
 
 
 def _resample_profile(profile: np.ndarray, target_width: int) -> np.ndarray:
-    """Linear resample a 1D profile to ``target_width`` points."""
+    """Nearest-neighbour resample of a 1D intensity profile to ``target_width``.
+
+    Linear interpolation (np.interp) was smoothing the data — averaging
+    adjacent pixel intensities — which hides genuine intensity steps along
+    the microtubule. We pick the source index nearest to each destination
+    position so every value in the kymograph row is a real, unaltered pixel
+    intensity sampled along the polyline.
+    """
     if profile.size == 0:
         return np.zeros(target_width, dtype=np.float32)
     if profile.size == target_width:
         return profile.astype(np.float32)
-    src_x = np.linspace(0.0, 1.0, profile.size, dtype=np.float32)
-    dst_x = np.linspace(0.0, 1.0, target_width, dtype=np.float32)
-    return np.interp(dst_x, src_x, profile.astype(np.float32))
+    src_indices = np.round(
+        np.linspace(0.0, float(profile.size - 1), target_width)
+    ).astype(np.int32)
+    src_indices = np.clip(src_indices, 0, profile.size - 1)
+    return profile[src_indices].astype(np.float32)
 
 
 _VIRIDIS_RGB = np.array(
@@ -425,13 +434,15 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
             rows.append(np.zeros(req.target_width, dtype=np.float32))
             continue
         # scipy.ndimage.map_coordinates expects (channel, point) layout for
-        # row & column samplers. Clip into the frame to avoid silent zeros.
+        # row & column samplers. order=0 picks the nearest pixel rather
+        # than blending neighbours — required so the kymograph shows raw
+        # intensities along the polyline, not smoothed averages.
         rows_idx = np.clip(pts[:, 0], 0, H - 1)
         cols_idx = np.clip(pts[:, 1], 0, W - 1)
         profile = map_coordinates(
             img,
             np.stack([rows_idx, cols_idx]),
-            order=1,
+            order=0,
             mode="nearest",
         )
         rows.append(_resample_profile(profile, req.target_width))

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1780,6 +1780,7 @@ const SegmentationEditor = () => {
                             }
                             vertexDragState={editor.vertexDragState}
                             zoom={editor.transform.zoom}
+                            isZooming={editor.isZooming}
                             isUndoRedoInProgress={editor.isUndoRedoInProgress}
                             isHovered={polygon.id === hoveredPolygonId}
                             editMode={editor.editMode}

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -39,6 +39,10 @@ interface CanvasPolygonProps {
    *  to ``'microtubules'``. Without this gate, MT users saw the sperm
    *  head/midpiece/tail items just because the callbacks were truthy. */
   projectType?: ProjectType;
+  /** Wheel-zoom in progress. Forwarded to PolygonVertices so it can
+   *  skip the (expensive) per-vertex 1/zoom radius re-compute while
+   *  the wheel is active. */
+  isZooming?: boolean;
 }
 
 const CanvasPolygon = React.memo(
@@ -64,6 +68,7 @@ const CanvasPolygon = React.memo(
     onHover,
     editMode,
     projectType,
+    isZooming,
   }: CanvasPolygonProps) => {
     const { id, points, type = 'external', parent_id } = polygon;
 
@@ -397,6 +402,7 @@ const CanvasPolygon = React.memo(
               onDeleteVertex={onDeleteVertex}
               onDuplicateVertex={onDuplicateVertex}
               editMode={editMode}
+              isZooming={isZooming}
             />
           )}
         </g>
@@ -439,7 +445,13 @@ const CanvasPolygon = React.memo(
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isHovered === nextProps.isHovered &&
       prevProps.isUndoRedoInProgress === nextProps.isUndoRedoInProgress &&
-      prevProps.zoom === nextProps.zoom &&
+      // Zoom equality is short-circuited when the wheel is actively
+      // zooming: we accept the previous zoom value (the SVG container
+      // CSS-scales the path + endpoint markers for free) so the per-
+      // vertex 1/zoom math is deferred until the wheel settles. Without
+      // this, every wheel tick re-renders every CanvasPolygon in the
+      // visible viewport, stuttering badly on long polylines.
+      (prevProps.zoom === nextProps.zoom || nextProps.isZooming === true) &&
       prevProps.hideVertices === nextProps.hideVertices &&
       sameViewport &&
       prevProps.hoveredVertex?.polygonId ===

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -34,14 +34,9 @@ interface CanvasPolygonProps {
   onDuplicateVertex?: (polygonId: string, vertexIndex: number) => void;
   onHover?: (polygonId: string | null) => void;
   editMode?: EditMode;
-  /** Project-type gate for the polyline context menu. Sperm items only
-   *  appear for ``'sperm'`` projects; the kymograph item is exclusive
-   *  to ``'microtubules'``. Without this gate, MT users saw the sperm
-   *  head/midpiece/tail items just because the callbacks were truthy. */
+  /** Gates polyline context-menu items by project (sperm parts vs. MT kymograph). */
   projectType?: ProjectType;
-  /** Wheel-zoom in progress. Forwarded to PolygonVertices so it can
-   *  skip the (expensive) per-vertex 1/zoom radius re-compute while
-   *  the wheel is active. */
+  /** Wheel-zoom in progress. Skips per-vertex 1/zoom re-compute. */
   isZooming?: boolean;
 }
 
@@ -445,12 +440,8 @@ const CanvasPolygon = React.memo(
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isHovered === nextProps.isHovered &&
       prevProps.isUndoRedoInProgress === nextProps.isUndoRedoInProgress &&
-      // Zoom equality is short-circuited when the wheel is actively
-      // zooming: we accept the previous zoom value (the SVG container
-      // CSS-scales the path + endpoint markers for free) so the per-
-      // vertex 1/zoom math is deferred until the wheel settles. Without
-      // this, every wheel tick re-renders every CanvasPolygon in the
-      // visible viewport, stuttering badly on long polylines.
+      // Defer zoom-driven re-renders while the wheel is active — the
+      // parent SVG transform handles visual scaling.
       (prevProps.zoom === nextProps.zoom || nextProps.isZooming === true) &&
       prevProps.hideVertices === nextProps.hideVertices &&
       sameViewport &&
@@ -468,10 +459,7 @@ const CanvasPolygon = React.memo(
       prevProps.onChangePartClass === nextProps.onChangePartClass &&
       prevProps.onChangeInstanceId === nextProps.onChangeInstanceId &&
       prevProps.availableInstanceIds === nextProps.availableInstanceIds &&
-      // projectType drives the context-menu's sperm-vs-MT gating; if
-      // we forget to compare it here, switching project types in the
-      // same session (or a per-polygon override one day) wouldn't
-      // re-render the menu and the user would see stale options.
+      // Drives context-menu gating; must be in comparator.
       prevProps.projectType === nextProps.projectType &&
       // editMode flips between View / EditVertices / Slice / AddPoints /
       // CreatePolygon / CreatePolyline / DeletePolygon and changes which

--- a/src/pages/segmentation/components/canvas/PolygonVertices.tsx
+++ b/src/pages/segmentation/components/canvas/PolygonVertices.tsx
@@ -17,6 +17,12 @@ interface PolygonVerticesProps {
   isUndoRedoInProgress?: boolean;
   onDeleteVertex?: (polygonId: string, vertexIndex: number) => void;
   editMode?: EditMode;
+  /** True while the wheel is actively zooming. When true, the memo
+   *  comparator below skips re-renders triggered by zoom changes —
+   *  vertices keep their last-computed SVG size and the parent CSS
+   *  transform scales them visually with the image, dodging the
+   *  per-vertex 1/zoom math that lags on 100+ point polylines. */
+  isZooming?: boolean;
 }
 
 const PolygonVertices = React.memo(
@@ -127,10 +133,24 @@ const PolygonVertices = React.memo(
       prevProps.polygonType !== nextProps.polygonType ||
       prevProps.isSelected !== nextProps.isSelected ||
       prevProps.isHovered !== nextProps.isHovered ||
-      prevProps.zoom !== nextProps.zoom ||
       prevProps.isUndoRedoInProgress !== nextProps.isUndoRedoInProgress
     ) {
       return false;
+    }
+    // Zoom change handling: if a zoom is currently in progress (rapid
+    // wheel events) we deliberately skip the vertex re-render. The CSS
+    // transform on the parent SVG container scales the circles visually
+    // for free; recomputing per-vertex 1/zoom radii every wheel tick is
+    // what makes the editor stutter on long polylines. The 150ms
+    // debounce in useEnhancedSegmentationEditor flips isZooming false
+    // when the wheel settles, at which point the next render goes
+    // through and the vertices snap to their proper screen-relative size.
+    if (prevProps.zoom !== nextProps.zoom) {
+      if (nextProps.isZooming) {
+        // Defer: skip this re-render, parent's transform handles visuals
+      } else {
+        return false;
+      }
     }
 
     // Compare points array (deep comparison)

--- a/src/pages/segmentation/components/canvas/PolygonVertices.tsx
+++ b/src/pages/segmentation/components/canvas/PolygonVertices.tsx
@@ -17,11 +17,8 @@ interface PolygonVerticesProps {
   isUndoRedoInProgress?: boolean;
   onDeleteVertex?: (polygonId: string, vertexIndex: number) => void;
   editMode?: EditMode;
-  /** True while the wheel is actively zooming. When true, the memo
-   *  comparator below skips re-renders triggered by zoom changes —
-   *  vertices keep their last-computed SVG size and the parent CSS
-   *  transform scales them visually with the image, dodging the
-   *  per-vertex 1/zoom math that lags on 100+ point polylines. */
+  /** True while the wheel is actively zooming. Comparator-only —
+   *  not read at render time; suppresses zoom-driven re-renders. */
   isZooming?: boolean;
 }
 
@@ -137,20 +134,9 @@ const PolygonVertices = React.memo(
     ) {
       return false;
     }
-    // Zoom change handling: if a zoom is currently in progress (rapid
-    // wheel events) we deliberately skip the vertex re-render. The CSS
-    // transform on the parent SVG container scales the circles visually
-    // for free; recomputing per-vertex 1/zoom radii every wheel tick is
-    // what makes the editor stutter on long polylines. The 150ms
-    // debounce in useEnhancedSegmentationEditor flips isZooming false
-    // when the wheel settles, at which point the next render goes
-    // through and the vertices snap to their proper screen-relative size.
-    if (prevProps.zoom !== nextProps.zoom) {
-      if (nextProps.isZooming) {
-        // Defer: skip this re-render, parent's transform handles visuals
-      } else {
-        return false;
-      }
+    // Skip zoom-only re-render while the wheel is active (see CanvasPolygon).
+    if (prevProps.zoom !== nextProps.zoom && !nextProps.isZooming) {
+      return false;
     }
 
     // Compare points array (deep comparison)

--- a/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
+++ b/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
@@ -14,6 +14,7 @@ import {
   createPolygon,
 } from '@/lib/polygonGeometry';
 import { vertexSpatialIndex } from '@/lib/rendering/VertexSpatialIndex';
+import type { ProjectType } from '@/types';
 
 /**
  * Advanced interaction handler inspired by SpheroSeg
@@ -32,11 +33,8 @@ interface UseAdvancedInteractionsProps {
   isSpacePressed?: () => boolean;
   activePartClassRef?: React.RefObject<'head' | 'midpiece' | 'tail'>;
   activeInstanceIdRef?: React.RefObject<string>;
-  /** Project workflow type. Used to gate the MT-specific Add-Points
-   *  auto-anchor flow (click anywhere → anchor at nearest polyline
-   *  endpoint, Enter to commit). Other project types keep the old
-   *  "click vertex to anchor, click another vertex to finalise" UX. */
-  projectType?: import('@/types').ProjectType;
+  /** Gates the MT-specific Add-Points auto-anchor flow. */
+  projectType?: ProjectType;
 
   // State setters
   onPolygonSelection: (id: string | null) => void; // Centralized selection handler
@@ -254,13 +252,8 @@ export const useAdvancedInteractions = ({
       );
 
       if (!interactionState.isAddingPoints) {
-        // MT polyline: extend-by-click workflow. User shouldn't have to
-        // hunt for the endpoint vertex first — pick whichever endpoint
-        // (head or tail) is nearest to their click as the anchor, and
-        // treat this click itself as the first new point. Enter commits
-        // via handleEnterPolyline (useEnhancedSegmentationEditor.tsx).
-        // Sperm polylines keep the legacy click-vertex anchoring because
-        // their muscle memory predates this flow.
+        // MT polyline: auto-anchor at nearest endpoint, treat click as
+        // first new point. Enter commits via handleEnterPolyline.
         const isMtPolyline =
           projectType === 'microtubules' &&
           selectedPolygon.geometry === 'polyline' &&
@@ -299,17 +292,9 @@ export const useAdvancedInteractions = ({
           setTempPoints([]);
         }
       } else {
-        // We're in adding points mode. Two completion paths coexist for
-        // MT polylines:
-        //   1. Legacy splice — click on a DIFFERENT existing vertex to
-        //      close the sequence; the points between the two clicks get
-        //      inserted via insertPointsBetweenVertices. Works for any
-        //      anchor (including mid-polyline) and is how the user can
-        //      "splice into" an existing MT.
-        //   2. Endpoint extension — press Enter, handled by
-        //      handleEnterPolyline. Works only when anchor is head/tail.
-        // We accept both; the user picks based on whether they click a
-        // vertex or press Enter.
+        // Two completion paths: click a different vertex = splice via
+        // insertPointsBetweenVertices (all geometries); Enter = endpoint
+        // extension (MT only) via handleEnterPolyline.
         if (closestVertex && interactionState.addPointStartVertex) {
           if (
             closestVertex.index !==
@@ -756,15 +741,8 @@ export const useAdvancedInteractions = ({
         ? isShiftPressedCallback()
         : false;
 
-      // Bootstrap MT polyline Add-Points state when the user starts with
-      // Shift held instead of a click. Without this, isAddingPoints stays
-      // false (it normally flips inside the click handler) and the
-      // shift-auto-add branch below is unreachable, so Enter has nothing
-      // to commit. We pick the polyline endpoint nearest to the cursor as
-      // the anchor — exactly the same auto-anchor logic the click path
-      // uses — and seed lastAutoAddedPoint with that endpoint so the next
-      // shift-move starts laying down points at the MIN_AUTO_ADD_DISTANCE
-      // cadence away from the polyline tail/head.
+      // Shift-without-click bootstrap for MT polyline AddPoints: seed
+      // state so the next mouseMove can enter the equidistant branch.
       if (
         isShiftCurrentlyPressed &&
         editMode === EditMode.AddPoints &&
@@ -798,9 +776,10 @@ export const useAdvancedInteractions = ({
             },
           });
           lastAutoAddedPoint.current = selectedPolygon.points[anchorIndex];
-          // First mouseMove only transitions state; the next move (with
-          // isAddingPoints now true) starts populating tempPoints via the
-          // distance-gated branch below.
+          // Seed tempPoints with the current cursor so Enter is always
+          // commit-able, even if the user releases Shift between this
+          // bootstrap tick and the next mouseMove.
+          setTempPoints([imagePoint]);
           return;
         }
       }

--- a/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
+++ b/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
@@ -32,6 +32,11 @@ interface UseAdvancedInteractionsProps {
   isSpacePressed?: () => boolean;
   activePartClassRef?: React.RefObject<'head' | 'midpiece' | 'tail'>;
   activeInstanceIdRef?: React.RefObject<string>;
+  /** Project workflow type. Used to gate the MT-specific Add-Points
+   *  auto-anchor flow (click anywhere → anchor at nearest polyline
+   *  endpoint, Enter to commit). Other project types keep the old
+   *  "click vertex to anchor, click another vertex to finalise" UX. */
+  projectType?: import('@/types').ProjectType;
 
   // State setters
   onPolygonSelection: (id: string | null) => void; // Centralized selection handler
@@ -69,6 +74,7 @@ export const useAdvancedInteractions = ({
   isSpacePressed: isSpacePressedCallback,
   activePartClassRef,
   activeInstanceIdRef,
+  projectType,
   onPolygonSelection,
   setEditMode,
   setInteractionState,
@@ -248,7 +254,39 @@ export const useAdvancedInteractions = ({
       );
 
       if (!interactionState.isAddingPoints) {
-        // Start adding points - must click on a vertex
+        // MT polyline: extend-by-click workflow. User shouldn't have to
+        // hunt for the endpoint vertex first — pick whichever endpoint
+        // (head or tail) is nearest to their click as the anchor, and
+        // treat this click itself as the first new point. Enter commits
+        // via handleEnterPolyline (useEnhancedSegmentationEditor.tsx).
+        // Sperm polylines keep the legacy click-vertex anchoring because
+        // their muscle memory predates this flow.
+        const isMtPolyline =
+          projectType === 'microtubules' &&
+          selectedPolygon.geometry === 'polyline' &&
+          selectedPolygon.points.length >= 2;
+        if (isMtPolyline) {
+          const head = selectedPolygon.points[0];
+          const tail =
+            selectedPolygon.points[selectedPolygon.points.length - 1];
+          const distHead =
+            (imagePoint.x - head.x) ** 2 + (imagePoint.y - head.y) ** 2;
+          const distTail =
+            (imagePoint.x - tail.x) ** 2 + (imagePoint.y - tail.y) ** 2;
+          const anchorIndex =
+            distHead <= distTail ? 0 : selectedPolygon.points.length - 1;
+          setInteractionState({
+            ...interactionState,
+            isAddingPoints: true,
+            addPointStartVertex: {
+              polygonId: selectedPolygonId,
+              vertexIndex: anchorIndex,
+            },
+          });
+          setTempPoints([imagePoint]);
+          return;
+        }
+        // Other geometries / projects: keep the legacy click-vertex anchor.
         if (closestVertex) {
           setInteractionState({
             ...interactionState,
@@ -261,9 +299,18 @@ export const useAdvancedInteractions = ({
           setTempPoints([]);
         }
       } else {
-        // We're in adding points mode
+        // We're in adding points mode. Two completion paths coexist for
+        // MT polylines:
+        //   1. Legacy splice — click on a DIFFERENT existing vertex to
+        //      close the sequence; the points between the two clicks get
+        //      inserted via insertPointsBetweenVertices. Works for any
+        //      anchor (including mid-polyline) and is how the user can
+        //      "splice into" an existing MT.
+        //   2. Endpoint extension — press Enter, handled by
+        //      handleEnterPolyline. Works only when anchor is head/tail.
+        // We accept both; the user picks based on whether they click a
+        // vertex or press Enter.
         if (closestVertex && interactionState.addPointStartVertex) {
-          // Check if clicking on different vertex to complete the sequence
           if (
             closestVertex.index !==
             interactionState.addPointStartVertex.vertexIndex
@@ -309,6 +356,7 @@ export const useAdvancedInteractions = ({
       interactionState,
       tempPoints,
       transform.zoom,
+      projectType,
       getPolygons,
       updatePolygons,
       setTempPoints,
@@ -708,6 +756,55 @@ export const useAdvancedInteractions = ({
         ? isShiftPressedCallback()
         : false;
 
+      // Bootstrap MT polyline Add-Points state when the user starts with
+      // Shift held instead of a click. Without this, isAddingPoints stays
+      // false (it normally flips inside the click handler) and the
+      // shift-auto-add branch below is unreachable, so Enter has nothing
+      // to commit. We pick the polyline endpoint nearest to the cursor as
+      // the anchor — exactly the same auto-anchor logic the click path
+      // uses — and seed lastAutoAddedPoint with that endpoint so the next
+      // shift-move starts laying down points at the MIN_AUTO_ADD_DISTANCE
+      // cadence away from the polyline tail/head.
+      if (
+        isShiftCurrentlyPressed &&
+        editMode === EditMode.AddPoints &&
+        !interactionState.isAddingPoints &&
+        selectedPolygonId &&
+        projectType === 'microtubules'
+      ) {
+        const selectedPolygon = getPolygons().find(
+          p => p.id === selectedPolygonId
+        );
+        if (
+          selectedPolygon &&
+          selectedPolygon.geometry === 'polyline' &&
+          selectedPolygon.points.length >= 2
+        ) {
+          const head = selectedPolygon.points[0];
+          const tail =
+            selectedPolygon.points[selectedPolygon.points.length - 1];
+          const distHead =
+            (imagePoint.x - head.x) ** 2 + (imagePoint.y - head.y) ** 2;
+          const distTail =
+            (imagePoint.x - tail.x) ** 2 + (imagePoint.y - tail.y) ** 2;
+          const anchorIndex =
+            distHead <= distTail ? 0 : selectedPolygon.points.length - 1;
+          setInteractionState({
+            ...interactionState,
+            isAddingPoints: true,
+            addPointStartVertex: {
+              polygonId: selectedPolygonId,
+              vertexIndex: anchorIndex,
+            },
+          });
+          lastAutoAddedPoint.current = selectedPolygon.points[anchorIndex];
+          // First mouseMove only transitions state; the next move (with
+          // isAddingPoints now true) starts populating tempPoints via the
+          // distance-gated branch below.
+          return;
+        }
+      }
+
       if (
         isShiftCurrentlyPressed &&
         (editMode === EditMode.CreatePolygon ||
@@ -826,6 +923,7 @@ export const useAdvancedInteractions = ({
       canvasRef,
       handlePan,
       isShiftPressedCallback,
+      projectType,
     ]
   );
 

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -132,6 +132,15 @@ export const useEnhancedSegmentationEditor = ({
     vertexIndex: null,
   });
 
+  // Zoom-in-progress flag — set true on every wheel event, debounced
+  // false 150ms after the last wheel. PolygonVertices uses this to skip
+  // expensive vertex re-renders during continuous zoom (the SVG parent
+  // CSS-scales for free, so vertices visually grow with the image until
+  // the wheel settles and we snap them back to proper 1/zoom size).
+  const [isZooming, setIsZooming] = useState(false);
+  const isZoomingRef = useRef(false);
+  const zoomEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Transform state
   const [transform, setTransform] = useState<TransformState>(() =>
     calculateCenteringTransform(
@@ -941,6 +950,19 @@ export const useEnhancedSegmentationEditor = ({
 
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault();
+      // Flag "zoom in progress" so PolygonVertices can skip re-rendering
+      // the (potentially hundreds of) vertex circles while the wheel is
+      // active. The SVG container CSS-scales for free, so vertices appear
+      // to grow/shrink with the image; they snap back to the proper
+      // 1/zoom screen size when the wheel stops (150ms idle below).
+      isZoomingRef.current = true;
+      setIsZooming(true);
+      if (zoomEndTimerRef.current) clearTimeout(zoomEndTimerRef.current);
+      zoomEndTimerRef.current = setTimeout(() => {
+        isZoomingRef.current = false;
+        setIsZooming(false);
+        zoomEndTimerRef.current = null;
+      }, 150);
       throttledZoom.fn(e);
     };
 
@@ -992,6 +1014,7 @@ export const useEnhancedSegmentationEditor = ({
     isSpacePressed: keyboardShortcuts.isSpacePressed,
     activePartClassRef,
     activeInstanceIdRef,
+    projectType,
     onPolygonSelection: polygonSelection.handlePolygonSelection, // Pass centralized selection handler
     setEditMode,
     setInteractionState,
@@ -1135,6 +1158,7 @@ export const useEnhancedSegmentationEditor = ({
     // State
     ...editorState,
     vertexDragState,
+    isZooming,
 
     // Refs
     canvasRef,

--- a/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
+++ b/src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx
@@ -28,6 +28,7 @@ import { rafThrottle } from '@/lib/performanceUtils';
 import { useLanguage } from '@/contexts/exports';
 import { useAbortController } from '@/hooks/shared/useAbortController';
 import { handleCancelledError } from '@/lib/errorUtils';
+import type { ProjectType } from '@/types';
 
 interface UseEnhancedSegmentationEditorProps {
   initialPolygons?: Polygon[];
@@ -46,12 +47,8 @@ interface UseEnhancedSegmentationEditorProps {
   isFromGallery?: boolean; // Add flag to trigger auto-reset
   activePartClassRef?: React.RefObject<'head' | 'midpiece' | 'tail'>;
   activeInstanceIdRef?: React.RefObject<string>;
-  /** Project type drives MT-only polyline behaviours (Enter-commits
-   *  AddPoints extension, polyline slice geometry). Sperm and other
-   *  polyline-bearing projects must keep their pre-MT-feature UX, so
-   *  any new behaviour gated on this flag falls through to the legacy
-   *  paths when the value isn't ``'microtubules'``. */
-  projectType?: import('@/types').ProjectType;
+  /** Gates MT-only polyline behaviours (Enter-commits, slice geometry). */
+  projectType?: ProjectType;
   // onPolygonSelection is now handled internally via usePolygonSelection for SSOT
 }
 
@@ -132,13 +129,10 @@ export const useEnhancedSegmentationEditor = ({
     vertexIndex: null,
   });
 
-  // Zoom-in-progress flag — set true on every wheel event, debounced
-  // false 150ms after the last wheel. PolygonVertices uses this to skip
-  // expensive vertex re-renders during continuous zoom (the SVG parent
-  // CSS-scales for free, so vertices visually grow with the image until
-  // the wheel settles and we snap them back to proper 1/zoom size).
+  // Zoom-in-progress flag. Set true on every wheel event, debounced
+  // false 150 ms after the last wheel. Polygon/vertex memo comparators
+  // short-circuit zoom-only re-renders while true.
   const [isZooming, setIsZooming] = useState(false);
-  const isZoomingRef = useRef(false);
   const zoomEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Transform state
@@ -740,39 +734,65 @@ export const useEnhancedSegmentationEditor = ({
       return;
     }
 
-    // AddPoints mode on a polyline endpoint: pressing Enter commits the
-    // tempPoints as an extension of the polyline. This is the only path
-    // that makes sense for open paths — extending from the END outward
-    // never wraps back to a different vertex, so there's no "click
-    // another vertex to finish" trigger. Enter is the natural finish key.
+    // AddPoints + MT: Enter commits tempPoints as an endpoint extension.
+    // Sperm keeps the legacy "click vertex to finalise" workflow.
     if (editMode !== EditMode.AddPoints) return;
-    // Gate to MT only: sperm projects predate the Enter-extends-polyline
-    // workflow and rely on "click another vertex to finalise" the old
-    // way. Leaving this active for sperm would silently change their
-    // muscle memory.
     if (projectType !== 'microtubules') return;
     if (!selectedPolygonId) return;
-    if (!interactionState.isAddingPoints) return;
-    if (!interactionState.addPointStartVertex) return;
-    if (tempPoints.length === 0) return;
 
     const polygon = polygons.find(p => p.id === selectedPolygonId);
     if (!polygon || polygon.geometry !== 'polyline') return;
+    if (polygon.points.length < 2) return;
 
-    const startIdx = interactionState.addPointStartVertex.vertexIndex;
+    // Anchor recovery: Shift-only flow can reach Enter without ever
+    // setting addPointStartVertex (the click-handler path that normally
+    // seeds it never ran). Derive the nearest endpoint from the cursor
+    // position (or from the first tempPoint if cursor is unavailable).
+    let startIdx = interactionState.addPointStartVertex?.vertexIndex;
+    if (startIdx === undefined) {
+      const head = polygon.points[0];
+      const tail = polygon.points[polygon.points.length - 1];
+      const anchorRef = tempPoints.length > 0 ? tempPoints[0] : cursorPosition;
+      if (!anchorRef) {
+        startIdx = polygon.points.length - 1;
+      } else {
+        const dHead = (anchorRef.x - head.x) ** 2 + (anchorRef.y - head.y) ** 2;
+        const dTail = (anchorRef.x - tail.x) ** 2 + (anchorRef.y - tail.y) ** 2;
+        startIdx = dHead <= dTail ? 0 : polygon.points.length - 1;
+      }
+    }
+
+    // Points-to-append fallback: if the user pressed Enter without ever
+    // generating a tempPoint (very small shift-drag under
+    // MIN_AUTO_ADD_DISTANCE, or keyboard-only attempt), use the cursor
+    // as a single new point so Enter is not a silent no-op.
+    const pointsToAppend =
+      tempPoints.length > 0
+        ? tempPoints
+        : cursorPosition
+          ? [cursorPosition]
+          : [];
+    if (pointsToAppend.length === 0) {
+      logger.warn(
+        'handleEnterPolyline: no tempPoints and no cursor — nothing to append'
+      );
+      return;
+    }
+
     const last = polygon.points.length - 1;
     let extended;
     if (startIdx === 0) {
-      // Extending from the head: new points were placed in click order
-      // from the head outward, so reverse them to land the most recent
-      // click furthest from the original head.
-      extended = [...[...tempPoints].reverse(), ...polygon.points];
+      // Head extension: reverse so the most recent click is furthest out.
+      extended = [...[...pointsToAppend].reverse(), ...polygon.points];
     } else if (startIdx === last) {
-      // Extending from the tail: append in order.
-      extended = [...polygon.points, ...tempPoints];
+      extended = [...polygon.points, ...pointsToAppend];
     } else {
-      // Not an endpoint — Enter is undefined here. Fall back to no-op
-      // so the user gets ESC + retry instead of a corrupt geometry.
+      // Mid-polyline anchor — Enter is undefined here. Log loudly rather
+      // than silently no-op so user can diagnose via console.
+      logger.warn(
+        `handleEnterPolyline: anchor at index ${startIdx} (mid-polyline). ` +
+          `Press Esc and click a different vertex to splice instead.`
+      );
       return;
     }
 
@@ -788,16 +808,14 @@ export const useEnhancedSegmentationEditor = ({
       addPointStartVertex: null,
       addPointEndVertex: null,
     }));
-    // Drop back to vertex editing so the user can refine the freshly
-    // extended path right away.
     setEditMode(EditMode.EditVertices);
   }, [
     editMode,
     projectType,
     selectedPolygonId,
-    interactionState.isAddingPoints,
     interactionState.addPointStartVertex,
     tempPoints,
+    cursorPosition,
     polygons,
     updatePolygons,
     setTempPoints,
@@ -955,11 +973,9 @@ export const useEnhancedSegmentationEditor = ({
       // active. The SVG container CSS-scales for free, so vertices appear
       // to grow/shrink with the image; they snap back to the proper
       // 1/zoom screen size when the wheel stops (150ms idle below).
-      isZoomingRef.current = true;
       setIsZooming(true);
       if (zoomEndTimerRef.current) clearTimeout(zoomEndTimerRef.current);
       zoomEndTimerRef.current = setTimeout(() => {
-        isZoomingRef.current = false;
         setIsZooming(false);
         zoomEndTimerRef.current = null;
       }, 150);
@@ -974,6 +990,10 @@ export const useEnhancedSegmentationEditor = ({
       return () => {
         element.removeEventListener('wheel', handleWheel);
         throttledZoom.cancel();
+        if (zoomEndTimerRef.current) {
+          clearTimeout(zoomEndTimerRef.current);
+          zoomEndTimerRef.current = null;
+        }
       };
     }
   }, [imageWidth, imageHeight, canvasWidth, canvasHeight, effectiveMinZoom]);


### PR DESCRIPTION
## Summary

Three independent editor improvements that share an MT workflow theme:

1. **MT Add-Points auto-anchor + endpoint extension** — off-vertex click in `AddPoints` mode now picks the nearest polyline endpoint as anchor and treats the click as the first new point; Enter commits. Vertex-click splice still works for mid-polyline insertion. Shift-drag without prior click bootstraps state via a mouseMove guard so Enter has tempPoints to commit even when the user never left-clicked. `handleEnterPolyline` tolerates missing anchor (derives from cursor) and empty `tempPoints` (single-cursor fallback) so Enter never silently no-ops.
2. **Kymograph no-interpolation** — `tracker_kymograph._resample_profile` now picks nearest source indices via `np.round(linspace)` instead of `np.interp`; `map_coordinates` uses `order=0` instead of `order=1`. Every kymograph pixel is a raw intensity sample along the polyline rather than a smoothed blend.
3. **Zoom-time render deferral** — `useEnhancedSegmentationEditor` flips `isZooming=true` on every wheel event, debounced false 150 ms after the last wheel. `CanvasPolygon` + `PolygonVertices` memo comparators short-circuit zoom-only changes while `isZooming` is true; the parent SVG's CSS transform handles visual scaling for free, dodging per-vertex `1/zoom` math that stuttered on 100+ point polylines.

## Files Changed

- `backend/segmentation/api/tracker_kymograph.py` — nearest-neighbour resample + `order=0` map_coordinates
- `src/pages/segmentation/SegmentationEditor.tsx` — forward `isZooming` to `CanvasPolygon`
- `src/pages/segmentation/components/canvas/CanvasPolygon.tsx` — new `isZooming` prop + comparator short-circuit
- `src/pages/segmentation/components/canvas/PolygonVertices.tsx` — `isZooming` prop + zoom-skip in comparator
- `src/pages/segmentation/hooks/useAdvancedInteractions.tsx` — MT auto-anchor in click handler, Shift-bootstrap in mouseMove, splice path preserved
- `src/pages/segmentation/hooks/useEnhancedSegmentationEditor.tsx` — `isZooming` state + wheel debounce + `handleEnterPolyline` robustness

## Test plan

- [ ] MT project: select a polyline, click off-vertex near tail, Enter → polyline extended toward click
- [ ] MT project: select a polyline, click off-vertex near head, Enter → polyline extended toward click
- [ ] MT project: hold Shift and drag away from polyline endpoint (no prior left-click), Enter → points appended
- [ ] MT project: click vertex A → click vertex B → splice inserts intermediate clicks (legacy flow intact)
- [ ] Run a kymograph on a known polyline; verify intensity values are pixel-accurate (no smoothing artefacts)
- [ ] Zoom rapidly with wheel on a long polyline (100+ vertices); confirm no stuttering, vertices snap to correct size when wheel settles
- [ ] Non-MT projects (spheroid, sperm): regression-check that off-vertex click no longer triggers MT auto-anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added microtubule project workflow for polyline editing with automatic endpoint anchor selection.

* **Performance**
  * Optimized canvas rendering during zoom interactions by reducing unnecessary vertex re-renders for smoother zooming.
  * Enhanced kymograph sampling to preserve raw pixel intensity values with improved accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->