### PR TITLE
refactor(segmentation): extract SegmentationEditor logic into 6 tested units

### DIFF
--- a/docs/superpowers/specs/2026-05-30-segmentation-editor-refactor-design.md
+++ b/docs/superpowers/specs/2026-05-30-segmentation-editor-refactor-design.md
@@ -1,0 +1,115 @@
+# SegmentationEditor logic extraction (structural refactor)
+
+**Date:** 2026-05-30
+**Status:** Approved, ready for implementation
+**Branch:** `refactor/segmentation-editor-extract-logic`
+
+## Context / problem
+
+`src/pages/segmentation/SegmentationEditor.tsx` is a 2073-line god-component — the
+most complex orchestrator in the repo. It juggles ~16 concerns (data loading,
+polygon transform, the editor core hook, WebSocket status sync, resegment +
+background poll, frame-slider choreography, navigation, auto-center, abort
+management, polygon CRUD, MT cross-frame selection, an 8-memo render pipeline,
+and a deep JSX tree) in one file: 10 `useState`, ~6 `useRef`, 15 `useMemo`,
+15 `useCallback`, 11 `useEffect`.
+
+It is effectively untestable: importing it in a test eagerly pulls
+`socket.io-client` (via `useSegmentationQueue`), the full Radix/shadcn tree (via
+`CanvasPolygon`/panels), Axios + interceptors, and canvas-compositing libs.
+Vitest doesn't code-split, so the combined module graph (~3.8 GB) OOMs the
+worker. Only a calibrated ~22-test orchestration file can cover it at all.
+
+## Decision (agreed)
+
+**Goal = testable extracted units, logic-only.** Pull the cohesive _logic_ into
+separate **light-import** files so each gets a fast unit test that never imports
+socket.io/Radix/Axios. The orchestrator shrinks to a thin coordinator. The
+**JSX render tree and its prop-threading are NOT touched** this pass (lowest
+regression risk on the part most likely to break behavior subtly); the
+JSX-slimming (an `EditorContext` + sub-component split) is a clearly-scoped
+future pass. **Zero behavior change** — this is a structural refactor only.
+
+## The 6 extraction units
+
+Each moves to its own file + a focused unit test. Ordered safest → riskiest;
+this is also the implementation order (each stage committed + verified before
+the next).
+
+| #   | Unit                                              | What moves (current lines)                                                                                                                                                                      | Interface                                                                                             |
+| --- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1   | `transformSegmentationPolygons()` — **pure util** | `initialPolygons` memo (326-442)                                                                                                                                                                | `(raw: SegmentationPolygon[], dims) => Polygon[]`                                                     |
+| 2   | `usePolygonRenderProps()`                         | render memos (1233-1413): `renderablePolygons`, `visiblePolygons`, `frameHiddenIds`, `hasPolylines`, `polylineKind`, `availableInstanceIds`/`availableInstanceKey`, `legacyModes`, `navContext` | `({ editor, hiddenPolygonIds, imageDimensions, … }) => {…}`                                           |
+| 3   | `usePolygonHandlers()`                            | CRUD callbacks (1104-1305) + `hiddenPolygonIds` / `hoveredPolygonId` / `persistedSelectionTrackId` state                                                                                        | `({ editor, imageId }) => { handlers…, hiddenPolygonIds, setHovered…, … }`                            |
+| 4   | `usePersistedMtSelection()`                       | MT cross-frame selection effect (1150-1187)                                                                                                                                                     | `({ editor, imageId })` (owns `persistedSelectionTrackId`)                                            |
+| 5   | `useSegmentationLoader()`                         | data-load cluster (154-844): `segmentationPolygons` + `imageDimensions` state, primary load effect, RQ-cache path, abort/cleanup effects                                                        | `({ projectId, imageId, selectedImage, getSignal, queryClient }) => {…}`                              |
+| 6   | `useResegment()`                                  | resegment + poll (1440-1611): `isResegmenting`, `showResegmentChannelDialog`, `resegPollSeqRef`, `effectiveResegmentModel`, `startResegmentPoll`, `runResegment`, `handleResegmentCurrentFrame` | `({ projectId, imageId, projectType, selectedModel, videoChannels, queryClient, onReloaded }) => {…}` |
+
+**Out of scope:** the frame-slider seed + reverse-sync effects (1617-1684) stay
+in the orchestrator — highest oscillation risk (`~7 Hz` URL-flip bug), only 2
+effects with a `wasPlayingRef`, little to gain by moving. The JSX tree,
+prop-threading, and `onSave` closure also stay.
+
+## Hazard containment (the 5 tight couplings)
+
+1. **`previousImageIdRef` dual-writer** (auto-center effect + abort-on-imageId
+   effect both write it). → The ref and **both** writer effects stay in the
+   orchestrator; neither moves into a hook.
+2. **`onSave` wide closure** (`projectImages`, `imageDimensions`, `imageId`,
+   `queryClient`, `t`). → Stays inline in the orchestrator, passed to
+   `useEnhancedSegmentationEditor` exactly as today. Not extracted.
+3. **video↔resegment TDZ** (`handleResegmentCurrentFrame` reads
+   `video.container.channels`). → `useResegment` takes `videoChannels` as a
+   **parameter**; it never calls `useVideoFrames` itself (would duplicate the
+   query). Orchestrator passes `video.container?.channels ?? null` after the
+   `const video = …` line — preserving call order.
+4. **`editor` fan-out to 14+ sites.** → Untouched (logic-only). Hooks receive
+   `editor` as an argument; JSX keeps threading props.
+5. **`reloadNonce` bridges loader ↔ editor hook.** → `reloadNonce` +
+   `handleReloadedPolygons` **stay in the orchestrator** as the liaison;
+   `handleReloadedPolygons` is passed into `useResegment({ onReloaded })` and
+   `reloadNonce` into `useEnhancedSegmentationEditor`.
+
+## Testing
+
+- **Per-unit (the coverage win):** each extracted unit gets a focused unit test
+  with light imports — fast, no OOM. `transformSegmentationPolygons` is a pure
+  function (degenerate-shape filtering, point mapping, id coercion,
+  `parentIds→parent_id`); the hooks are tested with `renderHook` + mocked
+  `editor`/`apiClient`.
+- **Regression safety net:** after every stage —
+  `SegmentationEditor.orchestration.test.tsx` +
+  `SegmentationEditor.integration.test.tsx` stay green, and `make ci`
+  (tsc + eslint 0 warnings + i18n) is clean.
+
+## Verification (CLAUDE.md gates, before claiming done)
+
+Production-mode local preview + Playwright walkthrough of the editor's critical
+paths, **0 console errors**:
+
+1. Load an image → polygons render.
+2. Video frame-slider: scrub **and** play → converges, no oscillation.
+3. Resegment → reload-nonce repaint + success toast (no manual F5).
+4. Undo / redo.
+5. MT color stability across frames / sperm instance panel.
+6. Save → success.
+
+## Sequencing
+
+Staged, safest-first (units 1→6). After each stage: run the new unit test +
+both orchestration/integration tests + `make ci`; commit. Riskier units (5
+loader, 6 resegment — they own effects) come last, once the pattern is proven.
+A stage that shows a Playwright behavior diff reverts cleanly without touching
+the others.
+
+## Expected outcome
+
+`SegmentationEditor.tsx` drops from ~2073 → ~1150–1300 LOC (thin coordinator +
+the untouched JSX), with ~750–900 LOC of logic relocated into 6 independently
+unit-tested files.
+
+## Out of scope
+
+- JSX restructure / `EditorContext` / sub-component split (future pass).
+- The frame-slider choreography, `onSave`, and any behavior change.
+- `useEnhancedSegmentationEditor` internals (the 1246-line core hook).

--- a/src/components/settings/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/components/settings/__tests__/DeleteAccountDialog.test.tsx
@@ -34,6 +34,10 @@ describe('DeleteAccountDialog', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Cookie-auth: AuthProvider only probes /auth/profile when the non-secret
+    // `authenticated` hint cookie is present. Set it so the provider hydrates
+    // the user (the getUserProfile mock then decides authed vs signed-out).
+    document.cookie = 'authenticated=1';
     mockNavigate.mockReset();
   });
 

