### PR TITLE
feat(export): warn modal when MT export omits intensity calculation

### DIFF
--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -42,6 +42,16 @@ import { EXPORT_DEFAULTS } from '@/lib/export-config';
 import { ImageSelectionGrid } from './components/ImageSelectionGrid';
 import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
 import { UniversalCancelButton } from '@/components/ui/universal-cancel-button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 interface AdvancedExportDialogProps {
   open: boolean;
@@ -182,6 +192,21 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       }, [images, exportOptions.pixelToMicrometerScale, updateExportOptions]);
 
+      const [showIncompleteWarning, setShowIncompleteWarning] = useState(false);
+
+      // Microtubule intensity columns require a selected channel. If the user
+      // requested metrics but didn't enable intensity (or pick a channel), the
+      // export still produces microtubule LENGTH but omits the per-channel
+      // intensity columns — so warn before exporting that the metric set will
+      // be incomplete.
+      const shouldWarnIncompleteMetrics =
+        isMTProject &&
+        (exportOptions.metricsFormats?.length ?? 0) > 0 &&
+        !(
+          (exportOptions.mtMetrics?.enabled ?? false) &&
+          (exportOptions.mtMetrics?.channels?.length ?? 0) > 0
+        );
+
       const handleExport = async () => {
         try {
           await startExport(projectName);
@@ -192,746 +217,807 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       };
 
+      // Intercept the Export click: on an MT project missing intensity, pop the
+      // incomplete-metrics confirmation modal first; otherwise export directly.
+      const handleExportClick = () => {
+        if (shouldWarnIncompleteMetrics) {
+          setShowIncompleteWarning(true);
+        } else {
+          void handleExport();
+        }
+      };
+
+      const confirmIncompleteExport = () => {
+        setShowIncompleteWarning(false);
+        void handleExport();
+      };
+
       return (
-        <Dialog open={open} onOpenChange={onClose}>
-          <DialogContent className="max-w-[95vw] sm:max-w-2xl md:max-w-4xl max-h-[90vh] overflow-y-auto px-4 sm:px-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-base sm:text-lg">
-                <Package className="h-4 w-4 sm:h-5 sm:w-5" />
-                {t('export.advancedOptions')}
-              </DialogTitle>
-              <DialogDescription className="text-xs sm:text-sm">
-                {t('export.configureSettings')}
-              </DialogDescription>
-            </DialogHeader>
+        <>
+          <Dialog open={open} onOpenChange={onClose}>
+            <DialogContent className="max-w-[95vw] sm:max-w-2xl md:max-w-4xl max-h-[90vh] overflow-y-auto px-4 sm:px-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2 text-base sm:text-lg">
+                  <Package className="h-4 w-4 sm:h-5 sm:w-5" />
+                  {t('export.advancedOptions')}
+                </DialogTitle>
+                <DialogDescription className="text-xs sm:text-sm">
+                  {t('export.configureSettings')}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="w-full"
-            >
-              <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 gap-1 sm:gap-0 h-auto sm:h-10">
-                <TabsTrigger value="general" className="text-sm h-10 sm:h-auto">
-                  {t('export.general')}
-                </TabsTrigger>
-                <TabsTrigger
-                  value="visualization"
-                  className="text-sm h-10 sm:h-auto"
-                >
-                  {t('export.visualization')}
-                </TabsTrigger>
-                <TabsTrigger value="formats" className="text-sm h-10 sm:h-auto">
-                  {t('export.formatsTab')}
-                </TabsTrigger>
-              </TabsList>
+              <Tabs
+                value={activeTab}
+                onValueChange={setActiveTab}
+                className="w-full"
+              >
+                <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 gap-1 sm:gap-0 h-auto sm:h-10">
+                  <TabsTrigger
+                    value="general"
+                    className="text-sm h-10 sm:h-auto"
+                  >
+                    {t('export.general')}
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="visualization"
+                    className="text-sm h-10 sm:h-auto"
+                  >
+                    {t('export.visualization')}
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="formats"
+                    className="text-sm h-10 sm:h-auto"
+                  >
+                    {t('export.formatsTab')}
+                  </TabsTrigger>
+                </TabsList>
 
-              <TabsContent value="general" className="space-y-3 sm:space-y-4">
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <FileImage className="h-4 w-4" />
-                      {t('export.exportContents')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.selectContent')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 sm:space-y-4 p-0">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="original-images"
-                        checked={exportOptions.includeOriginalImages}
-                        onCheckedChange={checked =>
-                          updateExportOptions({
-                            includeOriginalImages: !!checked,
-                          })
-                        }
-                      />
-                      <Label
-                        htmlFor="original-images"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.includeOriginal')}
-                      </Label>
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="visualizations"
-                        checked={exportOptions.includeVisualizations}
-                        onCheckedChange={checked =>
-                          updateExportOptions({
-                            includeVisualizations: !!checked,
-                          })
-                        }
-                      />
-                      <Label
-                        htmlFor="visualizations"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.includeVisualizations')}
-                      </Label>
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="documentation"
-                        checked={exportOptions.includeDocumentation}
-                        onCheckedChange={checked =>
-                          updateExportOptions({
-                            includeDocumentation: !!checked,
-                          })
-                        }
-                      />
-                      <Label
-                        htmlFor="documentation"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.includeDocumentation')}
-                      </Label>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <Settings className="h-4 w-4" />
-                      {t('export.scaleConversion')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.scaleDescription')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 sm:space-y-4 p-0">
-                    <div className="space-y-2 sm:space-y-3">
-                      <Label
-                        htmlFor="scale-input"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.pixelToMicrometerScale')} (
-                        {t('export.scaleUnit')})
-                      </Label>
-                      <Input
-                        id="scale-input"
-                        type="number"
-                        step="0.001"
-                        min="0.001"
-                        max="1000"
-                        placeholder={t('export.scalePlaceholder')}
-                        value={exportOptions.pixelToMicrometerScale || ''}
-                        onChange={e => {
-                          // Any interaction disables further auto-fill —
-                          // including clearing the field, so a user who
-                          // wipes the auto-suggested value doesn't get it
-                          // silently re-applied on the next image refresh.
-                          hasUserTouchedScaleRef.current = true;
-                          const value = e.target.value;
-
-                          // Handle empty string
-                          if (value === '') {
+                <TabsContent value="general" className="space-y-3 sm:space-y-4">
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <FileImage className="h-4 w-4" />
+                        {t('export.exportContents')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.selectContent')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 sm:space-y-4 p-0">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="original-images"
+                          checked={exportOptions.includeOriginalImages}
+                          onCheckedChange={checked =>
                             updateExportOptions({
-                              pixelToMicrometerScale: undefined,
-                            });
-                            return;
+                              includeOriginalImages: !!checked,
+                            })
                           }
+                        />
+                        <Label
+                          htmlFor="original-images"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.includeOriginal')}
+                        </Label>
+                      </div>
 
-                          const numValue = parseFloat(value);
-
-                          // Handle NaN case by not updating
-                          if (isNaN(numValue)) {
-                            return;
-                          }
-
-                          // Round to 3 decimal places to match input precision
-                          const roundedValue =
-                            Math.round(numValue * 1000) / 1000;
-
-                          // Validate rounded value: enforce min 0.001 and max 1000
-                          if (roundedValue >= 0.001 && roundedValue <= 1000) {
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="visualizations"
+                          checked={exportOptions.includeVisualizations}
+                          onCheckedChange={checked =>
                             updateExportOptions({
-                              pixelToMicrometerScale: roundedValue,
-                            });
+                              includeVisualizations: !!checked,
+                            })
                           }
-                        }}
-                        className="w-full"
-                      />
-                    </div>
-                  </CardContent>
-                </Card>
+                        />
+                        <Label
+                          htmlFor="visualizations"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.includeVisualizations')}
+                        </Label>
+                      </div>
 
-                {/* Microtubule-only section. Rendered ABOVE the image
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="documentation"
+                          checked={exportOptions.includeDocumentation}
+                          onCheckedChange={checked =>
+                            updateExportOptions({
+                              includeDocumentation: !!checked,
+                            })
+                          }
+                        />
+                        <Label
+                          htmlFor="documentation"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.includeDocumentation')}
+                        </Label>
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <Settings className="h-4 w-4" />
+                        {t('export.scaleConversion')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.scaleDescription')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 sm:space-y-4 p-0">
+                      <div className="space-y-2 sm:space-y-3">
+                        <Label
+                          htmlFor="scale-input"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.pixelToMicrometerScale')} (
+                          {t('export.scaleUnit')})
+                        </Label>
+                        <Input
+                          id="scale-input"
+                          type="number"
+                          step="0.001"
+                          min="0.001"
+                          max="1000"
+                          placeholder={t('export.scalePlaceholder')}
+                          value={exportOptions.pixelToMicrometerScale || ''}
+                          onChange={e => {
+                            // Any interaction disables further auto-fill —
+                            // including clearing the field, so a user who
+                            // wipes the auto-suggested value doesn't get it
+                            // silently re-applied on the next image refresh.
+                            hasUserTouchedScaleRef.current = true;
+                            const value = e.target.value;
+
+                            // Handle empty string
+                            if (value === '') {
+                              updateExportOptions({
+                                pixelToMicrometerScale: undefined,
+                              });
+                              return;
+                            }
+
+                            const numValue = parseFloat(value);
+
+                            // Handle NaN case by not updating
+                            if (isNaN(numValue)) {
+                              return;
+                            }
+
+                            // Round to 3 decimal places to match input precision
+                            const roundedValue =
+                              Math.round(numValue * 1000) / 1000;
+
+                            // Validate rounded value: enforce min 0.001 and max 1000
+                            if (roundedValue >= 0.001 && roundedValue <= 1000) {
+                              updateExportOptions({
+                                pixelToMicrometerScale: roundedValue,
+                              });
+                            }
+                          }}
+                          className="w-full"
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {/* Microtubule-only section. Rendered ABOVE the image
                     grid because for MT projects the per-channel +
                     band-width choices change which images make sense
                     to export — deciding the metrics first feels more
                     natural than scrolling past the image picker.
                     Only mounted when projectType === 'microtubules'
                     (intensity sampling needs the raw ND2/TIFF on disk). */}
-                {isMTProject && (
-                  <MicrotubuleMetricsSection
-                    value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
-                    onChange={next => updateExportOptions({ mtMetrics: next })}
-                    availableChannels={availableChannels}
-                  />
-                )}
-
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <FileImage className="h-4 w-4" />
-                      {t('export.selectedImages')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.chooseImages')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="p-0">
-                    <ImageSelectionGrid
-                      images={images}
-                      selectedImageIds={
-                        exportOptions.selectedImageIds ||
-                        images.map(img => img.id)
+                  {isMTProject && (
+                    <MicrotubuleMetricsSection
+                      value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
+                      onChange={next =>
+                        updateExportOptions({ mtMetrics: next })
                       }
-                      onSelectionChange={selectedIds =>
-                        updateExportOptions({ selectedImageIds: selectedIds })
-                      }
+                      availableChannels={availableChannels}
                     />
-                  </CardContent>
-                </Card>
-              </TabsContent>
+                  )}
 
-              <TabsContent
-                value="visualization"
-                className="space-y-3 sm:space-y-4"
-              >
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <Palette className="h-4 w-4" />
-                      {t('export.colorSettings')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.colorSettings')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4 sm:space-y-6 p-0">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="show-numbers"
-                        checked={
-                          exportOptions.visualizationOptions?.showNumbers
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <FileImage className="h-4 w-4" />
+                        {t('export.selectedImages')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.chooseImages')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="p-0">
+                      <ImageSelectionGrid
+                        images={images}
+                        selectedImageIds={
+                          exportOptions.selectedImageIds ||
+                          images.map(img => img.id)
                         }
-                        onCheckedChange={checked =>
-                          updateExportOptions({
-                            visualizationOptions: {
-                              ...exportOptions.visualizationOptions,
-                              showNumbers: !!checked,
-                            },
-                          })
+                        onSelectionChange={selectedIds =>
+                          updateExportOptions({ selectedImageIds: selectedIds })
                         }
                       />
-                      <Label
-                        htmlFor="show-numbers"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.showNumbers')}
-                      </Label>
-                    </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
 
-                    <div className="space-y-2">
-                      <Label className="text-sm sm:text-base">
-                        {t('export.strokeColor')}
-                      </Label>
-                      <div className="flex gap-2">
-                        <Input
-                          type="color"
-                          value={
-                            exportOptions.visualizationOptions?.polygonColors
-                              ?.external ||
-                            EXPORT_DEFAULTS.COLORS.EXTERNAL_POLYGON
+                <TabsContent
+                  value="visualization"
+                  className="space-y-3 sm:space-y-4"
+                >
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <Palette className="h-4 w-4" />
+                        {t('export.colorSettings')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.colorSettings')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4 sm:space-y-6 p-0">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="show-numbers"
+                          checked={
+                            exportOptions.visualizationOptions?.showNumbers
                           }
-                          onChange={e =>
+                          onCheckedChange={checked =>
                             updateExportOptions({
                               visualizationOptions: {
                                 ...exportOptions.visualizationOptions,
-                                polygonColors: {
-                                  ...exportOptions.visualizationOptions
-                                    ?.polygonColors,
-                                  external: e.target.value,
-                                },
+                                showNumbers: !!checked,
                               },
                             })
                           }
-                          className="w-full sm:w-20 h-10 sm:h-9"
                         />
-                        <Input
-                          value={
-                            exportOptions.visualizationOptions?.polygonColors
-                              ?.external ||
-                            EXPORT_DEFAULTS.COLORS.EXTERNAL_POLYGON
-                          }
-                          onChange={e =>
-                            updateExportOptions({
-                              visualizationOptions: {
-                                ...exportOptions.visualizationOptions,
-                                polygonColors: {
-                                  ...exportOptions.visualizationOptions
-                                    ?.polygonColors,
-                                  external: e.target.value,
-                                },
-                              },
-                            })
-                          }
-                          className="flex-1"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label className="text-sm sm:text-base">
-                        {t('export.backgroundColor')}
-                      </Label>
-                      <div className="flex gap-2">
-                        <Input
-                          type="color"
-                          value={
-                            exportOptions.visualizationOptions?.polygonColors
-                              ?.internal ||
-                            EXPORT_DEFAULTS.COLORS.INTERNAL_POLYGON
-                          }
-                          onChange={e =>
-                            updateExportOptions({
-                              visualizationOptions: {
-                                ...exportOptions.visualizationOptions,
-                                polygonColors: {
-                                  ...exportOptions.visualizationOptions
-                                    ?.polygonColors,
-                                  internal: e.target.value,
-                                },
-                              },
-                            })
-                          }
-                          className="w-full sm:w-20 h-10 sm:h-9"
-                        />
-                        <Input
-                          value={
-                            exportOptions.visualizationOptions?.polygonColors
-                              ?.internal ||
-                            EXPORT_DEFAULTS.COLORS.INTERNAL_POLYGON
-                          }
-                          onChange={e =>
-                            updateExportOptions({
-                              visualizationOptions: {
-                                ...exportOptions.visualizationOptions,
-                                polygonColors: {
-                                  ...exportOptions.visualizationOptions
-                                    ?.polygonColors,
-                                  internal: e.target.value,
-                                },
-                              },
-                            })
-                          }
-                          className="flex-1"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <div className="flex justify-between items-center">
-                        <Label className="text-sm">
-                          {t('export.strokeWidth')}
+                        <Label
+                          htmlFor="show-numbers"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.showNumbers')}
                         </Label>
-                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                          {exportOptions.visualizationOptions?.strokeWidth || 2}
-                          px
-                        </span>
                       </div>
-                      <Slider
-                        className="touch-manipulation"
-                        value={[
-                          exportOptions.visualizationOptions?.strokeWidth || 2,
-                        ]}
-                        onValueChange={([value]) =>
-                          updateExportOptions({
-                            visualizationOptions: {
-                              ...exportOptions.visualizationOptions,
-                              strokeWidth: value,
-                            },
-                          })
-                        }
-                        min={1}
-                        max={10}
-                        step={1}
-                      />
-                    </div>
 
-                    <div className="space-y-2">
-                      <div className="flex justify-between items-center">
-                        <Label className="text-sm">
-                          {t('export.fontSize')}
+                      <div className="space-y-2">
+                        <Label className="text-sm sm:text-base">
+                          {t('export.strokeColor')}
                         </Label>
-                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                          {exportOptions.visualizationOptions?.fontSize || 32}px
-                        </span>
+                        <div className="flex gap-2">
+                          <Input
+                            type="color"
+                            value={
+                              exportOptions.visualizationOptions?.polygonColors
+                                ?.external ||
+                              EXPORT_DEFAULTS.COLORS.EXTERNAL_POLYGON
+                            }
+                            onChange={e =>
+                              updateExportOptions({
+                                visualizationOptions: {
+                                  ...exportOptions.visualizationOptions,
+                                  polygonColors: {
+                                    ...exportOptions.visualizationOptions
+                                      ?.polygonColors,
+                                    external: e.target.value,
+                                  },
+                                },
+                              })
+                            }
+                            className="w-full sm:w-20 h-10 sm:h-9"
+                          />
+                          <Input
+                            value={
+                              exportOptions.visualizationOptions?.polygonColors
+                                ?.external ||
+                              EXPORT_DEFAULTS.COLORS.EXTERNAL_POLYGON
+                            }
+                            onChange={e =>
+                              updateExportOptions({
+                                visualizationOptions: {
+                                  ...exportOptions.visualizationOptions,
+                                  polygonColors: {
+                                    ...exportOptions.visualizationOptions
+                                      ?.polygonColors,
+                                    external: e.target.value,
+                                  },
+                                },
+                              })
+                            }
+                            className="flex-1"
+                          />
+                        </div>
                       </div>
-                      <Slider
-                        className="touch-manipulation"
-                        value={[
-                          exportOptions.visualizationOptions?.fontSize || 32,
-                        ]}
-                        onValueChange={([value]) =>
-                          updateExportOptions({
-                            visualizationOptions: {
-                              ...exportOptions.visualizationOptions,
-                              fontSize: value,
-                            },
-                          })
-                        }
-                        min={10}
-                        max={50}
-                        step={2}
-                      />
-                    </div>
 
-                    <div className="space-y-2">
-                      <div className="flex justify-between items-center">
-                        <Label className="text-sm">Transparency</Label>
-                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                          {Math.round(
+                      <div className="space-y-2">
+                        <Label className="text-sm sm:text-base">
+                          {t('export.backgroundColor')}
+                        </Label>
+                        <div className="flex gap-2">
+                          <Input
+                            type="color"
+                            value={
+                              exportOptions.visualizationOptions?.polygonColors
+                                ?.internal ||
+                              EXPORT_DEFAULTS.COLORS.INTERNAL_POLYGON
+                            }
+                            onChange={e =>
+                              updateExportOptions({
+                                visualizationOptions: {
+                                  ...exportOptions.visualizationOptions,
+                                  polygonColors: {
+                                    ...exportOptions.visualizationOptions
+                                      ?.polygonColors,
+                                    internal: e.target.value,
+                                  },
+                                },
+                              })
+                            }
+                            className="w-full sm:w-20 h-10 sm:h-9"
+                          />
+                          <Input
+                            value={
+                              exportOptions.visualizationOptions?.polygonColors
+                                ?.internal ||
+                              EXPORT_DEFAULTS.COLORS.INTERNAL_POLYGON
+                            }
+                            onChange={e =>
+                              updateExportOptions({
+                                visualizationOptions: {
+                                  ...exportOptions.visualizationOptions,
+                                  polygonColors: {
+                                    ...exportOptions.visualizationOptions
+                                      ?.polygonColors,
+                                    internal: e.target.value,
+                                  },
+                                },
+                              })
+                            }
+                            className="flex-1"
+                          />
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex justify-between items-center">
+                          <Label className="text-sm">
+                            {t('export.strokeWidth')}
+                          </Label>
+                          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                            {exportOptions.visualizationOptions?.strokeWidth ||
+                              2}
+                            px
+                          </span>
+                        </div>
+                        <Slider
+                          className="touch-manipulation"
+                          value={[
+                            exportOptions.visualizationOptions?.strokeWidth ||
+                              2,
+                          ]}
+                          onValueChange={([value]) =>
+                            updateExportOptions({
+                              visualizationOptions: {
+                                ...exportOptions.visualizationOptions,
+                                strokeWidth: value,
+                              },
+                            })
+                          }
+                          min={1}
+                          max={10}
+                          step={1}
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex justify-between items-center">
+                          <Label className="text-sm">
+                            {t('export.fontSize')}
+                          </Label>
+                          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                            {exportOptions.visualizationOptions?.fontSize || 32}
+                            px
+                          </span>
+                        </div>
+                        <Slider
+                          className="touch-manipulation"
+                          value={[
+                            exportOptions.visualizationOptions?.fontSize || 32,
+                          ]}
+                          onValueChange={([value]) =>
+                            updateExportOptions({
+                              visualizationOptions: {
+                                ...exportOptions.visualizationOptions,
+                                fontSize: value,
+                              },
+                            })
+                          }
+                          min={10}
+                          max={50}
+                          step={2}
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex justify-between items-center">
+                          <Label className="text-sm">Transparency</Label>
+                          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                            {Math.round(
+                              (exportOptions.visualizationOptions
+                                ?.transparency || 0.3) * 100
+                            )}
+                            %
+                          </span>
+                        </div>
+                        <Slider
+                          className="touch-manipulation"
+                          value={[
                             (exportOptions.visualizationOptions?.transparency ||
-                              0.3) * 100
+                              0.3) * 100,
+                          ]}
+                          onValueChange={([value]) =>
+                            updateExportOptions({
+                              visualizationOptions: {
+                                ...exportOptions.visualizationOptions,
+                                transparency: value / 100,
+                              },
+                            })
+                          }
+                          min={0}
+                          max={100}
+                          step={10}
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="formats" className="space-y-3 sm:space-y-4">
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <FileJson className="h-4 w-4" />
+                        {t('export.formatsTab')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.formatsTab')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 sm:space-y-4 p-0">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="coco-format"
+                          checked={exportOptions.annotationFormats?.includes(
+                            'coco'
                           )}
-                          %
-                        </span>
+                          onCheckedChange={checked => {
+                            const formats =
+                              exportOptions.annotationFormats || [];
+                            updateExportOptions({
+                              annotationFormats: checked
+                                ? [...formats, 'coco']
+                                : formats.filter(f => f !== 'coco'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="coco-format"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.includeCocoFormat')}
+                        </Label>
                       </div>
-                      <Slider
-                        className="touch-manipulation"
-                        value={[
-                          (exportOptions.visualizationOptions?.transparency ||
-                            0.3) * 100,
-                        ]}
-                        onValueChange={([value]) =>
-                          updateExportOptions({
-                            visualizationOptions: {
-                              ...exportOptions.visualizationOptions,
-                              transparency: value / 100,
-                            },
-                          })
-                        }
-                        min={0}
-                        max={100}
-                        step={10}
-                      />
-                    </div>
-                  </CardContent>
-                </Card>
-              </TabsContent>
 
-              <TabsContent value="formats" className="space-y-3 sm:space-y-4">
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <FileJson className="h-4 w-4" />
-                      {t('export.formatsTab')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.formatsTab')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 sm:space-y-4 p-0">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="coco-format"
-                        checked={exportOptions.annotationFormats?.includes(
-                          'coco'
-                        )}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.annotationFormats || [];
-                          updateExportOptions({
-                            annotationFormats: checked
-                              ? [...formats, 'coco']
-                              : formats.filter(f => f !== 'coco'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="coco-format"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.includeCocoFormat')}
-                      </Label>
-                    </div>
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="yolo-format"
+                          checked={exportOptions.annotationFormats?.includes(
+                            'yolo'
+                          )}
+                          onCheckedChange={checked => {
+                            const formats =
+                              exportOptions.annotationFormats || [];
+                            updateExportOptions({
+                              annotationFormats: checked
+                                ? [...formats, 'yolo']
+                                : formats.filter(f => f !== 'yolo'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="yolo-format"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.exportFormats.yolo')}
+                        </Label>
+                      </div>
 
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="yolo-format"
-                        checked={exportOptions.annotationFormats?.includes(
-                          'yolo'
-                        )}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.annotationFormats || [];
-                          updateExportOptions({
-                            annotationFormats: checked
-                              ? [...formats, 'yolo']
-                              : formats.filter(f => f !== 'yolo'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="yolo-format"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.exportFormats.yolo')}
-                      </Label>
-                    </div>
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="json-format"
+                          checked={exportOptions.annotationFormats?.includes(
+                            'json'
+                          )}
+                          onCheckedChange={checked => {
+                            const formats =
+                              exportOptions.annotationFormats || [];
+                            updateExportOptions({
+                              annotationFormats: checked
+                                ? [...formats, 'json']
+                                : formats.filter(f => f !== 'json'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="json-format"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.includeJsonMetadata')}
+                        </Label>
+                      </div>
+                    </CardContent>
+                  </Card>
 
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="json-format"
-                        checked={exportOptions.annotationFormats?.includes(
-                          'json'
-                        )}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.annotationFormats || [];
-                          updateExportOptions({
-                            annotationFormats: checked
-                              ? [...formats, 'json']
-                              : formats.filter(f => f !== 'json'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="json-format"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.includeJsonMetadata')}
-                      </Label>
-                    </div>
-                  </CardContent>
-                </Card>
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
+                        <FileSpreadsheet className="h-4 w-4" />
+                        {t('export.outputSettings')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.generateExcel')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 sm:space-y-4 p-0">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="excel-metrics"
+                          checked={exportOptions.metricsFormats?.includes(
+                            'excel'
+                          )}
+                          onCheckedChange={checked => {
+                            const formats = exportOptions.metricsFormats || [];
+                            updateExportOptions({
+                              metricsFormats: checked
+                                ? [...formats, 'excel']
+                                : formats.filter(f => f !== 'excel'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="excel-metrics"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.exportFormats.excel')}
+                        </Label>
+                      </div>
 
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
-                      <FileSpreadsheet className="h-4 w-4" />
-                      {t('export.outputSettings')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.generateExcel')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 sm:space-y-4 p-0">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="excel-metrics"
-                        checked={exportOptions.metricsFormats?.includes(
-                          'excel'
-                        )}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.metricsFormats || [];
-                          updateExportOptions({
-                            metricsFormats: checked
-                              ? [...formats, 'excel']
-                              : formats.filter(f => f !== 'excel'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="excel-metrics"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.exportFormats.excel')}
-                      </Label>
-                    </div>
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="csv-metrics"
+                          checked={exportOptions.metricsFormats?.includes(
+                            'csv'
+                          )}
+                          onCheckedChange={checked => {
+                            const formats = exportOptions.metricsFormats || [];
+                            updateExportOptions({
+                              metricsFormats: checked
+                                ? [...formats, 'csv']
+                                : formats.filter(f => f !== 'csv'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="csv-metrics"
+                          className="text-sm sm:text-base"
+                        >
+                          CSV (Comma-separated values)
+                        </Label>
+                      </div>
 
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="csv-metrics"
-                        checked={exportOptions.metricsFormats?.includes('csv')}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.metricsFormats || [];
-                          updateExportOptions({
-                            metricsFormats: checked
-                              ? [...formats, 'csv']
-                              : formats.filter(f => f !== 'csv'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="csv-metrics"
-                        className="text-sm sm:text-base"
-                      >
-                        CSV (Comma-separated values)
-                      </Label>
-                    </div>
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="json-metrics"
+                          checked={exportOptions.metricsFormats?.includes(
+                            'json'
+                          )}
+                          onCheckedChange={checked => {
+                            const formats = exportOptions.metricsFormats || [];
+                            updateExportOptions({
+                              metricsFormats: checked
+                                ? [...formats, 'json']
+                                : formats.filter(f => f !== 'json'),
+                            });
+                          }}
+                        />
+                        <Label
+                          htmlFor="json-metrics"
+                          className="text-sm sm:text-base"
+                        >
+                          {t('export.exportFormats.json')}
+                        </Label>
+                      </div>
+                    </CardContent>
+                  </Card>
 
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="json-metrics"
-                        checked={exportOptions.metricsFormats?.includes('json')}
-                        onCheckedChange={checked => {
-                          const formats = exportOptions.metricsFormats || [];
-                          updateExportOptions({
-                            metricsFormats: checked
-                              ? [...formats, 'json']
-                              : formats.filter(f => f !== 'json'),
-                          });
-                        }}
-                      />
-                      <Label
-                        htmlFor="json-metrics"
-                        className="text-sm sm:text-base"
-                      >
-                        {t('export.exportFormats.json')}
-                      </Label>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <Card className="p-3 sm:p-4">
-                  <CardHeader className="p-0 pb-3 sm:pb-4">
-                    <CardTitle className="text-sm sm:text-base">
-                      {t('export.completed')}
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      {t('export.configureSettings')}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-2 text-sm p-0">
-                    <div>
-                      • Images:{' '}
-                      {exportOptions.selectedImageIds?.length || images.length}
-                    </div>
-                    {exportOptions.includeOriginalImages && (
-                      <div>• Original images included</div>
-                    )}
-                    {exportOptions.includeVisualizations && (
-                      <div>• Visualizations with numbered polygons</div>
-                    )}
-                    {exportOptions.annotationFormats?.length > 0 && (
+                  <Card className="p-3 sm:p-4">
+                    <CardHeader className="p-0 pb-3 sm:pb-4">
+                      <CardTitle className="text-sm sm:text-base">
+                        {t('export.completed')}
+                      </CardTitle>
+                      <CardDescription className="text-xs sm:text-sm">
+                        {t('export.configureSettings')}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm p-0">
                       <div>
-                        • Annotations:{' '}
-                        {exportOptions.annotationFormats
-                          .join(', ')
-                          .toUpperCase()}
+                        • Images:{' '}
+                        {exportOptions.selectedImageIds?.length ||
+                          images.length}
                       </div>
-                    )}
-                    {exportOptions.metricsFormats?.length > 0 && (
-                      <div>
-                        • Metrics:{' '}
-                        {exportOptions.metricsFormats.join(', ').toUpperCase()}
-                      </div>
-                    )}
-                    {exportOptions.includeDocumentation && (
-                      <div>• Documentation and metadata</div>
-                    )}
-                    <div>• No compression (full quality)</div>
-                  </CardContent>
-                </Card>
-              </TabsContent>
-            </Tabs>
+                      {exportOptions.includeOriginalImages && (
+                        <div>• Original images included</div>
+                      )}
+                      {exportOptions.includeVisualizations && (
+                        <div>• Visualizations with numbered polygons</div>
+                      )}
+                      {exportOptions.annotationFormats?.length > 0 && (
+                        <div>
+                          • Annotations:{' '}
+                          {exportOptions.annotationFormats
+                            .join(', ')
+                            .toUpperCase()}
+                        </div>
+                      )}
+                      {exportOptions.metricsFormats?.length > 0 && (
+                        <div>
+                          • Metrics:{' '}
+                          {exportOptions.metricsFormats
+                            .join(', ')
+                            .toUpperCase()}
+                        </div>
+                      )}
+                      {exportOptions.includeDocumentation && (
+                        <div>• Documentation and metadata</div>
+                      )}
+                      <div>• No compression (full quality)</div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
 
-            {/* Connection Status */}
-            {!wsConnected && (
-              <div className="flex items-center gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                <WifiOff className="h-4 w-4 text-amber-600" />
-                <span className="text-sm text-amber-800">
-                  WebSocket connection lost. Using fallback polling for updates.
-                </span>
-              </div>
-            )}
-
-            {/* Export Progress */}
-            {isExporting && (
-              <div className="space-y-2">
-                <div className="flex justify-between text-sm">
-                  <span>{exportStatus}</span>
-                  <span>{Math.round(exportProgress)}%</span>
-                </div>
-                <Progress value={exportProgress} className="w-full" />
-              </div>
-            )}
-
-            {/* Completed Export - Manual Download */}
-            {completedJobId && !isExporting && !isDownloading && (
-              <div className="flex items-center gap-2 p-3 bg-green-50 border border-green-200 rounded-lg relative">
-                <AlertCircle className="h-4 w-4 text-green-600" />
-                <div className="flex-1">
-                  <span className="text-sm text-green-800">
-                    {exportStatus ||
-                      "Export completed successfully! Click below to download if it didn't start automatically."}
+              {/* Connection Status */}
+              {!wsConnected && (
+                <div className="flex items-center gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                  <WifiOff className="h-4 w-4 text-amber-600" />
+                  <span className="text-sm text-amber-800">
+                    WebSocket connection lost. Using fallback polling for
+                    updates.
                   </span>
                 </div>
-                <Button
-                  size="sm"
-                  onClick={triggerDownload}
-                  className="ml-2"
-                  title={
-                    isDownloading
-                      ? 'Click to stop animation when download completes'
-                      : 'Download export file'
-                  }
-                >
-                  {isDownloading ? (
-                    <>
-                      <RefreshCw className="h-4 w-4 mr-1 animate-spin" />
-                      {t('export.downloading') || 'Downloading...'}
-                    </>
-                  ) : (
-                    <>
-                      <Download className="h-4 w-4 mr-1" />
-                      {t('export.download')}
-                    </>
-                  )}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={dismissExport}
-                  className="ml-1 h-6 w-6 p-0"
-                  title="Dismiss"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-            )}
-
-            {/* Failed Export */}
-            {currentJob?.status === 'failed' && (
-              <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
-                <AlertCircle className="h-4 w-4 text-red-600" />
-                <span className="text-sm text-red-800">
-                  Export failed: {currentJob.message || 'Unknown error'}
-                </span>
-              </div>
-            )}
-
-            <DialogFooter className="flex-col sm:flex-row gap-2">
-              {/* Close dialog button - only shown when not exporting */}
-              {!isExporting && (
-                <Button
-                  variant="outline"
-                  onClick={onClose}
-                  className="w-full sm:w-auto"
-                >
-                  {t('common.cancel')}
-                </Button>
               )}
 
-              {/* Universal Cancel/Export Button */}
-              <UniversalCancelButton
-                operationType="export"
-                isOperationActive={isExporting}
-                isCancelling={isDownloading} // Use downloading state as cancelling indicator
-                onCancel={cancelExport}
-                onPrimaryAction={handleExport}
-                primaryText={t('export.startExport')}
-                disabled={false}
-                className="w-full sm:w-auto"
-              />
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+              {/* Export Progress */}
+              {isExporting && (
+                <div className="space-y-2">
+                  <div className="flex justify-between text-sm">
+                    <span>{exportStatus}</span>
+                    <span>{Math.round(exportProgress)}%</span>
+                  </div>
+                  <Progress value={exportProgress} className="w-full" />
+                </div>
+              )}
+
+              {/* Completed Export - Manual Download */}
+              {completedJobId && !isExporting && !isDownloading && (
+                <div className="flex items-center gap-2 p-3 bg-green-50 border border-green-200 rounded-lg relative">
+                  <AlertCircle className="h-4 w-4 text-green-600" />
+                  <div className="flex-1">
+                    <span className="text-sm text-green-800">
+                      {exportStatus ||
+                        "Export completed successfully! Click below to download if it didn't start automatically."}
+                    </span>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={triggerDownload}
+                    className="ml-2"
+                    title={
+                      isDownloading
+                        ? 'Click to stop animation when download completes'
+                        : 'Download export file'
+                    }
+                  >
+                    {isDownloading ? (
+                      <>
+                        <RefreshCw className="h-4 w-4 mr-1 animate-spin" />
+                        {t('export.downloading') || 'Downloading...'}
+                      </>
+                    ) : (
+                      <>
+                        <Download className="h-4 w-4 mr-1" />
+                        {t('export.download')}
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={dismissExport}
+                    className="ml-1 h-6 w-6 p-0"
+                    title="Dismiss"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+
+              {/* Failed Export */}
+              {currentJob?.status === 'failed' && (
+                <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
+                  <AlertCircle className="h-4 w-4 text-red-600" />
+                  <span className="text-sm text-red-800">
+                    Export failed: {currentJob.message || 'Unknown error'}
+                  </span>
+                </div>
+              )}
+
+              <DialogFooter className="flex-col sm:flex-row gap-2">
+                {/* Close dialog button - only shown when not exporting */}
+                {!isExporting && (
+                  <Button
+                    variant="outline"
+                    onClick={onClose}
+                    className="w-full sm:w-auto"
+                  >
+                    {t('common.cancel')}
+                  </Button>
+                )}
+
+                {/* Universal Cancel/Export Button */}
+                <UniversalCancelButton
+                  operationType="export"
+                  isOperationActive={isExporting}
+                  isCancelling={isDownloading} // Use downloading state as cancelling indicator
+                  onCancel={cancelExport}
+                  onPrimaryAction={handleExportClick}
+                  primaryText={t('export.startExport')}
+                  disabled={false}
+                  className="w-full sm:w-auto"
+                />
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <AlertDialog
+            open={showIncompleteWarning}
+            onOpenChange={setShowIncompleteWarning}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {t('export.mt.incompleteTitle')}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t('export.mt.incompleteBody')}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+                <AlertDialogAction onClick={confirmIncompleteExport}>
+                  {t('export.mt.incompleteConfirm')}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
       );
     }
   );

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1140,6 +1140,10 @@ export default {
         'Tento projekt nemá metadata o kanálech. Pro získání metrik podle kanálů znovu nahrajte video.',
       selectChannelRequired:
         'Pro export metrik intenzity podle kanálů vyberte alespoň jeden kanál.',
+      incompleteTitle: 'Výpočet intenzit nezvolen',
+      incompleteBody:
+        'Nemáte zapnutý výpočet intenzity signálu podle kanálů, takže exportované metriky budou neúplné: zahrnuta bude pouze délka mikrotubulů, bez sloupců s intenzitou podle kanálů. Přesto exportovat?',
+      incompleteConfirm: 'Přesto exportovat',
     },
     advancedExport: 'Pokročilý export',
     advancedOptions: 'Pokročilé možnosti exportu',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1151,6 +1151,10 @@ export default {
         'Dieses Projekt hat keine Kanal-Metadaten. Laden Sie das Video erneut hoch, um kanalspezifische Metriken zu erhalten.',
       selectChannelRequired:
         'Wählen Sie mindestens einen Kanal, um kanalspezifische Intensitätsmetriken zu exportieren.',
+      incompleteTitle: 'Intensitätsberechnung nicht ausgewählt',
+      incompleteBody:
+        'Sie haben die kanalweise Signalintensitätsberechnung nicht aktiviert, daher sind die exportierten Metriken unvollständig: Es wird nur die Mikrotubuli-Länge einbezogen, ohne die kanalspezifischen Intensitätsspalten. Trotzdem exportieren?',
+      incompleteConfirm: 'Trotzdem exportieren',
     },
     advancedExport: 'Erweiterter Export',
     advancedOptions: 'Erweiterte Export-Optionen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1131,6 +1131,10 @@ export default {
         'This project has no per-channel metadata. Re-upload the video to get channel-specific metrics.',
       selectChannelRequired:
         'Select at least one channel to export per-channel intensity metrics.',
+      incompleteTitle: 'Intensity calculation not selected',
+      incompleteBody:
+        'You have not enabled per-channel signal-intensity calculation, so the exported metrics will be incomplete: only microtubule length will be included, without the per-channel intensity columns. Export anyway?',
+      incompleteConfirm: 'Export anyway',
     },
     // Dialog headers
     advancedExport: 'Advanced Export',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1135,6 +1135,10 @@ export default {
         'Este proyecto no tiene metadatos de canales. Vuelva a subir el vídeo para obtener métricas por canal.',
       selectChannelRequired:
         'Seleccione al menos un canal para exportar las métricas de intensidad por canal.',
+      incompleteTitle: 'Cálculo de intensidad no seleccionado',
+      incompleteBody:
+        'No ha activado el cálculo de intensidad de señal por canal, por lo que las métricas exportadas estarán incompletas: solo se incluirá la longitud de los microtúbulos, sin las columnas de intensidad por canal. ¿Exportar de todos modos?',
+      incompleteConfirm: 'Exportar de todos modos',
     },
     advancedExport: 'Exportación Avanzada',
     advancedOptions: 'Opciones Avanzadas de Exportación',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1140,6 +1140,10 @@ export default {
         'Ce projet ne contient pas de métadonnées de canaux. Téléversez à nouveau la vidéo pour obtenir des métriques par canal.',
       selectChannelRequired:
         "Sélectionnez au moins un canal pour exporter les métriques d'intensité par canal.",
+      incompleteTitle: "Calcul d'intensité non sélectionné",
+      incompleteBody:
+        "Vous n'avez pas activé le calcul de l'intensité du signal par canal ; les métriques exportées seront donc incomplètes : seule la longueur des microtubules sera incluse, sans les colonnes d'intensité par canal. Exporter quand même ?",
+      incompleteConfirm: 'Exporter quand même',
     },
     advancedExport: 'Export Avancé',
     advancedOptions: "Options d'Exportation Avancées",

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1049,6 +1049,10 @@ export default {
       channelsLabel: '要采样的通道',
       noChannels: '该项目没有通道元数据。请重新上传视频以获取按通道的指标。',
       selectChannelRequired: '请至少选择一个通道以导出按通道的强度指标。',
+      incompleteTitle: '未选择强度计算',
+      incompleteBody:
+        '您尚未启用按通道的信号强度计算，因此导出的指标将不完整：仅包含微管长度，而不含按通道的强度列。仍要导出吗？',
+      incompleteConfirm: '仍要导出',
     },
     advancedExport: '高级导出',
     advancedOptions: '高级导出选项',


### PR DESCRIPTION
## What
On a **microtubule** project, if the user requests metrics but hasn't enabled per-channel **intensity calculation** (or hasn't picked a channel), clicking **Export** now opens a confirmation **modal** warning that the metric set will be **incomplete** — only microtubule length will be included, without the per-channel intensity columns — with **"Export anyway"** / **Cancel**.

## Why
After #219, MT export without a channel still produces length metrics + a post-export toast. Per user request, this adds an explicit **pre-export** warning modal so the user notices *before* exporting and can go back to enable intensity / pick a channel.

## How
FE-only (`AdvancedExportDialog`):
- `handleExportClick` intercepts the Export click; when `shouldWarnIncompleteMetrics` (MT project + metrics requested + intensity not enabled/no channel) it opens an `AlertDialog`, otherwise exports directly.
- "Export anyway" → proceeds (length-only); Cancel → returns to the dialog.
- New i18n keys `export.mt.{incompleteTitle,incompleteBody,incompleteConfirm}` in all 6 locales.

`make ci` green (1481 keys, all locales complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)