### PR TITLE
fix(language): LanguageContext used wrong field name on the wire

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -84,7 +84,11 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
     (async () => {
       try {
         const profile = await apiClient.getUserProfile();
-        const pref = profile?.preferredLang as Language | undefined;
+        // BE serialises preferredLang as `language` on the wire (see
+        // userService.getUserProfile). The TS Profile type still names
+        // the field after the DB column, hence the cast.
+        const pref = (profile as { language?: string } | undefined)
+          ?.language as Language | undefined;
         if (cancelled || !pref || !SUPPORTED_LANGUAGES.includes(pref)) return;
         if (manualOverrideRef.current) return;
         localStorage.setItem('language', pref);
@@ -143,7 +147,11 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({
 
       if (user) {
         try {
-          await apiClient.updateUserProfile({ preferredLang: newLanguage });
+          // BE updateProfileSchema expects `language`, not `preferredLang`.
+          // UpdateProfile TS type still uses the DB column name; cast.
+          await apiClient.updateUserProfile({
+            language: newLanguage,
+          } as unknown as Parameters<typeof apiClient.updateUserProfile>[0]);
         } catch (error: unknown) {
           const errorMessage =
             getErrorMessage(error) || 'Failed to save language';


### PR DESCRIPTION
## Summary

**Latent bug** discovered while testing kymograph axis labels across 6 languages in PR #206 verification:

- `LanguageContext.tsx:87` read \`profile?.preferredLang\` — but the BE serialises this DB column as \`language\` on the wire (see \`userService.ts:83\`). Profile-fetch language override never fired for any user.
- `LanguageContext.tsx:146` symmetric write: sent \`{preferredLang: newLanguage}\` but \`updateProfileSchema\` accepts \`{language: ...}\` only. Zod strip-rejects the unknown key silently, so user language preference never persisted to DB.

Users could still get non-English UI when their \`navigator.language\` matched a supported locale, masking the bug. After explicitly toggling language in settings, the change persisted via \`localStorage\` but not via the database — meaning logging in on another device showed the OS-default language again.

## Fix

Read \`profile.language\` and write \`{ language: ... }\` via casts. TS \`Profile\` / \`UpdateProfile\` types still use the DB column name (\`preferredLang\` / \`preferredTheme\`); renaming would cascade through 10+ test files. The cast at the call site honestly represents the wire-vs-type mismatch without expanding scope.

## Out of scope

Same wire-name mismatch exists in:
- \`AuthContext.tsx:102, 113\` (sync local prefs on login)
- \`ThemeContext.tsx:69\` (sends \`preferred_theme\` snake_case)

These have the same root cause and can be addressed in a follow-up.

## Test plan

- [x] Manual verification: set user.language=fr via API, cleared localStorage, reloaded — profile-fetch correctly set lang='fr' and kymograph rendered French labels
- [ ] Login on a fresh browser (no localStorage) for a user whose DB language is non-EN — UI should now match DB preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)