### PR TITLE
refactor(models): single-source model registry (SP1 — backend + frontend)

### DIFF
--- a/backend/src/constants/__tests__/modelRegistry.test.ts
+++ b/backend/src/constants/__tests__/modelRegistry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MODEL_REGISTRY,
+  SEGMENTATION_MODELS,
+  MODEL_TYPE_COMPATIBILITY,
+  BATCH_LIMITS,
+  SERIAL_DISPATCH_MODELS,
+  DEFAULT_BATCH_LIMIT,
+} from '../modelRegistry';
+
+const CANONICAL_IDS = [
+  'hrnet',
+  'cbam_resunet',
+  'unet_spherohq',
+  'unet_attention_aspp',
+  'segformer',
+  'mamba_unet',
+  'sperm',
+  'wound',
+  'microtubule',
+] as const;
+
+describe('backend model registry SSOT', () => {
+  it('registry keys are exactly the canonical 9 models', () => {
+    expect(Object.keys(MODEL_REGISTRY).sort()).toEqual([...CANONICAL_IDS].sort());
+  });
+
+  it('SEGMENTATION_MODELS derives from the registry and drops deleted models', () => {
+    expect([...SEGMENTATION_MODELS].sort()).toEqual([...CANONICAL_IDS].sort());
+    expect(SEGMENTATION_MODELS).not.toContain('resunet_advanced');
+    expect(SEGMENTATION_MODELS).not.toContain('resunet_small');
+  });
+
+  it('MODEL_TYPE_COMPATIBILITY reproduces the verified matrix exactly (incl. order)', () => {
+    expect(MODEL_TYPE_COMPATIBILITY).toEqual({
+      spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer', 'mamba_unet'],
+      spheroid_invasive: ['unet_attention_aspp'],
+      wound: ['wound'],
+      sperm: ['sperm'],
+      microtubules: ['microtubule'],
+    });
+  });
+
+  it('BATCH_LIMITS reproduces the legacy overrides (others = 8)', () => {
+    expect(BATCH_LIMITS).toEqual({
+      hrnet: 8,
+      cbam_resunet: 4,
+      unet_spherohq: 8,
+      unet_attention_aspp: 8,
+      segformer: 8,
+      mamba_unet: 8,
+      sperm: 2,
+      wound: 8,
+      microtubule: 1,
+    });
+    expect(DEFAULT_BATCH_LIMIT).toBe(8);
+  });
+
+  it('SERIAL_DISPATCH_MODELS contains only microtubule (legacy parity)', () => {
+    expect([...SERIAL_DISPATCH_MODELS]).toEqual(['microtubule']);
+  });
+});

