### PR TITLE
feat(segmentation): add SegFormer-B0 as 4th standard-spheroid model

### DIFF
--- a/backend/segmentation/api/models.py
+++ b/backend/segmentation/api/models.py
@@ -9,6 +9,7 @@ class ModelType(str, Enum):
     CBAM_RESUNET = "cbam_resunet"
     UNET_SPHEROHQ = "unet_spherohq"
     UNET_ATTENTION_ASPP = "unet_attention_aspp"
+    SEGFORMER = "segformer"
     SPERM = "sperm"
     WOUND = "wound"
 

--- a/backend/segmentation/config/batch_sizes.json
+++ b/backend/segmentation/config/batch_sizes.json
@@ -48,6 +48,20 @@
       },
       "note": "Reduced for 8GB GPU limit"
     },
+    "segformer": {
+      "optimal_batch_size": 4,
+      "max_safe_batch_size": 8,
+      "expected_throughput": 40.0,
+      "memory_limit_mb": 1500,
+      "p95_latency_ms": 30.0,
+      "production_optimized": true,
+      "concurrent_processing": {
+        "max_concurrent_users": 2,
+        "memory_per_user_mb": 1500,
+        "expected_concurrent_throughput": 80.0
+      },
+      "note": "SegFormer-B0 SpheroMix model (1024x1024 input, 3.71M params). Vendor reports ~13ms / 79 img/s on L40S FP16; A5000 budget ~2x slower → ~30ms p95, ~40 img/s. Small encoder → low ~1.5GB footprint. Estimates pending A5000 benchmarking."
+    },
     "sperm": {
       "optimal_batch_size": 1,
       "max_safe_batch_size": 2,

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -66,6 +66,18 @@ except ImportError as e:
     MicrotubuleModel = None
     _microtubule_import_error = e
 
+# Optional SegFormer-B0 spheroid model import (requires transformers).
+_segformer_import_error = None
+try:
+    from models.segformer import SegFormerModel
+except ImportError as e:
+    logger.warning(
+        f"Could not import SegFormerModel: {e}. "
+        "SegFormer segmentation will not be available."
+    )
+    SegFormerModel = None
+    _segformer_import_error = e
+
 # Import the new inference executor
 from .inference_executor import (
     InferenceExecutor,
@@ -167,6 +179,13 @@ class ModelLoader:
             'class': UNetAttention,
             'pretrained_path': 'weights/unet_v4_weights.pth',
             'finetuned_path': 'weights/unet_v4_weights.pth',
+            'config_path': None
+        },
+        'segformer': {
+            # Will be None if transformers not installed
+            'class': SegFormerModel,
+            'pretrained_path': 'weights/segformer_b0_spheroseg.pth',
+            'finetuned_path': 'weights/segformer_b0_spheroseg.pth',
             'config_path': None
         },
         'sperm': {
@@ -278,6 +297,20 @@ class ModelLoader:
                     use_deep_supervision=False,
                     use_attention_gates=True, use_aspp=True
                 )
+            elif model_name == 'segformer':
+                # SegFormer-B0 wraps a HuggingFace model, so it can't use the
+                # generic torch.load + load_state_dict path below — it builds
+                # the HF architecture and loads weights via its own wrapper.
+                if SegFormerModel is None:
+                    raise ImportError(
+                        f"SegFormer model architecture not available: "
+                        f"{_segformer_import_error}"
+                    )
+                model = SegFormerModel()
+                model.load_weights(str(weights_full_path), self.device)
+                self.loaded_models[model_name] = model
+                logger.info(f"Successfully loaded SegFormer model from: {weights_full_path}")
+                return model
             elif model_name == 'sperm':
                 # Sperm segmentation model — uses its own pipeline (Mask2Former + graph assembly)
                 if SpermModel is None:

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -25,5 +25,11 @@ try:
 except ImportError:
     MicrotubuleModel = None
 
+# SegFormer-B0 spheroid model: optional import (requires transformers).
+try:
+    from .segformer import SegFormerModel
+except ImportError:
+    SegFormerModel = None
+
 __all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'UNetAttention', 'SpermModel',
-           'WoundModel', 'MicrotubuleModel']
+           'WoundModel', 'MicrotubuleModel', 'SegFormerModel']

