### PR TITLE
fix(video): handle multi-position ND2 in frame extraction

### DIFF
--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -56,6 +56,77 @@ def _sanitize_name(name: str | None, fallback: str) -> str:
     return safe or fallback
 
 
+class UnsupportedND2(ValueError):
+    """Raised for ND2 layouts we deliberately reject with a user-facing
+    message (rather than silently mis-extracting)."""
+
+
+def normalize_to_tcyx(arr: np.ndarray, axes: str) -> np.ndarray:
+    """Reshape an ND2 array to canonical ``(T, C, Y, X)``.
+
+    Handles the real-world axis layouts we see in the wild:
+
+    - ``Z`` (focus stack)            → max-intensity projection (singleton Z
+      is simply squeezed).
+    - singleton loop axes (``P``     → squeezed away. NIS-Elements often
+      position, ``S`` sample, …)        exports per-field files that still
+                                        carry a length-1 ``P`` axis, which
+                                        the old ``TCYX``-only path rejected.
+    - missing ``T`` and/or ``C``     → inserted as length-1 so ``arr[t, c]``
+                                        indexing downstream always works.
+
+    A genuine multi-position acquisition (a ``P`` / other loop axis with
+    size > 1) has no single-video meaning, so it is rejected with an
+    actionable :class:`UnsupportedND2` message instead of silently
+    exporting only the first position.
+
+    ``axes`` is the dimension-name string aligned with ``arr`` (e.g.
+    ``"PTCYX"``); ``len(axes) == arr.ndim``.
+    """
+    ax = list(axes)
+
+    if "Z" in ax:
+        zi = ax.index("Z")
+        arr = arr.max(axis=zi) if arr.shape[zi] > 1 else np.squeeze(arr, axis=zi)
+        ax.pop(zi)
+
+    # Drop non-core axes. Singletons squeeze cleanly; a size>1 loop axis is
+    # multi-position content we can't fold into one video.
+    i = 0
+    while i < len(ax):
+        a = ax[i]
+        if a in ("T", "C", "Y", "X"):
+            i += 1
+            continue
+        if arr.shape[i] == 1:
+            arr = np.squeeze(arr, axis=i)
+            ax.pop(i)
+            continue
+        raise UnsupportedND2(
+            f"Multi-position ND2 not supported: this file has {arr.shape[i]} "
+            f"positions ('{a}' axis). In NIS-Elements split the points into "
+            f"separate single-field files and re-upload one per video."
+        )
+
+    if "Y" not in ax or "X" not in ax:
+        raise UnsupportedND2(
+            f"Unsupported ND2 axes '{''.join(ax)}' shape={arr.shape}: "
+            f"no Y/X image plane found."
+        )
+
+    # Insert any missing leading dims so the canonical order is complete.
+    if "T" not in ax:
+        arr = arr[None, ...]
+        ax.insert(0, "T")
+    if "C" not in ax:
+        ci = ax.index("Y")
+        arr = np.expand_dims(arr, axis=ci)
+        ax.insert(ci, "C")
+
+    perm = [ax.index(a) for a in ("T", "C", "Y", "X")]
+    return np.transpose(arr, perm)
+
+
 def main() -> int:
     if len(sys.argv) < 3:
         print("usage: extract_nd2.py <src.nd2> <dest_dir>", file=sys.stderr)
@@ -80,37 +151,25 @@ def main() -> int:
         W = sizes.get("X", 0)
 
         arr = f.asarray()
-        axes = "".join(f.sizes.keys())  # e.g. "TCYX" or "TZCYX"
+        axes = "".join(f.sizes.keys())  # e.g. "TCYX", "TZCYX", "PTCYX"
 
-        # Reduce Z via max projection if present.
-        if "Z" in axes and Z > 1:
-            z_idx = axes.index("Z")
-            arr = arr.max(axis=z_idx)
-            axes = axes.replace("Z", "")
-            Z = 1
+        # Normalize to canonical (T, C, Y, X) — squeezes singleton loop axes
+        # (e.g. a length-1 P from per-field NIS exports), max-projects Z, and
+        # rejects genuine multi-position files with a user-facing message.
+        try:
+            arr = normalize_to_tcyx(arr, axes)
+        except UnsupportedND2 as exc:
+            print(str(exc), file=sys.stderr)
+            return 4
 
