### PR TITLE
fix(profile): ThemeContext + AuthContext used wrong wire field names

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -97,24 +97,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const localLanguage = localStorage.getItem('language');
 
       if (localTheme || localLanguage) {
-        const updateData: {
-          preferred_theme?: string;
-          preferredLang?: string;
-        } = {};
+        // Wire field names per BE updateProfileSchema: `theme`, `language`.
+        // TS UpdateProfile still uses DB column names (preferredTheme,
+        // preferredLang) so we cast at the boundary.
+        const updateData: { theme?: string; language?: string } = {};
 
         if (localTheme && ['light', 'dark', 'system'].includes(localTheme)) {
-          updateData.preferred_theme = localTheme;
+          updateData.theme = localTheme;
         }
 
         if (
           localLanguage &&
           ['en', 'cs', 'es', 'de', 'fr', 'zh'].includes(localLanguage)
         ) {
-          updateData.preferredLang = localLanguage;
+          updateData.language = localLanguage;
         }
 
         if (Object.keys(updateData).length > 0) {
-          await apiClient.updateUserProfile(updateData);
+          await apiClient.updateUserProfile(
+            updateData as unknown as Parameters<
+              typeof apiClient.updateUserProfile
+            >[0]
+          );
           logger.debug(
             'Successfully synced local preferences to database:',
             updateData

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -26,9 +26,11 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
       if (user) {
         try {
           const profileData = await apiClient.getUserProfile();
-
-          if (profileData && profileData.preferred_theme) {
-            const dbTheme = profileData.preferred_theme as Theme;
+          // BE serialises preferredTheme as `theme` on the wire
+          // (userService.ts). TS Profile still uses the DB column name.
+          const dbTheme = (profileData as { theme?: string } | undefined)
+            ?.theme as Theme | undefined;
+          if (dbTheme) {
             setThemeState(dbTheme);
             localStorage.setItem('theme', dbTheme);
             applyTheme(dbTheme);
@@ -66,7 +68,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
       // Uložení do databáze, pokud jsme přihlášeni
       if (user) {
         try {
-          await apiClient.updateUserProfile({ preferred_theme: newTheme });
+          // BE updateProfileSchema expects `theme`, not `preferred_theme`.
+          await apiClient.updateUserProfile({
+            theme: newTheme,
+          } as unknown as Parameters<typeof apiClient.updateUserProfile>[0]);
         } catch (error: unknown) {
           logger.error('Error updating profile:', error);
           const errorMessage = getErrorMessage(error) || 'Failed to save theme';


### PR DESCRIPTION
## Summary

Follow-up to PR #207 ([[project-profile-wire-field-mismatch]] memory). Two more contexts had the BE-wire-vs-DB-column field name mismatch:

### ThemeContext
- **Read**: \`profile.preferred_theme\` (snake_case!) — BE returns \`theme\`
- **Write**: \`{preferred_theme: ...}\` — BE expects \`theme\`

Both silently broken: dark-mode toggle persisted only via localStorage, never to DB. Logging in on another device showed the user's default (system) theme.

### AuthContext (login → server-sync of local preferences)
- Wrote \`{preferred_theme, preferredLang}\` — BE schema accepts \`{theme, language}\`. Zod silently strip-rejected both keys, so the one-time "anonymous session → logged-in session" preference sync never actually synced.

## Verified

PUT \`theme=dark\` via API → cleared \`localStorage.theme\` → reloaded — profile-fetch correctly applied dark mode:
- \`<html class="dark">\` ✅
- \`body { background: rgb(17, 24, 39) }\` ✅
- \`localStorage.theme\` re-populated to "dark" ✅

Cleaned up: profile restored to \`theme=light\` after testing.

## Implementation

TS \`Profile\` / \`UpdateProfile\` types still use DB column names; casts at call sites keep the patch surgical (renaming touches 10+ test files). Same pattern as PR #207.

## Out of scope

The TS type rename (\`preferredLang\` → \`language\`, \`preferredTheme\` → \`theme\`) is the proper long-term fix. Can be done as a single follow-up PR — touches the type definitions + all test files that mock profile data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved synchronization of user preferences between local storage and backend systems.
  * Enhanced data mapping for theme and language settings to align with backend API schema.
  * Increased reliability of preference persistence across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->