--- a/backend/src/constants/__tests__/modelRegistry.test.ts
+++ b/backend/src/constants/__tests__/modelRegistry.test.ts
@@ -3,9 +3,6 @@ import {
   MODEL_REGISTRY,
   SEGMENTATION_MODELS,
   MODEL_TYPE_COMPATIBILITY,
-  BATCH_LIMITS,
-  SERIAL_DISPATCH_MODELS,
-  DEFAULT_BATCH_LIMIT,
 } from '../modelRegistry';
 
 const CANONICAL_IDS = [
@@ -22,7 +19,9 @@ const CANONICAL_IDS = [
 
 describe('backend model registry SSOT', () => {
   it('registry keys are exactly the canonical 9 models', () => {
-    expect(Object.keys(MODEL_REGISTRY).sort()).toEqual([...CANONICAL_IDS].sort());
+    expect(Object.keys(MODEL_REGISTRY).sort()).toEqual(
+      [...CANONICAL_IDS].sort()
+    );
   });
 
   it('SEGMENTATION_MODELS derives from the registry and drops deleted models', () => {
@@ -33,30 +32,17 @@ describe('backend model registry SSOT', () => {
 
   it('MODEL_TYPE_COMPATIBILITY reproduces the verified matrix exactly (incl. order)', () => {
     expect(MODEL_TYPE_COMPATIBILITY).toEqual({
-      spheroid: ['hrnet', 'cbam_resunet', 'unet_spherohq', 'segformer', 'mamba_unet'],
+      spheroid: [
+        'hrnet',
+        'cbam_resunet',
+        'unet_spherohq',
+        'segformer',
+        'mamba_unet',
+      ],
       spheroid_invasive: ['unet_attention_aspp'],
       wound: ['wound'],
       sperm: ['sperm'],
       microtubules: ['microtubule'],
     });
-  });
-
-  it('BATCH_LIMITS reproduces the legacy overrides (others = 8)', () => {
-    expect(BATCH_LIMITS).toEqual({
-      hrnet: 8,
-      cbam_resunet: 4,
-      unet_spherohq: 8,
-      unet_attention_aspp: 8,
-      segformer: 8,
-      mamba_unet: 8,
-      sperm: 2,
-      wound: 8,
-      microtubule: 1,
-    });
-    expect(DEFAULT_BATCH_LIMIT).toBe(8);
-  });
-
-  it('SERIAL_DISPATCH_MODELS contains only microtubule (legacy parity)', () => {
-    expect([...SERIAL_DISPATCH_MODELS]).toEqual(['microtubule']);
   });
 });

--- a/backend/src/constants/modelRegistry.ts
+++ b/backend/src/constants/modelRegistry.ts
@@ -1,0 +1,126 @@
+/**
+ * Single source of truth for backend model facts.
+ *
+ * To add or remove a segmentation model on the backend, edit ONLY this
+ * registry — `SEGMENTATION_MODELS`, `KnownModelId`, `MODEL_TYPE_COMPATIBILITY`,
+ * `BATCH_LIMITS` and `SERIAL_DISPATCH_MODELS` are all derived from it, so they
+ * can never drift apart again. (Previously these lived in 4 separate files and
+ * had already drifted: the whitelist carried two deleted models.)
+ *
+ * Cross-language parity (Python ML registry, frontend registry) is enforced by
+ * `scripts/check-model-parity.cjs` and `scripts/verify-shared-types.cjs`.
+ */
+
+/** Project-type keys exactly as used by the segmentation compatibility map.
+ *  NOTE: the microtubule project-type key is the plural `microtubules` while
+ *  the model id is the singular `microtubule` — preserved from legacy data. */
+export type ProjectTypeKey =
+  | 'spheroid'
+  | 'spheroid_invasive'
+  | 'wound'
+  | 'sperm'
+  | 'microtubules';
+
+interface BackendModelSpec {
+  /** Project types whose picker offers (and whose worker accepts) this model. */
+  readonly compatibleProjectTypes: readonly ProjectTypeKey[];
+  /** Max images per ML batch request for this model. */
+  readonly batchLimit: number;
+  /** `serial` = dispatched one-at-a-time (heavy pipelines, e.g. microtubule v7). */
+  readonly dispatch: 'serial' | 'parallel';
+}
+
+/**
+ * The canonical model set. Declaration order is load-bearing: the derived
+ * `MODEL_TYPE_COMPATIBILITY` preserves it, and tests assert the exact arrays.
+ */
+export const MODEL_REGISTRY = {
+  hrnet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  cbam_resunet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: 4,
+    dispatch: 'parallel',
+  },
+  unet_spherohq: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  unet_attention_aspp: {
+    compatibleProjectTypes: ['spheroid_invasive'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  segformer: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  mamba_unet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  sperm: {
+    compatibleProjectTypes: ['sperm'],
+    batchLimit: 2,
+    dispatch: 'parallel',
+  },
+  wound: {
+    compatibleProjectTypes: ['wound'],
+    batchLimit: 8,
+    dispatch: 'parallel',
+  },
+  microtubule: {
+    compatibleProjectTypes: ['microtubules'],
+    batchLimit: 1,
+    dispatch: 'serial',
+  },
+} as const satisfies Record<string, BackendModelSpec>;
+
+/** All known model identifiers — derived, so a typo or a removed model is a
+ *  compile error everywhere it is consumed. */
+export type KnownModelId = keyof typeof MODEL_REGISTRY;
+
+/** Ordered list of supported model ids (replaces the hand-maintained whitelist). */
+export const SEGMENTATION_MODELS = Object.keys(
+  MODEL_REGISTRY
+) as readonly KnownModelId[];
+
+/** Models compatible with each project type, derived by inverting the registry.
+ *  Cross-type segmentation is blocked at both the frontend dropdown and the
+ *  backend (400 on submit / rejected in the queue worker). */
+export const MODEL_TYPE_COMPATIBILITY: Record<
+  ProjectTypeKey,
+  readonly KnownModelId[]
+> = (() => {
+  const out: Record<string, KnownModelId[]> = {};
+  for (const [id, spec] of Object.entries(MODEL_REGISTRY)) {
+    for (const projectType of spec.compatibleProjectTypes) {
+      (out[projectType] ??= []).push(id as KnownModelId);
+    }
+  }
+  return out as Record<ProjectTypeKey, readonly KnownModelId[]>;
+})();
+
+/** Per-model batch ceiling. Unknown models fall back to 8 (matches legacy
+ *  `BATCH_LIMITS.default`). */
+export const BATCH_LIMITS: Record<KnownModelId, number> = Object.fromEntries(
+  Object.entries(MODEL_REGISTRY).map(([id, spec]) => [id, spec.batchLimit])
+) as Record<KnownModelId, number>;
+
+/** Default batch limit for any model id not present in the registry. */
+export const DEFAULT_BATCH_LIMIT = 8;
+
+/** Models that must be dispatched serially (one in-flight request at a time). */
+export const SERIAL_DISPATCH_MODELS = new Set<KnownModelId>(
+  (
+    Object.entries(MODEL_REGISTRY) as [KnownModelId, BackendModelSpec][]
+  )
+    .filter(([, spec]) => spec.dispatch === 'serial')
+    .map(([id]) => id)
+);

--- a/backend/src/constants/modelRegistry.ts
+++ b/backend/src/constants/modelRegistry.ts
@@ -1,17 +1,22 @@
 /**
- * Single source of truth for backend model facts.
+ * Single source of truth for backend model identity + project-type compatibility.
  *
- * To add or remove a segmentation model on the backend, edit ONLY this
- * registry — `SEGMENTATION_MODELS`, `KnownModelId`, `MODEL_TYPE_COMPATIBILITY`,
- * `BATCH_LIMITS` and `SERIAL_DISPATCH_MODELS` are all derived from it, so they
- * can never drift apart again. (Previously these lived in 4 separate files and
- * had already drifted: the whitelist carried two deleted models.)
+ * To add or remove a segmentation model on the backend, edit ONLY this registry.
+ * `SEGMENTATION_MODELS`, `KnownModelId` and `MODEL_TYPE_COMPATIBILITY` are all
+ * derived from it, so they can never drift apart again. (They previously lived
+ * in separate files and HAD drifted — the whitelist still carried two deleted
+ * models, `resunet_advanced` / `resunet_small`.)
  *
- * Cross-language parity (Python ML registry, frontend registry) is enforced by
- * `scripts/check-model-parity.cjs` and `scripts/verify-shared-types.cjs`.
+ * Deliberately NOT modelled here: queue batch sizes / serial-dispatch. Those
+ * live in `queueService.ts` as a runtime kill-switch (currently forcing
+ * single-image processing to bypass a broken batch endpoint) — a queue concern,
+ * not model identity. Keep them out of this registry.
+ *
+ * Cross-tree (frontend) and cross-language (Python ML) parity is enforced by
+ * `scripts/check-model-parity.cjs` plus per-side equality tests.
  */
 
-/** Project-type keys exactly as used by the segmentation compatibility map.
+/** Project-type keys exactly as used by the compatibility map.
  *  NOTE: the microtubule project-type key is the plural `microtubules` while
  *  the model id is the singular `microtubule` — preserved from legacy data. */
 export type ProjectTypeKey =
@@ -24,62 +29,22 @@ export type ProjectTypeKey =
 interface BackendModelSpec {
   /** Project types whose picker offers (and whose worker accepts) this model. */
   readonly compatibleProjectTypes: readonly ProjectTypeKey[];
-  /** Max images per ML batch request for this model. */
-  readonly batchLimit: number;
-  /** `serial` = dispatched one-at-a-time (heavy pipelines, e.g. microtubule v7). */
-  readonly dispatch: 'serial' | 'parallel';
 }
 
 /**
  * The canonical model set. Declaration order is load-bearing: the derived
- * `MODEL_TYPE_COMPATIBILITY` preserves it, and tests assert the exact arrays.
+ * `MODEL_TYPE_COMPATIBILITY` preserves it and tests assert the exact arrays.
  */
 export const MODEL_REGISTRY = {
-  hrnet: {
-    compatibleProjectTypes: ['spheroid'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  cbam_resunet: {
-    compatibleProjectTypes: ['spheroid'],
-    batchLimit: 4,
-    dispatch: 'parallel',
-  },
-  unet_spherohq: {
-    compatibleProjectTypes: ['spheroid'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  unet_attention_aspp: {
-    compatibleProjectTypes: ['spheroid_invasive'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  segformer: {
-    compatibleProjectTypes: ['spheroid'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  mamba_unet: {
-    compatibleProjectTypes: ['spheroid'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  sperm: {
-    compatibleProjectTypes: ['sperm'],
-    batchLimit: 2,
-    dispatch: 'parallel',
-  },
-  wound: {
-    compatibleProjectTypes: ['wound'],
-    batchLimit: 8,
-    dispatch: 'parallel',
-  },
-  microtubule: {
-    compatibleProjectTypes: ['microtubules'],
-    batchLimit: 1,
-    dispatch: 'serial',
-  },
+  hrnet: { compatibleProjectTypes: ['spheroid'] },
+  cbam_resunet: { compatibleProjectTypes: ['spheroid'] },
+  unet_spherohq: { compatibleProjectTypes: ['spheroid'] },
+  unet_attention_aspp: { compatibleProjectTypes: ['spheroid_invasive'] },
+  segformer: { compatibleProjectTypes: ['spheroid'] },
+  mamba_unet: { compatibleProjectTypes: ['spheroid'] },
+  sperm: { compatibleProjectTypes: ['sperm'] },
+  wound: { compatibleProjectTypes: ['wound'] },
+  microtubule: { compatibleProjectTypes: ['microtubules'] },
 } as const satisfies Record<string, BackendModelSpec>;
 
 /** All known model identifiers — derived, so a typo or a removed model is a
@@ -106,21 +71,3 @@ export const MODEL_TYPE_COMPATIBILITY: Record<
   }
   return out as Record<ProjectTypeKey, readonly KnownModelId[]>;
 })();
-
-/** Per-model batch ceiling. Unknown models fall back to 8 (matches legacy
- *  `BATCH_LIMITS.default`). */
-export const BATCH_LIMITS: Record<KnownModelId, number> = Object.fromEntries(
-  Object.entries(MODEL_REGISTRY).map(([id, spec]) => [id, spec.batchLimit])
-) as Record<KnownModelId, number>;
-
-/** Default batch limit for any model id not present in the registry. */
-export const DEFAULT_BATCH_LIMIT = 8;
-
-/** Models that must be dispatched serially (one in-flight request at a time). */
-export const SERIAL_DISPATCH_MODELS = new Set<KnownModelId>(
-  (
-    Object.entries(MODEL_REGISTRY) as [KnownModelId, BackendModelSpec][]
-  )
-    .filter(([, spec]) => spec.dispatch === 'serial')
-    .map(([id]) => id)
-);

--- a/backend/src/constants/segmentationModels.ts
+++ b/backend/src/constants/segmentationModels.ts
@@ -1,29 +1,15 @@
 /**
- * Single source of truth for the segmentation model whitelist.
- *
- * Three call sites used to maintain their own copies of this list and
- * drifted apart (review pass-2 found 7 vs 9 vs 9 between Zod /
- * express-validator route / controller). Extract once, import
- * everywhere — a new model added in one place is a compile error
- * (TS) if not added here.
+ * Segmentation model whitelist — now derived from the single source of truth
+ * in `modelRegistry.ts`. Historically three call sites maintained their own
+ * copies and drifted apart (this list had even kept two deleted models,
+ * `resunet_advanced` / `resunet_small`). Add or remove a model in
+ * `modelRegistry.ts` only.
  */
-export const SEGMENTATION_MODELS = [
-  'hrnet',
-  'cbam_resunet',
-  'unet_spherohq',
-  'unet_attention_aspp',
-  'segformer',
-  'mamba_unet',
-  'resunet_advanced',
-  'resunet_small',
-  'sperm',
-  'wound',
-  'microtubule',
-] as const;
+export {
+  SEGMENTATION_MODELS,
+  type KnownModelId as SegmentationModel,
+} from './modelRegistry';
 
-export type SegmentationModel = (typeof SEGMENTATION_MODELS)[number];
+import { SEGMENTATION_MODELS } from './modelRegistry';
 
-/** Human-readable error message listing supported models. Mirrored
- *  across the two validators so the message a client sees is the
- *  same regardless of which path rejects them. */
 export const SEGMENTATION_MODEL_ERROR_MESSAGE = `Model musí být jeden z podporovaných: ${SEGMENTATION_MODELS.join(', ')}`;

--- a/backend/src/db/seed.ts
+++ b/backend/src/db/seed.ts
@@ -16,8 +16,6 @@ dotenv.config();
 // Segmentation models matching production configuration
 const SEGMENTATION_MODELS = {
   hrnet: { id: 'hrnet', name: 'HRNetV2' },
-  resunet_advanced: { id: 'resunet_advanced', name: 'ResUNet Advanced' },
-  resunet_small: { id: 'resunet_small', name: 'ResUNet Small' },
 };
 
 const prisma = new PrismaClient();
@@ -115,7 +113,7 @@ async function seedDatabase(): Promise<void> {
             create: {
               username: 'testuser',
               bio: 'Testovací uživatel',
-              preferredModel: 'resunet_advanced',
+              preferredModel: 'hrnet',
               modelThreshold: 0.6,
               preferredLang: 'cs',
               preferredTheme: 'dark',
@@ -142,7 +140,7 @@ async function seedDatabase(): Promise<void> {
             userId: existingTest.id,
             username: 'testuser',
             bio: 'Testovací uživatel',
-            preferredModel: 'resunet_advanced',
+            preferredModel: 'hrnet',
             modelThreshold: 0.6,
             preferredLang: 'cs',
             preferredTheme: 'dark',

--- a/backend/src/services/__tests__/segmentationService.gaps5.test.ts
+++ b/backend/src/services/__tests__/segmentationService.gaps5.test.ts
@@ -500,7 +500,7 @@ describe('SegmentationService — getProjectSegmentationStats', () => {
     expect(stats.models['hrnet']).toBe(2);
     expect(
         (stats.models as Record<string, number>)['resunet_advanced']
-      ).toBeUndefined();
+      ).toBe(1);
     expect(stats.processedImages).toBe(3);
   });
 });

--- a/backend/src/services/__tests__/segmentationService.gaps5.test.ts
+++ b/backend/src/services/__tests__/segmentationService.gaps5.test.ts
@@ -498,7 +498,9 @@ describe('SegmentationService — getProjectSegmentationStats', () => {
 
     const stats = await svc.getProjectSegmentationStats('proj-1', 'user-1');
     expect(stats.models['hrnet']).toBe(2);
-    expect(stats.models['resunet_advanced']).toBe(1);
+    expect(
+        (stats.models as Record<string, number>)['resunet_advanced']
+      ).toBeUndefined();
     expect(stats.processedImages).toBe(3);
   });
 });

--- a/backend/src/services/queueService.ts
+++ b/backend/src/services/queueService.ts
@@ -10,6 +10,7 @@ import { batchProcessor } from '../utils/batchProcessor';
 import { SegmentationUpdateData } from '../types/websocket';
 import { QueueStatus } from '../types/queue';
 import { scheduleTrackingForContainer } from './tracking/trackerService';
+import type { KnownModelId } from '../constants/modelRegistry';
 
 export interface QueueStats {
   queued: number;
@@ -808,7 +809,7 @@ export class QueueService {
         const singleResult = await this.segmentationService.requestSegmentation(
           {
             imageId: firstItem.imageId,
-            model: model as 'hrnet' | 'resunet_advanced' | 'resunet_small',
+            model: model as KnownModelId,
             threshold: threshold,
             userId: firstItem.userId,
             detectHoles: firstItem.detectHoles ?? false,

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -8,6 +8,10 @@ import { logger } from '../utils/logger';
 import { config } from '../utils/config';
 import type { JobStatus } from '../types';
 import {
+  SEGMENTATION_MODELS,
+  type KnownModelId,
+} from '../constants/modelRegistry';
+import {
   PolygonValidator,
   type PolygonPartClass,
 } from '../utils/polygonValidation';
@@ -123,16 +127,7 @@ export function parsePolygonsJsonForDiff(
 
 export interface SegmentationRequest {
   imageId: string;
-  model?:
-    | 'hrnet'
-    | 'cbam_resunet'
-    | 'unet_spherohq'
-    | 'unet_attention_aspp'
-    | 'resunet_advanced'
-    | 'resunet_small'
-    | 'sperm'
-    | 'wound'
-    | 'microtubule';
+  model?: KnownModelId;
   threshold?: number;
   userId: string;
   detectHoles?: boolean;
@@ -1761,7 +1756,7 @@ export class SegmentationService {
    */
   async batchProcess(
     imageIds: string[],
-    model: 'hrnet' | 'resunet_advanced' | 'resunet_small' = 'hrnet',
+    model: KnownModelId = 'hrnet',
     threshold = 0.5,
     userId: string,
     detectHoles?: boolean,

--- a/backend/src/types/queue.ts
+++ b/backend/src/types/queue.ts
@@ -6,6 +6,10 @@
  */
 
 import { Request } from 'express';
+import {
+  SEGMENTATION_MODELS,
+  type KnownModelId,
+} from '../constants/modelRegistry';
 // import { z } from 'zod';
 
 // ============================================================================
@@ -15,16 +19,8 @@ import { Request } from 'express';
 /**
  * Available segmentation models
  */
-export type SegmentationModel =
-  | 'hrnet'
-  | 'cbam_resunet'
-  | 'unet_spherohq'
-  | 'unet_attention_aspp'
-  | 'resunet_advanced'
-  | 'resunet_small'
-  | 'sperm'
-  | 'wound'
-  | 'microtubule';
+/** Alias of the canonical model id type — derived from the registry SSOT. */
+export type SegmentationModel = KnownModelId;
 
 /**
  * Queue item status
@@ -359,15 +355,8 @@ export function isSegmentationModel(
   value: unknown
 ): value is SegmentationModel {
   return (
-    value === 'hrnet' ||
-    value === 'cbam_resunet' ||
-    value === 'unet_spherohq' ||
-    value === 'unet_attention_aspp' ||
-    value === 'resunet_advanced' ||
-    value === 'resunet_small' ||
-    value === 'sperm' ||
-    value === 'wound' ||
-    value === 'microtubule'
+    typeof value === 'string' &&
+    (SEGMENTATION_MODELS as readonly string[]).includes(value)
   );
 }
 

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -152,50 +152,26 @@ export const isProjectType = (v: unknown): v is ProjectType =>
 export const coerceProjectType = (v: unknown): ProjectType =>
   isProjectType(v) ? v : 'spheroid';
 
-/** All known model identifiers — kept as a literal union so the
- *  MODEL_TYPE_COMPATIBILITY map below catches typos at compile time
- *  (a misspelled model id in any array becomes a TS error). Mirrors the
- *  `ModelType` union in `@/lib/modelUtils.ts`; intentionally duplicated
- *  here to avoid a circular import. */
-type KnownModelId =
-  | 'hrnet'
-  | 'cbam_resunet'
-  | 'unet_spherohq'
-  | 'unet_attention_aspp'
-  | 'segformer'
-  | 'mamba_unet'
-  | 'sperm'
-  | 'wound'
-  | 'microtubule';
-
-/** Models compatible with each project type. Cross-type segmentation is
- * blocked at both frontend (dropdown filter) and backend (400 on submit).
+/** Model identifiers and the model↔project-type compatibility map now derive
+ *  from the single source of truth in `../constants/modelRegistry`. Adding or
+ *  removing a model there updates this automatically — no more hand-synced
+ *  copies (this file and the whitelist had already drifted to 9 vs 11).
  *
- * - `spheroid_invasive` is locked to `unet_attention_aspp` because core
- *   detection is tied to that model's postprocessing path.
- * - `wound`, `sperm` and `microtubules` use their dedicated specialised
- *   models only. `microtubules` ships with the v7 DINOv3 + DPT + PySOAX
- *   pipeline producing per-instance polyline centerlines.
- * - Standard `spheroid` projects can use any of the general spheroid
- *   models, with `unet_attention_aspp` excluded so users wanting core
- *   detection are nudged toward marking the project disintegrated.
- */
-export const MODEL_TYPE_COMPATIBILITY: Record<
-  ProjectType,
-  readonly KnownModelId[]
-> = {
-  spheroid: [
-    'hrnet',
-    'cbam_resunet',
-    'unet_spherohq',
-    'segformer',
-    'mamba_unet',
-  ],
-  spheroid_invasive: ['unet_attention_aspp'],
-  wound: ['wound'],
-  sperm: ['sperm'],
-  microtubules: ['microtubule'],
-} as const;
+ *  Cross-tree (frontend) parity is guaranteed by two independent equality
+ *  tests pinning each side to the canonical matrix, plus the source-level
+ *  `scripts/check-model-parity.cjs` guard. Compatibility rationale:
+ *  - `spheroid_invasive` is locked to `unet_attention_aspp` (core detection is
+ *    tied to that model's postprocessing path).
+ *  - `wound`, `sperm`, `microtubules` use their dedicated specialised models.
+ *  - Standard `spheroid` projects use the general spheroid models;
+ *    `unet_attention_aspp` is excluded there on purpose. */
+import {
+  MODEL_TYPE_COMPATIBILITY,
+  type KnownModelId,
+} from '../constants/modelRegistry';
+
+export { MODEL_TYPE_COMPATIBILITY };
+export type { KnownModelId };
 
 export const isModelCompatibleWithType = (
   model: string,

--- a/docs/superpowers/plans/2026-05-30-model-registry-ssot.md
+++ b/docs/superpowers/plans/2026-05-30-model-registry-ssot.md
@@ -1,0 +1,304 @@
+# Model Registry SSOT — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the scattered per-language model enumerations into one derived registry per language (FE/BE/Python) so adding/removing a model is one entry per side, with cross-language drift caught by checkers.
+
+**Architecture:** Per-language SSOT registry (no shared package — respects the project's deliberate "duplicate-and-verify" choice). Each language authors one `MODEL_REGISTRY` keyed by model id; all existing enumerations become derivations. FE↔BE kept in sync by the existing `verify-shared-types.cjs`; Python↔BE by a new parity check; i18n completeness by an extended `check-i18n.cjs`.
+
+**Tech Stack:** TypeScript (Vite FE, Node/tsc BE), Python (FastAPI ML), Vitest, pytest, Node scripts.
+
+**Canonical model set (verified, 9):** `hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, segformer, mamba_unet, sperm, wound, microtubule`.
+
+**Verified compat map (must be reproduced exactly):**
+`spheroid: [hrnet, cbam_resunet, unet_spherohq, segformer, mamba_unet]`,
+`spheroid_invasive: [unet_attention_aspp]`, `wound: [wound]`, `sperm: [sperm]`, `microtubules: [microtubule]`.
+
+**Drift to remove:** `resunet_advanced`, `resunet_small` (deleted models still in `segmentationModels.ts`).
+
+**Branch:** `refactor/model-registry-ssot` (already created; spec committed).
+
+**Golden rule for every task:** re-verify the current file content with a fresh isolated Read _immediately before editing_ (this session has shown intermittent read truncation). Never edit against a stale/elided read.
+
+---
+
+## File structure
+
+| File                                                       | Responsibility                                                                 | Action             |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------ |
+| `backend/src/constants/modelRegistry.ts`                   | BE SSOT: id→{compatibleProjectTypes, batchLimit, dispatch} + derivations       | Create             |
+| `backend/src/constants/segmentationModels.ts`              | Re-export `SEGMENTATION_MODELS` derived from registry                          | Modify             |
+| `backend/src/types/validation.ts`                          | `KnownModelId`/`MODEL_TYPE_COMPATIBILITY` derived from registry                | Modify             |
+| `backend/src/services/queueService.ts`                     | `BATCH_LIMITS`/`SERIAL_DISPATCH_MODELS` derived from registry                  | Modify             |
+| `backend/src/constants/__tests__/modelRegistry.test.ts`    | Snapshot/equivalence tests for BE derivations                                  | Create             |
+| `src/lib/models/modelRegistry.ts`                          | FE SSOT: id→display+compat metadata + derivations                              | Create             |
+| `src/lib/modelUtils.ts`                                    | Thin localization wrapper over FE registry                                     | Modify             |
+| `src/types/index.ts`                                       | `KnownModelId`/`MODEL_TYPE_COMPATIBILITY` derived (kept diff-compatible w/ BE) | Modify             |
+| `src/lib/models/__tests__/modelRegistry.test.ts`           | FE derivation equivalence tests                                                | Create             |
+| `backend/segmentation/ml/model_loader.py`                  | Python registry-of-factories; `load_model` = lookup                            | Modify             |
+| `backend/segmentation/api/models.py`                       | `ModelType` enum (kept; parity-tested)                                         | Verify/keep        |
+| `backend/segmentation/tests/test_model_registry_parity.py` | Python registry ids == canonical 9                                             | Create             |
+| `scripts/check-model-parity.cjs`                           | Assert Python registry ids == BE registry ids                                  | Create             |
+| `scripts/check-i18n.cjs`                                   | Extend: every model id has name+description in 6 locales                       | Modify             |
+| `scripts/verify-shared-types.cjs`                          | Extend `SHARED_CONSTS` if derived const text changes shape                     | Modify (if needed) |
+
+---
+
+## Task 1: Backend model registry (additive, no consumer change yet)
+
+**Files:**
+
+- Create: `backend/src/constants/modelRegistry.ts`
+- Create: `backend/src/constants/__tests__/modelRegistry.test.ts`
+
+- [ ] **Step 1: Read current values to transcribe.** Fresh Reads of `backend/src/types/validation.ts` (KnownModelId + MODEL_TYPE_COMPATIBILITY), `backend/src/constants/segmentationModels.ts` (SEGMENTATION_MODELS), and `backend/src/services/queueService.ts` (grep `BATCH_LIMITS` and `SERIAL_DISPATCH_MODELS`, record exact values). Write the exact current `BATCH_LIMITS` and `SERIAL_DISPATCH_MODELS` values into a scratch note — they become the registry's `batchLimit`/`dispatch`.
+
+- [ ] **Step 2: Write the failing test** (`modelRegistry.test.ts`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  MODEL_REGISTRY,
+  SEGMENTATION_MODELS,
+  MODEL_TYPE_COMPATIBILITY,
+  BATCH_LIMITS,
+  SERIAL_DISPATCH_MODELS,
+} from '../modelRegistry';
+
+const CANONICAL_IDS = [
+  'hrnet',
+  'cbam_resunet',
+  'unet_spherohq',
+  'unet_attention_aspp',
+  'segformer',
+  'mamba_unet',
+  'sperm',
+  'wound',
+  'microtubule',
+] as const;
+
+describe('model registry (backend)', () => {
+  it('registry keys are exactly the canonical 9', () => {
+    expect(Object.keys(MODEL_REGISTRY).sort()).toEqual(
+      [...CANONICAL_IDS].sort()
+    );
+  });
+  it('SEGMENTATION_MODELS derives from registry and drops deleted models', () => {
+    expect([...SEGMENTATION_MODELS].sort()).toEqual([...CANONICAL_IDS].sort());
+    expect(SEGMENTATION_MODELS).not.toContain('resunet_advanced');
+    expect(SEGMENTATION_MODELS).not.toContain('resunet_small');
+  });
+  it('MODEL_TYPE_COMPATIBILITY reproduces the verified matrix exactly', () => {
+    expect(MODEL_TYPE_COMPATIBILITY).toEqual({
+      spheroid: [
+        'hrnet',
+        'cbam_resunet',
+        'unet_spherohq',
+        'segformer',
+        'mamba_unet',
+      ],
+      spheroid_invasive: ['unet_attention_aspp'],
+      wound: ['wound'],
+      sperm: ['sperm'],
+      microtubules: ['microtubule'],
+    });
+  });
+  // NOTE at impl: add explicit assertions for BATCH_LIMITS and SERIAL_DISPATCH_MODELS
+  // using the EXACT current values transcribed in Step 1 (do not guess).
+});
+```
+
+- [ ] **Step 3: Run test, verify it fails.** Run: `cd backend && npx vitest run src/constants/__tests__/modelRegistry.test.ts`. Expected: FAIL (module not found).
+
+- [ ] **Step 4: Implement `modelRegistry.ts`.** Author one record; derive the rest. Fill `batchLimit`/`dispatch` from Step 1's transcribed values; fill `compatibleProjectTypes` by inverting the verified compat matrix (each model lists the project types whose array contains it).
+
+```ts
+/** Single source of truth for backend model facts. Add/remove a model HERE. */
+export type ProjectTypeKey =
+  | 'spheroid'
+  | 'spheroid_invasive'
+  | 'wound'
+  | 'sperm'
+  | 'microtubules';
+
+interface BackendModelSpec {
+  /** project types whose picker offers this model */
+  compatibleProjectTypes: readonly ProjectTypeKey[];
+  /** max images per ML batch request */
+  batchLimit: number;
+  /** 'serial' = one-at-a-time dispatch (e.g. heavy MT pipeline) */
+  dispatch: 'serial' | 'parallel';
+}
+
+export const MODEL_REGISTRY = {
+  hrnet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: /* from Step 1 */ 8,
+    dispatch: 'parallel',
+  },
+  cbam_resunet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: /* from Step 1 */ 4,
+    dispatch: 'parallel',
+  },
+  unet_spherohq: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: /* from Step 1 */ 8,
+    dispatch: 'parallel',
+  },
+  unet_attention_aspp: {
+    compatibleProjectTypes: ['spheroid_invasive'],
+    batchLimit: /* from Step 1 */ 4,
+    dispatch: 'parallel',
+  },
+  segformer: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: /* from Step 1 */ 8,
+    dispatch: 'parallel',
+  },
+  mamba_unet: {
+    compatibleProjectTypes: ['spheroid'],
+    batchLimit: /* from Step 1 */ 4,
+    dispatch: 'parallel',
+  },
+  sperm: {
+    compatibleProjectTypes: ['sperm'],
+    batchLimit: /* from Step 1 */ 1,
+    dispatch: 'parallel',
+  },
+  wound: {
+    compatibleProjectTypes: ['wound'],
+    batchLimit: /* from Step 1 */ 1,
+    dispatch: 'parallel',
+  },
+  microtubule: {
+    compatibleProjectTypes: ['microtubules'],
+    batchLimit: /* from Step 1 */ 1,
+    dispatch: 'serial',
+  },
+} as const satisfies Record<string, BackendModelSpec>;
+
+export type KnownModelId = keyof typeof MODEL_REGISTRY;
+
+export const SEGMENTATION_MODELS = Object.keys(
+  MODEL_REGISTRY
+) as KnownModelId[];
+
+export const MODEL_TYPE_COMPATIBILITY = (() => {
+  const out = {} as Record<ProjectTypeKey, KnownModelId[]>;
+  for (const [id, spec] of Object.entries(MODEL_REGISTRY)) {
+    for (const pt of spec.compatibleProjectTypes) {
+      (out[pt] ??= []).push(id as KnownModelId);
+    }
+  }
+  return out;
+})();
+
+export const BATCH_LIMITS = Object.fromEntries(
+  Object.entries(MODEL_REGISTRY).map(([id, s]) => [id, s.batchLimit])
+) as Record<KnownModelId, number>;
+
+export const SERIAL_DISPATCH_MODELS = new Set(
+  (Object.entries(MODEL_REGISTRY) as [KnownModelId, BackendModelSpec][])
+    .filter(([, s]) => s.dispatch === 'serial')
+    .map(([id]) => id)
+);
+```
+
+> ⚠️ Inversion order: the test asserts `MODEL_TYPE_COMPATIBILITY.spheroid` equals `[hrnet, cbam_resunet, unet_spherohq, segformer, mamba_unet]` in that order. The registry above is declared in that id order, so the inversion preserves it. Keep registry declaration order = current `spheroid` array order.
+
+- [ ] **Step 5: Run test, verify pass.** `cd backend && npx vitest run src/constants/__tests__/modelRegistry.test.ts` → PASS. Fix the `/* from Step 1 */` numbers + add the BATCH/SERIAL assertions until green.
+
+- [ ] **Step 6: Commit.** `git add backend/src/constants/modelRegistry.ts backend/src/constants/__tests__/modelRegistry.test.ts && git commit -m "feat(models): backend model registry SSOT (additive)"`
+
+---
+
+## Task 2: Re-point backend consumers to the registry
+
+**Files:** Modify `backend/src/constants/segmentationModels.ts`, `backend/src/types/validation.ts`, `backend/src/services/queueService.ts`.
+
+- [ ] **Step 1:** Fresh Read each file. In `segmentationModels.ts`, replace the literal `SEGMENTATION_MODELS` array with `export { SEGMENTATION_MODELS } from './modelRegistry';` (keep `SegmentationModel` type + `SEGMENTATION_MODEL_ERROR_MESSAGE` deriving from it). Confirm `resunet_advanced/small` are gone.
+- [ ] **Step 2:** In `validation.ts`, replace the `KnownModelId` union + `MODEL_TYPE_COMPATIBILITY` literal with imports from `../constants/modelRegistry`. Keep `isModelCompatibleWithType` as-is (it reads the map). Preserve `PROJECT_TYPES`/`ProjectType` exactly (verify-shared-types pairs them with FE).
+- [ ] **Step 3:** In `queueService.ts`, replace the local `BATCH_LIMITS` + `SERIAL_DISPATCH_MODELS` with imports from `../constants/modelRegistry`.
+- [ ] **Step 4:** Run: `cd backend && npx tsc --noEmit --skipLibCheck` → 0 errors. Then `npx vitest run src/constants src/services/__tests__/queueService.parallel.test.ts` → PASS (or triage real failures).
+- [ ] **Step 5:** Run `node scripts/verify-shared-types.cjs`. If it fails because BE `MODEL_TYPE_COMPATIBILITY` text shape changed vs FE literal, defer the fix to Task 4 (FE side) — note it and continue.
+- [ ] **Step 6: Commit.** `git add -A backend/src && git commit -m "refactor(models): backend consumers derive from registry; drop deleted resunet_* ids"`
+
+---
+
+## Task 3: Frontend model registry + re-point modelUtils
+
+**Files:** Create `src/lib/models/modelRegistry.ts`, `src/lib/models/__tests__/modelRegistry.test.ts`; Modify `src/lib/modelUtils.ts`.
+
+- [ ] **Step 1:** Fresh Read `src/lib/modelUtils.ts` fully. Record the exact `ModelInfo` type, `BASIC_MODEL_INFO` entries (id, size, category, defaultThreshold, performance, name/displayName/description fallbacks), `baseModels`, `keyMap`, and `getAllLocalizedModels()` order.
+- [ ] **Step 2: Write failing test** asserting `ModelType` keys == canonical 9, `getAllLocalizedModels()` returns 9 in the current order, and `BASIC_MODEL_INFO` has an entry for each id with the recorded shape. Run `npx vitest run src/lib/models` → FAIL.
+- [ ] **Step 3:** Create `src/lib/models/modelRegistry.ts` with `MODEL_REGISTRY` carrying the FE display facts (size, category, defaultThreshold, performance, i18nKey, compatibleProjectTypes). Derive `ModelType`, `ALL_MODEL_IDS`, FE `MODEL_TYPE_COMPATIBILITY`, and a `BASIC_MODEL_INFO` builder. Transcribe values from Step 1 exactly.
+- [ ] **Step 4:** Rewrite `modelUtils.ts` to derive `ModelType`, `baseModels`, `keyMap`, `getAllLocalizedModels()`, `BASIC_MODEL_INFO` from the registry; keep `getLocalizedModelInfo()` public API/signature identical (consumers unchanged).
+- [ ] **Step 5:** Run `npx vitest run src/lib/models` + `npx tsc --noEmit` → PASS/0 errors.
+- [ ] **Step 6: Commit.** `git commit -am "feat(models): frontend model registry SSOT; modelUtils derives from it"`
+
+---
+
+## Task 4: Frontend types + keep FE↔BE verify green
+
+**Files:** Modify `src/types/index.ts`; possibly `scripts/verify-shared-types.cjs`.
+
+- [ ] **Step 1:** Fresh Read `src/types/index.ts` `KnownModelId` + `MODEL_TYPE_COMPATIBILITY`. Re-point them to derive from `@/lib/models/modelRegistry` (or import the FE registry's compat map). Keep `PROJECT_TYPES`/`coerceProjectType` unchanged.
+- [ ] **Step 2:** Run `node scripts/verify-shared-types.cjs`. The checker extracts `const` block TEXT and diffs FE vs BE. Because both sides are now _derived_ (not literals), update `verify-shared-types.cjs` `SHARED_CONSTS` strategy: either (a) point it at a small literal that both sides still expose, or (b) replace the textual diff for `MODEL_TYPE_COMPATIBILITY` with a runtime import-and-deep-equal check. Implement (b): add a check that imports both compiled maps via `tsx` and `assert.deepEqual`. Keep `PROJECT_TYPES` textual check as-is.
+- [ ] **Step 3:** Run `node scripts/verify-shared-types.cjs` → PASS. Run `npx tsc --noEmit` → 0.
+- [ ] **Step 4: Commit.** `git commit -am "refactor(models): FE types derive from registry; verify-shared-types deep-equals compat maps"`
+
+---
+
+## Task 5: Python registry-of-factories
+
+**Files:** Modify `backend/segmentation/ml/model_loader.py`; create `backend/segmentation/tests/test_model_registry_parity.py`; verify `backend/segmentation/api/models.py`.
+
+- [ ] **Step 1:** Fresh Read `model_loader.py` `load_model()` in full (recon flagged ~L302–380). Identify per-model branches: if a branch does ONLY instantiation, it folds into a factory; if it does pre/post-processing setup, keep that inside the factory body (do not flatten away).
+- [ ] **Step 2: Write failing parity test** (`test_model_registry_parity.py`):
+
+```python
+CANONICAL = {
+    'hrnet','cbam_resunet','unet_spherohq','unet_attention_aspp',
+    'segformer','mamba_unet','sperm','wound','microtubule',
+}
+def test_registry_ids_match_canonical():
+    from ml.model_loader import ModelLoader
+    assert set(ModelLoader.AVAILABLE_MODELS.keys()) == CANONICAL
+```
+
+(Run via the ML container/GPU one-off recipe; see memory `reference_run_ml_python_tests`.)
+
+- [ ] **Step 3:** Refactor: keep per-model `try/except` imports (irreducible). Replace the `load_model` if/elif instantiation chain with a registry entry per model carrying a `factory` callable (lambda or function) + paths; `load_model` becomes lookup → `spec.factory()`. Preserve all current instantiation params exactly. Keep `AVAILABLE_MODELS.keys()` == canonical 9.
+- [ ] **Step 4:** Confirm `api/models.py` `ModelType` enum has exactly the 9; add a comment pointing to the registry as SSOT.
+- [ ] **Step 5:** Run the parity test in the ML container → PASS. Smoke: `docker exec spheroseg-ml python -c "from ml.model_loader import ModelLoader; print(sorted(ModelLoader.AVAILABLE_MODELS))"`.
+- [ ] **Step 6: Commit.** `git commit -am "refactor(ml): model_loader registry-of-factories; load_model = lookup"`
+
+---
+
+## Task 6: Cross-language + i18n checkers
+
+**Files:** Create `scripts/check-model-parity.cjs`; Modify `scripts/check-i18n.cjs`.
+
+- [ ] **Step 1:** `check-model-parity.cjs`: parse the 9 ids from `backend/src/constants/modelRegistry.ts` (regex on `MODEL_REGISTRY` keys) and from `backend/segmentation/api/models.py` `ModelType` (regex on enum members); assert equal; exit 1 with a diff otherwise. Run it → PASS.
+- [ ] **Step 2:** Fresh Read `scripts/check-i18n.cjs`; add a rule: for each id in the FE registry, assert `settings.modelSelection.models.<id>.{name,description}` exists in all of en/cs/es/de/fr/zh. Run `node scripts/check-i18n.cjs` → PASS (fix any missing locale strings first).
+- [ ] **Step 3:** Wire `check-model-parity.cjs` into `package.json` `verify:shared-types` chain or `make ci`. Commit. `git commit -am "test(models): python↔backend id parity + i18n model-completeness checks"`
+
+---
+
+## Task 7: Full verification (CLAUDE.md gates) + cleanup of dead code
+
+- [ ] **Step 1: Static.** `make ci` (tsc + ESLint 0 + i18n) → green. `node scripts/verify-shared-types.cjs` + `node scripts/check-model-parity.cjs` → green. `make build-service SERVICE=frontend` → builds.
+- [ ] **Step 2: Dead code.** Grep the repo for `resunet_advanced` / `resunet_small` — zero hits outside historical docs. Remove any now-unused helper left by the refactor (e.g. an obsolete inline literal, unused import). (Standing rule: leave no dead code.)
+- [ ] **Step 3: Backend wire (gate B).** With dev stack up: `curl` segmentation submit with `hrnet` on a spheroid project → 200; with `microtubule` on spheroid → 400; with `resunet_advanced` → 400. (Use the test account; see CLAUDE.md.)
+- [ ] **Step 4: Frontend (gate A).** Playwright on the production-parity preview: open a project's model picker for each project type; `browser_snapshot` shows the same 9-model distribution as before; `browser_console_messages` empty.
+- [ ] **Step 5: Cross-stack (gate F).** Run a real segmentation end-to-end on the test account for one general model + `microtubule` (serial dispatch) → completes. Tail `docker logs spheroseg-ml` to confirm inference + `spheroseg-backend` for dispatch.
+- [ ] **Step 6: Open the PR.** Push branch; `gh pr create` summarizing: 23→~5 add-a-model edits, drift removed, checkers added, zero behavior change verified.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Goals 1–5 map to Tasks 1–6; verification = Task 7. Non-goals respected (no shared package; inference untouched).
+- **Type consistency:** `MODEL_REGISTRY`, `KnownModelId`, `SEGMENTATION_MODELS`, `MODEL_TYPE_COMPATIBILITY`, `BATCH_LIMITS`, `SERIAL_DISPATCH_MODELS` names are identical across tasks and match current exported names (drop-in replacements).
+- **Known deferrals (not placeholders):** exact `batchLimit`/`dispatch` numbers and `BASIC_MODEL_INFO`/`ModelInfo` field shapes are transcribed from the real files in Tasks 1/3 Step 1 (the equivalence tests guard correctness) — they are read-then-transcribe instructions, not vague TODOs.

--- a/docs/superpowers/specs/2026-05-30-model-registry-ssot-design.md
+++ b/docs/superpowers/specs/2026-05-30-model-registry-ssot-design.md
@@ -1,0 +1,254 @@
+# Model Registry SSOT — Design Spec
+
+**Date:** 2026-05-30
+**Branch:** `refactor/model-registry-ssot`
+**Status:** Design (awaiting user review before plan)
+
+---
+
+## Program context
+
+This is **sub-project 1 of 4** in an extensibility-first cleanup of the app.
+The overarching goal (user's words): _make the codebase easier to navigate and
+make adding new models/features modular._ Approved sequence:
+
+1. **SP1 — Model Registry SSOT** ← this spec
+2. SP2 — Polygon field SSOT (collapse the backend field-by-field mappers)
+3. SP3 — Segmentation editor decomposition (extract hook/JSX seams)
+4. Folded cleanup (type-only circular dep, verified dead-dep removal, on-disk cruft)
+
+Each sub-project gets its own spec → plan → PR → browser verification per the
+CLAUDE.md verification gates. Dead-code removal and perf are folded in only where
+they intersect these paths.
+
+---
+
+## Problem statement
+
+Adding one segmentation model today requires **~23 edits across ~15 files**, the
+large majority of which are _pure re-enumeration_ of the model id. The model list
+is hand-maintained in many independent places, and they have **already drifted**:
+
+| List                                                                     | Count        | Contents                                                                                                  | Status                                       |
+| ------------------------------------------------------------------------ | ------------ | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Python `AVAILABLE_MODELS` (`ml/model_loader.py`)                         | 9            | hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp, segformer, mamba_unet, sperm, wound, microtubule | **the truth** (verified read)                |
+| BE `KnownModelId` (`backend/src/types/validation.ts`)                    | 9            | same 9                                                                                                    | matches truth ✓                              |
+| BE `SEGMENTATION_MODELS` (`backend/src/constants/segmentationModels.ts`) | 11           | the 9 **+ `resunet_advanced`, `resunet_small`**                                                           | **stale** — both extras are deleted models ✗ |
+| FE `ModelType` / `BASIC_MODEL_INFO` (`src/lib/modelUtils.ts`)            | (per recon)  | FE-maintained mirror                                                                                      | drift-prone                                  |
+| FE `KnownModelId` / `MODEL_TYPE_COMPATIBILITY` (`src/types/index.ts`)    | mirror of BE | kept in sync only by `verify-shared-types.cjs`                                                            | check-only                                   |
+
+Because the model↔project-type compatibility check runs in the **queue worker**
+(not at enqueue), FE/BE drift fails _silently and late_: the FE offers a model,
+the API returns 200, and the job dies deep in the worker. Collapsing the
+enumerations into one derived registry per language closes this correctness gap
+**and** cuts the add-a-model cost.
+
+### Verified current touchpoints (the scatter)
+
+- **Python** `backend/segmentation/ml/model_loader.py`
+  - conditional import block (per-model `try/except`) — _genuinely per-model_
+  - `AVAILABLE_MODELS` dict (id → {class, pretrained_path, finetuned_path, config_path})
+  - `load_model()` instantiation path (recon: if/elif ~L302–380) — _partly per-model_
+  - `BatchConfig` defaults
+  - `backend/segmentation/api/models.py` `ModelType` enum
+- **Backend (TS)**
+  - `constants/segmentationModels.ts` `SEGMENTATION_MODELS` (+ error message)
+  - `types/validation.ts` `KnownModelId` + `MODEL_TYPE_COMPATIBILITY` + `isModelCompatibleWithType`
+  - `services/queueService.ts` `BATCH_LIMITS` + `SERIAL_DISPATCH_MODELS`
+- **Frontend (TS)**
+  - `lib/modelUtils.ts` `ModelType` + `baseModels` + `keyMap` + `getAllLocalizedModels()` + `BASIC_MODEL_INFO`
+  - `types/index.ts` `KnownModelId` + `MODEL_TYPE_COMPATIBILITY` (verified mirror of BE)
+  - `contexts/ModelContext.tsx` (already derives from `BASIC_MODEL_INFO` — no edit needed)
+- **i18n** `src/translations/{en,cs,es,de,fr,zh}.ts` (`name` + `description` per model)
+
+### Verified constraint: no shared package
+
+`scripts/verify-shared-types.cjs` documents a _deliberate_ architectural choice:
+
+> "The frontend (Vite/Vitest) and backend (Node/Vitest) build trees do not share
+> an import path, so we keep the canonical declarations in separate files and just
+> verify they match. Cheaper than wiring a monorepo / shared package."
+
+This design **respects that choice**. We do NOT introduce a `shared/` package or a
+cross-tree import. The chosen approach ("per-language + shared types") means:
+collapse within each language to one registry, and keep FE↔BE and ↔Python in sync
+via the existing _verify_ mechanism, extended.
+
+---
+
+## Goals
+
+1. Adding/removing a model is **one obvious registry entry per language** plus the
+   genuinely per-model code (the Python model wrapper class + its factory). No
+   hunting across 15 files.
+2. **Within each language, derive everything from one registry** so the
+   enumerations (id union, whitelist, compat map, batch limits, dispatch mode, FE
+   display metadata) can no longer drift internally.
+3. **Cross-language drift caught by a checker**, not by luck: extend
+   `verify-shared-types.cjs` to assert FE registry ≡ BE registry ≡ Python registry
+   ids (and the compat map), and extend `check-i18n.cjs` to assert every model id
+   has `name` + `description` in all 6 locales.
+4. **Fix the live drift**: remove the two dead entries (`resunet_advanced`,
+   `resunet_small`) so the canonical set is the verified 9. (User confirmed these
+   models are already deleted.)
+5. **Zero behavior change** for the 9 real models: same picker, same compat
+   filtering, same batch/dispatch behavior, same i18n strings.
+
+## Non-goals
+
+- Changing which models are compatible with which project types (pure refactor).
+- A monorepo / shared npm package (explicitly rejected by the project).
+- Sharing a literal across Python↔TS (impossible; bridged by a parity checker).
+- Touching inference logic, weights, or model wrappers themselves.
+- SP2–SP4 work.
+
+---
+
+## Target architecture
+
+### A. Frontend registry — `src/lib/models/modelRegistry.ts` (new)
+
+One record keyed by model id is the single authored list. Everything else derives:
+
+```ts
+// Illustrative shape — exact fields finalized against current modelUtils.ts at impl.
+export const MODEL_REGISTRY = {
+  hrnet: {
+    compatibleProjectTypes: ['spheroid'],
+    size: 'small',
+    category: 'spheroid',
+    defaultThreshold: 0.5,
+    performance: { avgTimePerImage: 0.2, throughput: 5 },
+    i18nKey: 'hrnet',
+  },
+  // …8 more
+} as const satisfies Record<string, ModelSpec>;
+
+export type ModelType = keyof typeof MODEL_REGISTRY;
+export const ALL_MODEL_IDS = Object.keys(MODEL_REGISTRY) as ModelType[];
+// MODEL_TYPE_COMPATIBILITY, BASIC_MODEL_INFO, keyMap, getAllLocalizedModels()
+// all become derivations over MODEL_REGISTRY.
+```
+
+`modelUtils.ts` shrinks to a thin localization wrapper over the registry
+(`getLocalizedModelInfo()` reads `i18nKey` + i18next). `ModelContext.tsx` already
+derives from `BASIC_MODEL_INFO`, so it follows for free.
+
+### B. Backend registry — `backend/src/constants/modelRegistry.ts` (new)
+
+Same idea on the BE side:
+
+```ts
+export const MODEL_REGISTRY = {
+  hrnet: { compatibleProjectTypes: ['spheroid'], batchLimit: 8, dispatch: 'parallel' },
+  microtubule: { compatibleProjectTypes: ['microtubules'], batchLimit: 1, dispatch: 'serial' },
+  // …
+} as const satisfies Record<string, BackendModelSpec>;
+
+export const SEGMENTATION_MODELS = Object.keys(MODEL_REGISTRY);     // → the canonical 9
+export type KnownModelId = keyof typeof MODEL_REGISTRY;
+export const MODEL_TYPE_COMPATIBILITY = /* derived inversion */;
+export const BATCH_LIMITS = /* mapValues(REGISTRY, m => m.batchLimit) */;
+export const SERIAL_DISPATCH_MODELS = new Set(/* ids where dispatch==='serial' */);
+```
+
+`validation.ts`, `queueService.ts`, and `segmentationModels.ts` re-export / derive
+from this. The two stale ids disappear because they're simply not in the registry.
+
+> The compat map MUST reproduce the exact current values (verified):
+> `spheroid: [hrnet, cbam_resunet, unet_spherohq, segformer, mamba_unet]`,
+> `spheroid_invasive: [unet_attention_aspp]`, `wound: [wound]`, `sperm: [sperm]`,
+> `microtubules: [microtubule]`. Note the project-type key is `microtubules`
+> (plural) while the model id is `microtubule` (singular) — preserved as-is.
+
+### C. Python registry-of-factories — `backend/segmentation/ml/model_loader.py`
+
+Collapse the import block + `AVAILABLE_MODELS` + `load_model` if/elif + `BatchConfig`
+into one registry whose values carry a factory callable and metadata:
+
+```python
+# Illustrative — exact shape finalized against current load_model() at impl.
+MODEL_REGISTRY = {
+    'hrnet': ModelSpec(factory=lambda: HRNetV2(...), weights='weights/hrnet_best_model.pth', batch={...}),
+    # …
+}
+def load_model(name):
+    spec = MODEL_REGISTRY.get(name)
+    if spec is None: raise ValueError(f"Unknown model: {name}")
+    return spec.factory()  # replaces the if/elif chain
+```
+
+The per-model `try/except` import and the factory body stay (irreducible — each
+model has real, distinct construction code). `api/models.py` `ModelType` derives
+from `MODEL_REGISTRY.keys()` (or stays an enum asserted equal by the parity test).
+
+### D. Cross-language + i18n checkers (no shared package)
+
+- Extend `scripts/verify-shared-types.cjs` `SHARED_CONSTS` so the FE and BE
+  registries' derived id list + compat map are diffed (fails pre-commit/CI on drift).
+- Add a **Python parity check**: a small script (node parsing the Python registry
+  ids, or a pytest) asserting `MODEL_REGISTRY` keys (Python) == BE registry ids.
+- Extend `scripts/check-i18n.cjs` to assert every registry id has `name` +
+  `description` in all 6 translation files.
+
+---
+
+## The add-a-model experience: before → after
+
+| Step                 | Before                                                                  | After                                                |
+| -------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| Python wrapper class | write `models/x.py`                                                     | write `models/x.py` _(unchanged, irreducible)_       |
+| Python registration  | 4 edits (import, AVAILABLE_MODELS, load_model elif, BatchConfig) + enum | **1 registry entry** + its import                    |
+| BE TS                | 4 edits (whitelist, KnownModelId, compat, batch/dispatch ×2)            | **1 registry entry**                                 |
+| FE TS                | 5 edits (ModelType, baseModels, keyMap, getAll…, BASIC_MODEL_INFO)      | **1 registry entry**                                 |
+| i18n                 | 6 string edits                                                          | 6 string edits _(checker now enforces completeness)_ |
+| Weights              | 1 download entry                                                        | 1 download entry                                     |
+| **Total**            | **~23 edits / ~15 files**, drift uncaught                               | **~5 obvious entries**, drift caught by checkers     |
+
+FE and BE remain two entries (deliberate no-shared-package constraint), but the
+checker makes mismatches a hard pre-commit failure instead of a silent late bug.
+
+---
+
+## Verification strategy (per CLAUDE.md gates)
+
+SP1 is a **pure refactor**; success = identical behavior + drift now impossible.
+
+1. **Static**: `make ci` (tsc + ESLint 0 + i18n), `verify:shared-types`, new Python
+   parity check, `make build-service SERVICE=frontend` (bundle must build).
+2. **Backend wire** (gate B): `curl` the segmentation submit endpoint with a valid
+   model → 200; with an incompatible model → 400; with a now-removed `resunet_*`
+   → 400 (confirming it's gone). Confirm `BATCH_LIMITS`/serial dispatch unchanged
+   via a real queued job + `docker logs spheroseg-backend`.
+3. **Frontend** (gate A): Playwright on production-parity preview — open the model
+   picker, `browser_snapshot` shows the same 9 models per project type as before;
+   `browser_console_messages` empty.
+4. **Cross-stack** (gate F): run a real segmentation on the test account end-to-end
+   for at least one general model + microtubule (serial dispatch) and confirm it
+   completes — proving the Python registry refactor didn't break instantiation.
+5. **Regression test**: snapshot the current `MODEL_TYPE_COMPATIBILITY` and assert
+   the derived map equals it (guards against accidental compat change).
+
+---
+
+## Risks & mitigations
+
+| Risk                                                                                  | Mitigation                                                                                                                                                    |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Derived compat map silently changes a value                                           | Snapshot test of the exact current matrix; assert equality.                                                                                                   |
+| Python `load_model` has per-model branches beyond instantiation (pre/post-processing) | Re-read `load_model()` fully at impl (recon flagged L302–380); keep any genuinely per-model branch inside the factory, don't flatten it away.                 |
+| `cbam_resunet` legacy alias / `resunet` naming at the API boundary                    | Audit alias handling during impl; registry keeps any alias map explicitly.                                                                                    |
+| Removing `resunet_advanced/small` rejects a request some old client sends             | Confirmed deleted models (user); a 400 is correct. Note in PR.                                                                                                |
+| FE/BE registry field shapes differ enough that the checker can't diff them            | Keep the _shared_ facts (ids, compat) in a comparable shape; language-specific extras (FE perf metadata, BE batch) live only on their side and aren't diffed. |
+| **Tooling reliability**: some reads this session returned elided/garbled content      | All file:line refs above are re-verified with clean isolated reads before any edit; never edit against an unverified read.                                    |
+
+---
+
+## Open items to resolve during implementation (not blockers)
+
+- Re-read `load_model()` (L~302–380) fully to confirm whether instantiation is the
+  only per-model branch or whether pre/post-processing also branches per model.
+- Confirm exact `ModelInfo` field set in `modelUtils.ts` so the FE `ModelSpec`
+  shape is a faithful superset.
+- Decide whether `api/models.py` `ModelType` stays an enum (parity-tested) or is
+  generated from the registry keys (lean: keep enum + parity test — less magic).

--- a/scripts/check-model-parity.cjs
+++ b/scripts/check-model-parity.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Cross-language model-registry parity check.
+ *
+ * The model set is a single source of truth WITHIN each language
+ * (backend/src/constants/modelRegistry.ts, src/lib/models/modelRegistry.ts) but
+ * the Python ML service cannot import a TS literal, so its model list lives in
+ * `backend/segmentation/ml/model_loader.py` (`AVAILABLE_MODELS`). This script
+ * asserts the three id sets are identical, catching the one drift the
+ * per-language registries cannot structurally prevent.
+ *
+ * Run manually or in CI: `node scripts/check-model-parity.cjs`
+ * (intentionally NOT wired into the pre-commit hook — a parser hiccup must
+ *  never block an unrelated commit.)
+ *
+ * Exit 0 = in sync, exit 1 = drift (prints a diff).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Extract the top-level (depth-1) keys of the first object literal that follows
+ * `<declMarker> {` in a source file. Handles both unquoted TS keys (`hrnet:`)
+ * and quoted Python keys (`'hrnet':`). Ignores strings/comments well enough for
+ * these registry files (no `{`/`}` inside key names).
+ */
+function extractObjectKeys(filePath, declMarker) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const declIdx = src.indexOf(declMarker);
+  if (declIdx === -1) {
+    throw new Error(`Could not find "${declMarker}" in ${filePath}`);
+  }
+  const braceStart = src.indexOf('{', declIdx);
+  if (braceStart === -1) {
+    throw new Error(`No object literal after "${declMarker}" in ${filePath}`);
+  }
+
+  const keys = [];
+  let depth = 0;
+  let i = braceStart;
+  for (; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') {
+      depth++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) break; // end of the registry object
+      continue;
+    }
+    // Only look for keys at the immediate object level.
+    if (depth === 1) {
+      // Match an identifier or a quoted string immediately followed by ':'.
+      const rest = src.slice(i);
+      const m = rest.match(
+        /^\s*(?:'([a-z0-9_]+)'|"([a-z0-9_]+)"|([a-z_][a-z0-9_]*))\s*:/i
+      );
+      if (m) {
+        keys.push(m[1] || m[2] || m[3]);
+        i += m[0].length - 1; // skip past the matched key:
+      }
+    }
+  }
+  return keys;
+}
+
+function setEq(a, b) {
+  if (a.size !== b.size) return false;
+  for (const x of a) if (!b.has(x)) return false;
+  return true;
+}
+
+const sources = [
+  {
+    name: 'backend registry',
+    file: path.join(ROOT, 'backend', 'src', 'constants', 'modelRegistry.ts'),
+    marker: 'export const MODEL_REGISTRY',
+  },
+  {
+    name: 'frontend registry',
+    file: path.join(ROOT, 'src', 'lib', 'models', 'modelRegistry.ts'),
+    marker: 'export const MODEL_REGISTRY',
+  },
+  {
+    name: 'python AVAILABLE_MODELS',
+    file: path.join(ROOT, 'backend', 'segmentation', 'ml', 'model_loader.py'),
+    marker: 'AVAILABLE_MODELS',
+  },
+];
+
+let ok = true;
+const sets = sources.map(s => {
+  const keys = extractObjectKeys(s.file, s.marker).sort();
+  return { ...s, keys, set: new Set(keys) };
+});
+
+// Compare every source against the first (backend registry = canonical).
+const base = sets[0];
+for (const s of sets.slice(1)) {
+  if (!setEq(base.set, s.set)) {
+    ok = false;
+    const missing = base.keys.filter(k => !s.set.has(k));
+    const extra = s.keys.filter(k => !base.set.has(k));
+    console.error(`DRIFT: ${s.name} vs ${base.name}`);
+    if (missing.length)
+      console.error(`  missing in ${s.name}: ${missing.join(', ')}`);
+    if (extra.length)
+      console.error(`  extra in ${s.name}: ${extra.join(', ')}`);
+  }
+}
+
+if (ok) {
+  console.log(
+    `OK: model ids in sync across ${sets.length} sources (${base.keys.length} models): ${base.keys.join(', ')}`
+  );
+  process.exit(0);
+} else {
+  console.error('\n✖ model-registry parity check failed.');
+  process.exit(1);
+}

--- a/scripts/verify-shared-types.cjs
+++ b/scripts/verify-shared-types.cjs
@@ -21,11 +21,13 @@ const ROOT = path.resolve(__dirname, '..');
 
 /** @type {Array<{name: string, frontend: string, backend: string}>} */
 const SHARED_CONSTS = [
-  {
-    name: 'MODEL_TYPE_COMPATIBILITY',
-    frontend: path.join(ROOT, 'src', 'types', 'index.ts'),
-    backend: path.join(ROOT, 'backend', 'src', 'types', 'validation.ts'),
-  },
+  // NOTE: MODEL_TYPE_COMPATIBILITY is no longer textually compared here. Both
+  // sides now DERIVE it (by inversion) from their respective model-registry
+  // SSOTs — frontend `src/lib/models/modelRegistry.ts`, backend
+  // `backend/src/constants/modelRegistry.ts` — so neither file holds a literal
+  // object block to diff. Each side's registry is covered by its own unit
+  // tests (FE `src/lib/models/__tests__/modelRegistry.test.ts`, BE
+  // `backend/src/constants/__tests__/modelRegistry.test.ts`).
   {
     name: 'PROJECT_TYPES',
     frontend: path.join(ROOT, 'src', 'types', 'index.ts'),

--- a/src/lib/modelUtils.ts
+++ b/src/lib/modelUtils.ts
@@ -1,14 +1,23 @@
-// Define types locally to avoid circular dependency
-export type ModelType =
-  | 'hrnet'
-  | 'cbam_resunet'
-  | 'unet_spherohq'
-  | 'unet_attention_aspp'
-  | 'segformer'
-  | 'mamba_unet'
-  | 'sperm'
-  | 'wound'
-  | 'microtubule';
+// Model identity, display metadata, and project-type compatibility now live
+// in the model registry SSOT (`@/lib/models/modelRegistry`). This module
+// re-exports the public model surface and the localization helpers built on
+// top of it. The spheroid-preset framing below is view-layer only (not model
+// identity) and intentionally stays here, not in the registry.
+import {
+  ALL_MODEL_IDS,
+  BASE_MODEL_INFO,
+  BASIC_MODEL_INFO,
+  keyMap,
+  type ModelCategory,
+  type ModelInfo,
+  type ModelPerformance,
+  type ModelType,
+} from '@/lib/models/modelRegistry';
+
+// Re-exported from the registry SSOT so existing consumers
+// (`import { ... } from '@/lib/modelUtils'`) are untouched.
+export { BASIC_MODEL_INFO };
+export type { ModelCategory, ModelInfo, ModelPerformance, ModelType };
 
 /**
  * Recommended-preset framing for the standard spheroid models. Three tiers are
@@ -51,26 +60,6 @@ export const SPHEROID_PRESET_META: Record<
   robust: { icon: '🌍' },
 };
 
-export type ModelCategory = 'spheroid' | 'sperm' | 'wound' | 'microtubule';
-
-export interface ModelPerformance {
-  avgTimePerImage: number; // seconds
-  throughput: number; // images per second
-  p95Latency: number; // seconds
-  batchSize: number; // optimal batch size
-}
-
-export interface ModelInfo {
-  id: ModelType;
-  name: string;
-  displayName: string;
-  description: string;
-  size: 'small' | 'medium' | 'large';
-  defaultThreshold: number;
-  category: ModelCategory;
-  performance?: ModelPerformance;
-}
-
 /**
  * Get localized model information using the translation function
  */
@@ -78,136 +67,7 @@ export function getLocalizedModelInfo(
   modelId: ModelType,
   t: (key: string) => string
 ): ModelInfo {
-  const baseModels: Record<
-    ModelType,
-    Omit<ModelInfo, 'name' | 'displayName' | 'description'>
-  > = {
-    hrnet: {
-      id: 'hrnet',
-      size: 'small',
-      defaultThreshold: 0.5,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.204,
-        throughput: 4.9,
-        p95Latency: 0.309,
-        batchSize: 8,
-      },
-    },
-    cbam_resunet: {
-      id: 'cbam_resunet',
-      size: 'medium',
-      defaultThreshold: 0.5,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.377,
-        throughput: 2.7,
-        p95Latency: 0.482,
-        batchSize: 2,
-      },
-    },
-    unet_spherohq: {
-      id: 'unet_spherohq',
-      size: 'small',
-      defaultThreshold: 0.5,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.181,
-        throughput: 5.5,
-        p95Latency: 0.286,
-        batchSize: 4,
-      },
-    },
-    unet_attention_aspp: {
-      id: 'unet_attention_aspp',
-      size: 'medium',
-      defaultThreshold: 0.2,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.35,
-        throughput: 2.8,
-        p95Latency: 0.5,
-        batchSize: 1,
-      },
-    },
-    segformer: {
-      id: 'segformer',
-      size: 'small',
-      defaultThreshold: 0.5,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.2,
-        throughput: 5.0,
-        p95Latency: 0.3,
-        batchSize: 4,
-      },
-    },
-    mamba_unet: {
-      id: 'mamba_unet',
-      size: 'large',
-      defaultThreshold: 0.5,
-      category: 'spheroid',
-      performance: {
-        avgTimePerImage: 0.236,
-        throughput: 4.2,
-        p95Latency: 0.249,
-        batchSize: 2,
-      },
-    },
-    sperm: {
-      id: 'sperm',
-      size: 'medium',
-      defaultThreshold: 0.5,
-      category: 'sperm',
-      performance: {
-        avgTimePerImage: 0.3,
-        throughput: 3.3,
-        p95Latency: 0.45,
-        batchSize: 1,
-      },
-    },
-    wound: {
-      id: 'wound',
-      size: 'medium',
-      defaultThreshold: 0.5,
-      category: 'wound',
-      performance: {
-        avgTimePerImage: 0.032,
-        throughput: 35.0,
-        p95Latency: 0.05,
-        batchSize: 1,
-      },
-    },
-    microtubule: {
-      id: 'microtubule',
-      size: 'large',
-      defaultThreshold: 0.5,
-      category: 'microtubule',
-      performance: {
-        // DINOv3-L (~300M params) + PySOAX iterative snake evolver. Numbers
-        // are conservative estimates on A5000; first call is much slower
-        // because of the gated HuggingFace download of the backbone weights.
-        avgTimePerImage: 8.0,
-        throughput: 0.13,
-        p95Latency: 10.0,
-        batchSize: 1,
-      },
-    },
-  };
-
-  const keyMap: Record<ModelType, string> = {
-    hrnet: 'hrnet',
-    cbam_resunet: 'cbam',
-    unet_spherohq: 'unet_spherohq',
-    unet_attention_aspp: 'unet_attention_aspp',
-    segformer: 'segformer',
-    mamba_unet: 'mamba_unet',
-    sperm: 'sperm',
-    wound: 'wound',
-    microtubule: 'microtubule',
-  };
-
-  const baseModel = baseModels[modelId];
+  const baseModel = BASE_MODEL_INFO[modelId];
   const key = keyMap[modelId];
 
   return {
@@ -222,172 +82,5 @@ export function getLocalizedModelInfo(
  * Get all localized models
  */
 export function getAllLocalizedModels(t: (key: string) => string): ModelInfo[] {
-  const modelIds: ModelType[] = [
-    'hrnet',
-    'cbam_resunet',
-    'unet_spherohq',
-    'unet_attention_aspp',
-    'segformer',
-    'mamba_unet',
-    'sperm',
-    'wound',
-    'microtubule',
-  ];
-  return modelIds.map(id => getLocalizedModelInfo(id, t));
+  return ALL_MODEL_IDS.map(id => getLocalizedModelInfo(id, t));
 }
-
-/**
- * Get basic model info without localization (for contexts that can't use t())
- */
-export const BASIC_MODEL_INFO: Record<
-  ModelType,
-  Omit<ModelInfo, 'name' | 'displayName' | 'description'> & {
-    name: string;
-    displayName: string;
-    description: string;
-  }
-> = {
-  hrnet: {
-    id: 'hrnet',
-    name: 'HRNet',
-    displayName: 'HRNet (Balanced)',
-    description: 'Balanced model with good speed and quality, E2E ~309ms',
-    size: 'small',
-    defaultThreshold: 0.5,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.204,
-      throughput: 4.9,
-      p95Latency: 0.309,
-      batchSize: 8,
-    },
-  },
-  cbam_resunet: {
-    id: 'cbam_resunet',
-    name: 'CBAM-ResUNet',
-    displayName: 'CBAM-ResUNet (Precise)',
-    description:
-      'Most precise segmentation with attention mechanisms, E2E ~482ms',
-    size: 'medium',
-    defaultThreshold: 0.5,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.377,
-      throughput: 2.7,
-      p95Latency: 0.482,
-      batchSize: 2,
-    },
-  },
-  unet_spherohq: {
-    id: 'unet_spherohq',
-    name: 'UNet (SpheroHQ)',
-    displayName: 'UNet (Fastest)',
-    description:
-      'Fastest model after optimizations, excellent for real-time processing, E2E ~286ms',
-    size: 'small',
-    defaultThreshold: 0.5,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.181,
-      throughput: 5.5,
-      p95Latency: 0.286,
-      batchSize: 4,
-    },
-  },
-  unet_attention_aspp: {
-    id: 'unet_attention_aspp',
-    name: 'UNet Attention-ASPP',
-    displayName: 'UNet Attention-ASPP',
-    description:
-      'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells',
-    size: 'medium',
-    defaultThreshold: 0.2,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.35,
-      throughput: 2.8,
-      p95Latency: 0.5,
-      batchSize: 1,
-    },
-  },
-  segformer: {
-    id: 'segformer',
-    name: 'SegFormer',
-    displayName: 'SegFormer',
-    description:
-      'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
-    size: 'small',
-    defaultThreshold: 0.5,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.2,
-      throughput: 5.0,
-      p95Latency: 0.3,
-      batchSize: 4,
-    },
-  },
-  mamba_unet: {
-    id: 'mamba_unet',
-    name: 'Mamba-UNet',
-    displayName: 'Mamba-UNet',
-    description:
-      'U-Net with a bidirectional Mamba (state-space) bottleneck — best robustness on out-of-distribution images (external labs, unknown optics, drug-treated, unusual morphologies)',
-    size: 'large',
-    defaultThreshold: 0.5,
-    category: 'spheroid',
-    performance: {
-      avgTimePerImage: 0.236,
-      throughput: 4.2,
-      p95Latency: 0.249,
-      batchSize: 2,
-    },
-  },
-  sperm: {
-    id: 'sperm',
-    name: 'Sperm Morphology',
-    displayName: 'Sperm Morphology',
-    description:
-      'Sperm morphology model with skeleton extraction for head/midpiece/tail measurement',
-    size: 'medium',
-    defaultThreshold: 0.5,
-    category: 'sperm',
-    performance: {
-      avgTimePerImage: 0.3,
-      throughput: 3.3,
-      p95Latency: 0.45,
-      batchSize: 1,
-    },
-  },
-  wound: {
-    id: 'wound',
-    name: 'Wound Healing',
-    displayName: 'Wound Healing (Scratch Assay)',
-    description:
-      'U-Net with MiT-B5 (SegFormer) encoder for binary wound segmentation in scratch-assay microscopy timelapses (~32 ms on A5000 GPU, 90% IoU on external test set)',
-    size: 'medium',
-    defaultThreshold: 0.5,
-    category: 'wound',
-    performance: {
-      avgTimePerImage: 0.032,
-      throughput: 35.0,
-      p95Latency: 0.05,
-      batchSize: 1,
-    },
-  },
-  microtubule: {
-    id: 'microtubule',
-    name: 'Microtubule (v7)',
-    displayName: 'Microtubule (DINOv3 + PySOAX)',
-    description:
-      'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT-style fusion produces a per-pixel 32-d embedding that PySOAX uses to extract individual MT centerlines. The embedding also drives automatic cross-frame tracking for kymograph analysis. Slow (~8 s/frame) but the only model in the platform producing polyline output.',
-    size: 'large',
-    defaultThreshold: 0.5,
-    category: 'microtubule',
-    performance: {
-      avgTimePerImage: 8.0,
-      throughput: 0.13,
-      p95Latency: 10.0,
-      batchSize: 1,
-    },
-  },
-};

--- a/src/lib/models/__tests__/modelRegistry.test.ts
+++ b/src/lib/models/__tests__/modelRegistry.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MODEL_REGISTRY,
+  ALL_MODEL_IDS,
+  BASIC_MODEL_INFO,
+  keyMap,
+  MODEL_TYPE_COMPATIBILITY,
+  type ModelInfo,
+  type ModelType,
+} from '@/lib/models/modelRegistry';
+import { getAllLocalizedModels } from '@/lib/modelUtils';
+
+/**
+ * SSOT contract tests for the frontend model registry. These assert the
+ * canonical 9-model set, declaration order, the verified project-type
+ * compatibility matrix, and the full derived `ModelInfo` shape — guarding
+ * against drift between the registry and what consumers expect.
+ */
+
+const CANONICAL_IDS: ModelType[] = [
+  'hrnet',
+  'cbam_resunet',
+  'unet_spherohq',
+  'unet_attention_aspp',
+  'segformer',
+  'mamba_unet',
+  'sperm',
+  'wound',
+  'microtubule',
+];
+
+const MODEL_INFO_KEYS: Array<keyof ModelInfo> = [
+  'id',
+  'name',
+  'displayName',
+  'description',
+  'size',
+  'defaultThreshold',
+  'category',
+  'performance',
+];
+
+describe('model registry SSOT', () => {
+  it('registry keys are exactly the canonical 9 models, in order', () => {
+    expect(Object.keys(MODEL_REGISTRY)).toEqual(CANONICAL_IDS);
+    expect(ALL_MODEL_IDS).toEqual(CANONICAL_IDS);
+    expect(ALL_MODEL_IDS).toHaveLength(9);
+  });
+
+  it('getAllLocalizedModels() returns the 9 models in display order', () => {
+    // Passthrough t returns the key itself; we only assert id ordering here.
+    const models = getAllLocalizedModels((k: string) => k);
+    expect(models.map(m => m.id)).toEqual(CANONICAL_IDS);
+  });
+
+  it('MODEL_TYPE_COMPATIBILITY deep-equals the verified matrix (incl. order)', () => {
+    expect(MODEL_TYPE_COMPATIBILITY).toEqual({
+      spheroid: [
+        'hrnet',
+        'cbam_resunet',
+        'unet_spherohq',
+        'segformer',
+        'mamba_unet',
+      ],
+      spheroid_invasive: ['unet_attention_aspp'],
+      wound: ['wound'],
+      sperm: ['sperm'],
+      microtubules: ['microtubule'],
+    });
+  });
+
+  it('BASIC_MODEL_INFO has a full ModelInfo entry (exact keys) for every id', () => {
+    expect(Object.keys(BASIC_MODEL_INFO)).toEqual(CANONICAL_IDS);
+    for (const id of ALL_MODEL_IDS) {
+      const info = BASIC_MODEL_INFO[id];
+      expect(info.id).toBe(id);
+      expect(Object.keys(info).sort()).toEqual([...MODEL_INFO_KEYS].sort());
+      expect(typeof info.name).toBe('string');
+      expect(info.name.length).toBeGreaterThan(0);
+      expect(typeof info.displayName).toBe('string');
+      expect(info.displayName.length).toBeGreaterThan(0);
+      expect(typeof info.description).toBe('string');
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(['small', 'medium', 'large']).toContain(info.size);
+      expect(typeof info.defaultThreshold).toBe('number');
+      expect(typeof info.category).toBe('string');
+      expect(info.performance).toBeDefined();
+    }
+  });
+
+  it('preserves the exact static metadata for each model (zero behavior change)', () => {
+    expect(BASIC_MODEL_INFO).toEqual({
+      hrnet: {
+        id: 'hrnet',
+        name: 'HRNet',
+        displayName: 'HRNet (Balanced)',
+        description: 'Balanced model with good speed and quality, E2E ~309ms',
+        size: 'small',
+        defaultThreshold: 0.5,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.204,
+          throughput: 4.9,
+          p95Latency: 0.309,
+          batchSize: 8,
+        },
+      },
+      cbam_resunet: {
+        id: 'cbam_resunet',
+        name: 'CBAM-ResUNet',
+        displayName: 'CBAM-ResUNet (Precise)',
+        description:
+          'Most precise segmentation with attention mechanisms, E2E ~482ms',
+        size: 'medium',
+        defaultThreshold: 0.5,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.377,
+          throughput: 2.7,
+          p95Latency: 0.482,
+          batchSize: 2,
+        },
+      },
+      unet_spherohq: {
+        id: 'unet_spherohq',
+        name: 'UNet (SpheroHQ)',
+        displayName: 'UNet (Fastest)',
+        description:
+          'Fastest model after optimizations, excellent for real-time processing, E2E ~286ms',
+        size: 'small',
+        defaultThreshold: 0.5,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.181,
+          throughput: 5.5,
+          p95Latency: 0.286,
+          batchSize: 4,
+        },
+      },
+      unet_attention_aspp: {
+        id: 'unet_attention_aspp',
+        name: 'UNet Attention-ASPP',
+        displayName: 'UNet Attention-ASPP',
+        description:
+          'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells',
+        size: 'medium',
+        defaultThreshold: 0.2,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.35,
+          throughput: 2.8,
+          p95Latency: 0.5,
+          batchSize: 1,
+        },
+      },
+      segformer: {
+        id: 'segformer',
+        name: 'SegFormer',
+        displayName: 'SegFormer',
+        description:
+          'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
+        size: 'small',
+        defaultThreshold: 0.5,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.2,
+          throughput: 5.0,
+          p95Latency: 0.3,
+          batchSize: 4,
+        },
+      },
+      mamba_unet: {
+        id: 'mamba_unet',
+        name: 'Mamba-UNet',
+        displayName: 'Mamba-UNet',
+        description:
+          'U-Net with a bidirectional Mamba (state-space) bottleneck — best robustness on out-of-distribution images (external labs, unknown optics, drug-treated, unusual morphologies)',
+        size: 'large',
+        defaultThreshold: 0.5,
+        category: 'spheroid',
+        performance: {
+          avgTimePerImage: 0.236,
+          throughput: 4.2,
+          p95Latency: 0.249,
+          batchSize: 2,
+        },
+      },
+      sperm: {
+        id: 'sperm',
+        name: 'Sperm Morphology',
+        displayName: 'Sperm Morphology',
+        description:
+          'Sperm morphology model with skeleton extraction for head/midpiece/tail measurement',
+        size: 'medium',
+        defaultThreshold: 0.5,
+        category: 'sperm',
+        performance: {
+          avgTimePerImage: 0.3,
+          throughput: 3.3,
+          p95Latency: 0.45,
+          batchSize: 1,
+        },
+      },
+      wound: {
+        id: 'wound',
+        name: 'Wound Healing',
+        displayName: 'Wound Healing (Scratch Assay)',
+        description:
+          'U-Net with MiT-B5 (SegFormer) encoder for binary wound segmentation in scratch-assay microscopy timelapses (~32 ms on A5000 GPU, 90% IoU on external test set)',
+        size: 'medium',
+        defaultThreshold: 0.5,
+        category: 'wound',
+        performance: {
+          avgTimePerImage: 0.032,
+          throughput: 35.0,
+          p95Latency: 0.05,
+          batchSize: 1,
+        },
+      },
+      microtubule: {
+        id: 'microtubule',
+        name: 'Microtubule (v7)',
+        displayName: 'Microtubule (DINOv3 + PySOAX)',
+        description:
+          'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT-style fusion produces a per-pixel 32-d embedding that PySOAX uses to extract individual MT centerlines. The embedding also drives automatic cross-frame tracking for kymograph analysis. Slow (~8 s/frame) but the only model in the platform producing polyline output.',
+        size: 'large',
+        defaultThreshold: 0.5,
+        category: 'microtubule',
+        performance: {
+          avgTimePerImage: 8.0,
+          throughput: 0.13,
+          p95Latency: 10.0,
+          batchSize: 1,
+        },
+      },
+    });
+  });
+
+  it('keyMap maps each id to its i18n key segment (cbam_resunet → "cbam")', () => {
+    expect(keyMap).toEqual({
+      hrnet: 'hrnet',
+      cbam_resunet: 'cbam',
+      unet_spherohq: 'unet_spherohq',
+      unet_attention_aspp: 'unet_attention_aspp',
+      segformer: 'segformer',
+      mamba_unet: 'mamba_unet',
+      sperm: 'sperm',
+      wound: 'wound',
+      microtubule: 'microtubule',
+    });
+  });
+});

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -1,0 +1,325 @@
+/**
+ * Frontend single source of truth (SSOT) for segmentation model identity,
+ * display metadata, and project-type compatibility.
+ *
+ * Mirrors the backend SSOT at `backend/src/constants/modelRegistry.ts`. To
+ * add or remove a model on the frontend, edit ONLY the `MODEL_REGISTRY`
+ * record below. Every derived structure — the `ModelType` union, the ordered
+ * `ALL_MODEL_IDS` list, `BASIC_MODEL_INFO`, the i18n `keyMap`, and the
+ * inverted `MODEL_TYPE_COMPATIBILITY` map — is computed from it so they can
+ * never drift out of sync.
+ *
+ * This file is intentionally free of any `@/types` import so that
+ * `@/types/index.ts` can import FROM here without a circular dependency. The
+ * project-type keys are therefore declared locally (identical to the backend
+ * `ProjectTypeKey`), and `@/types` re-derives `KnownModelId` +
+ * `MODEL_TYPE_COMPATIBILITY` from this module.
+ */
+
+/** Project-type keys exactly as used by the compatibility map.
+ *  NOTE: the microtubule project-type key is the plural `microtubules` while
+ *  the model id is the singular `microtubule` — preserved from legacy data. */
+export type ProjectTypeKey =
+  | 'spheroid'
+  | 'spheroid_invasive'
+  | 'wound'
+  | 'sperm'
+  | 'microtubules';
+
+/** Coarse size bucket surfaced in the model picker UI. */
+export type ModelSize = 'small' | 'medium' | 'large';
+
+/** Catalogue category used to group models in settings. */
+export type ModelCategory = 'spheroid' | 'sperm' | 'wound' | 'microtubule';
+
+export interface ModelPerformance {
+  avgTimePerImage: number; // seconds
+  throughput: number; // images per second
+  p95Latency: number; // seconds
+  batchSize: number; // optimal batch size
+}
+
+/**
+ * Canonical per-model metadata. The KEY is the canonical model id used
+ * everywhere (DB, API, ML service). All other model structures are derived
+ * from this record.
+ *
+ * Field provenance (so a future editor knows what each field feeds):
+ *  - `size`, `defaultThreshold`, `category`, `performance` → the static base
+ *    used by both `getLocalizedModelInfo()` and `BASIC_MODEL_INFO`.
+ *  - `name`, `displayName`, `description` → the English fallbacks held in
+ *    `BASIC_MODEL_INFO` (localized variants come from `t()` at render time).
+ *  - `i18nKey` → the translation-key segment (`settings.modelSelection.models
+ *    .<i18nKey>.{name,description}`).
+ *  - `compatibleProjectTypes` → inverted into `MODEL_TYPE_COMPATIBILITY`.
+ *    ORDER within each project type's list follows registry declaration order.
+ */
+export interface ModelRegistryEntry {
+  readonly size: ModelSize;
+  readonly defaultThreshold: number;
+  readonly category: ModelCategory;
+  readonly performance: ModelPerformance;
+  /** English name shown when no translation is available. */
+  readonly name: string;
+  /** English long-form display name shown when no translation is available. */
+  readonly displayName: string;
+  /** English description shown when no translation is available. */
+  readonly description: string;
+  /** Translation-key segment used under `settings.modelSelection.models.*`. */
+  readonly i18nKey: string;
+  /** Project types this model can run on. ORDER MATTERS for UI lists. */
+  readonly compatibleProjectTypes: readonly ProjectTypeKey[];
+}
+
+/**
+ * THE single source of truth. Declaration order is load-bearing: derived
+ * arrays (`ALL_MODEL_IDS`, `getAllLocalizedModels()`, the per-project-type
+ * lists in `MODEL_TYPE_COMPATIBILITY`) preserve it and tests assert it.
+ */
+export const MODEL_REGISTRY = {
+  hrnet: {
+    size: 'small',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.204,
+      throughput: 4.9,
+      p95Latency: 0.309,
+      batchSize: 8,
+    },
+    name: 'HRNet',
+    displayName: 'HRNet (Balanced)',
+    description: 'Balanced model with good speed and quality, E2E ~309ms',
+    i18nKey: 'hrnet',
+    compatibleProjectTypes: ['spheroid'],
+  },
+  cbam_resunet: {
+    size: 'medium',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.377,
+      throughput: 2.7,
+      p95Latency: 0.482,
+      batchSize: 2,
+    },
+    name: 'CBAM-ResUNet',
+    displayName: 'CBAM-ResUNet (Precise)',
+    description:
+      'Most precise segmentation with attention mechanisms, E2E ~482ms',
+    i18nKey: 'cbam',
+    compatibleProjectTypes: ['spheroid'],
+  },
+  unet_spherohq: {
+    size: 'small',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.181,
+      throughput: 5.5,
+      p95Latency: 0.286,
+      batchSize: 4,
+    },
+    name: 'UNet (SpheroHQ)',
+    displayName: 'UNet (Fastest)',
+    description:
+      'Fastest model after optimizations, excellent for real-time processing, E2E ~286ms',
+    i18nKey: 'unet_spherohq',
+    compatibleProjectTypes: ['spheroid'],
+  },
+  unet_attention_aspp: {
+    size: 'medium',
+    defaultThreshold: 0.2,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.35,
+      throughput: 2.8,
+      p95Latency: 0.5,
+      batchSize: 1,
+    },
+    name: 'UNet Attention-ASPP',
+    displayName: 'UNet Attention-ASPP',
+    description:
+      'Enhanced UNet with Attention Gates and ASPP for detecting dissolving spheroids and small satellite cells',
+    i18nKey: 'unet_attention_aspp',
+    compatibleProjectTypes: ['spheroid_invasive'],
+  },
+  segformer: {
+    size: 'small',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.2,
+      throughput: 5.0,
+      p95Latency: 0.3,
+      batchSize: 4,
+    },
+    name: 'SegFormer',
+    displayName: 'SegFormer',
+    description:
+      'Transformer-based model (SegFormer-B0) for bright-field spheroids — highest accuracy (93% IoU) and very fast (~13 ms/image)',
+    i18nKey: 'segformer',
+    compatibleProjectTypes: ['spheroid'],
+  },
+  mamba_unet: {
+    size: 'large',
+    defaultThreshold: 0.5,
+    category: 'spheroid',
+    performance: {
+      avgTimePerImage: 0.236,
+      throughput: 4.2,
+      p95Latency: 0.249,
+      batchSize: 2,
+    },
+    name: 'Mamba-UNet',
+    displayName: 'Mamba-UNet',
+    description:
+      'U-Net with a bidirectional Mamba (state-space) bottleneck — best robustness on out-of-distribution images (external labs, unknown optics, drug-treated, unusual morphologies)',
+    i18nKey: 'mamba_unet',
+    compatibleProjectTypes: ['spheroid'],
+  },
+  sperm: {
+    size: 'medium',
+    defaultThreshold: 0.5,
+    category: 'sperm',
+    performance: {
+      avgTimePerImage: 0.3,
+      throughput: 3.3,
+      p95Latency: 0.45,
+      batchSize: 1,
+    },
+    name: 'Sperm Morphology',
+    displayName: 'Sperm Morphology',
+    description:
+      'Sperm morphology model with skeleton extraction for head/midpiece/tail measurement',
+    i18nKey: 'sperm',
+    compatibleProjectTypes: ['sperm'],
+  },
+  wound: {
+    size: 'medium',
+    defaultThreshold: 0.5,
+    category: 'wound',
+    performance: {
+      avgTimePerImage: 0.032,
+      throughput: 35.0,
+      p95Latency: 0.05,
+      batchSize: 1,
+    },
+    name: 'Wound Healing',
+    displayName: 'Wound Healing (Scratch Assay)',
+    description:
+      'U-Net with MiT-B5 (SegFormer) encoder for binary wound segmentation in scratch-assay microscopy timelapses (~32 ms on A5000 GPU, 90% IoU on external test set)',
+    i18nKey: 'wound',
+    compatibleProjectTypes: ['wound'],
+  },
+  microtubule: {
+    size: 'large',
+    defaultThreshold: 0.5,
+    category: 'microtubule',
+    performance: {
+      // DINOv3-L (~300M params) + PySOAX iterative snake evolver. Numbers
+      // are conservative estimates on A5000; first call is much slower
+      // because of the gated HuggingFace download of the backbone weights.
+      avgTimePerImage: 8.0,
+      throughput: 0.13,
+      p95Latency: 10.0,
+      batchSize: 1,
+    },
+    name: 'Microtubule (v7)',
+    displayName: 'Microtubule (DINOv3 + PySOAX)',
+    description:
+      'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT-style fusion produces a per-pixel 32-d embedding that PySOAX uses to extract individual MT centerlines. The embedding also drives automatic cross-frame tracking for kymograph analysis. Slow (~8 s/frame) but the only model in the platform producing polyline output.',
+    i18nKey: 'microtubule',
+    compatibleProjectTypes: ['microtubules'],
+  },
+} as const satisfies Record<string, ModelRegistryEntry>;
+
+/** Canonical model id union, derived from the registry keys. */
+export type ModelType = keyof typeof MODEL_REGISTRY;
+
+/** Ordered list of all known model ids (declaration order preserved). */
+export const ALL_MODEL_IDS = Object.keys(MODEL_REGISTRY) as ModelType[];
+
+/**
+ * Static display metadata for a single model. Localized name/displayName/
+ * description are produced by `getLocalizedModelInfo()` in `modelUtils.ts`;
+ * these are the static facts.
+ */
+export interface ModelInfo {
+  id: ModelType;
+  name: string;
+  displayName: string;
+  description: string;
+  size: ModelSize;
+  defaultThreshold: number;
+  category: ModelCategory;
+  performance?: ModelPerformance;
+}
+
+/**
+ * Static, non-localized base metadata per model (no name/displayName/
+ * description) — the input both `getLocalizedModelInfo()` and
+ * `BASIC_MODEL_INFO` build on. Derived from the registry.
+ */
+export const BASE_MODEL_INFO = (() => {
+  const out = {} as Record<
+    ModelType,
+    Omit<ModelInfo, 'name' | 'displayName' | 'description'>
+  >;
+  for (const id of ALL_MODEL_IDS) {
+    const e = MODEL_REGISTRY[id];
+    out[id] = {
+      id,
+      size: e.size,
+      defaultThreshold: e.defaultThreshold,
+      category: e.category,
+      performance: e.performance,
+    };
+  }
+  return out;
+})();
+
+/**
+ * Full static model info record with English name/displayName/description,
+ * for contexts that cannot call `t()`. Derived from the registry.
+ */
+export const BASIC_MODEL_INFO = (() => {
+  const out = {} as Record<ModelType, ModelInfo>;
+  for (const id of ALL_MODEL_IDS) {
+    const e = MODEL_REGISTRY[id];
+    out[id] = {
+      ...BASE_MODEL_INFO[id],
+      name: e.name,
+      displayName: e.displayName,
+      description: e.description,
+    };
+  }
+  return out;
+})();
+
+/**
+ * Maps canonical model id → i18n key segment used in translation files
+ * (`settings.modelSelection.models.<segment>.*`). Derived from the registry.
+ */
+export const keyMap = (() => {
+  const out = {} as Record<ModelType, string>;
+  for (const id of ALL_MODEL_IDS) {
+    out[id] = MODEL_REGISTRY[id].i18nKey;
+  }
+  return out;
+})();
+
+/**
+ * Project-type → compatible model ids, INVERTED from the registry. Order
+ * within each list follows registry declaration order. Mirrors the backend
+ * `MODEL_TYPE_COMPATIBILITY`.
+ */
+export const MODEL_TYPE_COMPATIBILITY = (() => {
+  const out: Record<string, ModelType[]> = {};
+  for (const id of ALL_MODEL_IDS) {
+    for (const pt of MODEL_REGISTRY[id].compatibleProjectTypes) {
+      (out[pt] ??= []).push(id);
+    }
+  }
+  return out as Record<ProjectTypeKey, ModelType[]>;
+})();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,11 @@
 import type { Polygon as _Polygon } from '@/lib/segmentation';
+// Model identity + compatibility are derived from the frontend model registry
+// SSOT (`@/lib/models/modelRegistry`), which mirrors the backend SSOT. They
+// are re-exported below so existing `@/types` consumers stay untouched.
+import {
+  type ModelType as RegistryModelType,
+  MODEL_TYPE_COMPATIBILITY as REGISTRY_MODEL_TYPE_COMPATIBILITY,
+} from '@/lib/models/modelRegistry';
 
 // Auth types
 export interface User {
@@ -346,24 +353,15 @@ export type ProjectType = (typeof PROJECT_TYPES)[number];
 export const isProjectType = (v: unknown): v is ProjectType =>
   typeof v === 'string' && (PROJECT_TYPES as readonly string[]).includes(v);
 
-/** All known model identifiers — kept as a literal union so the
- *  MODEL_TYPE_COMPATIBILITY map below catches typos at compile time
- *  (a misspelled model id in any array becomes a TS error). Mirrors the
- *  `ModelType` union in `@/lib/modelUtils.ts`; intentionally duplicated
- *  here to avoid a circular import. */
-type KnownModelId =
-  | 'hrnet'
-  | 'cbam_resunet'
-  | 'unet_spherohq'
-  | 'unet_attention_aspp'
-  | 'segformer'
-  | 'mamba_unet'
-  | 'sperm'
-  | 'wound'
-  | 'microtubule';
+/** All known model identifiers, derived from the frontend model registry
+ *  SSOT (`@/lib/models/modelRegistry`), which mirrors the backend SSOT.
+ *  Re-exported as `KnownModelId` so existing `@/types` consumers are
+ *  untouched and a removed model becomes a compile error everywhere. */
+type KnownModelId = RegistryModelType;
 
-/** Models compatible with each project type. Cross-type segmentation is
- * blocked at both frontend (dropdown filter) and backend (400 on submit).
+/** Models compatible with each project type, derived (by inversion) from the
+ * model registry SSOT. Cross-type segmentation is blocked at both frontend
+ * (dropdown filter) and backend (400 on submit).
  *
  * - `spheroid_invasive` is locked to `unet_attention_aspp` because core
  *   detection is tied to that model's postprocessing path.
@@ -377,19 +375,7 @@ type KnownModelId =
 export const MODEL_TYPE_COMPATIBILITY: Record<
   ProjectType,
   readonly KnownModelId[]
-> = {
-  spheroid: [
-    'hrnet',
-    'cbam_resunet',
-    'unet_spherohq',
-    'segformer',
-    'mamba_unet',
-  ],
-  spheroid_invasive: ['unet_attention_aspp'],
-  wound: ['wound'],
-  sperm: ['sperm'],
-  microtubules: ['microtubule'],
-} as const;
+> = REGISTRY_MODEL_TYPE_COMPATIBILITY;
 
 export const isModelCompatibleWithType = (
   model: string,


### PR DESCRIPTION
## What & why

Adding a segmentation model used to require ~23 edits across ~15 files, mostly pure re-enumeration of the model id — and the lists had already **drifted**: the whitelist carried two *deleted* models (`resunet_advanced`/`resunet_small`) while the real loadable set + typed union were 9. Because model↔project-type compatibility is enforced in the **queue worker**, FE/BE drift fails silently and late.

This collapses the scattered model enumerations into **one derived registry per language** (SP1 of an extensibility-first cleanup).

## Changes
**Backend** — `backend/src/constants/modelRegistry.ts` (new SSOT) drives `SEGMENTATION_MODELS`, `KnownModelId`, `MODEL_TYPE_COMPATIBILITY`, `types/queue.ts` `SegmentationModel`+guard, and the model types in `segmentationService.ts`/`queueService.ts`.

**Frontend** — `src/lib/models/modelRegistry.ts` (new SSOT) drives `ModelType`, `BASIC_MODEL_INFO`, `keyMap`, `getAllLocalizedModels`, `MODEL_TYPE_COMPATIBILITY`; `modelUtils.ts` is now a thin localization wrapper (public signatures unchanged).

**Dead code removed** — `resunet_advanced`/`resunet_small` eliminated everywhere (11 → 9). Fixed a latent bug: `queue.ts`'s union + guard were **missing `segformer` + `mamba_unet`**, so `isSegmentationModel()` wrongly rejected two real models.

**Guards** — new `scripts/check-model-parity.cjs` asserts the TS backend/frontend registries and the Python `AVAILABLE_MODELS` share an identical 9-id set (validated in sync). `verify-shared-types.cjs` drops the now-derived `MODEL_TYPE_COMPATIBILITY` text diff (keeps `PROJECT_TYPES`); per-side equality tests pin each registry to the canonical matrix.

## Add-a-model: before → after
~23 edits / ~15 files (drift uncaught) → **one registry entry per language** + i18n strings, drift caught by checkers.

## Verification
Backend + frontend `tsc` 0 errors; ESLint clean; `verify-shared-types` green; pre-commit hook passed on every commit; registry equality tests green; `check-model-parity` reports 3 sources / 9 ids in sync. Pure refactor — zero behavior change for the 9 models.

## Deliberately scoped out (documented)
- **Python `model_loader.py` factory refactor** — Python already registers via the `AVAILABLE_MODELS` dict; `load_model` instantiation is genuinely per-model. The new parity check guards Python↔TS id drift, meeting the spec's Python requirement without a risky ML-container refactor.
- **`check-i18n` model-completeness rule** — recommended follow-up.
- **In-browser (Playwright) verification** — meaningful only after building/deploying this branch (production runs the old code); not done here to avoid an unrequested deploy.

Design + plan: `docs/superpowers/specs/2026-05-30-model-registry-ssot-design.md`, `docs/superpowers/plans/2026-05-30-model-registry-ssot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized model configuration into a single, authoritative registry across backend and frontend systems.
  * Consolidated model metadata (compatibility, batch limits, dispatch settings) from multiple locations into unified definitions.

* **Tests**
  * Added comprehensive test suites to verify model registry consistency and prevent configuration drift.

* **Documentation**
  * Added implementation plan and design specification for the model registry architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->