--- a/backend/segmentation/models/segformer.py
+++ b/backend/segmentation/models/segformer.py
@@ -1,0 +1,135 @@
+"""SegFormer-B0 spheroid-segmentation wrapper.
+
+Wraps a SegFormer-B0 (HuggingFace ``SegformerForSemanticSegmentation``)
+fine-tuned on the SpheroMix dataset (32,367 bright-field cancer-spheroid
+images). Reports 0.9335 Unified IoU on the HQ+DTS test split — the most
+accurate spheroid model in the platform — while being the smallest (3.71M
+params) and fastest (~13 ms / 1024x1024 image on an L40S).
+
+Design — why a thin ``nn.Module`` wrapper rather than a wound-style plain
+wrapper: SegFormer's preprocessing (1024 resize + ImageNet normalization) is
+identical to the other spheroid models, and its output is a binary mask ->
+closed polygons. So the model is exposed as an ``nn.Module`` whose ``forward``
+returns a single-channel ``(B, 1, H, W)`` foreground logit (``fg - bg``). That
+lets it flow through the shared ``ModelLoader.predict`` / ``predict_batch``
+pipeline unchanged: ``sigmoid(fg - bg) > 0.5`` is exactly the model's native
+two-class ``argmax``, so the existing sigmoid+threshold postprocessor and
+contour/hole/polygon extraction work without a dedicated ``predict_segformer``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Union
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+try:
+    from transformers import SegformerConfig, SegformerForSemanticSegmentation
+except ImportError as e:  # transformers missing -> model disabled by loader
+    SegformerConfig = None
+    SegformerForSemanticSegmentation = None
+    _segformer_import_error = e
+else:
+    _segformer_import_error = None
+
+
+class SegFormerModel(torch.nn.Module):
+    """SegFormer-B0 fine-tuned on SpheroMix, exposed as a single-channel
+    ``nn.Module`` so the shared spheroid inference path can drive it."""
+
+    HF_BASE = "nvidia/segformer-b0-finetuned-ade-512-512"
+
+    def __init__(self) -> None:
+        super().__init__()
+        if SegformerForSemanticSegmentation is None:
+            raise ImportError(
+                "transformers is required for SegFormerModel. "
+                f"Install it via requirements.txt. Original error: "
+                f"{_segformer_import_error}"
+            )
+        # Build the architecture from config only: this fetches the tiny
+        # config.json (cached in .hf-cache) but NOT the ADE pretrained weights,
+        # which we would immediately overwrite with our own checkpoint. The
+        # decode-head classifier gets 2 output channels because num_labels=2.
+        cfg = SegformerConfig.from_pretrained(self.HF_BASE, num_labels=2)
+        self.seg = SegformerForSemanticSegmentation(cfg)
+        self.seg.eval()
+        self.device: torch.device = torch.device("cpu")
+
+    def load_weights(self, weights_path: Union[str, Path],
+                     device: Union[str, torch.device]) -> "SegFormerModel":
+        """Load the ``.pth`` checkpoint and move to the target device.
+
+        Mirrors the wound model's safe-load policy: try ``weights_only=True``
+        first (mitigates CVE-2025-32434), fall back to ``weights_only=False``
+        (arbitrary pickle) only when ``ALLOW_UNSAFE_WEIGHTS`` is set — which it
+        is in the ML Dockerfile, because the checkpoints are our own shipped
+        artifacts.
+        """
+        self.device = torch.device(device) if isinstance(device, str) else device
+
+        try:
+            state = torch.load(
+                str(weights_path), map_location="cpu", weights_only=True
+            )
+        except Exception as e1:
+            if os.getenv("ALLOW_UNSAFE_WEIGHTS", "1") != "1":
+                logger.error(
+                    f"SegFormerModel: weights_only=True failed ({e1}) and "
+                    f"ALLOW_UNSAFE_WEIGHTS is not set — refusing to load."
+                )
+                raise
+            logger.error(
+                f"SegFormerModel: SECURITY — weights_only=True failed ({e1}); "
+                f"falling back to weights_only=False (arbitrary pickle). "
+                f"Safe only for trusted checkpoints (our own). "
+                f"Set ALLOW_UNSAFE_WEIGHTS=0 to refuse this fallback."
+            )
+            state = torch.load(
+                str(weights_path), map_location="cpu", weights_only=False
+            )
+
+        if isinstance(state, dict) and "model_state_dict" in state:
+            sd = state["model_state_dict"]
+        elif isinstance(state, dict) and "state_dict" in state:
+            sd = state["state_dict"]
+        else:
+            sd = state
+
+        # Tolerate finetuned-wrapper checkpoints that prefix every key with
+        # "net." (matches the released inference.py loader).
+        if any(k.startswith("net.") for k in list(sd.keys())[:3]):
+            sd = {(k[4:] if k.startswith("net.") else k): v for k, v in sd.items()}
+
+        self.seg.load_state_dict(sd, strict=True)
+        self.seg.to(self.device).eval()
+        logger.info(f"SegFormerModel loaded from {weights_path} on {self.device}")
+        return self
+
+    def to(self, device: Union[str, torch.device]) -> "SegFormerModel":
+        self.device = torch.device(device) if isinstance(device, str) else device
+        self.seg.to(self.device)
+        return self
+
+    def eval(self) -> "SegFormerModel":
+        self.seg.eval()
+        return self
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """``x``: ImageNet-normalized ``(B, 3, H, W)`` tensor from the shared
+        ``preprocess_image`` (H=W=1024). Returns a single-channel
+        ``(B, 1, H, W)`` foreground logit so the shared sigmoid+threshold
+        postprocessor reproduces the model's two-class argmax."""
+        out = self.seg(pixel_values=x)
+        # SegFormer logits are at 1/4 input resolution; upsample to input size.
+        logits = F.interpolate(
+            out.logits, size=x.shape[-2:], mode="bilinear", align_corners=False
+        )
+        # fg - bg: sigmoid(.) > 0.5  <=>  argmax([bg, fg]) == 1
+        return logits[:, 1:2, :, :] - logits[:, 0:1, :, :]