--- a/src/contexts/__tests__/LanguageContext.test.tsx
+++ b/src/contexts/__tests__/LanguageContext.test.tsx
@@ -77,6 +77,10 @@ describe('LanguageContext', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Cookie-auth: AuthProvider only probes /auth/profile when the non-secret
+    // `authenticated` hint cookie is present. Set it so the provider hydrates
+    // the user (the getUserProfile mock then decides authed vs signed-out).
+    document.cookie = 'authenticated=1';
 
     localStorageMock = createLocalStorageMock();
     Object.defineProperty(window, 'localStorage', {

--- a/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/src/contexts/__tests__/ThemeContext.test.tsx
@@ -80,6 +80,10 @@ describe('ThemeContext', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Cookie-auth: AuthProvider only probes /auth/profile when the non-secret
+    // `authenticated` hint cookie is present. Set it so the provider hydrates
+    // the user (the getUserProfile mock then decides authed vs signed-out).
+    document.cookie = 'authenticated=1';
     localStorageMock.clear();
 
     // Install spies on the real DOM nodes so @testing-library/react keeps

--- a/src/hooks/__tests__/useProjectForm.test.tsx
+++ b/src/hooks/__tests__/useProjectForm.test.tsx
@@ -86,6 +86,10 @@ describe('useProjectForm', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Cookie-auth: AuthProvider only probes /auth/profile when the non-secret
+    // `authenticated` hint cookie is present. Set it so the provider hydrates
+    // the user (the getUserProfile mock then decides authed vs signed-out).
+    document.cookie = 'authenticated=1';
   });
 
   describe('initial state', () => {

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -33,7 +33,7 @@ import TopToolbar from './components/TopToolbar';
 import PolygonListPanel from './components/PolygonListPanel';
 import SpermInstancePanel from './components/SpermInstancePanel';
 import MicrotubuleInstancePanel from './components/MicrotubuleInstancePanel';
-import { isMicrotubuleInstance } from './utils/instanceColors';
+import { usePolygonRenderProps } from './hooks/usePolygonRenderProps';
 import ChannelsSection from './components/sidebar/ChannelsSection';
 import DisplaySection from './components/sidebar/DisplaySection';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
@@ -45,7 +45,6 @@ import CanvasContent from './components/canvas/CanvasContent';
 import VideoFrameImage from './components/canvas/VideoFrameImage';
 import FrameWindowPrefetcher from './components/canvas/FrameWindowPrefetcher';
 import FrameLoadingGate from './components/canvas/FrameLoadingGate';
-import { polygonVisibilityManager } from '@/lib/rendering/PolygonVisibilityManager';
 import { SegmentChannelDialog } from '@/components/project/SegmentChannelDialog';
 import CanvasPolygon from './components/canvas/CanvasPolygon';
 import CanvasSvgFilters from './components/canvas/CanvasSvgFilters';
@@ -1113,45 +1112,24 @@ const SegmentationEditor = () => {
   );
 
   // Check if any polylines exist to conditionally show SpermInstancePanel
-  const hasPolylines = useMemo(
-    () => editor.polygons.some(p => p.geometry === 'polyline'),
-    [editor.polygons]
-  );
-
-  // Discriminate sperm vs microtubule projects so the sidebar shows the
-  // right panel. Authoritative signal: `polygon.class` ('sperm' or
-  // 'microtubule') is stamped by the ML model when it produces the
-  // polygon. Each project uses one model, so the first polyline whose
-  // class we recognise is sufficient — no majority-counting needed.
-  // Legacy/manually-drawn polylines without `class` fall back to
-  // `partClass` (sperm head/midpiece/tail) or `mt_` instanceId prefix.
-  const polylineKind = useMemo<'sperm' | 'microtubule' | null>(() => {
-    for (const p of editor.polygons) {
-      if (p.geometry !== 'polyline') continue;
-      if (p.class === 'microtubule') return 'microtubule';
-      if (p.class === 'sperm') return 'sperm';
-      if (p.partClass) return 'sperm';
-      if (isMicrotubuleInstance(p.instanceId)) return 'microtubule';
-    }
-    return null;
-  }, [editor.polygons]);
-
-  // Compute available sperm instance IDs for context menu (from existing polylines + active).
-  // Two-stage memo: first derive a stable string key, then split into array only when key changes.
-  // This prevents new array references on unrelated polygon edits (e.g. vertex drags).
-  const availableInstanceKey = useMemo(() => {
-    const ids = new Set<string>();
-    for (const p of editor.polygons) {
-      if (p.geometry === 'polyline' && p.instanceId) ids.add(p.instanceId);
-    }
-    ids.add(activeInstanceId);
-    return Array.from(ids).sort().join(',');
-  }, [editor.polygons, activeInstanceId]);
-
-  const availableInstanceIds = useMemo(
-    () => availableInstanceKey.split(',').filter(Boolean),
-    [availableInstanceKey]
-  );
+  // Pure render-derivation pipeline (polyline/instance discrimination, legacy
+  // edit-mode booleans, two-stage hidden/degenerate → frustum-cull filter).
+  // Extracted to usePolygonRenderProps for isolated unit testing.
+  const {
+    hasPolylines,
+    polylineKind,
+    availableInstanceIds,
+    legacyModes,
+    visiblePolygons,
+    frameHiddenIds,
+  } = usePolygonRenderProps({
+    editor,
+    hiddenPolygonIds,
+    imageDimensions,
+    canvasWidth,
+    canvasHeight,
+    activeInstanceId,
+  });
 
   // Generic handler for updating a single field on a polygon by ID
   const handleUpdatePolygonField = useCallback(
@@ -1198,17 +1176,6 @@ const SegmentationEditor = () => {
   // throws "Cannot access 'X' before initialization" at runtime. Moved
   // ~100 lines down to live next to `const video = useVideoFrames(...)`.
 
-  // Convert new EditMode to legacy booleans for compatibility
-  const legacyModes = useMemo(
-    () => ({
-      editMode: editor.editMode === EditMode.EditVertices,
-      slicingMode: editor.editMode === EditMode.Slice,
-      pointAddingMode: editor.editMode === EditMode.AddPoints,
-      deleteMode: editor.editMode === EditMode.DeletePolygon,
-    }),
-    [editor.editMode]
-  );
-
   // Compute navigation context that EditorHeader uses for the
   // currentImageIndex / totalImages display + the Back/Next disabled
   // gating. For video frame children we treat the sibling frames as the
@@ -1237,63 +1204,6 @@ const SegmentationEditor = () => {
   }, [projectImages, imageId]);
 
   const currentImageIndex = navContext.index;
-
-  // Stage 1: filter hidden / degenerate polygons.
-  const renderablePolygons = useMemo(
-    () =>
-      editor.polygons.filter(polygon => {
-        if (hiddenPolygonIds.has(polygonKey(polygon)) || !polygon.points)
-          return false;
-        const minPoints = polygon.geometry === 'polyline' ? 2 : 3;
-        return polygon.points.length >= minPoints;
-      }),
-    [editor.polygons, hiddenPolygonIds]
-  );
-
-  // Stage 2: frustum-cull off-viewport polygons via the visibility manager.
-  // The manager's internal threshold guards small counts (< 10 polygons
-  // → no culling), so MT/single-polyline cases pay zero overhead. Sperm
-  // projects with 50+ polylines at high zoom typically halve the SVG
-  // node count under this filter. We pass through `selectedPolygonId`
-  // so the manager never culls the focused polygon even if it scrolls
-  // off-screen briefly during a drag.
-  const visiblePolygons = useMemo(() => {
-    if (renderablePolygons.length < 10) return renderablePolygons;
-    const containerWidth = imageDimensions?.width || canvasWidth;
-    const containerHeight = imageDimensions?.height || canvasHeight;
-    return polygonVisibilityManager.getVisiblePolygons(renderablePolygons, {
-      zoom: editor.transform.zoom,
-      offset: {
-        x: editor.transform.translateX,
-        y: editor.transform.translateY,
-      },
-      containerWidth,
-      containerHeight,
-      selectedPolygonId: editor.selectedPolygonId,
-      forceRenderSelected: true,
-    }).visiblePolygons;
-  }, [
-    renderablePolygons,
-    editor.transform.zoom,
-    editor.transform.translateX,
-    editor.transform.translateY,
-    editor.selectedPolygonId,
-    imageDimensions,
-    canvasWidth,
-    canvasHeight,
-  ]);
-
-  // Panels still consume polygon.id, so project the stable-key set
-  // down per frame.
-  const frameHiddenIds = useMemo(
-    () =>
-      new Set(
-        editor.polygons
-          .filter(p => hiddenPolygonIds.has(polygonKey(p)))
-          .map(p => p.id)
-      ),
-    [editor.polygons, hiddenPolygonIds]
-  );
 
   // Video mode: derive videoContainerId from the selected row. Frames
   // (which are what the user opens in practice) carry the container id

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -16,9 +16,8 @@ import { useSegmentationReload } from './hooks/useSegmentationReload';
 import { useSegmentationQueue } from '@/hooks/useSegmentationQueue';
 import { useCoordinatedAbortController } from '@/hooks/shared/useAbortController';
 import useDebounce from '@/hooks/useDebounce';
-import { EditMode } from './types';
 import { shouldPreventCanvasDeselection } from './config/modeConfig';
-import { Polygon, polygonKey, type PolygonKey } from '@/lib/segmentation';
+import { polygonKey } from '@/lib/segmentation';
 import apiClient, { SegmentationPolygon } from '@/lib/api';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
@@ -26,6 +25,7 @@ import { handleCancelledError } from '@/lib/errorUtils';
 import { generateSafePolygonKey } from '@/lib/polygonIdUtils';
 import { ensureBrowserCompatibleUrl } from '@/lib/tiffUtils';
 import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
+import { usePolygonHandlers } from './hooks/usePolygonHandlers';
 
 // New layout components
 import VerticalToolbar from './components/VerticalToolbar';
@@ -155,20 +155,6 @@ const SegmentationEditor = () => {
     width: number;
     height: number;
   } | null>(null);
-  // Stores STABLE keys (trackId where present, else polygon.id) so a
-  // microtubule hidden on one frame stays hidden when the user scrubs.
-  // Branded `Set<PolygonKey>` makes accidental key-by-other-string a
-  // compile error.
-  const [hiddenPolygonIds, setHiddenPolygonIds] = useState<Set<PolygonKey>>(
-    new Set()
-  );
-  // Cross-frame selection persistence: when the user picks an MT
-  // polyline, remember its trackId so frame scrubs can re-select the
-  // same MT instance on the new frame. null = no persistent selection.
-  const [persistedSelectionTrackId, setPersistedSelectionTrackId] = useState<
-    string | null
-  >(null);
-  const [hoveredPolygonId, setHoveredPolygonId] = useState<string | null>(null);
   const [canvasDimensions, setCanvasDimensions] = useState({
     width: 800,
     height: 600,
@@ -725,44 +711,6 @@ const SegmentationEditor = () => {
     queryClient,
   ]);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') return;
-    const filteredPolygons = editor.polygons.filter(
-      polygon => !hiddenPolygonIds.has(polygonKey(polygon))
-    );
-    logger.debug('🎨 Polygon rendering state:', {
-      totalPolygons: editor.polygons.length,
-      visiblePolygons: filteredPolygons.length,
-      hiddenCount: hiddenPolygonIds.size,
-      imageDimensions,
-      transform: editor.transform,
-      svgViewBox: `0 0 ${imageDimensions?.width || canvasWidth} ${imageDimensions?.height || canvasHeight}`,
-      firstPolygon: filteredPolygons[0]
-        ? {
-            id: filteredPolygons[0].id,
-            pointsCount: filteredPolygons[0].points?.length || 0,
-            samplePoints: filteredPolygons[0].points?.slice(0, 5),
-            bounds:
-              filteredPolygons[0].points?.length > 0
-                ? {
-                    minX: Math.min(...filteredPolygons[0].points.map(p => p.x)),
-                    maxX: Math.max(...filteredPolygons[0].points.map(p => p.x)),
-                    minY: Math.min(...filteredPolygons[0].points.map(p => p.y)),
-                    maxY: Math.max(...filteredPolygons[0].points.map(p => p.y)),
-                  }
-                : null,
-          }
-        : null,
-    });
-  }, [
-    editor.polygons,
-    hiddenPolygonIds,
-    imageDimensions,
-    canvasHeight,
-    canvasWidth,
-    editor.transform,
-  ]);
-
   // Listen for segmentation completion and auto-reload polygons (debounced) with cancellation
   const handleSegmentationStatusUpdate = useCallback(() => {
     // Only proceed if we have a WebSocket update for the current image
@@ -983,133 +931,25 @@ const SegmentationEditor = () => {
     }
   };
 
-  // Legacy compatibility handlers
-  const handleTogglePolygonVisibility = (polygonId: string) => {
-    // Map current-frame polygon.id → stable key (trackId or id) so the
-    // hide state survives frame changes for MTs.
-    const target = editor.polygons.find(p => p.id === polygonId);
-    if (!target) return;
-    const key = polygonKey(target);
-    setHiddenPolygonIds(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(key)) {
-        newSet.delete(key);
-      } else {
-        newSet.add(key);
-      }
-      return newSet;
-    });
-  };
-
-  const handleDeletePolygonFromPanel = (polygonId: string) => {
-    const target = editor.polygons.find(p => p.id === polygonId);
-    editor.handleDeletePolygon(polygonId);
-    if (target) {
-      const key = polygonKey(target);
-      setHiddenPolygonIds(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(key);
-        return newSet;
-      });
-    }
-  };
-
-  // Capture trackId at click so frame scrubbing re-attaches selection
-  // to the same MT instance on the new frame.
-  const handleSelectPolygon = useCallback(
-    (polygonId: string | null) => {
-      if (polygonId === null) {
-        setPersistedSelectionTrackId(null);
-      } else {
-        const p = editor.polygons.find(x => x.id === polygonId);
-        setPersistedSelectionTrackId(p?.trackId ?? null);
-      }
-      editor.handlePolygonSelection(polygonId);
-    },
-    [editor]
-  );
-
-  // Cross-frame selection remap. When polygons load for a new frame
-  // (initialPolygons replaces editor.polygons), find the polygon that
-  // shares the persisted trackId and re-select it. If no sibling exists
-  // on this frame (track wasn't matched here), selection is left null
-  // by the editor's own image-change reset and we don't fight it — but
-  // we log so a missing match is debuggable when a user reports
-  // "selection lost".
-  useEffect(() => {
-    if (!persistedSelectionTrackId) return;
-    const match = editor.polygons.find(
-      p => p.trackId === persistedSelectionTrackId
-    );
-    if (match) {
-      if (editor.selectedPolygonId !== match.id) {
-        editor.setSelectedPolygonId(match.id);
-      }
-    } else if (editor.polygons.length > 0) {
-      // Polygons loaded but no match — track is not present on this
-      // frame. Surface via debug log so support can correlate user
-      // reports; UI deliberately stays quiet (toast on every scrub past
-      // a gap would be obnoxious).
-      logger.debug('Selected MT track not present on current frame', {
-        trackId: persistedSelectionTrackId,
-        frameImageId: imageId,
-      });
-    }
-    // Intentionally narrow deps: passing the whole `editor` object
-    // would re-fire on every render of useEnhancedSegmentationEditor
-    // (cursor moves, hovers). The destructured fields capture
-    // exactly the state this effect needs to react to.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    editor.polygons,
-    persistedSelectionTrackId,
-    editor.selectedPolygonId,
-    editor.setSelectedPolygonId,
-    imageId,
-  ]);
-
-  // Context menu handlers for polygon right-click
-  const handleDeletePolygonFromContextMenu = useCallback(
-    (polygonId: string) => {
-      const target = editor.polygons.find(p => p.id === polygonId);
-      editor.handleDeletePolygon(polygonId);
-      if (target) {
-        const key = polygonKey(target);
-        setHiddenPolygonIds(prev => {
-          const newSet = new Set(prev);
-          newSet.delete(key);
-          return newSet;
-        });
-      }
-    },
-    [editor]
-  );
-
-  const handleSlicePolygonFromContextMenu = useCallback(
-    (polygonId: string) => {
-      // Select the polygon and switch to slice mode (skip to step 2)
-      editor.setSelectedPolygonId(polygonId);
-      editor.setEditMode(EditMode.Slice);
-    },
-    [editor]
-  );
-
-  const handleEditPolygonFromContextMenu = useCallback(
-    (polygonId: string) => {
-      // Select the polygon and switch to edit vertices mode
-      editor.setSelectedPolygonId(polygonId);
-      editor.setEditMode(EditMode.EditVertices);
-    },
-    [editor]
-  );
-
-  // Context menu handlers for vertex right-click
-  const handleDeleteVertexFromContextMenu = useCallback(
-    (polygonId: string, vertexIndex: number) => {
-      editor.handleDeleteVertex(polygonId, vertexIndex);
-    },
-    [editor]
-  );
+  // Polygon CRUD handlers + owned state (hiddenPolygonIds, hoveredPolygonId,
+  // persistedSelectionTrackId) + the MT cross-frame selection remap effect.
+  // Called BEFORE usePolygonRenderProps because that hook takes hiddenPolygonIds
+  // as a parameter.
+  const {
+    hiddenPolygonIds,
+    hoveredPolygonId,
+    setHoveredPolygonId,
+    handleTogglePolygonVisibility,
+    handleDeletePolygonFromPanel,
+    handleSelectPolygon,
+    handleDeletePolygonFromContextMenu,
+    handleSlicePolygonFromContextMenu,
+    handleEditPolygonFromContextMenu,
+    handleDeleteVertexFromContextMenu,
+    handleRenamePolygon,
+    handleChangeInstanceId,
+    handleChangePartClass,
+  } = usePolygonHandlers({ editor, imageId });
 
   // Check if any polylines exist to conditionally show SpermInstancePanel
   // Pure render-derivation pipeline (polyline/instance discrimination, legacy
@@ -1131,38 +971,45 @@ const SegmentationEditor = () => {
     activeInstanceId,
   });
 
-  // Generic handler for updating a single field on a polygon by ID
-  const handleUpdatePolygonField = useCallback(
-    (polygonId: string, updates: Partial<Polygon>) => {
-      const currentPolygons = editor.getPolygons();
-      const updatedPolygons = currentPolygons.map(p =>
-        p.id === polygonId ? { ...p, ...updates } : p
-      );
-      editor.updatePolygons(updatedPolygons);
-    },
-    // editor object reference is stable; tracking individual methods avoids
-    // re-creating this callback when unrelated editor state changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [editor.getPolygons, editor.updatePolygons]
-  );
-
-  const handleRenamePolygon = useCallback(
-    (polygonId: string, name: string) =>
-      handleUpdatePolygonField(polygonId, { name }),
-    [handleUpdatePolygonField]
-  );
-
-  const handleChangeInstanceId = useCallback(
-    (polygonId: string, instanceId: string) =>
-      handleUpdatePolygonField(polygonId, { instanceId }),
-    [handleUpdatePolygonField]
-  );
-
-  const handleChangePartClass = useCallback(
-    (polygonId: string, partClass: 'head' | 'midpiece' | 'tail') =>
-      handleUpdatePolygonField(polygonId, { partClass }),
-    [handleUpdatePolygonField]
-  );
+  // Development-only debug logger: logs polygon rendering state.
+  // Moved here (after usePolygonHandlers) so hiddenPolygonIds is in scope.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+    const filteredPolygons = editor.polygons.filter(
+      polygon => !hiddenPolygonIds.has(polygonKey(polygon))
+    );
+    logger.debug('🎨 Polygon rendering state:', {
+      totalPolygons: editor.polygons.length,
+      visiblePolygons: filteredPolygons.length,
+      hiddenCount: hiddenPolygonIds.size,
+      imageDimensions,
+      transform: editor.transform,
+      svgViewBox: `0 0 ${imageDimensions?.width || canvasWidth} ${imageDimensions?.height || canvasHeight}`,
+      firstPolygon: filteredPolygons[0]
+        ? {
+            id: filteredPolygons[0].id,
+            pointsCount: filteredPolygons[0].points?.length || 0,
+            samplePoints: filteredPolygons[0].points?.slice(0, 5),
+            bounds:
+              filteredPolygons[0].points?.length > 0
+                ? {
+                    minX: Math.min(...filteredPolygons[0].points.map(p => p.x)),
+                    maxX: Math.max(...filteredPolygons[0].points.map(p => p.x)),
+                    minY: Math.min(...filteredPolygons[0].points.map(p => p.y)),
+                    maxY: Math.max(...filteredPolygons[0].points.map(p => p.y)),
+                  }
+                : null,
+          }
+        : null,
+    });
+  }, [
+    editor.polygons,
+    hiddenPolygonIds,
+    imageDimensions,
+    canvasHeight,
+    canvasWidth,
+    editor.transform,
+  ]);
 
   // Re-run ML segmentation on the currently-open frame using the
   // user-selected model + threshold. Overwrites the existing

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -23,13 +23,9 @@ import apiClient, { SegmentationPolygon } from '@/lib/api';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { handleCancelledError } from '@/lib/errorUtils';
-import {
-  generateSafePolygonKey,
-  validatePolygonId,
-  ensureValidPolygonId,
-  logPolygonIdIssue,
-} from '@/lib/polygonIdUtils';
+import { generateSafePolygonKey } from '@/lib/polygonIdUtils';
 import { ensureBrowserCompatibleUrl } from '@/lib/tiffUtils';
+import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
 
 // New layout components
 import VerticalToolbar from './components/VerticalToolbar';
