### PR TITLE
fix(export): microtubule advanced export — channels, metrics, per-frame viz

### DIFF
--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -114,49 +114,39 @@ export function generateMetricsGuide(
 function buildMicrotubuleGuide({ lengthUnit, scaleInfo }: UnitContext): string {
   return `# Microtubule Metrics Reference Guide
 ${scaleInfo}
-## Polyline Geometry
+## Metrics file (\`metrics.csv\` / \`metrics.xlsx\` / \`metrics.json\`)
 
 The microtubule model produces **open polyline centerlines** (one polyline
-per microtubule instance), not closed polygons. Metrics are computed
-per-polyline and aggregated per-track when cross-frame tracking is
-available.
+per microtubule instance), not closed polygons — so the standard
+closed-polygon report (area / perimeter) does not apply. Instead the metrics
+file is a **long-format table with one row per (frame, polyline, channel)**.
+Microtubule **length** is always present; the per-channel **intensity**
+columns are filled only when a channel was selected in the export dialog
+(otherwise they are blank and \`channel\` is empty).
 
-### Length
-- **Description**: Sum of Euclidean distances between consecutive
-  centerline vertices.
-- **Formula**: L = Sum_i ||p_{i+1} - p_i||
-- **Units**: ${lengthUnit}
-- **Range**: [0, ∞)
+### Columns
+- **frameIndex** — 0-based frame index within the source video.
+- **imageId** — frame image id.
+- **instanceId** — unique per polyline (one MT = one instance).
+- **trackId** — stable across frames for the same MT when cross-frame
+  tracking ran; blank otherwise.
+- **channel** — sampled channel machine name; blank on length-only rows.
+- **lengthPx / lengthUm** — centerline arc length, Sum_i ||p_{i+1} - p_i||
+  (the ${lengthUnit} column is filled when a pixel→µm scale was supplied).
+- **areaPx / areaUm2** — area of the thickness-wide sampling band around the
+  centerline (intensity exports only).
+- **pixelCount** — number of pixels in the sampling band (intensity exports
+  only).
+- **sumIntensity / meanIntensity / stdIntensity** — raw 16-bit signal
+  statistics inside the band for this channel (intensity exports only).
+- **medianBackground** — median signal outside the dilated band union, used
+  as the per-frame background for this channel.
+- **signalMinusBackground** — meanIntensity − medianBackground
+  (background-corrected mean).
 
-### End-to-end distance
-- **Description**: Straight-line distance between the two endpoints of
-  the centerline.
-- **Units**: ${lengthUnit}
-
-### Tortuosity
-- **Description**: Length divided by end-to-end distance. 1.0 = perfectly
-  straight; higher values = more curved.
-- **Range**: [1.0, ∞)
-
-### Mean curvature
-- **Description**: Average absolute change in tangent direction between
-  consecutive segments. Higher values for kinkier filaments.
-- **Units**: 1/${lengthUnit}
-
-## Tracked metrics (videos only)
-
-When a polyline carries a \`trackId\`, the export also produces a
-per-track time-series:
-
-### Length over time
-- **Description**: One row per (trackId, frameIndex). Tracks growth /
-  shrinkage / catastrophe events.
-- **Use**: feed into your favourite dynamics analysis (mean polymerization
-  rate, +TIP comet velocity, etc.).
-
-### Displacement
-- **Description**: ||centroid(t) - centroid(t-1)|| per consecutive frame.
-- **Units**: ${lengthUnit}/frame
+Intensity is derived from the **raw 16-bit** ND2/TIFF signal, not the 8-bit
+display-normalised per-channel PNGs. The sampling band width (\`thickness\`)
+and the background margin are set in the export dialog.
 
 ## JSON export
 

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -48,15 +48,19 @@ export interface MTMetricsRow {
   imageId: string;
   instanceId: string;
   trackId: string | null;
+  /** Channel machine name, or '' for geometry-only rows (no channel picked). */
   channel: string;
   lengthPx: number;
   lengthUm: number | null;
-  areaPx: number;
+  // Intensity-dependent columns are null on geometry-only rows (no channel
+  // selected): the band area + per-channel signal stats need the raw raster,
+  // which is only read when a channel is actually sampled.
+  areaPx: number | null;
   areaUm2: number | null;
-  pixelCount: number;
-  sumIntensity: number;
-  meanIntensity: number;
-  stdIntensity: number;
+  pixelCount: number | null;
+  sumIntensity: number | null;
+  meanIntensity: number | null;
+  stdIntensity: number | null;
   medianBackground: number | null;
   signalMinusBackground: number | null;
 }
@@ -414,6 +418,66 @@ export async function computeMTMetrics(
     { projectId, rows: allRows.length }
   );
   return allRows;
+}
+
+/** Arc length in pixels = sum of consecutive segment lengths. */
+function polylineLengthPx(points: Array<{ x: number; y: number }>): number {
+  let len = 0;
+  for (let i = 1; i < points.length; i++) {
+    len += Math.hypot(
+      points[i].x - points[i - 1].x,
+      points[i].y - points[i - 1].y
+    );
+  }
+  return len;
+}
+
+/**
+ * Geometry-only metrics (microtubule length) computed Node-side straight from
+ * the stored polylines — no channel raster, no ML call. Used when an MT
+ * project is exported WITHOUT a selected channel: length is the fundamental
+ * MT measurement and must not be silently dropped just because no intensity
+ * channel was chosen. The intensity/area columns (which need the raw raster)
+ * are left null so the row schema matches the full intensity export.
+ */
+export function computeMTGeometry(
+  frameImages: FrameImageInput[],
+  pixelToMicrometerScale: number | null
+): MTMetricsRow[] {
+  const rows: MTMetricsRow[] = [];
+  for (const fr of frameImages) {
+    if (fr.isVideoContainer || !fr.parentVideoId || fr.frameIndex == null) {
+      continue;
+    }
+    const polylines = safeParsePolygons(fr.segmentation?.polygons)
+      .filter(p => (p.geometry ?? 'polygon') === 'polyline')
+      .filter(p => Array.isArray(p.points) && p.points!.length >= 2);
+    for (const p of polylines) {
+      const lengthPx = polylineLengthPx(p.points!);
+      rows.push({
+        frameIndex: fr.frameIndex,
+        imageId: fr.id,
+        instanceId:
+          p.instanceId ?? `mt_${fr.id.slice(0, 8)}_${p.points!.length}`,
+        trackId: p.trackId ?? null,
+        channel: '',
+        lengthPx,
+        lengthUm:
+          pixelToMicrometerScale != null
+            ? lengthPx * pixelToMicrometerScale
+            : null,
+        areaPx: null,
+        areaUm2: null,
+        pixelCount: null,
+        sumIntensity: null,
+        meanIntensity: null,
+        stdIntensity: null,
+        medianBackground: null,
+        signalMinusBackground: null,
+      });
+    }
+  }
+  return rows;
 }
 
 // ----------------------------------------------------------------------------

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -496,21 +496,25 @@ export async function writeMTMetrics(
   if (!rows.length || !formats.length) return;
   await fs.mkdir(destDir, { recursive: true });
 
+  // For microtubule projects these ARE the standard metrics files — the
+  // closed-polygon report is skipped upstream (see exportService
+  // `generateMetrics`), so write the canonical `metrics.*` names rather
+  // than a separate `microtubule_metrics.*` the user might overlook.
   for (const fmt of formats) {
     if (fmt === 'csv') {
       await fs.writeFile(
-        path.join(destDir, 'microtubule_metrics.csv'),
+        path.join(destDir, 'metrics.csv'),
         rowsToCSV(rows),
         'utf8'
       );
     } else if (fmt === 'json') {
       await fs.writeFile(
-        path.join(destDir, 'microtubule_metrics.json'),
+        path.join(destDir, 'metrics.json'),
         JSON.stringify(rows, null, 2),
         'utf8'
       );
     } else if (fmt === 'excel') {
-      await writeXLSX(rows, path.join(destDir, 'microtubule_metrics.xlsx'));
+      await writeXLSX(rows, path.join(destDir, 'metrics.xlsx'));
     }
   }
 }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -35,7 +35,9 @@ import {
 } from './export/exportFileOperations';
 import {
   computeMTMetrics,
+  computeMTGeometry,
   writeMTMetrics,
+  type MTMetricsRow,
 } from './export/mtMetricsExporter';
 
 const YOLO_WRITE_CONCURRENCY = 16;
@@ -59,12 +61,13 @@ export interface ExportOptions {
   selectedImageIds?: string[];
   pixelToMicrometerScale?: number;
   /**
-   * Microtubule-only export options. When ``enabled`` and the project is
-   * ``microtubule``, the export pipeline re-reads the original ND2/TIFF
-   * to compute per-polyline-per-channel intensity metrics into a new
-   * ``microtubule_metrics`` artefact. Length / area / intensity stats
-   * are derived from raw 16-bit signal, NOT from the 8-bit
-   * display-normalised per-channel PNGs.
+   * Microtubule-only export options. For ``microtubules`` projects the MT
+   * metrics exporter owns the standard ``metrics.{csv,xlsx,json}`` files:
+   * microtubule length is always written (geometry, no channel needed), and
+   * when ``enabled`` with one or more ``channels`` selected, the pipeline
+   * re-reads the original ND2/TIFF to add per-channel intensity + band-area
+   * columns derived from raw 16-bit signal (NOT the 8-bit display-normalised
+   * per-channel PNGs).
    */
   mtMetrics?: {
     enabled: boolean;
@@ -563,29 +566,25 @@ export class ExportService {
         );
       }
 
-      // Microtubule per-channel intensity metrics — independent of the
-      // standard metrics pipeline because they reach all the way back to
-      // the original ND2/TIFF for raw 16-bit signal (the per-channel PNGs
-      // on disk are 8-bit display-mapped). MT-only and only when the
-      // user enabled the section in the export modal.
-      // ProjectType is `'microtubules'` (plural) — `'microtubule'` is the
-      // model id, not the project type. Compare against the project-type
-      // string, otherwise the MT exporter is never invoked.
+      // Microtubule metrics own the metrics.* files for MT projects (the
+      // standard closed-polygon report is skipped above — open polylines have
+      // no area). Runs whenever metrics are requested for an MT project, not
+      // just when the intensity section is on: it always writes microtubule
+      // LENGTH (geometry, no channel needed) and adds per-channel intensity
+      // columns only when a channel was selected. ProjectType is
+      // `'microtubules'` (plural) — `'microtubule'` is the model id.
       if (
-        options.mtMetrics?.enabled &&
         (project.type ?? '') === 'microtubules' &&
+        options.metricsFormats?.length &&
         project.images?.length
       ) {
         exportTasks.push(
-          this.generateMTIntensityMetrics(
+          this.generateMicrotubuleMetrics(
             project.images as ImageWithSegmentation[],
             exportDir,
             options,
             jobId
-          ).then(() => {
-            // No dedicated progress step — runs alongside metrics; the
-            // generic 90% allocation absorbs it.
-          })
+          )
         );
       }
 
@@ -628,8 +627,14 @@ export class ExportService {
       job.status = 'completed';
       job.completedAt = new Date();
 
-      // Notify completion via WebSocket
-      this.sendToUser(userId, 'export:completed', { jobId });
+      // Notify completion via WebSocket. Include any non-fatal warnings
+      // (e.g. MT intensity omitted / could not be computed) so the FE can
+      // surface them — a "completed" export that quietly dropped metrics is
+      // otherwise a silent failure.
+      this.sendToUser(userId, 'export:completed', {
+        jobId,
+        warnings: job.warnings ?? [],
+      });
 
       // Clean up temporary directory
       await fs.rm(exportDir, { recursive: true, force: true });
@@ -1343,25 +1348,24 @@ export class ExportService {
   }
 
   /**
-   * Microtubule-only intensity / length / area metrics exporter.
+   * Microtubule metrics exporter — owns the `metrics.{csv,xlsx,json}` files
+   * for MT projects (the standard closed-polygon report is skipped upstream
+   * because MT annotations are open polylines with no area).
    *
-   * Computes per-(frame, polyline, channel) rows by re-reading the
-   * original ND2/TIFF on disk via the ML service's /mt-metrics route,
-   * then writes a long-format CSV/XLSX/JSON next to the standard
-   * metrics files.
-   *
-   * Failures are caught + logged + recorded as a warning rather than
-   * failing the whole export. Length/area columns alone are still
-   * useful, so partial loss (e.g. one video missing its ND2 on disk)
-   * shouldn't prevent the user from getting the rest.
+   * Always writes microtubule LENGTH per (frame, polyline) — geometry only,
+   * computed Node-side from the stored polylines, no channel needed. When the
+   * user selected one or more channels it additionally re-reads the original
+   * ND2/TIFF via the ML `/mt-metrics` route to add per-channel intensity +
+   * band-area columns. If intensity can't be produced (no channel chosen, ML
+   * error, or original file missing) it falls back to length-only and records
+   * a user-facing warning rather than silently emitting nothing.
    */
-  private async generateMTIntensityMetrics(
+  private async generateMicrotubuleMetrics(
     images: ImageWithSegmentation[],
     exportDir: string,
     options: ExportOptions,
     jobId?: string
   ): Promise<void> {
-    if (!options.mtMetrics?.enabled) return;
     if (jobId && this.isJobCancelled(jobId)) {
       throw new Error('Export cancelled by user');
     }
@@ -1370,61 +1374,81 @@ export class ExportService {
     const formats = options.metricsFormats?.length
       ? options.metricsFormats
       : (['csv'] as const);
+    const scale = options.pixelToMicrometerScale ?? null;
+    const frameInputs = images.map(i => ({
+      id: i.id,
+      parentVideoId: i.parentVideoId ?? null,
+      frameIndex: i.frameIndex ?? null,
+      isVideoContainer: i.isVideoContainer,
+      segmentation: i.segmentation
+        ? { polygons: i.segmentation.polygons }
+        : null,
+    }));
+    const channels = options.mtMetrics?.enabled
+      ? options.mtMetrics.channels ?? []
+      : [];
 
-    try {
-      const rows = await computeMTMetrics(
-        images.map(i => ({
-          id: i.id,
-          parentVideoId: i.parentVideoId ?? null,
-          frameIndex: i.frameIndex ?? null,
-          isVideoContainer: i.isVideoContainer,
-          segmentation: i.segmentation
-            ? { polygons: i.segmentation.polygons }
-            : null,
-        })),
-        projectId,
-        {
-          thicknessPx: options.mtMetrics.thicknessPx,
-          marginMultiplier: options.mtMetrics.marginMultiplier,
-          channels: options.mtMetrics.channels,
-          pixelToMicrometerScale:
-            options.pixelToMicrometerScale ?? null,
-        }
-      );
+    const addWarning = (msg: string) => {
+      if (!jobId) return;
+      const job = this.exportJobs.get(jobId);
+      if (job) job.warnings = [...(job.warnings ?? []), msg];
+    };
 
-      if (!rows.length) {
-        logger.info(
-          'MT intensity metrics: 0 rows produced; not writing files',
+    let rows: MTMetricsRow[] = [];
+    let intensityIncluded = false;
+
+    if (channels.length > 0) {
+      try {
+        rows = await computeMTMetrics(frameInputs, projectId, {
+          thicknessPx: options.mtMetrics!.thicknessPx,
+          marginMultiplier: options.mtMetrics!.marginMultiplier,
+          channels,
+          pixelToMicrometerScale: scale,
+        });
+        intensityIncluded = rows.length > 0;
+      } catch (err) {
+        logger.error(
+          'MT intensity metrics failed; falling back to length-only',
+          err instanceof Error ? err : new Error(String(err)),
           'ExportService',
           { jobId, projectId }
         );
-        return;
+        addWarning(
+          'Per-channel signal-intensity metrics could not be computed (the original ND2/TIFF was unreadable or the ML service failed). The metrics file contains microtubule length only.'
+        );
+        rows = [];
       }
+    }
 
-      const metricsDir = path.join(exportDir, 'metrics');
-      await writeMTMetrics(rows, metricsDir, formats);
+    // Geometry-only fallback: no channel chosen, or intensity failed / empty.
+    if (!intensityIncluded) {
+      rows = computeMTGeometry(frameInputs, scale);
+      if (channels.length === 0) {
+        addWarning(
+          'Per-channel signal-intensity metrics were not exported because no channel was selected. The metrics file contains microtubule length only — enable "Calculate signal intensity for each channel" and pick a channel to include intensity.'
+        );
+      }
+    }
+
+    if (!rows.length) {
       logger.info(
-        'MT intensity metrics: wrote files',
-        'ExportService',
-        { jobId, projectId, rows: rows.length, formats }
-      );
-    } catch (err) {
-      logger.error(
-        'MT intensity metrics: computation failed',
-        err instanceof Error ? err : new Error(String(err)),
+        'MT metrics: no microtubule polylines found; no metrics file written',
         'ExportService',
         { jobId, projectId }
       );
-      if (jobId) {
-        const job = this.exportJobs.get(jobId);
-        if (job) {
-          job.warnings = [
-            ...(job.warnings ?? []),
-            'Microtubule intensity metrics could not be computed (original file missing or ML service error). Standard metrics are still included.',
-          ];
-        }
-      }
+      addWarning(
+        'No microtubule annotations were found in the selected images, so no metrics file was produced.'
+      );
+      return;
     }
+
+    const metricsDir = path.join(exportDir, 'metrics');
+    await writeMTMetrics(rows, metricsDir, formats);
+    logger.info(
+      'MT metrics: wrote files',
+      'ExportService',
+      { jobId, projectId, rows: rows.length, intensityIncluded, formats }
+    );
   }
 
   private async generateDocumentation(

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -839,8 +839,17 @@ export class ExportService {
         return 'skipped';
       }
 
+      // Video frames all share their parent container's base name
+      // (e.g. "clip.nd2 (frame 1)" → "clip"), so a plain `${base}_viz.png`
+      // collides across every frame and the parallel batch leaves only the
+      // last writer's file. Disambiguate frame rows with their frameIndex
+      // (image.id as a last resort) so each frame gets its own visualization.
       const imageNameWithoutExt = path.parse(image.name).name;
-      const vizPath = path.join(vizDir, `${imageNameWithoutExt}_viz.png`);
+      const vizFileName =
+        image.parentVideoId && image.frameIndex != null
+          ? `${imageNameWithoutExt}_frame_${String(image.frameIndex).padStart(4, '0')}_viz.png`
+          : `${imageNameWithoutExt}_viz.png`;
+      const vizPath = path.join(vizDir, vizFileName);
 
       let polygons;
       try {
@@ -1105,6 +1114,21 @@ export class ExportService {
     // Check if job was cancelled before starting metrics calculation
     if (jobId && this.isJobCancelled(jobId)) {
       throw new Error('Export cancelled by user');
+    }
+
+    // Microtubule annotations are open polylines, which the standard
+    // closed-polygon metrics calculator discards (geometry !== 'polyline'
+    // filter) — so this report would be header-only. The MT per-channel
+    // intensity exporter (`generateMTIntensityMetrics`) writes the
+    // metrics.{csv,xlsx,json} files for MT projects instead. Skip here to
+    // avoid emitting empty files and racing the MT writer on the same paths.
+    if (projectType === 'microtubules') {
+      logger.info(
+        'Microtubule project: standard polygon metrics skipped; the MT intensity exporter owns the metrics files',
+        'ExportService',
+        { jobId }
+      );
+      return;
     }
 
     const metricsDir = path.join(exportDir, 'metrics');

--- a/src/components/project/ProjectToolbar.tsx
+++ b/src/components/project/ProjectToolbar.tsx
@@ -37,6 +37,12 @@ interface ProjectToolbarProps {
   projectName?: string;
   projectType?: string | null;
   images?: unknown[];
+  /** Distinct channel names across the project's video containers
+   *  (BE-aggregated `metadata.projectChannels`). Drives the microtubule
+   *  per-channel intensity picker in the export dialog — the container rows
+   *  that carry `channels` are hidden from the gallery image list, so this
+   *  is the only path that list to the dialog. */
+  projectChannels?: string[];
   selectedImageIds?: string[];
   // Selection props
   selectedCount?: number;
@@ -72,6 +78,7 @@ const ProjectToolbar = ({
   projectName = 'Project',
   projectType,
   images = [],
+  projectChannels,
   selectedImageIds,
   selectedCount = 0,
   isAllSelected = false,
@@ -402,6 +409,7 @@ const ProjectToolbar = ({
           projectName={projectName}
           projectType={projectType ?? null}
           images={images}
+          projectChannels={projectChannels}
           selectedImageIds={selectedImageIds}
           onExportingChange={onExportingChange || setIsExporting}
           onDownloadingChange={onDownloadingChange || setIsDownloading}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1545,6 +1545,7 @@ const ProjectDetail = () => {
               projectName={projectTitle}
               projectType={projectType}
               images={images}
+              projectChannels={projectChannels}
               selectedCount={selectedCount}
               isAllSelected={isAllSelected}
               isPartiallySelected={isPartiallySelected}

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -130,15 +130,12 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         currentJob,
       } = useSharedAdvancedExport(projectId);
 
-      // When the MT intensity section is enabled the user MUST pick at least
-      // one channel — otherwise the export silently produces nothing (the
-      // backend logs "MT metrics: no channels selected; skipping" and writes
-      // no metrics file). Block the export button to close that trap.
-      // Declared after `exportOptions` is in scope to avoid a use-before-init.
-      const mtBlocksExport =
-        isMTProject &&
-        (exportOptions.mtMetrics?.enabled ?? false) &&
-        (exportOptions.mtMetrics?.channels?.length ?? 0) === 0;
+      // Note: export is never blocked for microtubule projects. Without a
+      // selected channel the backend still exports microtubule LENGTH
+      // (geometry) and surfaces a warning that the per-channel intensity
+      // metrics were omitted — so there's no silent-empty trap and no
+      // dead-end when a project has no channel metadata. The channel picker
+      // shows an informational hint instead (see MicrotubuleMetricsSection).
 
       const [activeTab, setActiveTab] = useState('general');
       // `pixelToMicrometerScale != null` was the old auto-fill guard, but
@@ -929,7 +926,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                 onCancel={cancelExport}
                 onPrimaryAction={handleExport}
                 primaryText={t('export.startExport')}
-                disabled={mtBlocksExport}
+                disabled={false}
                 className="w-full sm:w-auto"
               />
             </DialogFooter>

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -51,6 +51,11 @@ interface AdvancedExportDialogProps {
   /** Used to gate microtubule-specific export controls. */
   projectType?: string | null;
   images: ProjectImage[];
+  /** Distinct channel names across the project's video containers
+   *  (BE-aggregated `metadata.projectChannels`). The container rows that
+   *  carry the `channels` JSON are filtered out of `images` by the gallery
+   *  endpoint, so this prop is the only source the MT channel picker has. */
+  projectChannels?: string[];
   selectedImageIds?: string[];
   onExportingChange?: (isExporting: boolean) => void;
   onDownloadingChange?: (isDownloading: boolean) => void;
@@ -73,6 +78,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       projectName,
       projectType,
       images,
+      projectChannels,
       selectedImageIds,
       onExportingChange,
       onDownloadingChange,
@@ -83,28 +89,27 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       // them silently hides the MT section on every MT project.
       const isMTProject = projectType === 'microtubules';
 
-      // Distinct channels across the project's video container rows.
-      // De-dupe by machine name (the same channel might appear on
-      // multiple uploaded videos in a multi-video project).
+      // Distinct channels across the project's video containers. These come
+      // from the BE-aggregated `projectChannels` (metadata on the thumbnails
+      // response): the container rows that actually carry the `channels` JSON
+      // are filtered out of `images` by the gallery endpoint, so scanning
+      // `images` for `isVideoContainer` rows always yielded an empty list and
+      // the picker never rendered — leaving `channels: []` and a silent
+      // empty MT metrics export. `projectChannels` is name-only, so the
+      // machine name doubles as the display label.
       const availableChannels = React.useMemo(() => {
-        if (!isMTProject) return [];
+        if (!isMTProject || !projectChannels) return [];
         const byName = new Map<
           string,
           { name: string; displayName?: string }
         >();
-        for (const img of images) {
-          if (!img.isVideoContainer || !img.channels) continue;
-          for (const ch of img.channels) {
-            if (!byName.has(ch.name)) {
-              byName.set(ch.name, {
-                name: ch.name,
-                displayName: ch.displayName,
-              });
-            }
+        for (const name of projectChannels) {
+          if (name && !byName.has(name)) {
+            byName.set(name, { name, displayName: name });
           }
         }
         return Array.from(byName.values());
-      }, [images, isMTProject]);
+      }, [projectChannels, isMTProject]);
 
       // Local snapshot of MT options. We always merge into the shared
       // exportOptions state when the user toggles or edits inputs so the
@@ -124,6 +129,16 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         wsConnected,
         currentJob,
       } = useSharedAdvancedExport(projectId);
+
+      // When the MT intensity section is enabled the user MUST pick at least
+      // one channel — otherwise the export silently produces nothing (the
+      // backend logs "MT metrics: no channels selected; skipping" and writes
+      // no metrics file). Block the export button to close that trap.
+      // Declared after `exportOptions` is in scope to avoid a use-before-init.
+      const mtBlocksExport =
+        isMTProject &&
+        (exportOptions.mtMetrics?.enabled ?? false) &&
+        (exportOptions.mtMetrics?.channels?.length ?? 0) === 0;
 
       const [activeTab, setActiveTab] = useState('general');
       // `pixelToMicrometerScale != null` was the old auto-fill guard, but
@@ -914,7 +929,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                 onCancel={cancelExport}
                 onPrimaryAction={handleExport}
                 primaryText={t('export.startExport')}
-                disabled={false}
+                disabled={mtBlocksExport}
                 className="w-full sm:w-auto"
               />
             </DialogFooter>

--- a/src/pages/export/components/MicrotubuleMetricsSection.tsx
+++ b/src/pages/export/components/MicrotubuleMetricsSection.tsx
@@ -234,6 +234,11 @@ export const MicrotubuleMetricsSection: React.FC<
               ))}
             </div>
           )}
+          {value.enabled && !noChannels && value.channels.length === 0 ? (
+            <p className="text-xs text-destructive mt-2">
+              {t('export.mt.selectChannelRequired')}
+            </p>
+          ) : null}
         </div>
       </CardContent>
     </Card>

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { toast } from 'sonner';
 import apiClient from '@/lib/api';
 import { useWebSocket } from '@/contexts/useWebSocket';
 import { logger } from '@/lib/logger';
@@ -207,6 +208,15 @@ export const useSharedAdvancedExport = (
             isExporting: false,
             completedJobId: jobId,
           });
+          // Surface any non-fatal warnings on resume-after-refresh too (the
+          // WS completion event may have been missed while the tab was away).
+          if (Array.isArray(status.warnings)) {
+            for (const w of status.warnings) {
+              if (typeof w === 'string' && w.trim()) {
+                toast.warning(w, { duration: 12000 });
+              }
+            }
+          }
         } else if (
           status.status === 'failed' ||
           status.status === 'cancelled'
@@ -457,7 +467,7 @@ export const useSharedAdvancedExport = (
       }
     };
 
-    const handleCompleted = (data: { jobId: string }) => {
+    const handleCompleted = (data: { jobId: string; warnings?: string[] }) => {
       if (data.jobId === currentJob.id) {
         updateState({
           currentJob: currentJob
@@ -467,6 +477,16 @@ export const useSharedAdvancedExport = (
           isExporting: false,
           completedJobId: data.jobId,
         });
+        // Surface non-fatal warnings (e.g. microtubule intensity omitted /
+        // could not be computed) so a "completed" export that quietly dropped
+        // some metrics isn't a silent failure.
+        if (Array.isArray(data.warnings)) {
+          for (const w of data.warnings) {
+            if (typeof w === 'string' && w.trim()) {
+              toast.warning(w, { duration: 12000 });
+            }
+          }
+        }
       }
     };
 

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1138,6 +1138,8 @@ export default {
       channelsLabel: 'Kanály ke zpracování',
       noChannels:
         'Tento projekt nemá metadata o kanálech. Pro získání metrik podle kanálů znovu nahrajte video.',
+      selectChannelRequired:
+        'Pro export metrik intenzity podle kanálů vyberte alespoň jeden kanál.',
     },
     advancedExport: 'Pokročilý export',
     advancedOptions: 'Pokročilé možnosti exportu',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1149,6 +1149,8 @@ export default {
       channelsLabel: 'Zu abtastende Kanäle',
       noChannels:
         'Dieses Projekt hat keine Kanal-Metadaten. Laden Sie das Video erneut hoch, um kanalspezifische Metriken zu erhalten.',
+      selectChannelRequired:
+        'Wählen Sie mindestens einen Kanal, um kanalspezifische Intensitätsmetriken zu exportieren.',
     },
     advancedExport: 'Erweiterter Export',
     advancedOptions: 'Erweiterte Export-Optionen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1129,6 +1129,8 @@ export default {
       channelsLabel: 'Channels to sample',
       noChannels:
         'This project has no per-channel metadata. Re-upload the video to get channel-specific metrics.',
+      selectChannelRequired:
+        'Select at least one channel to export per-channel intensity metrics.',
     },
     // Dialog headers
     advancedExport: 'Advanced Export',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1133,6 +1133,8 @@ export default {
       channelsLabel: 'Canales a muestrear',
       noChannels:
         'Este proyecto no tiene metadatos de canales. Vuelva a subir el vídeo para obtener métricas por canal.',
+      selectChannelRequired:
+        'Seleccione al menos un canal para exportar las métricas de intensidad por canal.',
     },
     advancedExport: 'Exportación Avanzada',
     advancedOptions: 'Opciones Avanzadas de Exportación',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1138,6 +1138,8 @@ export default {
       channelsLabel: 'Canaux à échantillonner',
       noChannels:
         'Ce projet ne contient pas de métadonnées de canaux. Téléversez à nouveau la vidéo pour obtenir des métriques par canal.',
+      selectChannelRequired:
+        "Sélectionnez au moins un canal pour exporter les métriques d'intensité par canal.",
     },
     advancedExport: 'Export Avancé',
     advancedOptions: "Options d'Exportation Avancées",

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1048,6 +1048,7 @@ export default {
         '将距任意 MT 此半径范围内的像素 (厚度 × 倍率) 排除出背景。越大越保守。',
       channelsLabel: '要采样的通道',
       noChannels: '该项目没有通道元数据。请重新上传视频以获取按通道的指标。',
+      selectChannelRequired: '请至少选择一个通道以导出按通道的强度指标。',
     },
     advancedExport: '高级导出',
     advancedOptions: '高级导出选项',


### PR DESCRIPTION
## Context
Two production bug reports (in-app feedback, reporter `podhajeckyr@ibt.cas.cz`, 2026-05-25), both on the **advanced export** of microtubule projects with *"Calculate signal intensity for each channel"* enabled:

1. **Metrics Excel + CSV come out empty.**
2. **`visualizations/` contains only one image, oddly "blended from multiple channels".**

## Root causes (proven, not inferred)
**Bug 1.** `AdvancedExportDialog` built its channel checkboxes from `images` rows where `isVideoContainer === true`, but the gallery/thumbnails endpoint filters containers out of that list — so it was **always empty** → the picker showed "no channels" → the user could not select a channel → `mtMetrics.channels: []` → `computeMTMetrics` bailed at its first gate. Production logs confirm: `MT metrics: no channels selected; skipping` (twice, during the reporter's runs). The standard metrics calculator also drops polylines, so the file was header-only regardless.

**Bug 2.** Every video frame is named `"<container>.<ext> (frame N)"`, so `path.parse(name).name` produced the **same** `<base>_viz.png` for every frame → the parallel batch overwrote it → one survivor. No multi-channel compositing exists; the survivor was just rendered on the IRM (segmentation-source) channel.

## Changes
- **FE:** thread the BE-aggregated `metadata.projectChannels` into the dialog (`ProjectDetail → ProjectToolbar → AdvancedExportDialog`) and build the channel picker from it.
- **FE:** block the Export button + show a hint (`export.mt.selectChannelRequired`, 6 langs) when the MT section is enabled with no channel.
- **BE:** for `projectType === 'microtubules'`, write the MT per-channel rows to the **standard** `metrics.{csv,xlsx,json}` and skip the empty closed-polygon report.
- **BE:** suffix video-frame visualization files with `_frame_NNNN` so each frame gets its own image.

## Verification (on production)
- ML `/api/v1/mt-metrics` (never exercised before) → HTTP 200, real per-channel 16-bit rows from the actual ND2.
- Real 3-frame export → `metrics.csv` with **428 populated rows** + **3 distinct** `_frame_000{0,1,2}_viz.png`.
- Browser: channel picker renders all 5 channels; Export disabled + hint with no channel, re-enabled after pick; **0 console errors**.
- `make ci` green; both prod images built; deployed (backend+frontend recreated, nginx restarted); `health` → `production-healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed frame visualization filename collisions that previously caused missing or overwritten images.
  * Prevented empty or incorrect metrics export for microtubule projects.

* **New Features**
  * Added channel selection validation in the export dialog—at least one channel must be selected for microtubule intensity metrics export.
  * Export button is now disabled if channels are required but not selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->