--- a/backend/src/constants/segmentationModels.ts
+++ b/backend/src/constants/segmentationModels.ts
@@ -12,6 +12,7 @@ export const SEGMENTATION_MODELS = [
   'cbam_resunet',
   'unet_spherohq',
   'unet_attention_aspp',
+  'segformer',
   'resunet_advanced',
   'resunet_small',
   'sperm',

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -162,6 +162,7 @@ type KnownModelId =
   | 'cbam_resunet'
   | 'unet_spherohq'
   | 'unet_attention_aspp'
+  | 'segformer'
   | 'sperm'
   | 'wound'
   | 'microtubule';
@@ -182,7 +183,7 @@ export const MODEL_TYPE_COMPATIBILITY: Record<
   ProjectType,
   readonly KnownModelId[]
 > = {
-  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq'],
+  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer'],
   spheroid_invasive: ['unet_attention_aspp'],
   wound: ['wound'],
   sperm: ['sperm'],

--- a/src/lib/modelUtils.ts
+++ b/src/lib/modelUtils.ts
@@ -4,6 +4,7 @@ export type ModelType =
   | 'cbam_resunet'
   | 'unet_spherohq'
   | 'unet_attention_aspp'
+  | 'segformer'
   | 'sperm'
   | 'wound'
   | 'microtubule';
@@ -87,6 +88,18 @@ export function getLocalizedModelInfo(
         batchSize: 1,
       },
     },
+    segformer: {
+      id: 'segformer',
+      size: 'small',
+      defaultThreshold: 0.5,
+      category: 'spheroid',
+      performance: {
+        avgTimePerImage: 0.2,
+        throughput: 5.0,
+        p95Latency: 0.3,
+        batchSize: 4,
+      },
+    },
     sperm: {
       id: 'sperm',
       size: 'medium',
@@ -133,6 +146,7 @@ export function getLocalizedModelInfo(
     cbam_resunet: 'cbam',
     unet_spherohq: 'unet_spherohq',
     unet_attention_aspp: 'unet_attention_aspp',
+    segformer: 'segformer',
     sperm: 'sperm',
     wound: 'wound',
     microtubule: 'microtubule',
@@ -158,6 +172,7 @@ export function getAllLocalizedModels(t: (key: string) => string): ModelInfo[] {
     'cbam_resunet',
     'unet_spherohq',
     'unet_attention_aspp',
+    'segformer',
     'sperm',
     'wound',
     'microtubule',
@@ -237,6 +252,22 @@ export const BASIC_MODEL_INFO: Record<
       throughput: 2.8,
       p95Latency: 0.5,
       batchSize: 1,
+    },
+  },
+  segformer: {
+    id: 'segformer',
+    name: 'SegFormer',
+    displayName: 'SegFormer',
+    description:
+      'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
+    size: 'small',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.2,
+      throughput: 5.0,
+      p95Latency: 0.3,
+      batchSize: 4,
     },
   },
   sperm: {

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -455,6 +455,11 @@ export default {
           description:
             'Vylepšený UNet s Attention Gates a ASPP pro detekci rozpadajících se sféroidů a malých satelitních buněk (~0.35s/snímek)',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            'Model založený na transformeru (SegFormer-B0) pro sféroidy ve světlém poli — nejvyšší přesnost (93% IoU) a velmi rychlý (~13 ms/snímek)',
+        },
         sperm: {
           name: 'Morfologie spermií',
           description:
@@ -491,6 +496,8 @@ export default {
         'Nejrychlejší model po optimalizacích! Výborný pro zpracování v reálném čase (E2E ~286ms, 5.5 obr/s)',
       unet_attention_aspp:
         'Vylepšený UNet s Attention Gates a ASPP bottleneck pro detekci rozpadajících se sféroidů a malých satelitních buněk (35.5M parametrů)',
+      segformer:
+        'Model SegFormer-B0 založený na transformeru, trénovaný na datasetu SpheroMix. Nejvyšší přesnost segmentace sféroidů v platformě (93% IoU) a zároveň nejmenší a nejrychlejší model (~13 ms/snímek).',
       sperm:
         'Model morfologie spermií s extrakcí kostry pro měření hlavy, středního dílu a bičíku',
       wound:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -475,6 +475,11 @@ export default {
           description:
             'Erweitertes UNet mit Attention Gates und ASPP zur Erkennung zerfallender Sphäroide und kleiner Satellitenzellen (~0.35s/Bild)',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            'Transformer-basiertes Modell (SegFormer-B0) für Hellfeld-Sphäroide – höchste Genauigkeit (93% IoU) und sehr schnell (~13 ms/Bild)',
+        },
         sperm: {
           name: 'Spermien-Morphologie',
           description:
@@ -511,6 +516,8 @@ export default {
         'Schnellstes Modell nach Optimierungen! Hervorragend für Echtzeitverarbeitung (E2E ~286ms, 5.5 Bilder/s)',
       unet_attention_aspp:
         'Erweitertes UNet mit Attention Gates und ASPP-Bottleneck zur Erkennung zerfallender Sphäroide und kleiner Satellitenzellen (35,5M Parameter)',
+      segformer:
+        'Transformer-basiertes SegFormer-B0-Modell, trainiert auf dem SpheroMix-Datensatz. Höchste Sphäroid-Genauigkeit der Plattform (93% IoU) bei gleichzeitig kleinstem und schnellstem Modell (~13 ms/Bild).',
       sperm:
         'Spermienmorphologie-Modell mit Skelettextraktion zur Messung von Kopf, Mittelstück und Schwanz',
       wound:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -469,6 +469,11 @@ export default {
           description:
             'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells (~0.35s/image)',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
+        },
         sperm: {
           name: 'Sperm Morphology',
           description:
@@ -505,6 +510,8 @@ export default {
         'Fastest model after optimizations! Excellent for real-time processing (E2E ~286ms, 5.5 img/s)',
       unet_attention_aspp:
         'Enhanced UNet with Attention Gates and ASPP bottleneck for detecting dissolving spheroids and small satellite cells (35.5M params)',
+      segformer:
+        'Transformer-based SegFormer-B0 model trained on the SpheroMix dataset. Highest spheroid accuracy in the platform (93% IoU) while being the smallest and fastest model (~13 ms/image).',
       sperm:
         'Sperm morphology model with skeleton extraction for head, midpiece, and tail measurement',
       wound:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -453,6 +453,11 @@ export default {
           description:
             'UNet mejorado con Attention Gates y ASPP para detectar esferoides en disolución y pequeñas células satélite (~0.35s/imagen)',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            'Modelo basado en transformador (SegFormer-B0) para esferoides de campo claro: máxima precisión (93% IoU) y muy rápido (~13 ms/imagen)',
+        },
         sperm: {
           name: 'Morfología espermática',
           description:
@@ -489,6 +494,8 @@ export default {
         '¡El modelo más rápido después de las optimizaciones! Excelente para procesamiento en tiempo real (E2E ~286ms, 5.5 img/s)',
       unet_attention_aspp:
         'UNet mejorado con Attention Gates y cuello de botella ASPP para detectar esferoides en disolución y pequeñas células satélite (35,5M parámetros)',
+      segformer:
+        'Modelo SegFormer-B0 basado en transformador, entrenado con el conjunto de datos SpheroMix. La mayor precisión de segmentación de esferoides de la plataforma (93% IoU), siendo además el modelo más pequeño y rápido (~13 ms/imagen).',
       sperm:
         'Modelo de morfología espermática con extracción de esqueleto para medir cabeza, pieza media y cola',
       wound:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -466,6 +466,11 @@ export default {
           description:
             'UNet amélioré avec Attention Gates et ASPP pour la détection de sphéroïdes en dissolution et de petites cellules satellites (~0.35s/image)',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            'Modèle basé sur un transformeur (SegFormer-B0) pour les sphéroïdes en fond clair — précision maximale (93% IoU) et très rapide (~13 ms/image)',
+        },
         sperm: {
           name: 'Morphologie des spermatozoïdes',
           description:
@@ -502,6 +507,8 @@ export default {
         'Le modèle le plus rapide après optimisations! Excellent pour le traitement en temps réel (E2E ~286ms, 5.5 img/s)',
       unet_attention_aspp:
         'UNet amélioré avec Attention Gates et goulot ASPP pour la détection de sphéroïdes en dissolution et de petites cellules satellites (35,5M paramètres)',
+      segformer:
+        'Modèle SegFormer-B0 basé sur un transformeur, entraîné sur le jeu de données SpheroMix. Meilleure précision de segmentation des sphéroïdes de la plateforme (93% IoU), tout en étant le modèle le plus petit et le plus rapide (~13 ms/image).',
       sperm:
         'Modèle de morphologie spermatique avec extraction de squelette pour la mesure de la tête, de la pièce intermédiaire et de la queue',
       wound:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -422,6 +422,11 @@ export default {
           description:
             '增强型UNet，配备注意力门控和ASPP，用于检测溶解中的球体和小型卫星细胞（约0.35秒/图像）',
         },
+        segformer: {
+          name: 'SegFormer',
+          description:
+            '基于 Transformer 的模型（SegFormer-B0），用于明场球体分割——精度最高（93% IoU）且速度极快（约 13 毫秒/图像）',
+        },
         sperm: {
           name: '精子形态学',
           description:
@@ -455,6 +460,8 @@ export default {
         '优化后最快的模型！非常适合实时处理 (E2E ~286ms, 5.5 图像/秒)',
       unet_attention_aspp:
         '增强型UNet，配备注意力门控和ASPP瓶颈层，用于检测溶解中的球体和小型卫星细胞（3550万参数）',
+      segformer:
+        '基于 Transformer 的 SegFormer-B0 模型，在 SpheroMix 数据集上训练。平台中球体分割精度最高（93% IoU），同时是体积最小、速度最快的模型（约 13 毫秒/图像）。',
       sperm: '精子形态模型，通过骨架提取测量头部、中段和尾部',
       wound:
         '用于划痕实验显微镜的伤口分割的U-Net + MiT-B5（SegFormer编码器）模型。每张图像一个二进制伤口区域；非常适合愈合速度的时间延迟拍摄。',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -356,6 +356,7 @@ type KnownModelId =
   | 'cbam_resunet'
   | 'unet_spherohq'
   | 'unet_attention_aspp'
+  | 'segformer'
   | 'sperm'
   | 'wound'
   | 'microtubule';
@@ -376,7 +377,7 @@ export const MODEL_TYPE_COMPATIBILITY: Record<
   ProjectType,
   readonly KnownModelId[]
 > = {
-  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq'],
+  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer'],
   spheroid_invasive: ['unet_attention_aspp'],
   wound: ['wound'],
   sperm: ['sperm'],


### PR DESCRIPTION
## Summary
- Adds the SpheroMix-trained **SegFormer-B0** checkpoint as the 4th model in the standard `spheroid` group (alongside HRNet, CBAM-ResUNet, UNet-SpheroHQ). 93% IoU, ~13 ms/image, 3.71M params.
- The model is wrapped as a thin `nn.Module` (`models/segformer.py`) whose `forward()` returns a single-channel `fg−bg` logit, so `sigmoid>0.5` reproduces the model's two-class `argmax` and it **reuses the shared `ModelLoader.predict` spheroid pipeline** (polygon extraction, hole detection, batching) with no `routes.py` dispatch change.
- No new Python dependency — `transformers==4.57.0` is already present for the microtubule backbone.

## Changes by layer
- **ML** (`backend/segmentation/`): new `models/segformer.py` wrapper (HF model built from config, strict `state_dict` load, `net.` prefix tolerance); guarded import + `AVAILABLE_MODELS` entry + early-return `load_model` branch in `ml/model_loader.py`; `ModelType.SEGFORMER` enum; `config/batch_sizes.json` entry.
- **Backend** (`backend/src/`): `'segformer'` added to `SEGMENTATION_MODELS`, `KnownModelId`, and `MODEL_TYPE_COMPATIBILITY.spheroid`.
- **Frontend** (`src/`): `lib/modelUtils.ts` (`ModelType`, `baseModels`, `keyMap`, `BASIC_MODEL_INFO`); **`src/types/index.ts`** frontend `MODEL_TYPE_COMPATIBILITY`/`KnownModelId` kept byte-identical to backend (enforced by `verify-shared-types.cjs`); `segformer` strings in **both** i18n surfaces across all 6 locales.

## Test plan
- [x] `make ci` green (TS + ESLint 0 warnings + i18n complete in 6 languages)
- [x] `verify-shared-types.cjs` passes (FE↔BE `MODEL_TYPE_COMPATIBILITY` in sync)
- [x] ML: wrapper loads on CUDA, inference 0.21s, real polygon (447 vertices); foreground fraction ~3.7%, conf 0.994 — genuinely discriminating
- [x] API/queue cross-stack: on a standard `spheroid` project, batch → worker → ML → `segmentations` row flips to `model=segformer`
- [x] UI (Playwright, live prod): SegFormer renders as 4th card in *Spheroid Models*, 0 console errors; **Resegment frame** with SegFormer selected runs with no compatibility error and updates the result
- Note: deployed to production (`ml`, `frontend`, `backend` rebuilt + recreated). `spheroid_invasive` projects intentionally remain locked to `unet_attention_aspp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SegFormer-B0 model for spheroid segmentation tasks.
  * Model is now available in the model selection UI.
  * Added localized descriptions in English, German, Czech, Spanish, French, and Chinese.

* **Chores**
  * Configured batch size and performance parameters for the new model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->