### PR TITLE
feat(segmentation): add Mamba-UNet (robust OOD model) + reframe picker into Fast/Accurate/Robust presets

### DIFF
--- a/backend/segmentation/api/models.py
+++ b/backend/segmentation/api/models.py
@@ -10,6 +10,7 @@ class ModelType(str, Enum):
     UNET_SPHEROHQ = "unet_spherohq"
     UNET_ATTENTION_ASPP = "unet_attention_aspp"
     SEGFORMER = "segformer"
+    MAMBA_UNET = "mamba_unet"
     SPERM = "sperm"
     WOUND = "wound"
 

--- a/backend/segmentation/config/batch_sizes.json
+++ b/backend/segmentation/config/batch_sizes.json
@@ -62,6 +62,20 @@
       },
       "note": "SegFormer-B0 SpheroMix model (1024x1024 input, 3.71M params). Vendor reports ~13ms / 79 img/s on L40S FP16; A5000 budget ~2x slower → ~30ms p95, ~40 img/s. Small encoder → low ~1.5GB footprint. Estimates pending A5000 benchmarking."
     },
+    "mamba_unet": {
+      "optimal_batch_size": 1,
+      "max_safe_batch_size": 2,
+      "expected_throughput": 4.2,
+      "memory_limit_mb": 5500,
+      "p95_latency_ms": 249.0,
+      "production_optimized": true,
+      "concurrent_processing": {
+        "max_concurrent_users": 1,
+        "memory_per_user_mb": 5500,
+        "expected_concurrent_throughput": 4.2
+      },
+      "note": "Mamba-UNet (U-Net + bidirectional Mamba SSM bottleneck, 90.75M params, 1024x1024). Best OOD generalization (HTS-Seg IoU 0.587). Measured on A5000 (522-image run): E2E inference 235.6ms mean (P5-P95 216-249), E2E total 253.9ms, ~4.2 img/s single. Forward-only batch throughput peaks at batch 2 (10.9 img/s); memory-bound (3GB@B1, 15GB@B8, OOM@B16) so max_safe pinned to 2. Runs fp32 (Mamba bottleneck upcasts) vs vendor's 26ms L40S FP16."
+    },
     "sperm": {
       "optimal_batch_size": 1,
       "max_safe_batch_size": 2,

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -79,10 +79,12 @@ except ImportError as e:
     _segformer_import_error = e
 
 # Optional Mamba-UNet spheroid model import (requires mamba_ssm CUDA kernels).
+# OSError is caught alongside ImportError: an ABI-mismatched compiled .so can
+# raise OSError on load, and that must disable only this model, not the service.
 _mamba_unet_import_error = None
 try:
     from models.mamba_unet import UMamba
-except ImportError as e:
+except (ImportError, OSError) as e:
     logger.warning(
         f"Could not import UMamba (Mamba-UNet): {e}. "
         "Mamba-UNet segmentation will not be available."

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -78,6 +78,18 @@ except ImportError as e:
     SegFormerModel = None
     _segformer_import_error = e
 
+# Optional Mamba-UNet spheroid model import (requires mamba_ssm CUDA kernels).
+_mamba_unet_import_error = None
+try:
+    from models.mamba_unet import UMamba
+except ImportError as e:
+    logger.warning(
+        f"Could not import UMamba (Mamba-UNet): {e}. "
+        "Mamba-UNet segmentation will not be available."
+    )
+    UMamba = None
+    _mamba_unet_import_error = e
+
 # Import the new inference executor
 from .inference_executor import (
     InferenceExecutor,
@@ -188,6 +200,13 @@ class ModelLoader:
             'finetuned_path': 'weights/segformer_b0_spheroseg.pth',
             'config_path': None
         },
+        'mamba_unet': {
+            # Will be None if mamba_ssm not installed
+            'class': UMamba,
+            'pretrained_path': 'weights/mamba_unet_spheroseg.pth',
+            'finetuned_path': 'weights/mamba_unet_spheroseg.pth',
+            'config_path': None
+        },
         'sperm': {
             'class': SpermModel,  # Will be None if sperm.py not yet copied
             'pretrained_path': 'sperm_final/best_model.pth',
@@ -288,6 +307,15 @@ class ModelLoader:
                 # UNet optimized for SpheroHQ dataset
                 model = UNet(in_channels=3, out_channels=1, features=[64, 128, 256, 512, 1024],
                            use_instance_norm=True, dropout_rate=0.0, use_deep_supervision=False)
+            elif model_name == 'mamba_unet':
+                # U-Net + bidirectional Mamba bottleneck (best OOD generalization).
+                # Plain nn.Module with single-channel logits -> flows through the
+                # generic torch.load + sigmoid/threshold path below, like UNet.
+                if UMamba is None:
+                    raise ImportError(
+                        f"Mamba-UNet architecture not available: {_mamba_unet_import_error}"
+                    )
+                model = UMamba(in_channels=3, out_channels=1, use_instance_norm=True)
             elif model_name == 'unet_attention_aspp':
                 # Enhanced UNet with Attention Gates + ASPP for dissolving spheroids
                 model = UNetAttention(

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -31,5 +31,11 @@ try:
 except ImportError:
     SegFormerModel = None
 
+# Mamba-UNet spheroid model: optional import (requires mamba_ssm CUDA kernels).
+try:
+    from .mamba_unet import UMamba
+except ImportError:
+    UMamba = None
+
 __all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'UNetAttention', 'SpermModel',
-           'WoundModel', 'MicrotubuleModel', 'SegFormerModel']
+           'WoundModel', 'MicrotubuleModel', 'SegFormerModel', 'UMamba']

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -32,9 +32,17 @@ except ImportError:
     SegFormerModel = None
 
 # Mamba-UNet spheroid model: optional import (requires mamba_ssm CUDA kernels).
+# Catch OSError too: a present-but-ABI-mismatched .so raises OSError/ImportError
+# on load, and we want that to disable only this model (with a log), not crash
+# the whole package import.
 try:
     from .mamba_unet import UMamba
-except ImportError:
+except (ImportError, OSError) as _e:
+    import logging as _logging
+
+    _logging.getLogger(__name__).warning(
+        "Could not import UMamba (Mamba-UNet): %s. Model unavailable.", _e
+    )
     UMamba = None
 
 __all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'UNetAttention', 'SpermModel',

--- a/backend/segmentation/models/mamba_unet.py
+++ b/backend/segmentation/models/mamba_unet.py
@@ -1,0 +1,146 @@
+"""U-Mamba: U-Net with Mamba blocks in the bottleneck.
+
+Inspired by Ma et al. 2024 (bowang-lab/U-Mamba). Standard CNN encoder/decoder
+(same as our UNet) preserves 2D spatial locality where it matters; the
+bottleneck is augmented with Mamba SSM blocks operating on the flattened
+spatial sequence -- at 1024^2 input the bottleneck is 32x32 = 1024 tokens,
+well within Mamba's effective range.
+
+Rationale: placing Mamba only at the deepest (32x32) feature level gives Mamba
+long-range modelling power without the sequence-length blowup; the CNN portions
+handle local pattern extraction.
+
+Requires ``mamba_ssm`` (CUDA-compiled selective-scan kernels). The import is
+guarded one level up (``models/__init__.py`` + ``ml/model_loader.py``) so a
+missing build disables only this model, not the whole service.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from mamba_ssm import Mamba
+
+
+def get_norm_layer(num_features: int, use_instance_norm: bool = True) -> nn.Module:
+    return nn.InstanceNorm2d(num_features, affine=True) if use_instance_norm else nn.BatchNorm2d(num_features)
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, use_instance_norm: bool = True, dropout: float = 0.0):
+        super().__init__()
+        self.double_conv = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            get_norm_layer(out_channels, use_instance_norm),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(p=dropout) if dropout > 0 else nn.Identity(),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            get_norm_layer(out_channels, use_instance_norm),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x):
+        return self.double_conv(x)
+
+
+class MambaBottleneckBlock(nn.Module):
+    """Bidirectional Mamba on flattened 2D bottleneck features.
+
+    Forward and reversed scans are summed (poor man's bi-directional Mamba),
+    which mitigates the 1D-raster asymmetry on 2D inputs. Adds a residual
+    connection to keep gradient flow stable when Mamba is small relative to
+    the surrounding CNN.
+    """
+
+    def __init__(self, channels: int, d_state: int = 16, d_conv: int = 4, expand: int = 2):
+        super().__init__()
+        self.norm = nn.LayerNorm(channels)
+        self.mamba_fwd = Mamba(d_model=channels, d_state=d_state, d_conv=d_conv, expand=expand)
+        self.mamba_bwd = Mamba(d_model=channels, d_state=d_state, d_conv=d_conv, expand=expand)
+        self.skip_scale = nn.Parameter(torch.ones(1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C, H, W)
+        if x.dtype == torch.float16:
+            x = x.float()
+        B, C, H, W = x.shape
+        x_seq = x.flatten(2).transpose(1, 2)        # (B, H*W, C)
+        x_norm = self.norm(x_seq)
+        y_fwd = self.mamba_fwd(x_norm)
+        y_bwd = torch.flip(self.mamba_bwd(torch.flip(x_norm, dims=[1])), dims=[1])
+        y = y_fwd + y_bwd + self.skip_scale * x_seq
+        return y.transpose(1, 2).reshape(B, C, H, W)
+
+
+class UMamba(nn.Module):
+    """U-Net with Mamba bottleneck."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 1,
+        features: list[int] | None = None,
+        use_instance_norm: bool = True,
+        dropout_rate: float = 0.1,
+        num_mamba_blocks: int = 2,
+    ):
+        super().__init__()
+        if features is None:
+            features = [64, 128, 256, 512, 1024]
+
+        self.init_conv = DoubleConv(in_channels, features[0], use_instance_norm, dropout=0.0)
+
+        # Encoder path
+        self.downs = nn.ModuleList()
+        self.pools = nn.ModuleList()
+        for i in range(len(features) - 1):
+            self.downs.append(
+                DoubleConv(features[i], features[i + 1], use_instance_norm, dropout=dropout_rate if i > 0 else 0.0)
+            )
+            self.pools.append(nn.MaxPool2d(kernel_size=2, stride=2))
+
+        # Bottleneck = CNN conv + Mamba block(s) + CNN conv
+        self.bottleneck_pre = DoubleConv(features[-2], features[-1], use_instance_norm, dropout=dropout_rate * 1.5)
+        self.bottleneck_mamba = nn.Sequential(
+            *[MambaBottleneckBlock(features[-1]) for _ in range(num_mamba_blocks)]
+        )
+        self.bottleneck_post = DoubleConv(features[-1], features[-1], use_instance_norm, dropout=dropout_rate)
+
+        # Decoder path
+        self.ups = nn.ModuleList()
+        self.decoder_blocks = nn.ModuleList()
+        for i in range(len(features) - 1, 0, -1):
+            self.ups.append(nn.ConvTranspose2d(features[i], features[i - 1], kernel_size=2, stride=2))
+            self.decoder_blocks.append(
+                DoubleConv(features[i], features[i - 1], use_instance_norm, dropout=dropout_rate if i > 1 else 0.0)
+            )
+
+        # Final 1x1
+        self.final_conv = nn.Conv2d(features[0], out_channels, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.init_conv(x)
+        skips = [x]
+        # Encoder loop excludes the last down (last down is fused with bottleneck)
+        for pool, down in zip(self.pools[:-1], self.downs[:-1]):
+            x = pool(x)
+            x = down(x)
+            skips.append(x)
+
+        # Bottleneck: pool to lowest resolution, then DoubleConv features[-2]->features[-1],
+        # Mamba blocks at the bottleneck spatial resolution, then DoubleConv keeps features[-1]
+        x = self.pools[-1](x)
+        x = self.bottleneck_pre(x)
+        x = self.bottleneck_mamba(x)
+        x = self.bottleneck_post(x)
+
+        # Decoder loop: 4 stages, mirroring encoder + initial down
+        skips_rev = skips[::-1]
+        for i, (up, dec) in enumerate(zip(self.ups, self.decoder_blocks)):
+            x = up(x)
+            skip = skips_rev[i]
+            if x.shape[-2:] != skip.shape[-2:]:
+                x = nn.functional.interpolate(x, size=skip.shape[-2:], mode="bilinear", align_corners=False)
+            x = torch.cat([skip, x], dim=1)
+            x = dec(x)
+
+        return self.final_conv(x)

--- a/backend/segmentation/models/mamba_unet.py
+++ b/backend/segmentation/models/mamba_unet.py
@@ -3,10 +3,10 @@
 Inspired by Ma et al. 2024 (bowang-lab/U-Mamba). Standard CNN encoder/decoder
 (same as our UNet) preserves 2D spatial locality where it matters; the
 bottleneck is augmented with Mamba SSM blocks operating on the flattened
-spatial sequence -- at 1024^2 input the bottleneck is 32x32 = 1024 tokens,
-well within Mamba's effective range.
+spatial sequence -- at 1024^2 input the 4-pool bottleneck is 64x64 = 4096
+tokens, well within Mamba's effective range.
 
-Rationale: placing Mamba only at the deepest (32x32) feature level gives Mamba
+Rationale: placing Mamba only at the deepest (64x64) feature level gives Mamba
 long-range modelling power without the sequence-length blowup; the CNN portions
 handle local pattern extraction.
 

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -45,5 +45,12 @@ tifffile>=2024.1.30
 nd2>=0.10.0
 huggingface_hub>=0.20
 
+# Mamba-UNet dependency. einops is a pure-Python runtime dep of mamba_ssm and is
+# safe to build in the slim wheel-builder. The CUDA-compiled kernels themselves
+# (mamba-ssm==2.2.4, causal-conv1d==1.4.0) are NOT listed here — they are built
+# in the dedicated CUDA-devel stage of docker/ml.optimized.Dockerfile (the slim
+# builder has no nvcc) and installed from those wheels in the runtime stage.
+einops>=0.7.0
+
 # Prometheus metrics
 prometheus-fastapi-instrumentator==6.1.0

--- a/backend/src/constants/segmentationModels.ts
+++ b/backend/src/constants/segmentationModels.ts
@@ -13,6 +13,7 @@ export const SEGMENTATION_MODELS = [
   'unet_spherohq',
   'unet_attention_aspp',
   'segformer',
+  'mamba_unet',
   'resunet_advanced',
   'resunet_small',
   'sperm',

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -163,6 +163,7 @@ type KnownModelId =
   | 'unet_spherohq'
   | 'unet_attention_aspp'
   | 'segformer'
+  | 'mamba_unet'
   | 'sperm'
   | 'wound'
   | 'microtubule';
@@ -183,7 +184,13 @@ export const MODEL_TYPE_COMPATIBILITY: Record<
   ProjectType,
   readonly KnownModelId[]
 > = {
-  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer'],
+  spheroid: [
+    'hrnet',
+    'cbam_resunet',
+    'unet_spherohq',
+    'segformer',
+    'mamba_unet',
+  ],
   spheroid_invasive: ['unet_attention_aspp'],
   wound: ['wound'],
   sperm: ['sperm'],

--- a/docker/ml.optimized.Dockerfile
+++ b/docker/ml.optimized.Dockerfile
@@ -1,6 +1,38 @@
 # Optimized multi-stage build for ML service with minimal size
 # This is the most critical optimization as ML images are the largest
 
+# Stage 0: CUDA-devel builder for Mamba-UNet kernels (mamba-ssm + causal-conv1d).
+# These are CUDA-compiled extensions with NO prebuilt wheel for torch 2.6, and the
+# pinned versions (2.2.4 / 1.4.0) avoid the triton 3.5 requirement of newer
+# releases. We compile them against torch 2.6.0+cu124 for the A5000 (sm_86) here.
+# This heavy CUDA-devel image is discarded; only the resulting wheels move forward.
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS mamba-builder
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.10 python3.10-dev python3-pip git build-essential ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/python3.10 /usr/local/bin/python && \
+    python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+# torch must be importable: mamba-ssm builds with --no-build-isolation and its
+# setup.py imports torch to find CUDA paths + the C++ ABI flag.
+RUN pip install --no-cache-dir torch==2.6.0 \
+    --index-url https://download.pytorch.org/whl/cu124
+ENV TORCH_CUDA_ARCH_LIST="8.6" \
+    MAMBA_FORCE_BUILD="TRUE" \
+    CAUSAL_CONV1D_FORCE_BUILD="TRUE" \
+    MAX_JOBS="4"
+WORKDIR /mamba-wheels
+# Build from the git tags, NOT PyPI: the PyPI sdists for these packages omit the
+# csrc/ CUDA sources (they ship prebuilt wheels only), so a source build from
+# PyPI fails with "csrc/*.cpp missing". The git repos contain the sources.
+RUN pip wheel --no-cache-dir --no-build-isolation --no-deps \
+    "causal-conv1d @ git+https://github.com/Dao-AILab/causal-conv1d.git@v1.4.0" \
+    -w /mamba-wheels && \
+    pip wheel --no-cache-dir --no-build-isolation --no-deps \
+    "mamba-ssm @ git+https://github.com/state-spaces/mamba.git@v2.2.4" \
+    -w /mamba-wheels && \
+    ls -la /mamba-wheels
+
 # Stage 1: Python wheels builder
 FROM python:3.10-slim AS wheel-builder
 
@@ -38,7 +70,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Stage 2: Minimal runtime base
 FROM python:3.10-slim AS runtime-base
 
-# Install only essential runtime libraries
+# Install runtime libraries. gcc + python3-dev are required because mamba_ssm
+# pulls in Triton, which JIT-compiles a small CUDA driver helper (driver.c) at
+# runtime on first use and needs a host C compiler + Python headers. Without
+# them the compiled mamba kernels load but Triton dies with "Failed to find C
+# compiler". The other models don't use Triton.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \
     libglib2.0-0 \
@@ -47,6 +83,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxrender-dev \
     libgl1 \
     libglib2.0-0 \
+    gcc \
+    python3-dev \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -69,6 +107,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir --no-index --find-links /wheels \
     -r /app/requirements.txt && \
     rm -rf /wheels
+
+# Install the CUDA-compiled Mamba kernels (built in the mamba-builder stage
+# against this exact torch 2.6.0+cu124). --no-deps: torch/einops/triton are
+# already satisfied above. If this layer is ever absent, the Mamba-UNet import
+# guard disables only that model — the service still starts.
+COPY --from=mamba-builder /mamba-wheels /mamba-wheels
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --no-deps /mamba-wheels/*.whl && \
+    rm -rf /mamba-wheels
 
 # Copy application code
 COPY --chown=app:app backend/segmentation/ .

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
@@ -13,8 +13,13 @@ import { toast } from 'sonner';
 import { ModelType } from '@/contexts/useModel';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useLocalizedModels } from '@/hooks/useLocalizedModels';
-import { ModelInfo } from '@/lib/modelUtils';
-import { Cpu, Zap, Target } from 'lucide-react';
+import {
+  ModelInfo,
+  SPHEROID_PRESETS,
+  SPHEROID_PRESET_META,
+  SpheroidPresetTier,
+} from '@/lib/modelUtils';
+import { Cpu, Zap, Target, ChevronDown, ChevronUp } from 'lucide-react';
 
 const ModelSettingsSection = () => {
   const { t } = useLanguage();
@@ -29,12 +34,26 @@ const ModelSettingsSection = () => {
   // The disintegrated-spheroid workflow uses a dedicated model
   // (unet_attention_aspp) — surface it as its own section so users
   // aren't tempted to pick it for standard spheroid analysis.
+  const [showAdditional, setShowAdditional] = useState(false);
+
   const spheroidModels = useMemo(
     () =>
       availableModels.filter(
         m => m.category === 'spheroid' && m.id !== 'unet_attention_aspp'
       ),
     [availableModels]
+  );
+
+  // Reframe the standard spheroid models into recommended presets
+  // (Fast/Accurate/Robust) + a collapsed "Additional" group.
+  const presetModel = (tier: SpheroidPresetTier) =>
+    spheroidModels.find(m => SPHEROID_PRESETS[m.id] === tier);
+  const additionalModels = useMemo(
+    () =>
+      spheroidModels.filter(
+        m => (SPHEROID_PRESETS[m.id] ?? 'additional') === 'additional'
+      ),
+    [spheroidModels]
   );
   const spheroidInvasiveModels = useMemo(
     () => availableModels.filter(m => m.id === 'unet_attention_aspp'),
@@ -128,7 +147,51 @@ const ModelSettingsSection = () => {
             <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
               {t('settings.modelSelection.sections.spheroid')}
             </h4>
-            {spheroidModels.map(renderModelCard)}
+
+            {(['fast', 'accurate', 'robust'] as const).map(tier => {
+              const model = presetModel(tier);
+              if (!model) return null;
+              return (
+                <div key={tier} className="space-y-1.5">
+                  <div className="flex items-baseline gap-2">
+                    <span aria-hidden className="text-base">
+                      {SPHEROID_PRESET_META[tier].icon}
+                    </span>
+                    <span className="text-sm font-semibold">
+                      {t(`settings.modelSelection.presets.${tier}`)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 ml-6">
+                    {t(`settings.modelSelection.presetDescriptions.${tier}`)}
+                  </p>
+                  {renderModelCard(model)}
+                </div>
+              );
+            })}
+
+            {additionalModels.length > 0 && (
+              <div className="pt-1">
+                <button
+                  type="button"
+                  onClick={() => setShowAdditional(v => !v)}
+                  className="flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                  {showAdditional ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                  {showAdditional
+                    ? t('settings.modelSelection.presets.showLess')
+                    : t('settings.modelSelection.presets.showMore')}
+                </button>
+                {showAdditional && (
+                  <div className="space-y-4 pt-3">
+                    {additionalModels.map(renderModelCard)}
+                  </div>
+                )}
+              </div>
+            )}
 
             {spheroidInvasiveModels.length > 0 && (
               <>

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from '@/contexts/useLanguage';
 import { useLocalizedModels } from '@/hooks/useLocalizedModels';
 import {
   ModelInfo,
-  SPHEROID_PRESETS,
+  getSpheroidPreset,
   SPHEROID_PRESET_META,
   SpheroidPresetTier,
 } from '@/lib/modelUtils';
@@ -47,12 +47,9 @@ const ModelSettingsSection = () => {
   // Reframe the standard spheroid models into recommended presets
   // (Fast/Accurate/Robust) + a collapsed "Additional" group.
   const presetModel = (tier: SpheroidPresetTier) =>
-    spheroidModels.find(m => SPHEROID_PRESETS[m.id] === tier);
+    spheroidModels.find(m => getSpheroidPreset(m.id) === tier);
   const additionalModels = useMemo(
-    () =>
-      spheroidModels.filter(
-        m => (SPHEROID_PRESETS[m.id] ?? 'additional') === 'additional'
-      ),
+    () => spheroidModels.filter(m => getSpheroidPreset(m.id) === 'additional'),
     [spheroidModels]
   );
   const spheroidInvasiveModels = useMemo(

--- a/src/lib/modelUtils.ts
+++ b/src/lib/modelUtils.ts
@@ -17,22 +17,38 @@ export type ModelType =
  */
 export type SpheroidPresetTier = 'fast' | 'accurate' | 'robust' | 'additional';
 
-export const SPHEROID_PRESETS: Record<string, SpheroidPresetTier> = {
+/** The standard spheroid models that participate in the preset framing.
+ *  Excludes `unet_attention_aspp` (the disintegrated/invasive model, shown in
+ *  its own section). `satisfies Record<SpheroidModelId, …>` makes forgetting to
+ *  classify a newly-added spheroid model a compile error. */
+type SpheroidModelId =
+  | 'hrnet'
+  | 'cbam_resunet'
+  | 'unet_spherohq'
+  | 'segformer'
+  | 'mamba_unet';
+
+export const SPHEROID_PRESETS = {
   segformer: 'fast',
   cbam_resunet: 'accurate',
   mamba_unet: 'robust',
   hrnet: 'additional',
   unet_spherohq: 'additional',
-};
+} as const satisfies Record<SpheroidModelId, SpheroidPresetTier>;
 
-/** Icon + ordering for the three primary preset tiers. */
+/** Preset tier for a model id. Non-spheroid (or unmapped) ids fall back to
+ *  'additional' so the lookup stays total over ModelType. */
+export const getSpheroidPreset = (id: ModelType): SpheroidPresetTier =>
+  (SPHEROID_PRESETS as Record<string, SpheroidPresetTier>)[id] ?? 'additional';
+
+/** Icon for each of the three primary preset tiers. */
 export const SPHEROID_PRESET_META: Record<
   Exclude<SpheroidPresetTier, 'additional'>,
-  { icon: string; order: number }
+  { icon: string }
 > = {
-  fast: { icon: '⚡', order: 0 },
-  accurate: { icon: '🎯', order: 1 },
-  robust: { icon: '🌍', order: 2 },
+  fast: { icon: '⚡' },
+  accurate: { icon: '🎯' },
+  robust: { icon: '🌍' },
 };
 
 export type ModelCategory = 'spheroid' | 'sperm' | 'wound' | 'microtubule';

--- a/src/lib/modelUtils.ts
+++ b/src/lib/modelUtils.ts
@@ -5,9 +5,35 @@ export type ModelType =
   | 'unet_spherohq'
   | 'unet_attention_aspp'
   | 'segformer'
+  | 'mamba_unet'
   | 'sperm'
   | 'wound'
   | 'microtubule';
+
+/**
+ * Recommended-preset framing for the standard spheroid models. Three tiers are
+ * surfaced as primary cards (Fast/Accurate/Robust); the rest fall into a
+ * collapsed "Additional" group. View-layer only — not part of ModelInfo.
+ */
+export type SpheroidPresetTier = 'fast' | 'accurate' | 'robust' | 'additional';
+
+export const SPHEROID_PRESETS: Record<string, SpheroidPresetTier> = {
+  segformer: 'fast',
+  cbam_resunet: 'accurate',
+  mamba_unet: 'robust',
+  hrnet: 'additional',
+  unet_spherohq: 'additional',
+};
+
+/** Icon + ordering for the three primary preset tiers. */
+export const SPHEROID_PRESET_META: Record<
+  Exclude<SpheroidPresetTier, 'additional'>,
+  { icon: string; order: number }
+> = {
+  fast: { icon: '⚡', order: 0 },
+  accurate: { icon: '🎯', order: 1 },
+  robust: { icon: '🌍', order: 2 },
+};
 
 export type ModelCategory = 'spheroid' | 'sperm' | 'wound' | 'microtubule';
 
@@ -100,6 +126,18 @@ export function getLocalizedModelInfo(
         batchSize: 4,
       },
     },
+    mamba_unet: {
+      id: 'mamba_unet',
+      size: 'large',
+      defaultThreshold: 0.5,
+      category: 'spheroid',
+      performance: {
+        avgTimePerImage: 0.236,
+        throughput: 4.2,
+        p95Latency: 0.249,
+        batchSize: 2,
+      },
+    },
     sperm: {
       id: 'sperm',
       size: 'medium',
@@ -147,6 +185,7 @@ export function getLocalizedModelInfo(
     unet_spherohq: 'unet_spherohq',
     unet_attention_aspp: 'unet_attention_aspp',
     segformer: 'segformer',
+    mamba_unet: 'mamba_unet',
     sperm: 'sperm',
     wound: 'wound',
     microtubule: 'microtubule',
@@ -173,6 +212,7 @@ export function getAllLocalizedModels(t: (key: string) => string): ModelInfo[] {
     'unet_spherohq',
     'unet_attention_aspp',
     'segformer',
+    'mamba_unet',
     'sperm',
     'wound',
     'microtubule',
@@ -268,6 +308,22 @@ export const BASIC_MODEL_INFO: Record<
       throughput: 5.0,
       p95Latency: 0.3,
       batchSize: 4,
+    },
+  },
+  mamba_unet: {
+    id: 'mamba_unet',
+    name: 'Mamba-UNet',
+    displayName: 'Mamba-UNet',
+    description:
+      'U-Net with a bidirectional Mamba (state-space) bottleneck — best robustness on out-of-distribution images (external labs, unknown optics, drug-treated, unusual morphologies)',
+    size: 'large',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.236,
+      throughput: 4.2,
+      p95Latency: 0.249,
+      batchSize: 2,
     },
   },
   sperm: {

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -436,6 +436,19 @@ export default {
         wound: 'Modely hojení ran',
         microtubule: 'Modely mikrotubulů',
       },
+      presets: {
+        fast: 'Rychlý',
+        accurate: 'Přesný',
+        robust: 'Robustní',
+        showMore: 'Zobrazit další modely',
+        showLess: 'Skrýt další modely',
+      },
+      presetDescriptions: {
+        fast: 'Náhled v reálném čase, velké dávky, slabší GPU',
+        accurate: 'Laboratoře s HQ snímky, když nezáleží na čase',
+        robust:
+          'Externí laboratoře, neznámá optika, léčené vzorky, neobvyklé morfologie',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -459,6 +472,11 @@ export default {
           name: 'SegFormer',
           description:
             'Model založený na transformeru (SegFormer-B0) pro sféroidy ve světlém poli — nejvyšší přesnost (93% IoU) a velmi rychlý (~13 ms/snímek)',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            'U-Net s obousměrným Mamba (state-space) bottleneckem — nejlepší robustnost na snímcích mimo trénovací distribuci (neznámá optika, léčené vzorky, neobvyklé morfologie)',
         },
         sperm: {
           name: 'Morfologie spermií',
@@ -498,6 +516,8 @@ export default {
         'Vylepšený UNet s Attention Gates a ASPP bottleneck pro detekci rozpadajících se sféroidů a malých satelitních buněk (35.5M parametrů)',
       segformer:
         'Model SegFormer-B0 založený na transformeru, trénovaný na datasetu SpheroMix. Nejvyšší přesnost segmentace sféroidů v platformě (93% IoU) a zároveň nejmenší a nejrychlejší model (~13 ms/snímek).',
+      mamba_unet:
+        'U-Net s obousměrným Mamba (state-space) bottleneckem (90,75M parametrů). Nejlepší generalizace mimo distribuci v platformě (HTS-Seg IoU 0,587) — určený pro externí laboratoře, neznámou optiku, léčené vzorky a neobvyklé morfologie sféroidů.',
       sperm:
         'Model morfologie spermií s extrakcí kostry pro měření hlavy, středního dílu a bičíku',
       wound:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -454,6 +454,19 @@ export default {
         wound: 'Wundheilungs-Modelle',
         microtubule: 'Mikrotubuli-Modelle',
       },
+      presets: {
+        fast: 'Schnell',
+        accurate: 'Genau',
+        robust: 'Robust',
+        showMore: 'Weitere Modelle anzeigen',
+        showLess: 'Weitere Modelle ausblenden',
+      },
+      presetDescriptions: {
+        fast: 'Echtzeit-Vorschau, große Stapel, schwache GPU',
+        accurate: 'Labore mit HQ-Bildern, wenn Zeit keine Rolle spielt',
+        robust:
+          'Externe Labore, unbekannte Optik, behandelte Proben, ungewöhnliche Morphologien',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -479,6 +492,11 @@ export default {
           name: 'SegFormer',
           description:
             'Transformer-basiertes Modell (SegFormer-B0) für Hellfeld-Sphäroide – höchste Genauigkeit (93% IoU) und sehr schnell (~13 ms/Bild)',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            'U-Net mit bidirektionalem Mamba (State-Space)-Bottleneck – beste Robustheit bei Out-of-Distribution-Bildern (unbekannte Optik, behandelte Proben, ungewöhnliche Morphologien)',
         },
         sperm: {
           name: 'Spermien-Morphologie',
@@ -518,6 +536,8 @@ export default {
         'Erweitertes UNet mit Attention Gates und ASPP-Bottleneck zur Erkennung zerfallender Sphäroide und kleiner Satellitenzellen (35,5M Parameter)',
       segformer:
         'Transformer-basiertes SegFormer-B0-Modell, trainiert auf dem SpheroMix-Datensatz. Höchste Sphäroid-Genauigkeit der Plattform (93% IoU) bei gleichzeitig kleinstem und schnellstem Modell (~13 ms/Bild).',
+      mamba_unet:
+        'U-Net mit bidirektionalem Mamba (State-Space)-Bottleneck (90,75M Parameter). Beste Out-of-Distribution-Generalisierung der Plattform (HTS-Seg IoU 0,587) – für externe Labore, unbekannte Optik, behandelte Proben und ungewöhnliche Sphäroid-Morphologien.',
       sperm:
         'Spermienmorphologie-Modell mit Skelettextraktion zur Messung von Kopf, Mittelstück und Schwanz',
       wound:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -448,6 +448,19 @@ export default {
         wound: 'Wound Healing Models',
         microtubule: 'Microtubule Models',
       },
+      presets: {
+        fast: 'Fast',
+        accurate: 'Accurate',
+        robust: 'Robust',
+        showMore: 'Show additional models',
+        showLess: 'Hide additional models',
+      },
+      presetDescriptions: {
+        fast: 'Real-time preview, large batches, weak GPU',
+        accurate: 'Labs with HQ-like images, when time is not critical',
+        robust:
+          'External labs, unknown optics, drug-treated, unusual morphologies',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -473,6 +486,11 @@ export default {
           name: 'SegFormer',
           description:
             'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            'U-Net with a bidirectional Mamba (state-space) bottleneck — best robustness on out-of-distribution images (unknown optics, drug-treated, unusual morphologies)',
         },
         sperm: {
           name: 'Sperm Morphology',
@@ -512,6 +530,8 @@ export default {
         'Enhanced UNet with Attention Gates and ASPP bottleneck for detecting dissolving spheroids and small satellite cells (35.5M params)',
       segformer:
         'Transformer-based SegFormer-B0 model trained on the SpheroMix dataset. Highest spheroid accuracy in the platform (93% IoU) while being the smallest and fastest model (~13 ms/image).',
+      mamba_unet:
+        'U-Net with a bidirectional Mamba (state-space) bottleneck (90.75M params). Best out-of-distribution generalization in the platform (HTS-Seg IoU 0.587) — built for external labs, unknown optics, drug-treated and unusual spheroid morphologies.',
       sperm:
         'Sperm morphology model with skeleton extraction for head, midpiece, and tail measurement',
       wound:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -432,6 +432,20 @@ export default {
         wound: 'Modelos de cicatrización',
         microtubule: 'Modelos de microtúbulos',
       },
+      presets: {
+        fast: 'Rápido',
+        accurate: 'Preciso',
+        robust: 'Robusto',
+        showMore: 'Mostrar modelos adicionales',
+        showLess: 'Ocultar modelos adicionales',
+      },
+      presetDescriptions: {
+        fast: 'Vista previa en tiempo real, lotes grandes, GPU débil',
+        accurate:
+          'Laboratorios con imágenes HQ, cuando el tiempo no es crítico',
+        robust:
+          'Laboratorios externos, óptica desconocida, muestras tratadas, morfologías inusuales',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -457,6 +471,11 @@ export default {
           name: 'SegFormer',
           description:
             'Modelo basado en transformador (SegFormer-B0) para esferoides de campo claro: máxima precisión (93% IoU) y muy rápido (~13 ms/imagen)',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            'U-Net con cuello de botella Mamba (state-space) bidireccional: mejor robustez en imágenes fuera de distribución (óptica desconocida, muestras tratadas, morfologías inusuales)',
         },
         sperm: {
           name: 'Morfología espermática',
@@ -496,6 +515,8 @@ export default {
         'UNet mejorado con Attention Gates y cuello de botella ASPP para detectar esferoides en disolución y pequeñas células satélite (35,5M parámetros)',
       segformer:
         'Modelo SegFormer-B0 basado en transformador, entrenado con el conjunto de datos SpheroMix. La mayor precisión de segmentación de esferoides de la plataforma (93% IoU), siendo además el modelo más pequeño y rápido (~13 ms/imagen).',
+      mamba_unet:
+        'U-Net con cuello de botella Mamba (state-space) bidireccional (90,75M parámetros). La mejor generalización fuera de distribución de la plataforma (HTS-Seg IoU 0,587): para laboratorios externos, óptica desconocida, muestras tratadas y morfologías de esferoides inusuales.',
       sperm:
         'Modelo de morfología espermática con extracción de esqueleto para medir cabeza, pieza media y cola',
       wound:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -445,6 +445,20 @@ export default {
         wound: 'Modèles de cicatrisation',
         microtubule: 'Modèles de microtubules',
       },
+      presets: {
+        fast: 'Rapide',
+        accurate: 'Précis',
+        robust: 'Robuste',
+        showMore: 'Afficher plus de modèles',
+        showLess: 'Masquer les modèles supplémentaires',
+      },
+      presetDescriptions: {
+        fast: 'Aperçu en temps réel, grands lots, GPU faible',
+        accurate:
+          "Laboratoires avec images HQ, quand le temps n'est pas critique",
+        robust:
+          'Laboratoires externes, optique inconnue, échantillons traités, morphologies inhabituelles',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -470,6 +484,11 @@ export default {
           name: 'SegFormer',
           description:
             'Modèle basé sur un transformeur (SegFormer-B0) pour les sphéroïdes en fond clair — précision maximale (93% IoU) et très rapide (~13 ms/image)',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            'U-Net avec goulot Mamba (state-space) bidirectionnel — meilleure robustesse sur images hors distribution (optique inconnue, échantillons traités, morphologies inhabituelles)',
         },
         sperm: {
           name: 'Morphologie des spermatozoïdes',
@@ -509,6 +528,8 @@ export default {
         'UNet amélioré avec Attention Gates et goulot ASPP pour la détection de sphéroïdes en dissolution et de petites cellules satellites (35,5M paramètres)',
       segformer:
         'Modèle SegFormer-B0 basé sur un transformeur, entraîné sur le jeu de données SpheroMix. Meilleure précision de segmentation des sphéroïdes de la plateforme (93% IoU), tout en étant le modèle le plus petit et le plus rapide (~13 ms/image).',
+      mamba_unet:
+        'U-Net avec goulot Mamba (state-space) bidirectionnel (90,75M paramètres). Meilleure généralisation hors distribution de la plateforme (HTS-Seg IoU 0,587) : pour laboratoires externes, optique inconnue, échantillons traités et morphologies de sphéroïdes inhabituelles.',
       sperm:
         'Modèle de morphologie spermatique avec extraction de squelette pour la mesure de la tête, de la pièce intermédiaire et de la queue',
       wound:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -403,6 +403,18 @@ export default {
         wound: '伤口愈合模型',
         microtubule: '微管模型',
       },
+      presets: {
+        fast: '快速',
+        accurate: '精确',
+        robust: '稳健',
+        showMore: '显示更多模型',
+        showLess: '隐藏更多模型',
+      },
+      presetDescriptions: {
+        fast: '实时预览、大批量、弱 GPU',
+        accurate: '具有 HQ 图像的实验室，时间不紧张时',
+        robust: '外部实验室、未知光学、药物处理、异常形态',
+      },
       models: {
         hrnet: {
           name: 'HRNet',
@@ -426,6 +438,11 @@ export default {
           name: 'SegFormer',
           description:
             '基于 Transformer 的模型（SegFormer-B0），用于明场球体分割——精度最高（93% IoU）且速度极快（约 13 毫秒/图像）',
+        },
+        mamba_unet: {
+          name: 'Mamba-UNet',
+          description:
+            '带双向 Mamba（状态空间）瓶颈的 U-Net——在分布外图像上鲁棒性最佳（未知光学、药物处理、异常形态）',
         },
         sperm: {
           name: '精子形态学',
@@ -462,6 +479,8 @@ export default {
         '增强型UNet，配备注意力门控和ASPP瓶颈层，用于检测溶解中的球体和小型卫星细胞（3550万参数）',
       segformer:
         '基于 Transformer 的 SegFormer-B0 模型，在 SpheroMix 数据集上训练。平台中球体分割精度最高（93% IoU），同时是体积最小、速度最快的模型（约 13 毫秒/图像）。',
+      mamba_unet:
+        '带双向 Mamba（状态空间）瓶颈的 U-Net（9075 万参数）。平台中最佳的分布外泛化能力（HTS-Seg IoU 0.587）——专为外部实验室、未知光学、药物处理和异常球体形态而设计。',
       sperm: '精子形态模型，通过骨架提取测量头部、中段和尾部',
       wound:
         '用于划痕实验显微镜的伤口分割的U-Net + MiT-B5（SegFormer编码器）模型。每张图像一个二进制伤口区域；非常适合愈合速度的时间延迟拍摄。',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -357,6 +357,7 @@ type KnownModelId =
   | 'unet_spherohq'
   | 'unet_attention_aspp'
   | 'segformer'
+  | 'mamba_unet'
   | 'sperm'
   | 'wound'
   | 'microtubule';
@@ -377,7 +378,13 @@ export const MODEL_TYPE_COMPATIBILITY: Record<
   ProjectType,
   readonly KnownModelId[]
 > = {
-  spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer'],
+  spheroid: [
+    'hrnet',
+    'cbam_resunet',
+    'unet_spherohq',
+    'segformer',
+    'mamba_unet',
+  ],
   spheroid_invasive: ['unet_attention_aspp'],
   wound: ['wound'],
   sperm: ['sperm'],


### PR DESCRIPTION
## Summary
- Adds **Mamba-UNet** (U-Net + bidirectional Mamba SSM bottleneck, 90.75M params) as a 5th standard-`spheroid` model — best out-of-distribution generalization in the lineup (HTS-Seg IoU 0.587), for external labs / unknown optics / drug-treated / unusual morphologies.
- **Reframes the spheroid model picker** into 3 recommended presets — ⚡ **Fast** (SegFormer), 🎯 **Accurate** (CBAM-ResUNet), 🌍 **Robust** (Mamba-UNet) — with HRNet + U-Net (SpheroHQ) moved into a collapsed **"Show additional models"** group.

## Changes by layer
- **Docker**: new `nvidia/cuda:12.4.1-devel` build stage compiles `mamba-ssm==2.2.4` + `causal-conv1d==1.4.0` **from git tags** (PyPI sdists omit `csrc/`) against torch 2.6/cu124 for sm_86; wheels baked into the runtime stage. Added `gcc`+`python3-dev` to runtime for Triton's runtime JIT; `einops` to requirements.
- **ML**: `models/mamba_unet.py` (`UMamba`, import-guarded). Registered in `model_loader` via the **generic `torch.load` path** (single-channel sigmoid output, like HRNet — no wrapper). `ModelType.MAMBA_UNET`; measured `batch_sizes.json` entry.
- **Backend + FE shared types**: `mamba_unet` added to `SEGMENTATION_MODELS`, `KnownModelId`, `MODEL_TYPE_COMPATIBILITY.spheroid` (FE/BE kept in sync per `verify-shared-types`).
- **Frontend**: `modelUtils` + `SPHEROID_PRESETS` map; `ModelSettingsSection` preset reframe + collapsible Additional group; strings in all 6 locales.

## Test plan
- [x] ML image builds with compiled mamba kernels; `import mamba_ssm` + `UMamba` forward verified on the A5000.
- [x] `make ci` green (TS + ESLint 0 + i18n 1488 keys); `verify-shared-types` passes.
- [x] Prod cross-stack: `/models` lists `mamba_unet`; queue `forceResegment` on a standard spheroid project → ML inference (1.26s) → `segmentations` row flips to `model=mamba_unet`.
- [x] Playwright (live): Settings shows Fast/Accurate/Robust presets; "Show more" reveals HRNet + U-Net; 0 console errors.
- [x] 522-image benchmark (A5000): inference 235.6 ms, E2E 253.9 ms, ~4.2 img/s single; forward batch peaks at B=2 (10.9 img/s), memory-bound (OOM at B16).

Deployed to production (ml/frontend/backend rebuilt + recreated, nginx restarted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mamba-UNet as a selectable spheroid segmentation model.
  * Reorganized model selection into preset tiers (Fast, Accurate, Robust) with an expandable "Additional" section.
* **Bug Fixes / Compatibility**
  * Frontend/backend validation updated so the new model is available for spheroid projects.
* **Documentation / Localization**
  * Added translations and UI text for presets and the new model across supported locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->