-        # Normalize axes order to TCYX.
-        if axes == "CYX" and arr.ndim == 3:
-            arr = arr[None, ...]  # add T dim
-            T = 1
-        elif axes == "YX" and arr.ndim == 2:
-            arr = arr[None, None, ...]
-            T, C = 1, 1
-        elif axes == "TYX" and arr.ndim == 3:
-            arr = arr[:, None, :, :]
-            C = 1
-        elif axes != "TCYX":
-            # Try to reorder via numpy einsum-style transpose.
-            try:
-                target = "TCYX"
-                perm = [axes.index(ax) for ax in target if ax in axes]
-                arr = np.transpose(arr, perm)
-            except ValueError:
-                print(
-                    f"Unsupported ND2 axes='{axes}' shape={arr.shape}",
-                    file=sys.stderr,
-                )
-                return 4
+        # Trust the post-normalization shape over the raw `sizes` (which may
+        # have included the squeezed/projected axes).
+        T, C, H, W = (
+            int(arr.shape[0]),
+            int(arr.shape[1]),
+            int(arr.shape[2]),
+            int(arr.shape[3]),
+        )
 
         # Channel metadata: name + emission wavelength.
         # `displayName` is the human-friendly label (ND2 metadata name, or

--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -83,6 +83,11 @@ def normalize_to_tcyx(arr: np.ndarray, axes: str) -> np.ndarray:
     ``axes`` is the dimension-name string aligned with ``arr`` (e.g.
     ``"PTCYX"``); ``len(axes) == arr.ndim``.
     """
+    if len(axes) != arr.ndim:
+        raise UnsupportedND2(
+            f"ND2 axis metadata '{axes}' ({len(axes)} dims) does not match "
+            f"array ndim {arr.ndim} — cannot map to (T, C, Y, X)."
+        )
     ax = list(axes)
 
     if "Z" in ax:
@@ -142,16 +147,10 @@ def main() -> int:
         return 3
 
     with nd2.ND2File(str(src)) as f:
-        # sizes is an OrderedDict: {'T': N, 'C': N, 'Y': N, 'X': N} typically.
-        sizes = dict(f.sizes)
-        T = sizes.get("T", 1)
-        C = sizes.get("C", 1)
-        Z = sizes.get("Z", 1)
-        H = sizes.get("Y", 0)
-        W = sizes.get("X", 0)
-
         arr = f.asarray()
-        axes = "".join(f.sizes.keys())  # e.g. "TCYX", "TZCYX", "PTCYX"
+        # `f.sizes` is the dimension-name → size map, aligned with the
+        # `asarray()` axis order (e.g. "TCYX", "TZCYX", "PTCYX").
+        axes = "".join(f.sizes.keys())
 
         # Normalize to canonical (T, C, Y, X) — squeezes singleton loop axes
         # (e.g. a length-1 P from per-field NIS exports), max-projects Z, and
@@ -184,7 +183,8 @@ def main() -> int:
                 em_info = getattr(ch.channel, "emissionLambdaNm", None)
                 if isinstance(em_info, (int, float)):
                     emission = float(em_info)
-            except Exception:
+            except (IndexError, AttributeError, KeyError, TypeError):
+                # Optional per-channel metadata; fall back to "Channel N".
                 raw_name = None
                 emission = None
             has_raw = isinstance(raw_name, str) and raw_name.strip() != ""

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_nd2_normalize.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_nd2_normalize.py
@@ -1,0 +1,109 @@
+"""Unit tests for ``normalize_to_tcyx`` in ``extract_nd2.py``.
+
+The ND2 frame extractor used to handle only ``TCYX/CYX/YX/TYX``. A position
+(``P``) axis from well-plate / multipoint acquisitions made the array 5-D and
+crashed the transpose, so the upload failed with ``extraction_failed`` and an
+orphaned container (this hit a real user's WellE03-E07 / WellD05 uploads).
+``normalize_to_tcyx`` now squeezes singleton loop axes (a length-1 ``P`` from
+per-field NIS exports), max-projects ``Z``, inserts a missing ``T``/``C``, and
+*rejects* a genuine multi-position file (``P`` > 1) with a user-facing message
+instead of silently exporting only one position.
+
+These cases pin that contract: a refactor of the squeeze / insert / transpose
+order would otherwise silently corrupt frame extraction for whole classes of
+ND2 files with no compile-time signal.
+
+Pure function over numpy arrays — ``nd2`` is lazy-imported inside ``main()`` so
+it is not needed here, and there is no pytest dependency, so this runs in the
+backend container with a plain interpreter:
+
+  docker exec spheroseg-backend python3 \
+    backend/src/services/video/pythonHelpers/tests/test_extract_nd2_normalize.py
+
+It is also collectable by pytest (``python3 -m pytest .../tests/``) where the
+``test_*`` functions are discovered normally.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+HERE = os.path.dirname(__file__)
+HELPERS_DIR = os.path.abspath(os.path.join(HERE, ".."))
+sys.path.insert(0, HELPERS_DIR)
+
+from extract_nd2 import normalize_to_tcyx, UnsupportedND2  # noqa: E402
+
+
+def _mk(shape):
+    return np.arange(int(np.prod(shape)), dtype=np.uint16).reshape(shape)
+
+
+def _expect_unsupported(axes, shape):
+    try:
+        normalize_to_tcyx(_mk(shape), axes)
+    except UnsupportedND2:
+        return
+    raise AssertionError(
+        f"expected UnsupportedND2 for axes={axes!r} shape={shape}"
+    )
+
+
+def test_canonical_passthrough():
+    assert normalize_to_tcyx(_mk((2, 2, 4, 5)), "TCYX").shape == (2, 2, 4, 5)
+
+
+def test_singleton_position_squeezed():
+    # The regression: per-field NIS exports carry a length-1 P axis.
+    assert normalize_to_tcyx(_mk((1, 2, 3, 4, 5)), "PTCYX").shape == (2, 3, 4, 5)
+    assert normalize_to_tcyx(_mk((2, 1, 2, 4, 5)), "TPCYX").shape == (2, 2, 4, 5)
+    assert normalize_to_tcyx(_mk((1, 3, 4, 5)), "PCYX").shape == (1, 3, 4, 5)
+
+
+def test_missing_dims_inserted():
+    assert normalize_to_tcyx(_mk((3, 4, 5)), "CYX").shape == (1, 3, 4, 5)
+    assert normalize_to_tcyx(_mk((4, 5)), "YX").shape == (1, 1, 4, 5)
+    assert normalize_to_tcyx(_mk((2, 4, 5)), "TYX").shape == (2, 1, 4, 5)
+
+
+def test_z_is_max_projected_not_first_slice():
+    # TZCYX, Z=3; the brightest pixel is only on the last Z slice.
+    arr = np.zeros((1, 3, 1, 2, 2), dtype=np.uint16)
+    arr[0, 2, 0] = 9
+    out = normalize_to_tcyx(arr, "TZCYX")
+    assert out.shape == (1, 1, 2, 2)
+    assert out.max() == 9  # max projection, not arr[:, 0]
+
+
+def test_singleton_z_squeezed():
+    assert normalize_to_tcyx(_mk((2, 1, 2, 4, 5)), "TZCYX").shape == (2, 2, 4, 5)
+
+
+def test_multiposition_rejected():
+    _expect_unsupported("PTCYX", (3, 2, 4, 5))
+    _expect_unsupported("PCYX", (4, 3, 4, 5))
+
+
+def test_missing_yx_rejected():
+    _expect_unsupported("TC", (2, 3))
+
+
+def test_axes_ndim_mismatch_rejected():
+    # 3-D array described by a 4-char axes string.
+    _expect_unsupported("TCYX", (2, 4, 5))
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as exc:  # noqa: BLE001 - report all, exit non-zero
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    print(f"\n{'OK' if failures == 0 else f'{failures} FAILED'}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Context
While investigating empty/failed video containers reported via feedback, I found a cluster of ND2 uploads stuck at `segmentationStatus = extraction_failed` (0 frames, no channels, directory `rm -rf`'d, DB row orphaned). All were **well-plate / multipoint** ND2 files (`WellE03–E07`, `WellD05`); the ND2s that succeeded were single-position time-lapses.

## Root cause
`extract_nd2.py` only normalized `TCYX / CYX / YX / TYX` (+Z max-projection). A multipoint file carries a **`P` (position) axis**, making `f.asarray()` 5-D — but the transpose permutation was built only from `"TCYX"` (4 entries):

```python
perm = [axes.index(ax) for ax in "TCYX" if ax in axes]  # 4 entries
arr = np.transpose(arr, perm)                            # 5-D array → ValueError
```

→ `ValueError` → `return 4` → `pythonExtractor` rejects on the non-zero exit → `videoUploadService` marks `extraction_failed` and deletes the dir. Not size-related (the failures were *smaller* than the successes).

## Fix
Refactor axis handling into a pure, testable `normalize_to_tcyx(arr, axes)`:
- max-project `Z` (squeeze a singleton Z);
- **squeeze singleton loop axes** (`P`/`S` = 1) — NIS per-field exports carry a length-1 `P` the old path rejected;
- insert missing `T`/`C` as length-1, then transpose to canonical `(T, C, Y, X)`;
- reject a genuine multi-position file (`P` > 1) with an actionable `UnsupportedND2` message instead of a generic failure.

## Verification
- Unit-tested in the backend Python env (real numpy) across `TCYX / PTCYX(P=1) / TPCYX / CYX / YX / TYX / PCYX / TZCYX`, plus `P>1` rejection and a `Z` max-projection value check — **all pass**.
- Built + deployed backend; `health` → `production-healthy`; confirmed the new code is in the running image.
- ⚠️ The original failing files were cleaned up and logs rotated, so this is **not yet verified end-to-end against a real multipoint ND2** — a sample re-upload is needed to confirm whether the reporter's per-well files are `P=1` (now extract) or `P>1` (now a clear error).

Also (separately, user-approved): deleted the 7 orphan `extraction_failed` container rows (0 dependents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)