@@ -323,123 +319,10 @@ const SegmentationEditor = () => {
   const canvasHeight = canvasDimensions.height;
 
   // Get initial polygons from segmentation data
-  const initialPolygons = useMemo(() => {
-    // Return empty array if no segmentation data exists or if it's not an array
-    if (
-      !segmentationPolygons ||
-      !Array.isArray(segmentationPolygons) ||
-      segmentationPolygons.length === 0
-    ) {
-      return [];
-    }
-
-    // For large datasets, process in chunks to prevent blocking
-    const startTime = performance.now();
-
-    // Transform SegmentationPolygon[] to Polygon[] and filter out invalid polygons.
-    // Spreads `segPoly` so any wire-level field (trackId, future additions) reaches
-    // the editor without manual maintenance; only parentIds[] needs explicit
-    // conversion to parent_id (singular).
-    const polygons: Polygon[] = segmentationPolygons
-      .filter(segPoly => {
-        const minPoints = segPoly.geometry === 'polyline' ? 2 : 3;
-        return segPoly.points && segPoly.points.length >= minPoints;
-      })
-      .map((segPoly): Polygon | null => {
-        const validPoints = segPoly.points
-          .map(point => {
-            if (Array.isArray(point)) {
-              return { x: point[0], y: point[1] };
-            }
-            if (typeof point === 'object' && point !== null) {
-              if (typeof point.x === 'number' && typeof point.y === 'number') {
-                return point;
-              }
-              logger.warn(
-                'Skipping invalid point with non-numeric coordinates',
-                point
-              );
-              return null;
-            }
-            logger.warn('Skipping invalid point format', point);
-            return null;
-          })
-          .filter((point): point is { x: number; y: number } => point !== null);
-
-        const minValidPoints = segPoly.geometry === 'polyline' ? 2 : 3;
-        if (validPoints.length < minValidPoints) {
-          logger.warn('Dropping polygon due to insufficient valid points', {
-            polygonId: segPoly.id,
-          });
-          return null;
-        }
-
-        let polygonId = segPoly.id;
-        if (!validatePolygonId(segPoly.id)) {
-          logPolygonIdIssue(
-            segPoly,
-            'Invalid or missing polygon ID from ML service'
-          );
-          polygonId = ensureValidPolygonId(segPoly.id, 'ml_polygon');
-          logger.warn(
-            `Generated fallback ID: ${polygonId} for polygon with invalid ID: ${segPoly.id}`
-          );
-        }
-
-        const { parentIds, ...rest } = segPoly;
-        return {
-          ...rest,
-          id: polygonId,
-          points: validPoints,
-          parent_id: parentIds?.[0],
-        };
-      })
-      .filter((polygon): polygon is Polygon => polygon !== null);
-
-    const invalidCount = segmentationPolygons.length - polygons.length;
-    const processingTime = performance.now() - startTime;
-
-    if (invalidCount > 0) {
-      logger.warn(
-        `⚠️ Filtered out ${invalidCount} invalid polygons (missing or insufficient points)`
-      );
-    }
-
-    // Monitor processing time to detect performance issues
-    if (processingTime > 100) {
-      logger.warn(
-        `⚠️ Polygon processing took ${processingTime.toFixed(2)}ms for ${segmentationPolygons.length} polygons`
-      );
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      logger.debug('🔄 Transformed segmentation polygons for editor:', {
-        hasSegmentationData: true,
-        inputCount: segmentationPolygons.length,
-        validCount: polygons.length,
-        filteredOut: invalidCount,
-        processingTime: `${processingTime.toFixed(2)}ms`,
-        imageDimensions,
-        firstPolygon: polygons[0]
-          ? {
-              id: polygons[0].id,
-              type: polygons[0].type,
-              parent_id: polygons[0].parent_id,
-              pointsCount: polygons[0].points?.length || 0,
-              firstPoints: polygons[0].points?.slice(0, 3),
-            }
-          : null,
-        internalPolygonCount: polygons.filter(
-          p => p.type === 'internal' || p.parent_id
-        ).length,
-        externalPolygonCount: polygons.filter(
-          p => p.type === 'external' && !p.parent_id
-        ).length,
-      });
-    }
-
-    return polygons;
-  }, [segmentationPolygons, imageDimensions]);
+  const initialPolygons = useMemo(
+    () => transformSegmentationPolygons(segmentationPolygons, imageDimensions),
+    [segmentationPolygons, imageDimensions]
+  );
 
   // Determine if we should trigger auto-center (only on initial load from Project Detail)
   const shouldAutoCenter = useRef(false);

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -27,6 +27,7 @@ import { ensureBrowserCompatibleUrl } from '@/lib/tiffUtils';
 import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
 import { usePolygonHandlers } from './hooks/usePolygonHandlers';
 import { useSegmentationLoader } from './hooks/useSegmentationLoader';
+import { useResegment } from './hooks/useResegment';
 
 // New layout components
 import VerticalToolbar from './components/VerticalToolbar';
@@ -86,9 +87,6 @@ const SegmentationEditor = () => {
   const isInitialLoadRef = useRef(true);
   const previousImageIdRef = useRef<string | undefined>(undefined);
   const currentImageIdRef = useRef<string | undefined>(imageId);
-  // Monotonic token for the background resegment-completion poll so a new
-  // resegment (or image switch) invalidates a still-running poll.
-  const resegPollSeqRef = useRef(0);
 
   // Coordinated AbortController for all segmentation operations
   const { getSignal, abortAllOperations, abortAll } =
@@ -144,7 +142,6 @@ const SegmentationEditor = () => {
     [projectTitle]
   );
 
-  const [isResegmenting, setIsResegmenting] = useState(false);
   const [canvasDimensions, setCanvasDimensions] = useState({
     width: 800,
     height: 600,
@@ -804,176 +801,29 @@ const SegmentationEditor = () => {
     !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
 
   // ───────────────── Resegment chain ─────────────────
-  // Re-runs ML segmentation on the currently-open frame. Lives HERE
-  // (after `const video = useVideoFrames`) because
-  // `handleResegmentCurrentFrame` captures `video.container`; placing
-  // the useCallback above the const triggers a TDZ at runtime that
-  // the minifier surfaces as "Cannot access 'X' before initialization"
-  // (CLAUDE.md production bug #11).
-
-  // The backend enforces a per-project-type model whitelist. The
-  // user-chosen `selectedModel` is meaningful only for the generic
-  // spheroid project — typed projects must use their matching model
-  // (`spheroid_invasive` → `unet_attention_aspp` per backend's
-  // MODEL_TYPE_COMPATIBILITY) or the request gets rejected.
-  const effectiveResegmentModel = useMemo(() => {
-    if (projectType === 'microtubules') return 'microtubule';
-    if (projectType === 'sperm') return 'sperm';
-    if (projectType === 'wound') return 'wound';
-    if (projectType === 'spheroid_invasive') return 'unet_attention_aspp';
-    return selectedModel;
-  }, [projectType, selectedModel]);
-
-  // Channel picker state for multi-channel video frames.
-  const [showResegmentChannelDialog, setShowResegmentChannelDialog] =
-    useState(false);
-
-  // Background poll that refreshes the editor when a resegment completes.
-  // The WebSocket completion event is not a dependable trigger, so we poll
-  // the result's `updatedAt` over plain HTTP (no AbortController, so a
-  // re-rendering editor can't cancel it) and apply the fresh polygons
-  // directly once it advances. A seq token invalidates a stale poll when a
-  // new resegment starts or the user switches frames.
-  const startResegmentPoll = useCallback(
-    (targetImageId: string, prevStamp: string | null, announce: boolean) => {
-      const seq = ++resegPollSeqRef.current;
-      const deadline = Date.now() + 120_000;
-      const tick = async () => {
-        if (
-          seq !== resegPollSeqRef.current ||
-          targetImageId !== currentImageIdRef.current ||
-          Date.now() > deadline
-        ) {
-          return;
-        }
-        let fresh = null;
-        try {
-          fresh = await apiClient.getSegmentationResults(targetImageId);
-        } catch {
-          // transient — keep polling
-        }
-        if (
-          seq !== resegPollSeqRef.current ||
-          targetImageId !== currentImageIdRef.current
-        ) {
-          return;
-        }
-        if (fresh && fresh.updatedAt && fresh.updatedAt !== prevStamp) {
-          // Apply the already-fetched fresh result DIRECTLY rather than via
-          // reloadSegmentation. reloadSegmentation runs a second fetch behind
-          // its own AbortController + cleanup, which a concurrent reload (or
-          // the editor's churn) can cancel — leaving onPolygonsLoaded (and
-          // the reloadNonce bump) unfired. Here we:
-          //   1. write the React Query cache so the editor's load effect
-          //      (which re-runs on the segmentationStatus flip and reads
-          //      cache-first) can't clobber us back to the stale result, and
-          //   2. push state + bump reloadNonce via handleReloadedPolygons so
-          //      the canvas re-syncs even at an unchanged polygon count.
-          if (fresh.imageWidth && fresh.imageHeight) {
-            setImageDimensions({
-              width: fresh.imageWidth,
-              height: fresh.imageHeight,
-            });
-          }
-          setCachedSegmentationPolygons(queryClient, targetImageId, {
-            polygons: fresh.polygons ?? null,
-            imageWidth: fresh.imageWidth,
-            imageHeight: fresh.imageHeight,
-          });
-          handleReloadedPolygons(fresh.polygons ?? null);
-          if (announce) {
-            toast.success(t('segmentation.toolbar.resegmentSuccess'));
-          }
-          return;
-        }
-        setTimeout(tick, 2000);
-      };
-      setTimeout(tick, 2000);
-    },
-    [handleReloadedPolygons, setImageDimensions, queryClient, t]
-  );
-
-  // Pure request helper — shared by the direct (single-channel) path
-  // and the dialog's onConfirm callback.
-  const runResegment = useCallback(
-    async (channel?: string) => {
-      if (!imageId || isResegmenting) return;
-      setIsResegmenting(true);
-      try {
-        // Snapshot the current result timestamp so the completion poll can
-        // tell when the ML has written the *new* segmentation.
-        const prevStamp =
-          (await apiClient.getSegmentationResults(imageId).catch(() => null))
-            ?.updatedAt ?? null;
-        const result = await apiClient.requestBatchSegmentation(
-          [imageId],
-          effectiveResegmentModel,
-          confidenceThreshold,
-          detectHoles,
-          channel
-        );
-        // Batch endpoint returns HTTP 200 even when every image failed;
-        // surface the per-image outcome (review pass-2 silent-failure #5).
-        if (result.successful === 0) {
-          const firstError = result.results?.[0]?.error;
-          logger.error('Resegment returned 0 successes', { firstError });
-          toast.error(
-            firstError
-              ? `${t('segmentation.toolbar.resegmentFailed')}: ${firstError}`
-              : t('segmentation.toolbar.resegmentFailed')
-          );
-          return;
-        }
-        // Defense-in-depth: a 1-image call is always all-or-nothing,
-        // but if the helper is ever reused with >1 imageIds a partial
-        // failure must not be hidden by the success toast.
-        if (result.failed > 0) {
-          const firstError = result.results?.find(r => !r.success)?.error;
-          logger.warn('Resegment partial failure', { result });
-          toast.warning(
-            firstError
-              ? `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed: ${firstError})`
-              : `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed)`
-          );
-        }
-        // The job is now QUEUED — the ML has not produced the new polygons
-        // yet. Kick off a non-blocking background poll that refreshes the
-        // canvas + fires the success toast once the new segmentation lands;
-        // isResegmenting is cleared right away (finally) so the button never
-        // appears stuck while the ML runs.
-        startResegmentPoll(imageId, prevStamp, result.failed === 0);
-      } catch (err) {
-        if (handleCancelledError(err, 'resegment current frame')) return;
-        logger.error('Resegment failed', err);
-        toast.error(t('segmentation.toolbar.resegmentFailed'));
-      } finally {
-        setIsResegmenting(false);
-      }
-    },
-    [
-      imageId,
-      isResegmenting,
-      effectiveResegmentModel,
-      confidenceThreshold,
-      detectHoles,
-      startResegmentPoll,
-      t,
-    ]
-  );
-
-  // Top-toolbar Resegment entry point. Multichannel videos open the
-  // channel picker first (per CLAUDE.md spec); single-channel cases
-  // commit immediately.
-  const handleResegmentCurrentFrame = useCallback(() => {
-    if (!imageId || isResegmenting) return;
-    const channels = video.container?.channels ?? [];
-    if (channels.length > 1) {
-      setShowResegmentChannelDialog(true);
-      return;
-    }
-    void runResegment();
-  }, [imageId, isResegmenting, video.container, runResegment]);
-
+  // Lives HERE (after `const video = useVideoFrames`) to avoid the TDZ that
+  // would result from passing video.container?.channels before `video` is
+  // defined. CLAUDE.md production bug #11.
+  const {
+    isResegmenting,
+    showResegmentChannelDialog,
+    setShowResegmentChannelDialog,
+    runResegment,
+    handleResegmentCurrentFrame,
+  } = useResegment({
+    projectId,
+    imageId,
+    projectType,
+    selectedModel,
+    confidenceThreshold,
+    detectHoles,
+    videoChannels: video.container?.channels ?? null,
+    queryClient,
+    t,
+    onReloaded: handleReloadedPolygons,
+    setImageDimensions,
+    currentImageIdRef,
+  });
   // ─────────────── End resegment chain ───────────────
 
   // The overlay debounce moved into `FrameLoadingGate` — it needs

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -26,6 +26,7 @@ import { generateSafePolygonKey } from '@/lib/polygonIdUtils';
 import { ensureBrowserCompatibleUrl } from '@/lib/tiffUtils';
 import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
 import { usePolygonHandlers } from './hooks/usePolygonHandlers';
+import { useSegmentationLoader } from './hooks/useSegmentationLoader';
 
 // New layout components
 import VerticalToolbar from './components/VerticalToolbar';
@@ -62,10 +63,7 @@ import EditorLayout from './components/layout/EditorLayout';
 import { VideoModeOverlay } from './components/VideoModeOverlay';
 import { ImageDisplayProvider } from './contexts/ImageDisplayContext';
 import { useVideoFrames } from './hooks/useVideoFrames';
-import {
-  getCachedSegmentationPolygons,
-  setCachedSegmentationPolygons,
-} from './hooks/segmentationPolygonCache';
+import { setCachedSegmentationPolygons } from './hooks/segmentationPolygonCache';
 
 const EMPTY_HOVERED_VERTEX = { polygonId: null, vertexIndex: null } as const;
 
@@ -146,27 +144,30 @@ const SegmentationEditor = () => {
     [projectTitle]
   );
 
-  // State for segmentation polygons from API
-  const [segmentationPolygons, setSegmentationPolygons] = useState<
-    SegmentationPolygon[] | null
-  >(null);
   const [isResegmenting, setIsResegmenting] = useState(false);
-  const [imageDimensions, setImageDimensions] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
   const [canvasDimensions, setCanvasDimensions] = useState({
     width: 800,
     height: 600,
   });
-  // `loadedFrameKey` is `${imageId}::${channelsKey}` — both axes
-  // need to match before the Skeleton overlay can step aside.
-  // Tracking just `imageId` would let a channel toggle keep a stale
-  // composite painted while the new channel still decodes.
-  // The debounce that latches "show overlay" lives inside
-  // `FrameLoadingGate`, which is rendered under ImageDisplayProvider
-  // (it needs `visibleChannels` to construct the target key).
-  const [loadedFrameKey, setLoadedFrameKey] = useState<string | null>(null);
+
+  // Segmentation data-load cluster: polygons + dimensions + loadedFrameKey state
+  // + the primary loadSegmentation effect (cache-first → API) + handleImageLoad.
+  const {
+    segmentationPolygons,
+    setSegmentationPolygons,
+    imageDimensions,
+    setImageDimensions,
+    loadedFrameKey,
+    handleImageLoad,
+  } = useSegmentationLoader({
+    projectId,
+    imageId,
+    selectedImage,
+    getSignal,
+    queryClient,
+    t,
+    currentImageIdRef,
+  });
 
   // Bumped every time fresh segmentation data is reloaded (resegment / WS
   // completion). The editor's polygon-sync effect keys on this so a reload
@@ -178,7 +179,7 @@ const SegmentationEditor = () => {
       setSegmentationPolygons(polys);
       setReloadNonce(n => n + 1);
     },
-    []
+    [setSegmentationPolygons]
   );
 
   // Use custom hook for segmentation reload logic
@@ -471,246 +472,6 @@ const SegmentationEditor = () => {
     // 3. Leaving the editor (unmount autosave)
   });
 
-  // Load segmentation data with proper cancellation handling
-  useEffect(() => {
-    let isMounted = true;
-
-    // Update current image ref immediately
-    currentImageIdRef.current = imageId;
-
-    const loadSegmentation = async () => {
-      if (!projectId || !imageId) return;
-
-      // Get abort signal for main loading operation
-      const signal = getSignal('main-loading');
-
-      // Immediately clear polygons when switching images to prevent showing old data
-      setSegmentationPolygons(null);
-      setImageDimensions(null); // Also clear image dimensions
-      logger.debug(
-        '🧹 Cleared polygons and dimensions for new image:',
-        imageId
-      );
-
-      // Check if the image has completed segmentation before trying to fetch results
-      const hasSegmentation =
-        selectedImage?.segmentationStatus === 'completed' ||
-        selectedImage?.segmentationStatus === 'segmented';
-
-      if (!hasSegmentation) {
-        logger.debug(
-          'Image does not have completed segmentation, skipping fetch:',
-          {
-            imageId,
-            status: selectedImage?.segmentationStatus,
-          }
-        );
-
-        // Set image dimensions from project data if available
-        if (selectedImage?.width && selectedImage?.height) {
-          logger.debug(
-            '📐 Setting image dimensions from project data (no segmentation):',
-            {
-              width: selectedImage.width,
-              height: selectedImage.height,
-            }
-          );
-          if (isMounted && imageId === currentImageIdRef.current) {
-            setImageDimensions({
-              width: selectedImage.width,
-              height: selectedImage.height,
-            });
-          }
-        }
-        return;
-      }
-
-      // Cache hit: serve a previously-fetched / prefetched result
-      // without going to the network. The shared React Query cache
-      // is populated by the editor's own success path below and by
-      // the `useFrameWindowPrefetch` sliding window, so scrub-back
-      // and pre-warmed frames paint instantly.
-      const cached = getCachedSegmentationPolygons(queryClient, imageId);
-      if (cached !== undefined) {
-        if (!isMounted || imageId !== currentImageIdRef.current) return;
-        if (cached.imageWidth && cached.imageHeight) {
-          setImageDimensions({
-            width: cached.imageWidth,
-            height: cached.imageHeight,
-          });
-        } else if (selectedImage?.width && selectedImage?.height) {
-          setImageDimensions({
-            width: selectedImage.width,
-            height: selectedImage.height,
-          });
-        }
-        setSegmentationPolygons(cached.polygons);
-        return;
-      }
-
-      try {
-        const segmentationData = await apiClient.getSegmentationResults(
-          imageId,
-          {
-            signal,
-          }
-        );
-
-        // Verify we're still on the same image and component is mounted
-        if (
-          !isMounted ||
-          imageId !== currentImageIdRef.current ||
-          signal.aborted
-        ) {
-          logger.debug(
-            '🛑 Segmentation load cancelled - image changed or component unmounted'
-          );
-          return;
-        }
-
-        // Populate the shared cache with the *normalised* result so
-        // a future scrub-back or window-prefetch read can serve from
-        // RAM. Empty / 404 frames are cached as `polygons: null` to
-        // avoid retry storms on a fast scrub across non-segmented
-        // frames.
-        if (segmentationData && !segmentationData.polygons) {
-          // Backend returned a non-null payload without a polygons
-          // field — distinguishes a misshaped 200 from a legitimate
-          // "no segmentation yet" so a misconfigured response doesn't
-          // silently masquerade as empty for 60 s of staleTime.
-          logger.warn(
-            'Segmentation response present but missing polygons field — caching as empty',
-            { imageId }
-          );
-        }
-        setCachedSegmentationPolygons(queryClient, imageId, {
-          polygons: segmentationData?.polygons ?? null,
-          imageWidth: segmentationData?.imageWidth,
-          imageHeight: segmentationData?.imageHeight,
-        });
-
-        // Handle empty or null segmentation gracefully
-        if (!segmentationData || !segmentationData.polygons) {
-          logger.debug('No segmentation data found for image:', imageId);
-          if (isMounted && imageId === currentImageIdRef.current) {
-            setSegmentationPolygons(null);
-          }
-
-          // Still try to set image dimensions from project data if available
-          if (selectedImage?.width && selectedImage?.height) {
-            logger.debug(
-              '📐 Setting image dimensions from project data (no segmentation):',
-              {
-                width: selectedImage.width,
-                height: selectedImage.height,
-              }
-            );
-            if (isMounted && imageId === currentImageIdRef.current) {
-              setImageDimensions({
-                width: selectedImage.width,
-                height: selectedImage.height,
-              });
-            }
-          }
-          return;
-        }
-
-        const polygons = segmentationData.polygons;
-
-        // Extract image dimensions from segmentation data if available
-        if (segmentationData.imageWidth && segmentationData.imageHeight) {
-          logger.debug('📐 Setting image dimensions from segmentation data:', {
-            width: segmentationData.imageWidth,
-            height: segmentationData.imageHeight,
-          });
-          if (isMounted && imageId === currentImageIdRef.current) {
-            setImageDimensions({
-              width: segmentationData.imageWidth,
-              height: segmentationData.imageHeight,
-            });
-          }
-        } else if (selectedImage?.width && selectedImage?.height) {
-          // Fallback to image dimensions from project data (database)
-          logger.debug(
-            '📐 Setting image dimensions from project data (fallback):',
-            {
-              width: selectedImage.width,
-              height: selectedImage.height,
-            }
-          );
-          if (isMounted && imageId === currentImageIdRef.current) {
-            setImageDimensions({
-              width: selectedImage.width,
-              height: selectedImage.height,
-            });
-          }
-        }
-
-        logger.debug('📥 Loaded segmentation polygons from API:', {
-          imageId,
-          polygonCount: polygons.length,
-          imageDimensions:
-            segmentationData.imageWidth && segmentationData.imageHeight
-              ? `${segmentationData.imageWidth}x${segmentationData.imageHeight}`
-              : 'not available',
-          firstPolygon: polygons[0]
-            ? {
-                id: polygons[0].id,
-                type: polygons[0].type,
-                pointsCount: polygons[0].points?.length || 0,
-                samplePoints: polygons[0].points?.slice(0, 3),
-              }
-            : null,
-        });
-
-        // Final check before setting state
-        if (isMounted && imageId === currentImageIdRef.current) {
-          setSegmentationPolygons(polygons);
-        }
-      } catch (error: any) {
-        // Handle cancellation gracefully - don't show errors for cancelled requests
-        if (handleCancelledError(error, 'segmentation loading')) {
-          return;
-        }
-
-        // Only handle real errors if we're still on the same image
-        if (isMounted && imageId === currentImageIdRef.current) {
-          logger.error('Failed to load segmentation:', error);
-          // Set to null instead of showing error for missing segmentation
-          if (
-            error &&
-            typeof error === 'object' &&
-            'response' in error &&
-            (error as { response?: { status?: number } }).response?.status ===
-              404
-          ) {
-            logger.debug('No segmentation found for image (404):', imageId);
-            setSegmentationPolygons(null);
-          } else {
-            toast.error(t('toast.operationFailed'));
-            setSegmentationPolygons(null);
-          }
-        }
-      }
-    };
-
-    loadSegmentation();
-
-    return () => {
-      isMounted = false;
-      // Don't abort here - let the coordinated controller handle it
-    };
-  }, [
-    projectId,
-    imageId,
-    t,
-    selectedImage?.width,
-    selectedImage?.height,
-    selectedImage?.segmentationStatus,
-    getSignal,
-    queryClient,
-  ]);
-
   // Listen for segmentation completion and auto-reload polygons (debounced) with cancellation
   const handleSegmentationStatusUpdate = useCallback(() => {
     // Only proceed if we have a WebSocket update for the current image
@@ -842,41 +603,6 @@ const SegmentationEditor = () => {
       abortAll();
     };
   }, [abortAll]);
-
-  // Handle image load to get dimensions (only if not already set from segmentation data)
-  const handleImageLoad = (
-    width: number,
-    height: number,
-    channelsKey: string
-  ) => {
-    // Mark this `(imageId, channels)` pair as visible so the Skeleton
-    // overlay can step aside. The channelsKey comes from the canvas
-    // that just finished compositing — see `MultiChannelCanvas.onLoad`.
-    if (imageId) setLoadedFrameKey(`${imageId}::${channelsKey}`);
-    setImageDimensions(current => {
-      // Only update if dimensions are not already set from segmentation data
-      if (!current) {
-        logger.debug('📐 Setting image dimensions from image load:', {
-          width,
-          height,
-        });
-        return { width, height };
-      }
-
-      // Log if dimensions differ between image and segmentation data
-      if (current.width !== width || current.height !== height) {
-        logger.warn('⚠️ Image dimensions mismatch:', {
-          fromSegmentation: current,
-          fromImage: { width, height },
-          imageId,
-        });
-        // Keep segmentation data dimensions (they're more reliable)
-        return current;
-      }
-
-      return current;
-    });
-  };
 
   // Navigation functions
   const navigateToImage = (direction: 'prev' | 'next') => {

--- a/src/pages/segmentation/hooks/__tests__/usePolygonHandlers.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonHandlers.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePolygonHandlers } from '../usePolygonHandlers';
+import { EditMode } from '../../types';
+import { polygonKey, type Polygon, type PolygonKey } from '@/lib/segmentation';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const makePoly = (over: Partial<Polygon> = {}): Polygon =>
+  ({
+    id: 'p1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    type: 'external',
+    class: 'spheroid',
+    geometry: 'polygon',
+    ...over,
+  }) as Polygon;
+
+const makeEditor = (polygons: Polygon[] = []) => ({
+  polygons,
+  selectedPolygonId: null as string | null,
+  handleDeletePolygon: vi.fn(),
+  handlePolygonSelection: vi.fn(),
+  setSelectedPolygonId: vi.fn(),
+  setEditMode: vi.fn(),
+  handleDeleteVertex: vi.fn(),
+  getPolygons: vi.fn(() => polygons),
+  updatePolygons: vi.fn(),
+});
+
+describe('usePolygonHandlers', () => {
+  let editor: ReturnType<typeof makeEditor>;
+
+  beforeEach(() => {
+    editor = makeEditor();
+    vi.clearAllMocks();
+  });
+
+  // ─── initial state ────────────────────────────────────────────────────────
+
+  it('initialises with empty hidden set, null hovered/persisted', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+    expect(result.current.hiddenPolygonIds.size).toBe(0);
+    expect(result.current.hoveredPolygonId).toBeNull();
+    expect(result.current.persistedSelectionTrackId).toBeNull();
+  });
+
+  // ─── handleTogglePolygonVisibility ────────────────────────────────────────
+
+  it('toggles a polygon into hidden set (by stable key)', () => {
+    const poly = makePoly({ id: 'p1' });
+    editor = makeEditor([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleTogglePolygonVisibility('p1');
+    });
+
+    expect(result.current.hiddenPolygonIds.has(polygonKey(poly))).toBe(true);
+  });
+
+  it('toggles a polygon back out of hidden set', () => {
+    const poly = makePoly({ id: 'p1' });
+    editor = makeEditor([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleTogglePolygonVisibility('p1');
+    });
+    act(() => {
+      result.current.handleTogglePolygonVisibility('p1');
+    });
+
+    expect(result.current.hiddenPolygonIds.has(polygonKey(poly))).toBe(false);
+  });
+
+  it('ignores toggle for an id not in the polygon list', () => {
+    editor = makeEditor([]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleTogglePolygonVisibility('nonexistent');
+    });
+
+    expect(result.current.hiddenPolygonIds.size).toBe(0);
+  });
+
+  // ─── handleDeletePolygonFromPanel ─────────────────────────────────────────
+
+  it('calls editor.handleDeletePolygon and removes key from hidden set', () => {
+    const poly = makePoly({ id: 'p1' });
+    editor = makeEditor([poly]);
+    const key = polygonKey(poly) as PolygonKey;
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    // Pre-hide the polygon
+    act(() => {
+      result.current.setHiddenPolygonIds(new Set([key]));
+    });
+
+    act(() => {
+      result.current.handleDeletePolygonFromPanel('p1');
+    });
+
+    expect(editor.handleDeletePolygon).toHaveBeenCalledWith('p1');
+    expect(result.current.hiddenPolygonIds.has(key)).toBe(false);
+  });
+
+  // ─── handleSelectPolygon ─────────────────────────────────────────────────
+
+  it('clears persistedSelectionTrackId when selecting null', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleSelectPolygon(null);
+    });
+
+    expect(result.current.persistedSelectionTrackId).toBeNull();
+    expect(editor.handlePolygonSelection).toHaveBeenCalledWith(null);
+  });
+
+  it('persists trackId when selecting a polygon that has one', () => {
+    const poly = makePoly({ id: 'p1', trackId: 'mt-42' } as Partial<Polygon>);
+    editor = makeEditor([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleSelectPolygon('p1');
+    });
+
+    expect(result.current.persistedSelectionTrackId).toBe('mt-42');
+    expect(editor.handlePolygonSelection).toHaveBeenCalledWith('p1');
+  });
+
+  it('sets persistedSelectionTrackId to null when polygon has no trackId', () => {
+    const poly = makePoly({ id: 'p1' });
+    editor = makeEditor([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleSelectPolygon('p1');
+    });
+
+    expect(result.current.persistedSelectionTrackId).toBeNull();
+  });
+
+  // ─── MT cross-frame selection remap effect ────────────────────────────────
+
+  it('re-selects the matching polygon when a new frame loads with the same trackId', () => {
+    const polyOnFrame1 = makePoly({
+      id: 'pA',
+      trackId: 'mt-7',
+    } as Partial<Polygon>);
+    editor = makeEditor([polyOnFrame1]);
+    editor.selectedPolygonId = null;
+
+    const { result, rerender } = renderHook(
+      ({ ed, imgId }: { ed: typeof editor; imgId: string }) =>
+        usePolygonHandlers({ editor: ed, imageId: imgId }),
+      { initialProps: { ed: editor, imgId: 'frame-1' } }
+    );
+
+    // Select polygon on frame 1, capturing trackId
+    act(() => {
+      result.current.handleSelectPolygon('pA');
+    });
+
+    // Simulate frame change: editor now has a different polygon id for the same MT
+    const polyOnFrame2 = makePoly({
+      id: 'pB',
+      trackId: 'mt-7',
+    } as Partial<Polygon>);
+    const editor2 = makeEditor([polyOnFrame2]);
+    editor2.selectedPolygonId = null;
+
+    rerender({ ed: editor2, imgId: 'frame-2' });
+
+    expect(editor2.setSelectedPolygonId).toHaveBeenCalledWith('pB');
+  });
+
+  it('does NOT call setSelectedPolygonId if the same polygon is already selected', () => {
+    const poly = makePoly({ id: 'pA', trackId: 'mt-7' } as Partial<Polygon>);
+    editor = makeEditor([poly]);
+    editor.selectedPolygonId = 'pA'; // already selected
+
+    renderHook(
+      ({ ed }: { ed: typeof editor }) =>
+        usePolygonHandlers({ editor: ed, imageId: 'frame-1' }),
+      { initialProps: { ed: editor } }
+    );
+
+    // The effect runs on mount; since selectedPolygonId === match.id,
+    // setSelectedPolygonId must NOT be called (would cause an infinite loop).
+    expect(editor.setSelectedPolygonId).not.toHaveBeenCalled();
+  });
+
+  // ─── handleDeletePolygonFromContextMenu ───────────────────────────────────
+
+  it('deletes polygon and removes its key from the hidden set', () => {
+    const poly = makePoly({ id: 'p1' });
+    editor = makeEditor([poly]);
+    const key = polygonKey(poly) as PolygonKey;
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.setHiddenPolygonIds(new Set([key]));
+    });
+
+    act(() => {
+      result.current.handleDeletePolygonFromContextMenu('p1');
+    });
+
+    expect(editor.handleDeletePolygon).toHaveBeenCalledWith('p1');
+    expect(result.current.hiddenPolygonIds.has(key)).toBe(false);
+  });
+
+  // ─── handleSlicePolygonFromContextMenu ────────────────────────────────────
+
+  it('selects the polygon and sets Slice edit mode', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleSlicePolygonFromContextMenu('p1');
+    });
+
+    expect(editor.setSelectedPolygonId).toHaveBeenCalledWith('p1');
+    expect(editor.setEditMode).toHaveBeenCalledWith(EditMode.Slice);
+  });
+
+  // ─── handleEditPolygonFromContextMenu ────────────────────────────────────
+
+  it('selects the polygon and sets EditVertices mode', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleEditPolygonFromContextMenu('p1');
+    });
+
+    expect(editor.setSelectedPolygonId).toHaveBeenCalledWith('p1');
+    expect(editor.setEditMode).toHaveBeenCalledWith(EditMode.EditVertices);
+  });
+
+  // ─── handleDeleteVertexFromContextMenu ────────────────────────────────────
+
+  it('delegates vertex deletion to editor.handleDeleteVertex', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleDeleteVertexFromContextMenu('p1', 3);
+    });
+
+    expect(editor.handleDeleteVertex).toHaveBeenCalledWith('p1', 3);
+  });
+
+  // ─── handleUpdatePolygonField / handleRenamePolygon / etc. ───────────────
+
+  it('handleRenamePolygon updates the polygon name via updatePolygons', () => {
+    const poly = makePoly({ id: 'p1', name: 'old' });
+    editor = makeEditor([poly]);
+    editor.getPolygons.mockReturnValue([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleRenamePolygon('p1', 'new-name');
+    });
+
+    expect(editor.updatePolygons).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'p1', name: 'new-name' }),
+    ]);
+  });
+
+  it('handleChangeInstanceId updates the instanceId', () => {
+    const poly = makePoly({ id: 'p1', instanceId: 'sperm_1' });
+    editor = makeEditor([poly]);
+    editor.getPolygons.mockReturnValue([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleChangeInstanceId('p1', 'sperm_3');
+    });
+
+    expect(editor.updatePolygons).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'p1', instanceId: 'sperm_3' }),
+    ]);
+  });
+
+  it('handleChangePartClass updates the partClass', () => {
+    const poly = makePoly({ id: 'p1', partClass: 'head' } as Partial<Polygon>);
+    editor = makeEditor([poly]);
+    editor.getPolygons.mockReturnValue([poly]);
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+
+    act(() => {
+      result.current.handleChangePartClass('p1', 'tail');
+    });
+
+    expect(editor.updatePolygons).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'p1', partClass: 'tail' }),
+    ]);
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/usePolygonRenderProps.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonRenderProps.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePolygonRenderProps } from '../usePolygonRenderProps';
+import { EditMode } from '../../types';
+import { Polygon, polygonKey, type PolygonKey } from '@/lib/segmentation';
+
+const transform = { zoom: 1, translateX: 0, translateY: 0 };
+
+const poly = (over: Partial<Polygon> = {}): Polygon =>
+  ({
+    id: 'p1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    type: 'external',
+    ...over,
+  }) as Polygon;
+
+const run = (params: {
+  polygons: Polygon[];
+  hidden?: Set<PolygonKey>;
+  editMode?: EditMode;
+  selectedPolygonId?: string | null;
+  activeInstanceId?: string;
+}) =>
+  renderHook(() =>
+    usePolygonRenderProps({
+      editor: {
+        polygons: params.polygons,
+        editMode: params.editMode ?? EditMode.View,
+        selectedPolygonId: params.selectedPolygonId ?? null,
+        transform,
+      },
+      hiddenPolygonIds: params.hidden ?? new Set<PolygonKey>(),
+      imageDimensions: { width: 100, height: 100 },
+      canvasWidth: 100,
+      canvasHeight: 100,
+      activeInstanceId: params.activeInstanceId ?? 'sperm_1',
+    })
+  ).result.current;
+
+describe('usePolygonRenderProps', () => {
+  describe('hasPolylines / polylineKind', () => {
+    it('hasPolylines is false with only closed polygons', () => {
+      expect(run({ polygons: [poly()] }).hasPolylines).toBe(false);
+    });
+
+    it('detects a polyline and classifies sperm via class', () => {
+      const r = run({
+        polygons: [poly({ geometry: 'polyline', class: 'sperm' })],
+      });
+      expect(r.hasPolylines).toBe(true);
+      expect(r.polylineKind).toBe('sperm');
+    });
+
+    it('classifies microtubule via class', () => {
+      expect(
+        run({
+          polygons: [poly({ geometry: 'polyline', class: 'microtubule' })],
+        }).polylineKind
+      ).toBe('microtubule');
+    });
+
+    it('falls back to partClass → sperm', () => {
+      expect(
+        run({
+          polygons: [poly({ geometry: 'polyline', partClass: 'head' })],
+        }).polylineKind
+      ).toBe('sperm');
+    });
+
+    it('returns null when there are no polylines', () => {
+      expect(run({ polygons: [poly()] }).polylineKind).toBeNull();
+    });
+  });
+
+  describe('availableInstanceIds', () => {
+    it('merges polyline instanceIds with the active id, sorted+unique', () => {
+      const r = run({
+        polygons: [
+          poly({ geometry: 'polyline', instanceId: 'sperm_2' }),
+          poly({ geometry: 'polyline', instanceId: 'sperm_2' }),
+        ],
+        activeInstanceId: 'sperm_1',
+      });
+      expect(r.availableInstanceIds).toEqual(['sperm_1', 'sperm_2']);
+    });
+
+    it('keeps a stable array reference when polygons change but the id set does not', () => {
+      const polygons = [poly({ geometry: 'polyline', instanceId: 'sperm_1' })];
+      const { result, rerender } = renderHook(
+        ({ p }) =>
+          usePolygonRenderProps({
+            editor: {
+              polygons: p,
+              editMode: EditMode.View,
+              selectedPolygonId: null,
+              transform,
+            },
+            hiddenPolygonIds: new Set<PolygonKey>(),
+            imageDimensions: null,
+            canvasWidth: 100,
+            canvasHeight: 100,
+            activeInstanceId: 'sperm_1',
+          }),
+        { initialProps: { p: polygons } }
+      );
+      const first = result.current.availableInstanceIds;
+      // New array, same instanceId set → reference must be preserved (two-stage memo).
+      rerender({ p: [poly({ geometry: 'polyline', instanceId: 'sperm_1' })] });
+      expect(result.current.availableInstanceIds).toBe(first);
+    });
+  });
+
+  describe('legacyModes', () => {
+    it('maps the EditMode enum to the four legacy booleans', () => {
+      expect(
+        run({ polygons: [], editMode: EditMode.Slice }).legacyModes
+      ).toEqual({
+        editMode: false,
+        slicingMode: true,
+        pointAddingMode: false,
+        deleteMode: false,
+      });
+    });
+  });
+
+  describe('renderablePolygons', () => {
+    it('drops hidden polygons (keyed by stable polygonKey) and degenerate shapes', () => {
+      const visible = poly({ id: 'visible' });
+      const hidden = poly({ id: 'hidden' });
+      const degenerate = poly({ id: 'deg', points: [{ x: 0, y: 0 }] });
+      const r = run({
+        polygons: [visible, hidden, degenerate],
+        hidden: new Set<PolygonKey>([polygonKey(hidden)]),
+      });
+      expect(r.renderablePolygons.map(p => p.id)).toEqual(['visible']);
+    });
+
+    it('passes polygons straight through when under the cull threshold (<10)', () => {
+      const polygons = [poly({ id: 'a' }), poly({ id: 'b' })];
+      const r = run({ polygons });
+      // visiblePolygons === renderablePolygons (same ref) when count < 10
+      expect(r.visiblePolygons).toBe(r.renderablePolygons);
+    });
+  });
+
+  describe('frameHiddenIds', () => {
+    it('projects the stable-key hidden set down to per-frame polygon ids', () => {
+      const a = poly({ id: 'frame-id-1', trackId: 'mt-1' } as Partial<Polygon>);
+      const r = run({
+        polygons: [a],
+        hidden: new Set<PolygonKey>([polygonKey(a)]), // keyed by trackId
+      });
+      // panel-facing set uses polygon.id, not the trackId key
+      expect(r.frameHiddenIds.has('frame-id-1')).toBe(true);
+    });
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/useResegment.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/useResegment.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { useResegment } from '../useResegment';
+
+// ─── module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const mockGetSegmentation = vi.fn();
+const mockRequestBatch = vi.fn();
+vi.mock('@/lib/api', () => ({
+  default: {
+    getSegmentationResults: (...args: any[]) => mockGetSegmentation(...args),
+    requestBatchSegmentation: (...args: any[]) => mockRequestBatch(...args),
+  },
+}));
+
+const mockSetCached = vi.fn();
+vi.mock('../segmentationPolygonCache', () => ({
+  setCachedSegmentationPolygons: (...args: any[]) => mockSetCached(...args),
+}));
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const makeParams = (
+  overrides: Partial<Parameters<typeof useResegment>[0]> = {}
+) => ({
+  projectId: 'proj-1',
+  imageId: 'img-1',
+  projectType: 'spheroid' as string,
+  selectedModel: 'hrnet',
+  confidenceThreshold: 0.5,
+  detectHoles: false,
+  videoChannels: null,
+  queryClient: new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  }),
+  t: (key: string) => key,
+  onReloaded: vi.fn(),
+  setImageDimensions: vi.fn(),
+  currentImageIdRef: {
+    current: 'img-1',
+  } as React.MutableRefObject<string | undefined>,
+  ...overrides,
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('useResegment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetSegmentation.mockResolvedValue({
+      polygons: [],
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    mockRequestBatch.mockResolvedValue({
+      successful: 1,
+      failed: 0,
+      results: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ─── initial state ─────────────────────────────────────────────────────────
+
+  it('initialises with isResegmenting=false and dialog closed', () => {
+    const { result } = renderHook(() => useResegment(makeParams()));
+    expect(result.current.isResegmenting).toBe(false);
+    expect(result.current.showResegmentChannelDialog).toBe(false);
+  });
+
+  // ─── effectiveResegmentModel gating ────────────────────────────────────────
+
+  it.each([
+    ['microtubules', 'microtubule'],
+    ['sperm', 'sperm'],
+    ['wound', 'wound'],
+    ['spheroid_invasive', 'unet_attention_aspp'],
+    ['spheroid', 'hrnet'],
+  ])(
+    'maps projectType=%s → effectiveResegmentModel=%s',
+    (projectType, expected) => {
+      const { result } = renderHook(() =>
+        useResegment(makeParams({ projectType, selectedModel: 'hrnet' }))
+      );
+      expect(result.current.effectiveResegmentModel).toBe(expected);
+    }
+  );
+
+  // ─── handleResegmentCurrentFrame — single channel ─────────────────────────
+
+  it('calls runResegment directly when videoChannels is null', async () => {
+    const params = makeParams({ videoChannels: null });
+    const { result } = renderHook(() => useResegment(params));
+
+    await act(async () => {
+      result.current.handleResegmentCurrentFrame();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockRequestBatch).toHaveBeenCalledWith(
+      ['img-1'],
+      'hrnet',
+      0.5,
+      false,
+      undefined
+    );
+    expect(result.current.showResegmentChannelDialog).toBe(false);
+  });
+
+  it('calls runResegment directly when videoChannels has 1 channel', async () => {
+    const params = makeParams({
+      videoChannels: [{ name: 'DAPI', isSegmentationSource: true }],
+    });
+    const { result } = renderHook(() => useResegment(params));
+
+    await act(async () => {
+      result.current.handleResegmentCurrentFrame();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockRequestBatch).toHaveBeenCalled();
+    expect(result.current.showResegmentChannelDialog).toBe(false);
+  });
+
+  it('opens channel dialog when videoChannels has >1 channels', () => {
+    const params = makeParams({
+      videoChannels: [
+        { name: 'DAPI', isSegmentationSource: false },
+        { name: 'GFP', isSegmentationSource: true },
+      ],
+    });
+    const { result } = renderHook(() => useResegment(params));
+
+    act(() => {
+      result.current.handleResegmentCurrentFrame();
+    });
+
+    expect(result.current.showResegmentChannelDialog).toBe(true);
+    expect(mockRequestBatch).not.toHaveBeenCalled();
+  });
+
+  // ─── runResegment — success ────────────────────────────────────────────────
+
+  it('clears isResegmenting after a successful batch call', async () => {
+    const { result } = renderHook(() => useResegment(makeParams()));
+
+    await act(async () => {
+      await result.current.runResegment();
+    });
+
+    expect(result.current.isResegmenting).toBe(false);
+  });
+
+  it('passes channel argument to requestBatchSegmentation', async () => {
+    const { result } = renderHook(() => useResegment(makeParams()));
+
+    await act(async () => {
+      await result.current.runResegment('GFP');
+    });
+
+    expect(mockRequestBatch).toHaveBeenCalledWith(
+      ['img-1'],
+      'hrnet',
+      0.5,
+      false,
+      'GFP'
+    );
+  });
+
+  // ─── runResegment — 0 successes ────────────────────────────────────────────
+
+  it('shows error toast when batch returns 0 successful', async () => {
+    const { toast } = await import('sonner');
+    mockRequestBatch.mockResolvedValue({
+      successful: 0,
+      failed: 1,
+      results: [{ success: false, error: 'model OOM' }],
+    });
+
+    const { result } = renderHook(() => useResegment(makeParams()));
+
+    await act(async () => {
+      await result.current.runResegment();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(result.current.isResegmenting).toBe(false);
+  });
+
+  // ─── runResegment — partial failure ───────────────────────────────────────
+
+  it('shows warning toast when some results fail', async () => {
+    const { toast } = await import('sonner');
+    mockRequestBatch.mockResolvedValue({
+      successful: 1,
+      failed: 1,
+      results: [{ success: true }, { success: false, error: 'partial OOM' }],
+    });
+
+    const { result } = renderHook(() => useResegment(makeParams()));
+
+    await act(async () => {
+      await result.current.runResegment();
+    });
+
+    expect(toast.warning).toHaveBeenCalled();
+  });
+
+  // ─── startResegmentPoll — poll fires on new updatedAt ─────────────────────
+  // Test the poll mechanism by kicking off runResegment and advancing fake
+  // timers to the first tick. On tick 1 the stamp changed → onReloaded fires.
+
+  it('calls onReloaded when poll tick detects a new updatedAt', async () => {
+    const onReloaded = vi.fn();
+    const setImageDimensions = vi.fn();
+    const freshPolygons = [{ id: 'p-new', points: [], type: 'external' }];
+
+    // prevStamp snapshot call: returns old timestamp
+    mockGetSegmentation
+      .mockResolvedValueOnce({
+        updatedAt: 'old-ts',
+        polygons: [],
+      })
+      // poll tick 1: new timestamp — triggers apply immediately
+      .mockResolvedValue({
+        updatedAt: 'new-ts',
+        polygons: freshPolygons,
+        imageWidth: 800,
+        imageHeight: 600,
+      });
+
+    const params = makeParams({ onReloaded, setImageDimensions });
+    const { result } = renderHook(() => useResegment(params));
+
+    // Run the resegment call (snapshots prevStamp, enqueues the first poll tick)
+    await act(async () => {
+      await result.current.runResegment();
+    });
+
+    // Advance past the 2000 ms poll delay so tick() fires
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Flush all pending microtasks so the async tick body resolves
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onReloaded).toHaveBeenCalledWith(freshPolygons);
+    expect(setImageDimensions).toHaveBeenCalledWith({
+      width: 800,
+      height: 600,
+    });
+  });
+
+  // ─── does not re-enter when isResegmenting=true ───────────────────────────
+
+  it('does nothing when called while already resegmenting', async () => {
+    const { result } = renderHook(() => useResegment(makeParams()));
+
+    // Start first resegment (don't await so it stays in-flight)
+    let firstResegmentResolve!: () => void;
+    mockRequestBatch.mockImplementation(
+      () =>
+        new Promise<{ successful: number; failed: number; results: any[] }>(
+          resolve => {
+            firstResegmentResolve = () =>
+              resolve({ successful: 1, failed: 0, results: [] });
+          }
+        )
+    );
+
+    act(() => {
+      void result.current.runResegment();
+    });
+
+    // At this point isResegmenting should be true
+    expect(result.current.isResegmenting).toBe(true);
+
+    // Second call should be a no-op
+    await act(async () => {
+      await result.current.runResegment();
+    });
+
+    // Only 1 prevStamp + 1 batch call, not 2 batch calls
+    // (the second runResegment returned immediately)
+    expect(mockRequestBatch).toHaveBeenCalledTimes(1);
+
+    // Cleanup: resolve the first batch so the hook settles
+    await act(async () => {
+      firstResegmentResolve();
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/useSegmentationLoader.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/useSegmentationLoader.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { useSegmentationLoader } from '../useSegmentationLoader';
+
+// ─── module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const mockGetSegmentationResults = vi.fn();
+vi.mock('@/lib/api', () => ({
+  default: {
+    getSegmentationResults: (...args: any[]) =>
+      mockGetSegmentationResults(...args),
+  },
+}));
+
+const mockGetCached = vi.fn(() => undefined as any);
+const mockSetCached = vi.fn();
+vi.mock('../segmentationPolygonCache', () => ({
+  getCachedSegmentationPolygons: (...args: any[]) => mockGetCached(...args),
+  setCachedSegmentationPolygons: (...args: any[]) => mockSetCached(...args),
+}));
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const makeSignal = () =>
+  new AbortController().signal as AbortSignal & { aborted: boolean };
+
+const makeParams = (
+  overrides: Partial<Parameters<typeof useSegmentationLoader>[0]> = {}
+) => ({
+  projectId: 'proj-1',
+  imageId: 'img-1',
+  selectedImage: {
+    segmentationStatus: 'segmented',
+    width: 800,
+    height: 600,
+  },
+  getSignal: vi.fn(() => makeSignal()),
+  queryClient: new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  }),
+  t: (key: string) => key,
+  currentImageIdRef: { current: 'img-1' } as React.MutableRefObject<
+    string | undefined
+  >,
+  ...overrides,
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('useSegmentationLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCached.mockReturnValue(undefined); // cache miss by default
+    mockGetSegmentationResults.mockResolvedValue(null);
+  });
+
+  // ─── initial state ─────────────────────────────────────────────────────────
+
+  it('initialises with null polygons, dimensions and loadedFrameKey', () => {
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    expect(result.current.segmentationPolygons).toBeNull();
+    expect(result.current.imageDimensions).toBeNull();
+    expect(result.current.loadedFrameKey).toBeNull();
+  });
+
+  // ─── cache hit ─────────────────────────────────────────────────────────────
+
+  it('serves from cache and skips API when cache hit', async () => {
+    const polygons = [{ id: 'p1', points: [], type: 'external' }];
+    mockGetCached.mockReturnValue({
+      polygons,
+      imageWidth: 800,
+      imageHeight: 600,
+    });
+
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      expect(result.current.segmentationPolygons).toEqual(polygons);
+    });
+
+    expect(mockGetSegmentationResults).not.toHaveBeenCalled();
+    expect(result.current.imageDimensions).toEqual({ width: 800, height: 600 });
+  });
+
+  // ─── no segmentation status → skip fetch ──────────────────────────────────
+
+  it('skips API fetch when image has no completed segmentation', async () => {
+    const params = makeParams({
+      selectedImage: {
+        segmentationStatus: 'queued',
+        width: 512,
+        height: 512,
+      },
+    });
+
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      expect(result.current.imageDimensions).toEqual({
+        width: 512,
+        height: 512,
+      });
+    });
+
+    expect(mockGetSegmentationResults).not.toHaveBeenCalled();
+    expect(result.current.segmentationPolygons).toBeNull();
+  });
+
+  // ─── successful API fetch ──────────────────────────────────────────────────
+
+  it('fetches from API on cache miss and sets polygons + dimensions', async () => {
+    const polygons = [{ id: 'p1', points: [], type: 'external' }];
+    mockGetSegmentationResults.mockResolvedValue({
+      polygons,
+      imageWidth: 1024,
+      imageHeight: 768,
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      expect(result.current.segmentationPolygons).toEqual(polygons);
+    });
+
+    expect(result.current.imageDimensions).toEqual({
+      width: 1024,
+      height: 768,
+    });
+    expect(mockSetCached).toHaveBeenCalledWith(
+      params.queryClient,
+      'img-1',
+      expect.objectContaining({ polygons })
+    );
+  });
+
+  // ─── null API response → sets null polygons ────────────────────────────────
+
+  it('sets segmentationPolygons to null when API returns null', async () => {
+    mockGetSegmentationResults.mockResolvedValue(null);
+    const params = makeParams({
+      selectedImage: {
+        segmentationStatus: 'segmented',
+        width: 800,
+        height: 600,
+      },
+    });
+
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      // After null response, dims come from selectedImage fallback
+      expect(result.current.imageDimensions).toEqual({
+        width: 800,
+        height: 600,
+      });
+    });
+
+    expect(result.current.segmentationPolygons).toBeNull();
+  });
+
+  // ─── 404 error → silent null (no toast) ───────────────────────────────────
+
+  it('handles 404 error silently (sets null, no toast)', async () => {
+    const { toast } = await import('sonner');
+    const error = Object.assign(new Error('Not Found'), {
+      response: { status: 404 },
+    });
+    mockGetSegmentationResults.mockRejectedValue(error);
+
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      // dims come from selectedImage after 404
+      expect(result.current.imageDimensions).toBeNull();
+    });
+
+    expect(result.current.segmentationPolygons).toBeNull();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  // ─── non-404 error → toast ─────────────────────────────────────────────────
+
+  it('shows error toast and sets null on non-404 API errors', async () => {
+    const { toast } = await import('sonner');
+    mockGetSegmentationResults.mockRejectedValue(new Error('Server Error'));
+
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    expect(result.current.segmentationPolygons).toBeNull();
+  });
+
+  // ─── handleImageLoad ───────────────────────────────────────────────────────
+
+  it('handleImageLoad sets loadedFrameKey and imageDimensions when not yet set', async () => {
+    const params = makeParams({
+      selectedImage: { segmentationStatus: 'pending' },
+    });
+
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    act(() => {
+      result.current.handleImageLoad(640, 480, 'ch0');
+    });
+
+    expect(result.current.loadedFrameKey).toBe('img-1::ch0');
+    expect(result.current.imageDimensions).toEqual({ width: 640, height: 480 });
+  });
+
+  it('handleImageLoad keeps existing dimensions when already set from segmentation', async () => {
+    const polygons = [{ id: 'p1', points: [], type: 'external' }];
+    mockGetSegmentationResults.mockResolvedValue({
+      polygons,
+      imageWidth: 1024,
+      imageHeight: 768,
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    const params = makeParams();
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    // Wait for dimensions to be set from segmentation data
+    await waitFor(() => {
+      expect(result.current.imageDimensions).toEqual({
+        width: 1024,
+        height: 768,
+      });
+    });
+
+    // handleImageLoad with different dimensions should keep the segmentation dims
+    act(() => {
+      result.current.handleImageLoad(640, 480, 'ch0');
+    });
+
+    expect(result.current.imageDimensions).toEqual({
+      width: 1024,
+      height: 768,
+    });
+  });
+
+  // ─── setters are callable from outside ────────────────────────────────────
+
+  it('exposes setSegmentationPolygons for the orchestrator to call', () => {
+    const params = makeParams({
+      selectedImage: { segmentationStatus: 'pending' },
+    });
+    const { result } = renderHook(() => useSegmentationLoader(params));
+
+    const newPolys = [{ id: 'p99', points: [], type: 'external' }] as any;
+    act(() => {
+      result.current.setSegmentationPolygons(newPolys);
+    });
+
+    expect(result.current.segmentationPolygons).toEqual(newPolys);
+  });
+});

--- a/src/pages/segmentation/hooks/usePolygonHandlers.ts
+++ b/src/pages/segmentation/hooks/usePolygonHandlers.ts
@@ -1,0 +1,240 @@
+import { useState, useCallback, useEffect } from 'react';
+import { EditMode } from '../types';
+import { Polygon, polygonKey, type PolygonKey } from '@/lib/segmentation';
+import { logger } from '@/lib/logger';
+
+/**
+ * Minimal structural slice of the editor that polygon-handler callbacks read.
+ * Declared locally so this hook never pulls the full editor import graph
+ * (socket.io/Radix/Axios), keeping it unit-testable with a plain stub.
+ */
+interface HandlerEditor {
+  polygons: Polygon[];
+  selectedPolygonId: string | null;
+  handleDeletePolygon: (polygonId: string) => void;
+  handlePolygonSelection: (polygonId: string | null) => void;
+  setSelectedPolygonId: (polygonId: string | null) => void;
+  setEditMode: (mode: EditMode) => void;
+  handleDeleteVertex: (polygonId: string, vertexIndex: number) => void;
+  getPolygons: () => Polygon[];
+  updatePolygons: (polygons: Polygon[]) => void;
+}
+
+interface UsePolygonHandlersParams {
+  editor: HandlerEditor;
+  imageId: string | undefined;
+}
+
+/**
+ * Owns the polygon CRUD handlers lifted verbatim from SegmentationEditor
+ * (stages 3 + 4 merged — they share `persistedSelectionTrackId` state).
+ *
+ * Owns state:
+ *   - hiddenPolygonIds  (stable-key Set<PolygonKey>)
+ *   - hoveredPolygonId
+ *   - persistedSelectionTrackId
+ *
+ * Owns the MT cross-frame selection-remap effect (stage 4): when polygons
+ * load for a new frame, finds the polygon whose trackId matches the persisted
+ * selection and re-selects it in the editor.
+ */
+export function usePolygonHandlers({
+  editor,
+  imageId,
+}: UsePolygonHandlersParams) {
+  // Stores STABLE keys (trackId where present, else polygon.id) so a
+  // microtubule hidden on one frame stays hidden when the user scrubs.
+  // Branded `Set<PolygonKey>` makes accidental key-by-other-string a
+  // compile error.
+  const [hiddenPolygonIds, setHiddenPolygonIds] = useState<Set<PolygonKey>>(
+    new Set()
+  );
+  // Cross-frame selection persistence: when the user picks an MT
+  // polyline, remember its trackId so frame scrubs can re-select the
+  // same MT instance on the new frame. null = no persistent selection.
+  const [persistedSelectionTrackId, setPersistedSelectionTrackId] = useState<
+    string | null
+  >(null);
+  const [hoveredPolygonId, setHoveredPolygonId] = useState<string | null>(null);
+
+  // Legacy compatibility handlers
+  const handleTogglePolygonVisibility = (polygonId: string) => {
+    // Map current-frame polygon.id → stable key (trackId or id) so the
+    // hide state survives frame changes for MTs.
+    const target = editor.polygons.find(p => p.id === polygonId);
+    if (!target) return;
+    const key = polygonKey(target);
+    setHiddenPolygonIds(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(key)) {
+        newSet.delete(key);
+      } else {
+        newSet.add(key);
+      }
+      return newSet;
+    });
+  };
+
+  const handleDeletePolygonFromPanel = (polygonId: string) => {
+    const target = editor.polygons.find(p => p.id === polygonId);
+    editor.handleDeletePolygon(polygonId);
+    if (target) {
+      const key = polygonKey(target);
+      setHiddenPolygonIds(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(key);
+        return newSet;
+      });
+    }
+  };
+
+  // Capture trackId at click so frame scrubbing re-attaches selection
+  // to the same MT instance on the new frame.
+  const handleSelectPolygon = useCallback(
+    (polygonId: string | null) => {
+      if (polygonId === null) {
+        setPersistedSelectionTrackId(null);
+      } else {
+        const p = editor.polygons.find(x => x.id === polygonId);
+        setPersistedSelectionTrackId(p?.trackId ?? null);
+      }
+      editor.handlePolygonSelection(polygonId);
+    },
+    [editor]
+  );
+
+  // Cross-frame selection remap. When polygons load for a new frame
+  // (initialPolygons replaces editor.polygons), find the polygon that
+  // shares the persisted trackId and re-select it. If no sibling exists
+  // on this frame (track wasn't matched here), selection is left null
+  // by the editor's own image-change reset and we don't fight it — but
+  // we log so a missing match is debuggable when a user reports
+  // "selection lost".
+  useEffect(() => {
+    if (!persistedSelectionTrackId) return;
+    const match = editor.polygons.find(
+      p => p.trackId === persistedSelectionTrackId
+    );
+    if (match) {
+      if (editor.selectedPolygonId !== match.id) {
+        editor.setSelectedPolygonId(match.id);
+      }
+    } else if (editor.polygons.length > 0) {
+      // Polygons loaded but no match — track is not present on this
+      // frame. Surface via debug log so support can correlate user
+      // reports; UI deliberately stays quiet (toast on every scrub past
+      // a gap would be obnoxious).
+      logger.debug('Selected MT track not present on current frame', {
+        trackId: persistedSelectionTrackId,
+        frameImageId: imageId,
+      });
+    }
+    // Intentionally narrow deps: passing the whole `editor` object
+    // would re-fire on every render of useEnhancedSegmentationEditor
+    // (cursor moves, hovers). The destructured fields capture
+    // exactly the state this effect needs to react to.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    editor.polygons,
+    persistedSelectionTrackId,
+    editor.selectedPolygonId,
+    editor.setSelectedPolygonId,
+    imageId,
+  ]);
+
+  // Context menu handlers for polygon right-click
+  const handleDeletePolygonFromContextMenu = useCallback(
+    (polygonId: string) => {
+      const target = editor.polygons.find(p => p.id === polygonId);
+      editor.handleDeletePolygon(polygonId);
+      if (target) {
+        const key = polygonKey(target);
+        setHiddenPolygonIds(prev => {
+          const newSet = new Set(prev);
+          newSet.delete(key);
+          return newSet;
+        });
+      }
+    },
+    [editor]
+  );
+
+  const handleSlicePolygonFromContextMenu = useCallback(
+    (polygonId: string) => {
+      // Select the polygon and switch to slice mode (skip to step 2)
+      editor.setSelectedPolygonId(polygonId);
+      editor.setEditMode(EditMode.Slice);
+    },
+    [editor]
+  );
+
+  const handleEditPolygonFromContextMenu = useCallback(
+    (polygonId: string) => {
+      // Select the polygon and switch to edit vertices mode
+      editor.setSelectedPolygonId(polygonId);
+      editor.setEditMode(EditMode.EditVertices);
+    },
+    [editor]
+  );
+
+  // Context menu handlers for vertex right-click
+  const handleDeleteVertexFromContextMenu = useCallback(
+    (polygonId: string, vertexIndex: number) => {
+      editor.handleDeleteVertex(polygonId, vertexIndex);
+    },
+    [editor]
+  );
+
+  // Generic handler for updating a single field on a polygon by ID
+  const handleUpdatePolygonField = useCallback(
+    (polygonId: string, updates: Partial<Polygon>) => {
+      const currentPolygons = editor.getPolygons();
+      const updatedPolygons = currentPolygons.map(p =>
+        p.id === polygonId ? { ...p, ...updates } : p
+      );
+      editor.updatePolygons(updatedPolygons);
+    },
+    // editor object reference is stable; tracking individual methods avoids
+    // re-creating this callback when unrelated editor state changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [editor.getPolygons, editor.updatePolygons]
+  );
+
+  const handleRenamePolygon = useCallback(
+    (polygonId: string, name: string) =>
+      handleUpdatePolygonField(polygonId, { name }),
+    [handleUpdatePolygonField]
+  );
+
+  const handleChangeInstanceId = useCallback(
+    (polygonId: string, instanceId: string) =>
+      handleUpdatePolygonField(polygonId, { instanceId }),
+    [handleUpdatePolygonField]
+  );
+
+  const handleChangePartClass = useCallback(
+    (polygonId: string, partClass: 'head' | 'midpiece' | 'tail') =>
+      handleUpdatePolygonField(polygonId, { partClass }),
+    [handleUpdatePolygonField]
+  );
+
+  return {
+    hiddenPolygonIds,
+    setHiddenPolygonIds,
+    hoveredPolygonId,
+    setHoveredPolygonId,
+    persistedSelectionTrackId,
+    setPersistedSelectionTrackId,
+    handleTogglePolygonVisibility,
+    handleDeletePolygonFromPanel,
+    handleSelectPolygon,
+    handleDeletePolygonFromContextMenu,
+    handleSlicePolygonFromContextMenu,
+    handleEditPolygonFromContextMenu,
+    handleDeleteVertexFromContextMenu,
+    handleUpdatePolygonField,
+    handleRenamePolygon,
+    handleChangeInstanceId,
+    handleChangePartClass,
+  };
+}

--- a/src/pages/segmentation/hooks/usePolygonHandlers.ts
+++ b/src/pages/segmentation/hooks/usePolygonHandlers.ts
@@ -224,7 +224,6 @@ export function usePolygonHandlers({
     hoveredPolygonId,
     setHoveredPolygonId,
     persistedSelectionTrackId,
-    setPersistedSelectionTrackId,
     handleTogglePolygonVisibility,
     handleDeletePolygonFromPanel,
     handleSelectPolygon,

--- a/src/pages/segmentation/hooks/usePolygonRenderProps.ts
+++ b/src/pages/segmentation/hooks/usePolygonRenderProps.ts
@@ -1,0 +1,166 @@
+import { useMemo } from 'react';
+import { EditMode } from '../types';
+import { Polygon, polygonKey, type PolygonKey } from '@/lib/segmentation';
+import { isMicrotubuleInstance } from '../utils/instanceColors';
+import { polygonVisibilityManager } from '@/lib/rendering/PolygonVisibilityManager';
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Minimal structural slice of the editor that the render pipeline reads.
+ * Declared locally (rather than importing `useEnhancedSegmentationEditor`'s
+ * return type) so this hook stays dependency-light and unit-testable without
+ * the editor's heavy import graph.
+ */
+interface RenderEditor {
+  polygons: Polygon[];
+  editMode: EditMode;
+  selectedPolygonId: string | null;
+  transform: { zoom: number; translateX: number; translateY: number };
+}
+
+interface UsePolygonRenderPropsParams {
+  editor: RenderEditor;
+  hiddenPolygonIds: Set<PolygonKey>;
+  imageDimensions: ImageDimensions | null;
+  canvasWidth: number;
+  canvasHeight: number;
+  activeInstanceId: string;
+}
+
+/**
+ * The pure render-derivation pipeline lifted verbatim from `SegmentationEditor`:
+ * polyline/instance discrimination, the legacy edit-mode booleans, and the
+ * two-stage polygon render filter (hidden/degenerate → frustum cull). No side
+ * effects, no React state — just memoised derivations over the editor + view
+ * inputs, so it is independently unit-testable.
+ */
+export function usePolygonRenderProps({
+  editor,
+  hiddenPolygonIds,
+  imageDimensions,
+  canvasWidth,
+  canvasHeight,
+  activeInstanceId,
+}: UsePolygonRenderPropsParams) {
+  const hasPolylines = useMemo(
+    () => editor.polygons.some(p => p.geometry === 'polyline'),
+    [editor.polygons]
+  );
+
+  // Discriminate sperm vs microtubule projects so the sidebar shows the
+  // right panel. Authoritative signal: `polygon.class` ('sperm' or
+  // 'microtubule') is stamped by the ML model when it produces the
+  // polygon. Each project uses one model, so the first polyline whose
+  // class we recognise is sufficient — no majority-counting needed.
+  // Legacy/manually-drawn polylines without `class` fall back to
+  // `partClass` (sperm head/midpiece/tail) or `mt_` instanceId prefix.
+  const polylineKind = useMemo<'sperm' | 'microtubule' | null>(() => {
+    for (const p of editor.polygons) {
+      if (p.geometry !== 'polyline') continue;
+      if (p.class === 'microtubule') return 'microtubule';
+      if (p.class === 'sperm') return 'sperm';
+      if (p.partClass) return 'sperm';
+      if (isMicrotubuleInstance(p.instanceId)) return 'microtubule';
+    }
+    return null;
+  }, [editor.polygons]);
+
+  // Compute available sperm instance IDs for context menu (from existing polylines + active).
+  // Two-stage memo: first derive a stable string key, then split into array only when key changes.
+  // This prevents new array references on unrelated polygon edits (e.g. vertex drags).
+  const availableInstanceKey = useMemo(() => {
+    const ids = new Set<string>();
+    for (const p of editor.polygons) {
+      if (p.geometry === 'polyline' && p.instanceId) ids.add(p.instanceId);
+    }
+    ids.add(activeInstanceId);
+    return Array.from(ids).sort().join(',');
+  }, [editor.polygons, activeInstanceId]);
+
+  const availableInstanceIds = useMemo(
+    () => availableInstanceKey.split(',').filter(Boolean),
+    [availableInstanceKey]
+  );
+
+  // Convert new EditMode to legacy booleans for compatibility
+  const legacyModes = useMemo(
+    () => ({
+      editMode: editor.editMode === EditMode.EditVertices,
+      slicingMode: editor.editMode === EditMode.Slice,
+      pointAddingMode: editor.editMode === EditMode.AddPoints,
+      deleteMode: editor.editMode === EditMode.DeletePolygon,
+    }),
+    [editor.editMode]
+  );
+
+  // Stage 1: filter hidden / degenerate polygons.
+  const renderablePolygons = useMemo(
+    () =>
+      editor.polygons.filter(polygon => {
+        if (hiddenPolygonIds.has(polygonKey(polygon)) || !polygon.points)
+          return false;
+        const minPoints = polygon.geometry === 'polyline' ? 2 : 3;
+        return polygon.points.length >= minPoints;
+      }),
+    [editor.polygons, hiddenPolygonIds]
+  );
+
+  // Stage 2: frustum-cull off-viewport polygons via the visibility manager.
+  // The manager's internal threshold guards small counts (< 10 polygons
+  // → no culling), so MT/single-polyline cases pay zero overhead. Sperm
+  // projects with 50+ polylines at high zoom typically halve the SVG
+  // node count under this filter. We pass through `selectedPolygonId`
+  // so the manager never culls the focused polygon even if it scrolls
+  // off-screen briefly during a drag.
+  const visiblePolygons = useMemo(() => {
+    if (renderablePolygons.length < 10) return renderablePolygons;
+    const containerWidth = imageDimensions?.width || canvasWidth;
+    const containerHeight = imageDimensions?.height || canvasHeight;
+    return polygonVisibilityManager.getVisiblePolygons(renderablePolygons, {
+      zoom: editor.transform.zoom,
+      offset: {
+        x: editor.transform.translateX,
+        y: editor.transform.translateY,
+      },
+      containerWidth,
+      containerHeight,
+      selectedPolygonId: editor.selectedPolygonId,
+      forceRenderSelected: true,
+    }).visiblePolygons;
+  }, [
+    renderablePolygons,
+    editor.transform.zoom,
+    editor.transform.translateX,
+    editor.transform.translateY,
+    editor.selectedPolygonId,
+    imageDimensions,
+    canvasWidth,
+    canvasHeight,
+  ]);
+
+  // Panels still consume polygon.id, so project the stable-key set
+  // down per frame.
+  const frameHiddenIds = useMemo(
+    () =>
+      new Set(
+        editor.polygons
+          .filter(p => hiddenPolygonIds.has(polygonKey(p)))
+          .map(p => p.id)
+      ),
+    [editor.polygons, hiddenPolygonIds]
+  );
+
+  return {
+    hasPolylines,
+    polylineKind,
+    availableInstanceIds,
+    legacyModes,
+    renderablePolygons,
+    visiblePolygons,
+    frameHiddenIds,
+  };
+}

--- a/src/pages/segmentation/hooks/useResegment.ts
+++ b/src/pages/segmentation/hooks/useResegment.ts
@@ -1,0 +1,253 @@
+import { useState, useCallback, useRef, useMemo } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import apiClient, { type SegmentationPolygon } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { handleCancelledError } from '@/lib/errorUtils';
+import { toast } from 'sonner';
+import { setCachedSegmentationPolygons } from './segmentationPolygonCache';
+
+/**
+ * Minimal channel type for the multi-channel picker.
+ */
+interface VideoChannel {
+  name: string;
+  isSegmentationSource?: boolean;
+}
+
+interface UseResegmentParams {
+  projectId: string | undefined;
+  imageId: string | undefined;
+  projectType: string | undefined;
+  selectedModel: string;
+  confidenceThreshold: number;
+  detectHoles: boolean;
+  /** Channels from video.container?.channels (or null for standalone images). */
+  videoChannels: VideoChannel[] | null | undefined;
+  queryClient: QueryClient;
+  /** Translation function. */
+  t: (key: string) => string;
+  /** Liaison callback that bumps reloadNonce + sets segmentationPolygons. */
+  onReloaded: (polys: SegmentationPolygon[] | null) => void;
+  /** Setter from useSegmentationLoader — called when fresh dims arrive. */
+  setImageDimensions: React.Dispatch<
+    React.SetStateAction<{ width: number; height: number } | null>
+  >;
+  /** Ref tracking the currently-active imageId (written by orchestrator). */
+  currentImageIdRef: React.MutableRefObject<string | undefined>;
+}
+
+interface UseResegmentResult {
+  isResegmenting: boolean;
+  showResegmentChannelDialog: boolean;
+  setShowResegmentChannelDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  effectiveResegmentModel: string;
+  runResegment: (channel?: string) => Promise<void>;
+  handleResegmentCurrentFrame: () => void;
+}
+
+/**
+ * Owns the resegment + completion-poll cluster:
+ *   - isResegmenting + showResegmentChannelDialog state
+ *   - resegPollSeqRef (invalidation token)
+ *   - effectiveResegmentModel (project-type gating)
+ *   - startResegmentPoll (background HTTP poll — fires success toast + reloadNonce bump)
+ *   - runResegment (batch endpoint call + poll kickoff)
+ *   - handleResegmentCurrentFrame (top-toolbar entry point, opens channel picker or delegates)
+ *
+ * HAZARD — TDZ: this hook takes videoChannels as a PARAMETER so it never
+ * calls useVideoFrames itself (would duplicate the query). The orchestrator
+ * must call this hook AFTER `const video = useVideoFrames(...)` and pass
+ * `video.container?.channels ?? null` (CLAUDE.md production bug #11).
+ */
+export function useResegment({
+  projectId: _projectId,
+  imageId,
+  projectType,
+  selectedModel,
+  confidenceThreshold,
+  detectHoles,
+  videoChannels,
+  queryClient,
+  t,
+  onReloaded,
+  setImageDimensions,
+  currentImageIdRef,
+}: UseResegmentParams): UseResegmentResult {
+  const [isResegmenting, setIsResegmenting] = useState(false);
+
+  // Channel picker state for multi-channel video frames.
+  const [showResegmentChannelDialog, setShowResegmentChannelDialog] =
+    useState(false);
+
+  // Monotonic token for the background resegment-completion poll so a new
+  // resegment (or image switch) invalidates a still-running poll.
+  const resegPollSeqRef = useRef(0);
+
+  // The backend enforces a per-project-type model whitelist. The
+  // user-chosen `selectedModel` is meaningful only for the generic
+  // spheroid project — typed projects must use their matching model
+  // (`spheroid_invasive` → `unet_attention_aspp` per backend's
+  // MODEL_TYPE_COMPATIBILITY) or the request gets rejected.
+  const effectiveResegmentModel = useMemo(() => {
+    if (projectType === 'microtubules') return 'microtubule';
+    if (projectType === 'sperm') return 'sperm';
+    if (projectType === 'wound') return 'wound';
+    if (projectType === 'spheroid_invasive') return 'unet_attention_aspp';
+    return selectedModel;
+  }, [projectType, selectedModel]);
+
+  // Background poll that refreshes the editor when a resegment completes.
+  // The WebSocket completion event is not a dependable trigger, so we poll
+  // the result's `updatedAt` over plain HTTP (no AbortController, so a
+  // re-rendering editor can't cancel it) and apply the fresh polygons
+  // directly once it advances. A seq token invalidates a stale poll when a
+  // new resegment starts or the user switches frames.
+  const startResegmentPoll = useCallback(
+    (targetImageId: string, prevStamp: string | null, announce: boolean) => {
+      const seq = ++resegPollSeqRef.current;
+      const deadline = Date.now() + 120_000;
+      const tick = async () => {
+        if (
+          seq !== resegPollSeqRef.current ||
+          targetImageId !== currentImageIdRef.current ||
+          Date.now() > deadline
+        ) {
+          return;
+        }
+        let fresh = null;
+        try {
+          fresh = await apiClient.getSegmentationResults(targetImageId);
+        } catch {
+          // transient — keep polling
+        }
+        if (
+          seq !== resegPollSeqRef.current ||
+          targetImageId !== currentImageIdRef.current
+        ) {
+          return;
+        }
+        if (fresh && fresh.updatedAt && fresh.updatedAt !== prevStamp) {
+          // Apply the already-fetched fresh result DIRECTLY rather than via
+          // reloadSegmentation. reloadSegmentation runs a second fetch behind
+          // its own AbortController + cleanup, which a concurrent reload (or
+          // the editor's churn) can cancel — leaving onPolygonsLoaded (and
+          // the reloadNonce bump) unfired. Here we:
+          //   1. write the React Query cache so the editor's load effect
+          //      (which re-runs on the segmentationStatus flip and reads
+          //      cache-first) can't clobber us back to the stale result, and
+          //   2. push state + bump reloadNonce via onReloaded so
+          //      the canvas re-syncs even at an unchanged polygon count.
+          if (fresh.imageWidth && fresh.imageHeight) {
+            setImageDimensions({
+              width: fresh.imageWidth,
+              height: fresh.imageHeight,
+            });
+          }
+          setCachedSegmentationPolygons(queryClient, targetImageId, {
+            polygons: fresh.polygons ?? null,
+            imageWidth: fresh.imageWidth,
+            imageHeight: fresh.imageHeight,
+          });
+          onReloaded(fresh.polygons ?? null);
+          if (announce) {
+            toast.success(t('segmentation.toolbar.resegmentSuccess'));
+          }
+          return;
+        }
+        setTimeout(tick, 2000);
+      };
+      setTimeout(tick, 2000);
+    },
+    [onReloaded, setImageDimensions, queryClient, t, currentImageIdRef]
+  );
+
+  // Pure request helper — shared by the direct (single-channel) path
+  // and the dialog's onConfirm callback.
+  const runResegment = useCallback(
+    async (channel?: string) => {
+      if (!imageId || isResegmenting) return;
+      setIsResegmenting(true);
+      try {
+        // Snapshot the current result timestamp so the completion poll can
+        // tell when the ML has written the *new* segmentation.
+        const prevStamp =
+          (await apiClient.getSegmentationResults(imageId).catch(() => null))
+            ?.updatedAt ?? null;
+        const result = await apiClient.requestBatchSegmentation(
+          [imageId],
+          effectiveResegmentModel,
+          confidenceThreshold,
+          detectHoles,
+          channel
+        );
+        // Batch endpoint returns HTTP 200 even when every image failed;
+        // surface the per-image outcome (review pass-2 silent-failure #5).
+        if (result.successful === 0) {
+          const firstError = result.results?.[0]?.error;
+          logger.error('Resegment returned 0 successes', { firstError });
+          toast.error(
+            firstError
+              ? `${t('segmentation.toolbar.resegmentFailed')}: ${firstError}`
+              : t('segmentation.toolbar.resegmentFailed')
+          );
+          return;
+        }
+        // Defense-in-depth: a 1-image call is always all-or-nothing,
+        // but if the helper is ever reused with >1 imageIds a partial
+        // failure must not be hidden by the success toast.
+        if (result.failed > 0) {
+          const firstError = result.results?.find(r => !r.success)?.error;
+          logger.warn('Resegment partial failure', { result });
+          toast.warning(
+            firstError
+              ? `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed: ${firstError})`
+              : `${t('segmentation.toolbar.resegmentSuccess')} (${result.failed} failed)`
+          );
+        }
+        // The job is now QUEUED — the ML has not produced the new polygons
+        // yet. Kick off a non-blocking background poll that refreshes the
+        // canvas + fires the success toast once the new segmentation lands;
+        // isResegmenting is cleared right away (finally) so the button never
+        // appears stuck while the ML runs.
+        startResegmentPoll(imageId, prevStamp, result.failed === 0);
+      } catch (err) {
+        if (handleCancelledError(err, 'resegment current frame')) return;
+        logger.error('Resegment failed', err);
+        toast.error(t('segmentation.toolbar.resegmentFailed'));
+      } finally {
+        setIsResegmenting(false);
+      }
+    },
+    [
+      imageId,
+      isResegmenting,
+      effectiveResegmentModel,
+      confidenceThreshold,
+      detectHoles,
+      startResegmentPoll,
+      t,
+    ]
+  );
+
+  // Top-toolbar Resegment entry point. Multichannel videos open the
+  // channel picker first (per CLAUDE.md spec); single-channel cases
+  // commit immediately.
+  const handleResegmentCurrentFrame = useCallback(() => {
+    if (!imageId || isResegmenting) return;
+    const channels = videoChannels ?? [];
+    if (channels.length > 1) {
+      setShowResegmentChannelDialog(true);
+      return;
+    }
+    void runResegment();
+  }, [imageId, isResegmenting, videoChannels, runResegment]);
+
+  return {
+    isResegmenting,
+    showResegmentChannelDialog,
+    setShowResegmentChannelDialog,
+    effectiveResegmentModel,
+    runResegment,
+    handleResegmentCurrentFrame,
+  };
+}

--- a/src/pages/segmentation/hooks/useResegment.ts
+++ b/src/pages/segmentation/hooks/useResegment.ts
@@ -6,14 +6,6 @@ import { handleCancelledError } from '@/lib/errorUtils';
 import { toast } from 'sonner';
 import { setCachedSegmentationPolygons } from './segmentationPolygonCache';
 
-/**
- * Minimal channel type for the multi-channel picker.
- */
-interface VideoChannel {
-  name: string;
-  isSegmentationSource?: boolean;
-}
-
 interface UseResegmentParams {
   projectId: string | undefined;
   imageId: string | undefined;
@@ -21,8 +13,12 @@ interface UseResegmentParams {
   selectedModel: string;
   confidenceThreshold: number;
   detectHoles: boolean;
-  /** Channels from video.container?.channels (or null for standalone images). */
-  videoChannels: VideoChannel[] | null | undefined;
+  /**
+   * Channels from `video.container?.channels` (or null for standalone images).
+   * Only the count is read here (to decide whether to open the channel picker),
+   * so the element shape is intentionally opaque.
+   */
+  videoChannels: readonly unknown[] | null | undefined;
   queryClient: QueryClient;
   /** Translation function. */
   t: (key: string) => string;

--- a/src/pages/segmentation/hooks/useSegmentationLoader.ts
+++ b/src/pages/segmentation/hooks/useSegmentationLoader.ts
@@ -1,0 +1,376 @@
+import { useState, useEffect } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import apiClient, { type SegmentationPolygon } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { handleCancelledError } from '@/lib/errorUtils';
+import { toast } from 'sonner';
+import {
+  getCachedSegmentationPolygons,
+  setCachedSegmentationPolygons,
+} from './segmentationPolygonCache';
+
+/**
+ * Minimal structural slice of selectedImage that the loader reads.
+ * Declared locally so this hook stays light-import (no heavy component graph).
+ */
+interface SelectedImageSlice {
+  segmentationStatus?: string;
+  width?: number;
+  height?: number;
+}
+
+interface UseSegmentationLoaderParams {
+  projectId: string | undefined;
+  imageId: string | undefined;
+  selectedImage: SelectedImageSlice | undefined;
+  /** Returns an AbortSignal for the given operation name. */
+  getSignal: (name: string) => AbortSignal;
+  queryClient: QueryClient;
+  /** Translation function for error toasts. */
+  t: (key: string) => string;
+  /** Ref tracking the currently-active imageId (written by orchestrator). */
+  currentImageIdRef: React.MutableRefObject<string | undefined>;
+}
+
+interface UseSegmentationLoaderResult {
+  segmentationPolygons: SegmentationPolygon[] | null;
+  setSegmentationPolygons: React.Dispatch<
+    React.SetStateAction<SegmentationPolygon[] | null>
+  >;
+  imageDimensions: { width: number; height: number } | null;
+  setImageDimensions: React.Dispatch<
+    React.SetStateAction<{ width: number; height: number } | null>
+  >;
+  loadedFrameKey: string | null;
+  handleImageLoad: (width: number, height: number, channelsKey: string) => void;
+}
+
+/**
+ * Owns the segmentation data-load cluster:
+ *   - segmentationPolygons + imageDimensions + loadedFrameKey state
+ *   - primary loadSegmentation useEffect (cache-first → API fetch)
+ *   - handleImageLoad callback (marks frame as ready + updates dims)
+ *
+ * HAZARDS (per design doc):
+ *   - previousImageIdRef and its two writer effects stay in the orchestrator.
+ *   - reloadNonce + handleReloadedPolygons stay in the orchestrator (liaison).
+ *   - onSave closure stays inline in the orchestrator.
+ *   - The imageId-change abort/cleanup effect (dual-writes previousImageIdRef)
+ *     stays in the orchestrator.
+ */
+export function useSegmentationLoader({
+  projectId,
+  imageId,
+  selectedImage,
+  getSignal,
+  queryClient,
+  t,
+  currentImageIdRef,
+}: UseSegmentationLoaderParams): UseSegmentationLoaderResult {
+  // State for segmentation polygons from API
+  const [segmentationPolygons, setSegmentationPolygons] = useState<
+    SegmentationPolygon[] | null
+  >(null);
+  const [imageDimensions, setImageDimensions] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  // `loadedFrameKey` is `${imageId}::${channelsKey}` — both axes
+  // need to match before the Skeleton overlay can step aside.
+  // Tracking just `imageId` would let a channel toggle keep a stale
+  // composite painted while the new channel still decodes.
+  // The debounce that latches "show overlay" lives inside
+  // `FrameLoadingGate`, which is rendered under ImageDisplayProvider
+  // (it needs `visibleChannels` to construct the target key).
+  const [loadedFrameKey, setLoadedFrameKey] = useState<string | null>(null);
+
+  // Load segmentation data with proper cancellation handling
+  useEffect(() => {
+    let isMounted = true;
+
+    // Update current image ref immediately
+    currentImageIdRef.current = imageId;
+
+    const loadSegmentation = async () => {
+      if (!projectId || !imageId) return;
+
+      // Get abort signal for main loading operation
+      const signal = getSignal('main-loading');
+
+      // Immediately clear polygons when switching images to prevent showing old data
+      setSegmentationPolygons(null);
+      setImageDimensions(null); // Also clear image dimensions
+      logger.debug(
+        '🧹 Cleared polygons and dimensions for new image:',
+        imageId
+      );
+
+      // Check if the image has completed segmentation before trying to fetch results
+      const hasSegmentation =
+        selectedImage?.segmentationStatus === 'completed' ||
+        selectedImage?.segmentationStatus === 'segmented';
+
+      if (!hasSegmentation) {
+        logger.debug(
+          'Image does not have completed segmentation, skipping fetch:',
+          {
+            imageId,
+            status: selectedImage?.segmentationStatus,
+          }
+        );
+
+        // Set image dimensions from project data if available
+        if (selectedImage?.width && selectedImage?.height) {
+          logger.debug(
+            '📐 Setting image dimensions from project data (no segmentation):',
+            {
+              width: selectedImage.width,
+              height: selectedImage.height,
+            }
+          );
+          if (isMounted && imageId === currentImageIdRef.current) {
+            setImageDimensions({
+              width: selectedImage.width,
+              height: selectedImage.height,
+            });
+          }
+        }
+        return;
+      }
+
+      // Cache hit: serve a previously-fetched / prefetched result
+      // without going to the network. The shared React Query cache
+      // is populated by the editor's own success path below and by
+      // the `useFrameWindowPrefetch` sliding window, so scrub-back
+      // and pre-warmed frames paint instantly.
+      const cached = getCachedSegmentationPolygons(queryClient, imageId);
+      if (cached !== undefined) {
+        if (!isMounted || imageId !== currentImageIdRef.current) return;
+        if (cached.imageWidth && cached.imageHeight) {
+          setImageDimensions({
+            width: cached.imageWidth,
+            height: cached.imageHeight,
+          });
+        } else if (selectedImage?.width && selectedImage?.height) {
+          setImageDimensions({
+            width: selectedImage.width,
+            height: selectedImage.height,
+          });
+        }
+        setSegmentationPolygons(cached.polygons);
+        return;
+      }
+
+      try {
+        const segmentationData = await apiClient.getSegmentationResults(
+          imageId,
+          {
+            signal,
+          }
+        );
+
+        // Verify we're still on the same image and component is mounted
+        if (
+          !isMounted ||
+          imageId !== currentImageIdRef.current ||
+          signal.aborted
+        ) {
+          logger.debug(
+            '🛑 Segmentation load cancelled - image changed or component unmounted'
+          );
+          return;
+        }
+
+        // Populate the shared cache with the *normalised* result so
+        // a future scrub-back or window-prefetch read can serve from
+        // RAM. Empty / 404 frames are cached as `polygons: null` to
+        // avoid retry storms on a fast scrub across non-segmented
+        // frames.
+        if (segmentationData && !segmentationData.polygons) {
+          // Backend returned a non-null payload without a polygons
+          // field — distinguishes a misshaped 200 from a legitimate
+          // "no segmentation yet" so a misconfigured response doesn't
+          // silently masquerade as empty for 60 s of staleTime.
+          logger.warn(
+            'Segmentation response present but missing polygons field — caching as empty',
+            { imageId }
+          );
+        }
+        setCachedSegmentationPolygons(queryClient, imageId, {
+          polygons: segmentationData?.polygons ?? null,
+          imageWidth: segmentationData?.imageWidth,
+          imageHeight: segmentationData?.imageHeight,
+        });
+
+        // Handle empty or null segmentation gracefully
+        if (!segmentationData || !segmentationData.polygons) {
+          logger.debug('No segmentation data found for image:', imageId);
+          if (isMounted && imageId === currentImageIdRef.current) {
+            setSegmentationPolygons(null);
+          }
+
+          // Still try to set image dimensions from project data if available
+          if (selectedImage?.width && selectedImage?.height) {
+            logger.debug(
+              '📐 Setting image dimensions from project data (no segmentation):',
+              {
+                width: selectedImage.width,
+                height: selectedImage.height,
+              }
+            );
+            if (isMounted && imageId === currentImageIdRef.current) {
+              setImageDimensions({
+                width: selectedImage.width,
+                height: selectedImage.height,
+              });
+            }
+          }
+          return;
+        }
+
+        const polygons = segmentationData.polygons;
+
+        // Extract image dimensions from segmentation data if available
+        if (segmentationData.imageWidth && segmentationData.imageHeight) {
+          logger.debug('📐 Setting image dimensions from segmentation data:', {
+            width: segmentationData.imageWidth,
+            height: segmentationData.imageHeight,
+          });
+          if (isMounted && imageId === currentImageIdRef.current) {
+            setImageDimensions({
+              width: segmentationData.imageWidth,
+              height: segmentationData.imageHeight,
+            });
+          }
+        } else if (selectedImage?.width && selectedImage?.height) {
+          // Fallback to image dimensions from project data (database)
+          logger.debug(
+            '📐 Setting image dimensions from project data (fallback):',
+            {
+              width: selectedImage.width,
+              height: selectedImage.height,
+            }
+          );
+          if (isMounted && imageId === currentImageIdRef.current) {
+            setImageDimensions({
+              width: selectedImage.width,
+              height: selectedImage.height,
+            });
+          }
+        }
+
+        logger.debug('📥 Loaded segmentation polygons from API:', {
+          imageId,
+          polygonCount: polygons.length,
+          imageDimensions:
+            segmentationData.imageWidth && segmentationData.imageHeight
+              ? `${segmentationData.imageWidth}x${segmentationData.imageHeight}`
+              : 'not available',
+          firstPolygon: polygons[0]
+            ? {
+                id: polygons[0].id,
+                type: polygons[0].type,
+                pointsCount: polygons[0].points?.length || 0,
+                samplePoints: polygons[0].points?.slice(0, 3),
+              }
+            : null,
+        });
+
+        // Final check before setting state
+        if (isMounted && imageId === currentImageIdRef.current) {
+          setSegmentationPolygons(polygons);
+        }
+      } catch (error: any) {
+        // Handle cancellation gracefully - don't show errors for cancelled requests
+        if (handleCancelledError(error, 'segmentation loading')) {
+          return;
+        }
+
+        // Only handle real errors if we're still on the same image
+        if (isMounted && imageId === currentImageIdRef.current) {
+          logger.error('Failed to load segmentation:', error);
+          // Set to null instead of showing error for missing segmentation
+          if (
+            error &&
+            typeof error === 'object' &&
+            'response' in error &&
+            (error as { response?: { status?: number } }).response?.status ===
+              404
+          ) {
+            logger.debug('No segmentation found for image (404):', imageId);
+            setSegmentationPolygons(null);
+          } else {
+            toast.error(t('toast.operationFailed'));
+            setSegmentationPolygons(null);
+          }
+        }
+      }
+    };
+
+    loadSegmentation();
+
+    return () => {
+      isMounted = false;
+      // Don't abort here - let the coordinated controller handle it
+    };
+    // currentImageIdRef is a stable React ref object — intentionally omitted
+    // from the deps array. Adding it would cause the effect to re-run on every
+    // render since refs are mutable objects (the linter compares the ref object
+    // itself, not .current). The effect reads .current inside the async body,
+    // which always gets the latest value without requiring a dep listing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    projectId,
+    imageId,
+    t,
+    selectedImage?.width,
+    selectedImage?.height,
+    selectedImage?.segmentationStatus,
+    getSignal,
+    queryClient,
+  ]);
+
+  // Handle image load to get dimensions (only if not already set from segmentation data)
+  const handleImageLoad = (
+    width: number,
+    height: number,
+    channelsKey: string
+  ) => {
+    // Mark this `(imageId, channels)` pair as visible so the Skeleton
+    // overlay can step aside. The channelsKey comes from the canvas
+    // that just finished compositing — see `MultiChannelCanvas.onLoad`.
+    if (imageId) setLoadedFrameKey(`${imageId}::${channelsKey}`);
+    setImageDimensions(current => {
+      // Only update if dimensions are not already set from segmentation data
+      if (!current) {
+        logger.debug('📐 Setting image dimensions from image load:', {
+          width,
+          height,
+        });
+        return { width, height };
+      }
+
+      // Log if dimensions differ between image and segmentation data
+      if (current.width !== width || current.height !== height) {
+        logger.warn('⚠️ Image dimensions mismatch:', {
+          fromSegmentation: current,
+          fromImage: { width, height },
+          imageId,
+        });
+        // Keep segmentation data dimensions (they're more reliable)
+        return current;
+      }
+
+      return current;
+    });
+  };
+
+  return {
+    segmentationPolygons,
+    setSegmentationPolygons,
+    imageDimensions,
+    setImageDimensions,
+    loadedFrameKey,
+    handleImageLoad,
+  };
+}

--- a/src/pages/segmentation/hooks/useSegmentationLoader.ts
+++ b/src/pages/segmentation/hooks/useSegmentationLoader.ts
@@ -280,7 +280,7 @@ export function useSegmentationLoader({
         if (isMounted && imageId === currentImageIdRef.current) {
           setSegmentationPolygons(polygons);
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Handle cancellation gracefully - don't show errors for cancelled requests
         if (handleCancelledError(error, 'segmentation loading')) {
           return;

--- a/src/pages/segmentation/utils/__tests__/transformSegmentationPolygons.test.ts
+++ b/src/pages/segmentation/utils/__tests__/transformSegmentationPolygons.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import { transformSegmentationPolygons } from '../transformSegmentationPolygons';
+import type { SegmentationPolygon } from '@/lib/api';
+
+// Silence the deterministic warn/debug logs the transform emits.
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), debug: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const dims = { width: 100, height: 100 };
+
+// Minimal helper — only the fields the transform reads.
+const poly = (over: Partial<SegmentationPolygon> = {}): SegmentationPolygon =>
+  ({
+    id: 'p1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    type: 'external',
+    ...over,
+  }) as SegmentationPolygon;
+
+describe('transformSegmentationPolygons', () => {
+  describe('empty / invalid input', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty array', []],
+
+      ['non-array', {} as any],
+    ])('returns [] for %s', (_label, input) => {
+      expect(transformSegmentationPolygons(input, dims)).toEqual([]);
+    });
+  });
+
+  describe('degenerate-shape filtering', () => {
+    it('drops a polygon with fewer than 3 points', () => {
+      const out = transformSegmentationPolygons(
+        [
+          poly({
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+          }),
+        ],
+        dims
+      );
+      expect(out).toHaveLength(0);
+    });
+
+    it('keeps a polyline with exactly 2 points (lower minimum for polylines)', () => {
+      const out = transformSegmentationPolygons(
+        [
+          poly({
+            geometry: 'polyline',
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+          }),
+        ],
+        dims
+      );
+      expect(out).toHaveLength(1);
+      expect(out[0].points).toHaveLength(2);
+    });
+
+    it('drops a polyline with only 1 point', () => {
+      const out = transformSegmentationPolygons(
+        [poly({ geometry: 'polyline', points: [{ x: 0, y: 0 }] })],
+        dims
+      );
+      expect(out).toHaveLength(0);
+    });
+  });
+
+  describe('point normalisation', () => {
+    it('converts [x, y] tuple points to { x, y }', () => {
+      const out = transformSegmentationPolygons(
+        [
+          poly({
+            points: [
+              [0, 0],
+              [10, 0],
+              [10, 10],
+            ] as any,
+          }),
+        ],
+        dims
+      );
+      expect(out[0].points).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ]);
+    });
+
+    it('drops a polygon whose non-numeric points leave fewer than the minimum', () => {
+      const out = transformSegmentationPolygons(
+        [
+          poly({
+            points: [{ x: 0, y: 0 }, { x: 'nope', y: 1 } as any, null as any],
+          }),
+        ],
+        dims
+      );
+      expect(out).toHaveLength(0);
+    });
+  });
+
+  describe('id coercion', () => {
+    it('keeps a valid id unchanged', () => {
+      const out = transformSegmentationPolygons(
+        [poly({ id: 'valid-id' })],
+        dims
+      );
+      expect(out[0].id).toBe('valid-id');
+    });
+
+    it('replaces an empty/invalid id with a generated fallback', () => {
+      const out = transformSegmentationPolygons([poly({ id: '   ' })], dims);
+      expect(out).toHaveLength(1);
+      expect(typeof out[0].id).toBe('string');
+      expect(out[0].id.trim().length).toBeGreaterThan(0);
+      expect(out[0].id).not.toBe('   ');
+    });
+  });
+
+  describe('field mapping', () => {
+    it('converts parentIds[] to parent_id (first element)', () => {
+      const out = transformSegmentationPolygons(
+        [
+          poly({
+            type: 'internal',
+            parentIds: ['parent-7', 'parent-8'],
+          } as any),
+        ],
+        dims
+      );
+      expect(out[0].parent_id).toBe('parent-7');
+      // parentIds is not carried through (only parent_id)
+      expect('parentIds' in out[0]).toBe(false);
+    });
+
+    it('leaves parent_id undefined when there are no parentIds', () => {
+      const out = transformSegmentationPolygons([poly()], dims);
+      expect(out[0].parent_id).toBeUndefined();
+    });
+
+    it('spreads other wire fields (trackId, partClass) through unchanged', () => {
+      const out = transformSegmentationPolygons(
+        [poly({ trackId: 'mt-3', partClass: 'head' } as any)],
+        dims
+      );
+
+      expect((out[0] as any).trackId).toBe('mt-3');
+
+      expect((out[0] as any).partClass).toBe('head');
+    });
+  });
+
+  it('processes a mixed batch — keeping valid, dropping degenerate', () => {
+    const out = transformSegmentationPolygons(
+      [
+        poly({ id: 'keep-1' }),
+        poly({ id: 'drop-1', points: [{ x: 0, y: 0 }] }), // too few
+        poly({ id: 'keep-2' }),
+      ],
+      dims
+    );
+    expect(out.map(p => p.id)).toEqual(['keep-1', 'keep-2']);
+  });
+
+  it('does not require imageDimensions (used only for logging)', () => {
+    const out = transformSegmentationPolygons([poly({ id: 'x' })], null);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('x');
+  });
+});

--- a/src/pages/segmentation/utils/transformSegmentationPolygons.ts
+++ b/src/pages/segmentation/utils/transformSegmentationPolygons.ts
@@ -1,0 +1,151 @@
+import { Polygon } from '@/lib/segmentation';
+import type { SegmentationPolygon } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import {
+  validatePolygonId,
+  ensureValidPolygonId,
+  logPolygonIdIssue,
+} from '@/lib/polygonIdUtils';
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Transform raw ML/wire `SegmentationPolygon[]` into editor `Polygon[]`:
+ *  - drops degenerate shapes (min 2 pts for polylines, 3 for polygons)
+ *  - normalises points (`[x, y]` tuples or `{ x, y }`) and skips non-numeric
+ *    coordinates
+ *  - coerces invalid/missing IDs to a stable fallback (`ensureValidPolygonId`)
+ *  - converts `parentIds[]` → `parent_id` (singular)
+ *  - spreads every other wire field through unchanged (e.g. `trackId`,
+ *    `partClass`, future additions) so the editor sees them without manual
+ *    maintenance
+ *
+ * Extracted verbatim from the `initialPolygons` memo in `SegmentationEditor`.
+ * Pure and dependency-light (no React, no socket.io/Radix/Axios — note the
+ * `import type` on `SegmentationPolygon`), so it is directly unit-testable
+ * without the editor's heavy import graph. `imageDimensions` feeds only the
+ * development debug log and does not influence the output.
+ */
+export function transformSegmentationPolygons(
+  segmentationPolygons: SegmentationPolygon[] | null | undefined,
+  imageDimensions: ImageDimensions | null
+): Polygon[] {
+  // Return empty array if no segmentation data exists or if it's not an array
+  if (
+    !segmentationPolygons ||
+    !Array.isArray(segmentationPolygons) ||
+    segmentationPolygons.length === 0
+  ) {
+    return [];
+  }
+
+  // For large datasets, process in chunks to prevent blocking
+  const startTime = performance.now();
+
+  // Transform SegmentationPolygon[] to Polygon[] and filter out invalid polygons.
+  // Spreads `segPoly` so any wire-level field (trackId, future additions) reaches
+  // the editor without manual maintenance; only parentIds[] needs explicit
+  // conversion to parent_id (singular).
+  const polygons: Polygon[] = segmentationPolygons
+    .filter(segPoly => {
+      const minPoints = segPoly.geometry === 'polyline' ? 2 : 3;
+      return segPoly.points && segPoly.points.length >= minPoints;
+    })
+    .map((segPoly): Polygon | null => {
+      const validPoints = segPoly.points
+        .map(point => {
+          if (Array.isArray(point)) {
+            return { x: point[0], y: point[1] };
+          }
+          if (typeof point === 'object' && point !== null) {
+            if (typeof point.x === 'number' && typeof point.y === 'number') {
+              return point;
+            }
+            logger.warn(
+              'Skipping invalid point with non-numeric coordinates',
+              point
+            );
+            return null;
+          }
+          logger.warn('Skipping invalid point format', point);
+          return null;
+        })
+        .filter((point): point is { x: number; y: number } => point !== null);
+
+      const minValidPoints = segPoly.geometry === 'polyline' ? 2 : 3;
+      if (validPoints.length < minValidPoints) {
+        logger.warn('Dropping polygon due to insufficient valid points', {
+          polygonId: segPoly.id,
+        });
+        return null;
+      }
+
+      let polygonId = segPoly.id;
+      if (!validatePolygonId(segPoly.id)) {
+        logPolygonIdIssue(
+          segPoly,
+          'Invalid or missing polygon ID from ML service'
+        );
+        polygonId = ensureValidPolygonId(segPoly.id, 'ml_polygon');
+        logger.warn(
+          `Generated fallback ID: ${polygonId} for polygon with invalid ID: ${segPoly.id}`
+        );
+      }
+
+      const { parentIds, ...rest } = segPoly;
+      return {
+        ...rest,
+        id: polygonId,
+        points: validPoints,
+        parent_id: parentIds?.[0],
+      };
+    })
+    .filter((polygon): polygon is Polygon => polygon !== null);
+
+  const invalidCount = segmentationPolygons.length - polygons.length;
+  const processingTime = performance.now() - startTime;
+
+  if (invalidCount > 0) {
+    logger.warn(
+      `⚠️ Filtered out ${invalidCount} invalid polygons (missing or insufficient points)`
+    );
+  }
+
+  // Monitor processing time to detect performance issues
+  if (processingTime > 100) {
+    logger.warn(
+      `⚠️ Polygon processing took ${processingTime.toFixed(2)}ms for ${segmentationPolygons.length} polygons`
+    );
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    logger.debug('🔄 Transformed segmentation polygons for editor:', {
+      hasSegmentationData: true,
+      inputCount: segmentationPolygons.length,
+      validCount: polygons.length,
+      filteredOut: invalidCount,
+      processingTime: `${processingTime.toFixed(2)}ms`,
+      imageDimensions,
+      firstPolygon: polygons[0]
+        ? {
+            id: polygons[0].id,
+            type: polygons[0].type,
+            parent_id: polygons[0].parent_id,
+            pointsCount: polygons[0].points?.length || 0,
+            firstPoints: polygons[0].points?.slice(0, 3),
+          }
+        : null,
+      internalPolygonCount: polygons.filter(
+        p => p.type === 'internal' || p.parent_id
+      ).length,
+      externalPolygonCount: polygons.filter(
+        p => p.type === 'external' && !p.parent_id
+      ).length,
+    });
+  }
+
+  return polygons;
+}


### PR DESCRIPTION
## Summary

Structural refactor (ZERO behavior change) of the repo's hardest component. Extracts 6 logic units out of the 2073-LOC `SegmentationEditor.tsx` god-component (**now 1289 LOC, −38%**) into light-import, independently-testable files, and fixes the test-suite OOM for that logic.

**Spec:** `docs/superpowers/specs/2026-05-30-segmentation-editor-refactor-design.md`

## What moved (each verbatim → its own file + unit test)

| Stage | Unit | Tests |
|---|---|---|
| 1 | `transformSegmentationPolygons` (pure util) | 16 |
| 2 | `usePolygonRenderProps` (render-derivation memos) | 11 |
| 3+4 | `usePolygonHandlers` (CRUD + selection state + MT cross-frame effect) | 17 |
| 5 | `useSegmentationLoader` (data-load cluster) | 10 |
| 6 | `useResegment` (resegment + background poll) | 15 |

**69 new unit tests**, each ~1s (light imports — `import type` keeps `apiClient`/Axios/socket.io/Radix out of the graph), so logic that was previously locked behind the editor's ~3.8GB import graph is now testable. The JSX render tree, prop-threading, `onSave`, and the frame-slider choreography were deliberately left untouched (lowest-risk, scoped as a future pass).

## Hazards contained (per spec)

1. `previousImageIdRef` + both its writer effects stayed in the orchestrator.
2. `onSave` stayed inline.
3. `useResegment` takes `videoChannels` as a param, called after `const video = useVideoFrames(...)` (TDZ — CLAUDE.md bug #11).
4. `reloadNonce` + `handleReloadedPolygons` stayed as the liaison.
5. `usePolygonHandlers` called before `usePolygonRenderProps` (so `hiddenPolygonIds` is in scope).

## Review

Three specialist reviewers (behavior-preservation, silent-failure, type-design) verified each extracted body is verbatim-identical to the original, all hazards honored, no silent-failure regressions, hook order safe. Two honest-type fixes + one dead-return trim were applied. **No issues at confidence ≥80.**

## Verification

- 69 unit + 28 orchestration/integration tests green; **full FE suite 5747 passed / 0 failures**; `make ci` (TS + ESLint 0 + i18n) clean; production bundle builds (gate G).
- **Playwright editor walkthrough on production:** opened a segmented image → both polygons rendered with correct external/internal types + metrics; navigated to a second image → loader re-loaded/transformed/rendered correctly (the riskiest stage + the `previousImageIdRef` hazard); **0 console errors throughout.**

Also includes a fix for a latent PR #230 miss: 4 `AuthProvider`-rendering test files now set the `authenticated` hint cookie (surfaced by the full-suite run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup across multiple test suites to ensure consistent authentication state during testing
  * Added comprehensive test coverage for segmentation workflows and editor operations

* **Refactor**
  * Reorganized segmentation editor code into modular, independently testable units for improved maintainability and clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->