### PR TITLE
refactor(segmentation): centralize optional polygon fields into one SSOT

### DIFF
--- a/backend/src/services/__tests__/segmentationService.ssot.test.ts
+++ b/backend/src/services/__tests__/segmentationService.ssot.test.ts
@@ -1,0 +1,281 @@
+/**
+ * SP2 extensibility refactor — polygon-field SSOT property tests.
+ *
+ * These assert the *refactor goal*: a polygon carrying every optional metadata
+ * field survives the data-path round-trips unchanged, `_embedding` round-trips
+ * internally but is stripped at the serve boundary, parentIds<->parent_id
+ * converts both directions, and the untrusted-input validator still drops junk.
+ *
+ * If these pass, adding a new optional field requires only:
+ *   1. one entry in OPTIONAL_POLYGON_FIELDS (validator SSOT)
+ *   2. the explicit field on the two typed SegmentationPolygon contracts
+ * — the three service mappers spread and need no edits.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SegmentationService } from '../segmentationService';
+import type { SegmentationPolygon } from '../segmentationService';
+import {
+  PolygonValidator,
+  OPTIONAL_POLYGON_FIELDS,
+} from '../../utils/polygonValidation';
+
+// Mirror the mock set of the sibling segmentationService.*.test.ts files so
+// this file is independently runnable. `../../utils/config` is load-bearing:
+// its parseConfig calls process.exit(1) when env vars are absent, which aborts
+// the whole suite at import time when this file runs in isolation.
+vi.mock('../../utils/config', () => ({
+  config: {
+    SEGMENTATION_SERVICE_URL: 'http://localhost:8000',
+    STORAGE_TYPE: 'local',
+    STORAGE_LOCAL_PATH: '/tmp/test-storage',
+    UPLOAD_DIR: '/tmp/uploads',
+    NODE_ENV: 'test',
+  },
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../storage');
+vi.mock('../imageService');
+vi.mock('../../storage/index', () => ({
+  getStorageProvider: vi.fn(() => ({
+    getBuffer: vi.fn(),
+    saveBuffer: vi.fn(),
+    delete: vi.fn(),
+    exists: vi.fn(),
+  })),
+}));
+// Explicit class mocks: SegmentationService's constructor does
+// `new ThumbnailManager(...)`, and the update path calls
+// `.generateAllThumbnails(id).catch(...)` (no await), so the method must
+// return a real resolved promise — a bare auto-mock returns undefined and the
+// .catch() throws.
+vi.mock('../segmentationThumbnailService', () => ({
+  SegmentationThumbnailService: class {
+    generateThumbnail = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+vi.mock('../thumbnailManager', () => ({
+  ThumbnailManager: class {
+    generateAllThumbnails = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+const IMAGE_ID = 'img-1';
+const USER_ID = 'user-1';
+
+/** A polygon carrying every optional field plus an _embedding blob. */
+const fullPolygon = (): Record<string, unknown> => ({
+  id: 'poly-1',
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+  ],
+  type: 'external',
+  area: 42,
+  confidence: 0.9,
+  geometry: 'polyline',
+  partClass: 'head',
+  instanceId: 'sperm-7',
+  trackId: 'track-99',
+  name: 'Tail A',
+  // Server-only blob — must round-trip through DB but be stripped at serve.
+  _embedding: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+});
+
+describe('polygon-field SSOT round-trip', () => {
+  let prisma: any;
+  let imageService: any;
+
+  const makeService = () => new SegmentationService(prisma, imageService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = {
+      segmentation: {
+        findUnique: vi.fn(),
+        upsert: vi.fn(),
+        update: vi.fn(() => ({ __op: 'update' })),
+        create: vi.fn(),
+        findMany: vi.fn(),
+      },
+      image: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: vi.fn(),
+    };
+
+    imageService = {
+      getImageById: vi.fn().mockResolvedValue({
+        id: IMAGE_ID,
+        projectId: 'proj-1',
+        parentVideoId: null,
+        originalPath: '/x.png',
+      }),
+      updateSegmentationStatus: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('OPTIONAL_POLYGON_FIELDS registers all metadata fields and NOT _embedding', () => {
+    const keys = OPTIONAL_POLYGON_FIELDS.map(f => f.key);
+    expect(keys).toEqual(
+      expect.arrayContaining(['partClass', 'instanceId', 'trackId', 'name'])
+    );
+    expect(keys).not.toContain('_embedding');
+  });
+
+  it('save -> getSegmentationResults preserves every optional field and strips _embedding', async () => {
+    let storedJson = '';
+    prisma.segmentation.upsert.mockImplementation(async (args: any) => {
+      storedJson = args.create.polygons;
+      return { id: 'seg-1' };
+    });
+
+    const service = makeService();
+    await service.saveSegmentationResults(
+      IMAGE_ID,
+      [fullPolygon() as unknown as SegmentationPolygon],
+      'sperm',
+      0.5,
+      null,
+      1000,
+      640,
+      480,
+      USER_ID,
+      false
+    );
+
+    // The DB JSON must carry the optional fields AND _embedding (server-side).
+    const stored = JSON.parse(storedJson) as Array<Record<string, unknown>>;
+    expect(stored).toHaveLength(1);
+    expect(stored[0].partClass).toBe('head');
+    expect(stored[0].instanceId).toBe('sperm-7');
+    expect(stored[0].trackId).toBe('track-99');
+    expect(stored[0].name).toBe('Tail A');
+    expect(stored[0].geometry).toBe('polyline');
+    expect(stored[0]._embedding).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+
+    // Now serve it back: optional fields survive, _embedding is stripped.
+    prisma.segmentation.findUnique.mockResolvedValue({
+      polygons: storedJson,
+      model: 'sperm',
+      threshold: 0.5,
+      confidence: 0.9,
+      processingTime: 1000,
+      imageWidth: 640,
+      imageHeight: 480,
+      updatedAt: new Date(),
+    });
+
+    const served = await service.getSegmentationResults(IMAGE_ID, USER_ID);
+    expect(served).not.toBeNull();
+    const p = served!.polygons[0] as Record<string, unknown>;
+    expect(p.partClass).toBe('head');
+    expect(p.instanceId).toBe('sperm-7');
+    expect(p.trackId).toBe('track-99');
+    expect(p.name).toBe('Tail A');
+    expect(p.geometry).toBe('polyline');
+    expect(p._embedding).toBeUndefined();
+  });
+
+  it('updateSegmentationResults -> getSegmentationResults round-trips fields, converts parentIds, strips _embedding', async () => {
+    let updatedJson = '';
+    prisma.segmentation.findUnique.mockResolvedValue({
+      id: 'seg-1',
+      polygons: '[]',
+      model: 'manual',
+      threshold: 0.5,
+    });
+    prisma.segmentation.update.mockImplementation((args: any) => {
+      updatedJson = args.data.polygons;
+      return { __op: 'update' };
+    });
+    prisma.$transaction.mockImplementation(async (ops: any[]) =>
+      ops.map(() => ({
+        id: 'seg-1',
+        imageId: IMAGE_ID,
+        model: 'manual',
+        threshold: 0.5,
+        confidence: 0.9,
+        imageWidth: 640,
+        imageHeight: 480,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+    );
+
+    // Input is the wire shape: internal polygon with parentIds[].
+    const wirePoly = {
+      ...fullPolygon(),
+      type: 'internal',
+      parentIds: ['parent-xyz'],
+    };
+
+    const service = makeService();
+    await service.updateSegmentationResults(
+      IMAGE_ID,
+      [wirePoly as unknown as SegmentationPolygon],
+      USER_ID,
+      640,
+      480
+    );
+
+    // DB JSON: parentIds[] collapsed to parent_id, fields + _embedding kept.
+    const stored = JSON.parse(updatedJson) as Array<Record<string, unknown>>;
+    expect(stored[0].parent_id).toBe('parent-xyz');
+    expect(stored[0].parentIds).toBeUndefined();
+    expect(stored[0].partClass).toBe('head');
+    expect(stored[0].trackId).toBe('track-99');
+    expect(stored[0].name).toBe('Tail A');
+    expect(stored[0]._embedding).toBeDefined();
+
+    // Serve it: parent_id -> parentIds[], _embedding stripped.
+    prisma.segmentation.findUnique.mockResolvedValue({
+      polygons: updatedJson,
+      model: 'manual',
+      threshold: 0.5,
+      confidence: 0.9,
+      processingTime: null,
+      imageWidth: 640,
+      imageHeight: 480,
+      updatedAt: new Date(),
+    });
+
+    const served = await service.getSegmentationResults(IMAGE_ID, USER_ID);
+    const p = served!.polygons[0] as Record<string, unknown>;
+    expect(p.parentIds).toEqual(['parent-xyz']);
+    expect(p.partClass).toBe('head');
+    expect(p.trackId).toBe('track-99');
+    expect(p.name).toBe('Tail A');
+    expect((p as { parent_id?: unknown }).parent_id).toBeUndefined();
+    expect(p._embedding).toBeUndefined();
+  });
+
+  it('validator drops unknown/junk fields from untrusted input (security boundary)', () => {
+    const dirty = {
+      points: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+      ],
+      type: 'external',
+      trackId: 'keep-me',
+      arbitraryJunk: { nested: true },
+      // _embedding must NOT be admitted through the untrusted validate path.
+      _embedding: [[9, 9, 9]],
+    };
+    const result = PolygonValidator.validateSinglePolygon(dirty, 0) as Record<
+      string,
+      unknown
+    >;
+    expect(result).not.toBeNull();
+    expect(result.trackId).toBe('keep-me');
+    expect(result.arbitraryJunk).toBeUndefined();
+    expect(result._embedding).toBeUndefined();
+  });
+});

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -22,6 +22,19 @@ export interface SegmentationPoint {
   y: number;
 }
 
+/**
+ * Wire/API shape of a polygon (`parentIds` is the API array form of the DB's
+ * scalar `parent_id`). This is the typed contract for the backend.
+ *
+ * To add a NEW optional metadata field to the polygon data path:
+ *   1. Register it in `OPTIONAL_POLYGON_FIELDS` (the SSOT) in
+ *      `backend/src/utils/polygonValidation.ts` so it survives the untrusted
+ *      ML → DB validate path.
+ *   2. Add the explicit field here AND to the frontend twin
+ *      `SegmentationPolygon` in `src/lib/api.ts`.
+ * The mappers below (save / update / serve) spread already-validated data, so
+ * they need NO per-field edits — the field passes through automatically.
+ */
 export interface SegmentationPolygon {
   id: string;
   points: SegmentationPoint[];
@@ -39,6 +52,67 @@ export interface SegmentationPolygon {
    *  Editor state (hide/select) keys on this; cross-frame mutation
    *  propagation finds sibling polylines by matching trackId. */
   trackId?: string;
+}
+
+/**
+ * Editor-omitted polygon fields: stripped at the serve boundary
+ * (`getSegmentationResults` / `getBatchSegmentationResults`) before sending to
+ * the frontend. `_embedding` is a several-KB-per-polyline blob used only
+ * server-side by the tracker + kymograph routes; omitting it saves ~30-40 MB
+ * on a 100-frame microtubule video. It still round-trips through save/update
+ * (DB <-> internal) — it is only the response to the editor that drops it.
+ */
+export const EDITOR_OMITTED_POLYGON_FIELDS = ['_embedding'] as const;
+
+/**
+ * Build the DB-storage shape from an internal/validated polygon: spread every
+ * field through, then perform the one genuine transform — collapse the API's
+ * `parentIds[]` to the DB's scalar `parent_id`. Editor-only fields are NOT
+ * stripped here (they are server-side state that must persist); the serve
+ * boundary handles omission. Operates on already-validated data, so a spread
+ * is safe (the untrusted-input whitelist lives in the validator).
+ */
+function toDbPolygon(
+  polygon: SegmentationPolygon & Record<string, unknown>
+): Record<string, unknown> {
+  const { parentIds, ...rest } = polygon;
+  const dbPolygon: Record<string, unknown> = { ...rest };
+  // parentIds[] (API) -> parent_id (DB scalar). Preserve any pre-existing
+  // scalar parent_id when no array form is present.
+  if (parentIds && parentIds.length > 0) {
+    dbPolygon.parent_id = parentIds[0];
+  }
+  return dbPolygon;
+}
+
+/**
+ * Build the API/wire response shape from a stored/validated polygon: spread
+ * every field through (so future fields pass automatically), then perform the
+ * two genuine transforms — promote the DB's scalar `parent_id` to the API's
+ * `parentIds[]`, and strip the editor-omitted fields (`_embedding`).
+ */
+function toApiPolygon(
+  polygon: Record<string, unknown>,
+  fallbackId: () => string
+): SegmentationPolygon {
+  const { parent_id, ...rest } = polygon;
+  const api = rest as Record<string, unknown>;
+  for (const omitted of EDITOR_OMITTED_POLYGON_FIELDS) {
+    delete api[omitted];
+  }
+  return {
+    ...api,
+    id: (api.id as string) || fallbackId(),
+    points: ((api.points as SegmentationPoint[]) || []).map(p => ({
+      x: p.x,
+      y: p.y,
+    })),
+    area: (api.area as number) || 0,
+    confidence: (api.confidence as number) || 0.8,
+    type: (api.type as 'external' | 'internal') || 'external',
+    parentIds:
+      typeof parent_id === 'string' && parent_id ? [parent_id] : undefined,
+  } as SegmentationPolygon;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -891,33 +965,21 @@ export class SegmentationService {
           (segmentationResult.polygons?.length || 0) - validPolygons.length,
       });
 
-      // Assign IDs to polygons and fix parent_id relationships
+      // Assign IDs to polygons and convert to DB storage shape. toDbPolygon
+      // spreads every (already-validated) field through and collapses
+      // parentIds[] -> parent_id, so new optional fields need no edits here.
       const polygonsWithIds = validPolygons.map((polygon, index) => {
         // Generate ID if missing
         if (!polygon.id) {
           polygon.id = `polygon_${index + 1}`;
         }
 
-        // For database storage, we need to convert parentIds array to parent_id string
-        const dbPolygon: any = {
-          id: polygon.id,
-          points: polygon.points,
-          type: polygon.type,
-          area: polygon.area || 0,
-          confidence: polygon.confidence || 0.8,
-          // Preserve polyline fields for sperm model
-          ...(polygon.geometry && { geometry: polygon.geometry }),
-          ...(polygon.partClass && { partClass: polygon.partClass }),
-          ...(polygon.instanceId && { instanceId: polygon.instanceId }),
-        };
-
-        // Convert parentIds array to parent_id for database storage
-        if (polygon.parentIds && polygon.parentIds.length > 0) {
-          dbPolygon.parent_id = polygon.parentIds[0];
-        } else if ((polygon as any).parent_id) {
-          dbPolygon.parent_id = (polygon as any).parent_id;
-        }
-
+        const dbPolygon = toDbPolygon(
+          polygon as SegmentationPolygon & Record<string, unknown>
+        );
+        // Preserve historical defaults for the two numeric fields.
+        dbPolygon.area = polygon.area || 0;
+        dbPolygon.confidence = polygon.confidence || 0.8;
         return dbPolygon;
       });
 
@@ -954,8 +1016,10 @@ export class SegmentationService {
         polygonCount: polygonsWithIds.length,
         averageConfidence:
           polygonsWithIds.length > 0
-            ? polygonsWithIds.reduce((sum, p) => sum + (p.confidence || 0), 0) /
-              polygonsWithIds.length
+            ? polygonsWithIds.reduce(
+                (sum, p) => sum + ((p.confidence as number) || 0),
+                0
+              ) / polygonsWithIds.length
             : 0,
       };
 
@@ -1352,41 +1416,12 @@ export class SegmentationService {
     const polygons = polygonResult.isValid ? polygonResult.polygons : [];
 
     // Convert Polygon[] to SegmentationPolygon[] by adding required properties
-    const segmentationPolygons: SegmentationPolygon[] = polygons.map(
-      (polygon, _index) => ({
-        id: polygon.id || uuidv4(), // Preserve existing ID or generate new one
-        points: polygon.points.map(p => ({ x: p.x, y: p.y })),
-        area: polygon.area || 0, // Preserve area if available
-        confidence: polygon.confidence || 0.8,
-        type: (polygon as any).type || 'external', // Preserve original type or default to external
-        parentIds: (polygon as any).parent_id
-          ? [(polygon as any).parent_id]
-          : undefined, // Convert parent_id to parentIds array
-        // Preserve polyline fields (sperm model)
-        ...((polygon as any).geometry && {
-          geometry: (polygon as any).geometry,
-        }),
-        ...((polygon as any).partClass && {
-          partClass: (polygon as any).partClass,
-        }),
-        ...((polygon as any).instanceId && {
-          instanceId: (polygon as any).instanceId,
-        }),
-        // Microtubule cross-frame tracking carries the trackId on every
-        // sibling polyline; the editor uses it to colour-code tracks.
-        ...((polygon as any).trackId && {
-          trackId: (polygon as any).trackId,
-        }),
-        // Human-friendly label set in the editor; mirrored across
-        // sibling frames so a single rename is visible everywhere.
-        ...((polygon as any).name && {
-          name: (polygon as any).name,
-        }),
-        // _embedding is intentionally NOT propagated to the editor —
-        // it's a several-KB-per-polyline blob used only server-side by
-        // the tracker and kymograph routes. Stripping it here saves
-        // ~30-40 MB on a 100-frame video with 30 MTs per frame.
-      })
+    // toApiPolygon spreads every stored field through (so future metadata
+    // passes automatically), promotes parent_id -> parentIds[], and strips
+    // EDITOR_OMITTED_POLYGON_FIELDS (_embedding) — the ~30-40 MB saving on a
+    // 100-frame microtubule video.
+    const segmentationPolygons: SegmentationPolygon[] = polygons.map(polygon =>
+      toApiPolygon(polygon as unknown as Record<string, unknown>, uuidv4)
     );
 
     const result: SegmentationResponse = {
@@ -1456,26 +1491,14 @@ export class SegmentationService {
       where: { imageId },
     });
 
-    // Transform SegmentationPolygon[] to database format (parentIds -> parent_id)
-    const dbPolygons = polygons.map(polygon => ({
-      id: polygon.id,
-      points: polygon.points,
-      type: polygon.type,
-      area: polygon.area,
-      confidence: polygon.confidence,
-      parent_id:
-        polygon.parentIds && polygon.parentIds.length > 0
-          ? polygon.parentIds[0]
-          : undefined,
-      // Preserve polyline fields (sperm + microtubule models). trackId
-      // and name MUST round-trip — they're the basis of cross-frame
-      // identity and the user-set label.
-      ...(polygon.geometry && { geometry: polygon.geometry }),
-      ...(polygon.partClass && { partClass: polygon.partClass }),
-      ...(polygon.instanceId && { instanceId: polygon.instanceId }),
-      ...(polygon.trackId && { trackId: polygon.trackId }),
-      ...(polygon.name && { name: polygon.name }),
-    }));
+    // Transform SegmentationPolygon[] to database format. toDbPolygon spreads
+    // every field through (so trackId, name, partClass and any future field
+    // round-trip — they're the basis of cross-frame identity and the user-set
+    // label) and collapses parentIds[] -> parent_id. No per-field edits needed
+    // when a new optional field is added.
+    const dbPolygons = polygons.map(polygon =>
+      toDbPolygon(polygon as SegmentationPolygon & Record<string, unknown>)
+    );
     const polygonsJson = JSON.stringify(dbPolygons);
 
     // Calculate statistics from polygons
@@ -1885,35 +1908,10 @@ export class SegmentationService {
           ? polygonResult.polygons
           : [];
 
-        // Convert Polygon[] to SegmentationPolygon[] with IDs - same as single method
-        const polygons: SegmentationPolygon[] = parsedPolygons.map(
-          (polygon, _index) => ({
-            id: polygon.id || uuidv4(), // Preserve existing ID or generate new one
-            points: polygon.points.map(p => ({ x: p.x, y: p.y })),
-            area: polygon.area || 0, // Preserve area if available
-            confidence: polygon.confidence || 0.8,
-            type: (polygon as any).type || 'external', // Preserve original type or default to external
-            parentIds: (polygon as any).parent_id
-              ? [(polygon as any).parent_id]
-              : undefined, // Convert parent_id to parentIds array
-            // Preserve polyline fields (sperm model)
-            ...((polygon as any).geometry && {
-              geometry: (polygon as any).geometry,
-            }),
-            ...((polygon as any).partClass && {
-              partClass: (polygon as any).partClass,
-            }),
-            ...((polygon as any).instanceId && {
-              instanceId: (polygon as any).instanceId,
-            }),
-            ...((polygon as any).trackId && {
-              trackId: (polygon as any).trackId,
-            }),
-            ...((polygon as any).name && {
-              name: (polygon as any).name,
-            }),
-            // _embedding intentionally stripped — server-only blob.
-          })
+        // Same serve-boundary transform as getSegmentationResults: spread +
+        // parent_id->parentIds[] + strip EDITOR_OMITTED_POLYGON_FIELDS.
+        const polygons: SegmentationPolygon[] = parsedPolygons.map(polygon =>
+          toApiPolygon(polygon as unknown as Record<string, unknown>, uuidv4)
         );
 
         // Use same response format as single getSegmentationResults method

--- a/backend/src/utils/polygonValidation.ts
+++ b/backend/src/utils/polygonValidation.ts
@@ -36,6 +36,12 @@ export interface Polygon {
   type?: 'external' | 'internal';
   parent_id?: string;
   area?: number;
+  /** Open polyline (sperm tail / microtubule) vs closed polygon. */
+  geometry?: 'polygon' | 'polyline';
+  /** Sperm body part (head/midpiece/tail) or spheroid 'core'. */
+  partClass?: PolygonPartClass;
+  /** Per-detection sperm instance grouping id. */
+  instanceId?: string;
   /** Cross-frame microtubule track ID populated by trackerService after a
    *  video container's batch finishes segmentation. The validator must
    *  preserve it so the response builder in segmentationService can
@@ -47,6 +53,58 @@ export interface Polygon {
    *  rename survives subsequent reads. */
   name?: string;
 }
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────
+ * OPTIONAL POLYGON FIELD SSOT (single source of truth)
+ * ─────────────────────────────────────────────────────────────────────────
+ * This table is the ONE place to register an optional polygon metadata field.
+ * `validateSinglePolygon` iterates it, so adding a new optional field that
+ * should survive the untrusted-ML → DB → editor round-trip means adding ONE
+ * entry here (plus the explicit TS field on the typed contracts — see the
+ * `SegmentationPolygon` interfaces in backend `segmentationService.ts` and
+ * frontend `src/lib/api.ts`, both of which point back here).
+ *
+ * SECURITY BOUNDARY: this validator runs on UNTRUSTED ML-service output, so it
+ * intentionally does NOT blind-spread arbitrary input. Each entry whitelists a
+ * known field with a `coerce` fn that returns the cleaned value to store, or
+ * `undefined` to drop it. Unknown/junk fields never appear here and are
+ * therefore always discarded.
+ *
+ * NOTE: `_embedding` is deliberately ABSENT — it is a heavy server-only blob
+ * that must never be admitted through this untrusted-input path. The 3 mappers
+ * in `segmentationService.ts` operate on already-validated internal data and
+ * spread it (so `_embedding` does pass through there) but the serve boundary
+ * strips it again via `EDITOR_OMITTED_POLYGON_FIELDS`.
+ */
+export interface OptionalPolygonField {
+  /** Field name as it appears on both the raw input and the stored polygon. */
+  key: string;
+  /**
+   * Returns the cleaned value to copy onto the validated polygon, or
+   * `undefined` to drop the field. Must not mutate its argument.
+   */
+  coerce: (value: unknown) => unknown;
+}
+
+const coerceNonEmptyString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+export const OPTIONAL_POLYGON_FIELDS: readonly OptionalPolygonField[] = [
+  // partClass accepts both sperm parts (head/midpiece/tail) and 'core' for
+  // ASPP spheroid core polygons; older code only validated SpermPartClass
+  // which silently stripped 'core' during polygon JSON load.
+  {
+    key: 'partClass',
+    coerce: value =>
+      isValidPolygonPartClass(value) ? (value as PolygonPartClass) : undefined,
+  },
+  { key: 'instanceId', coerce: coerceNonEmptyString },
+  // Preserve cross-frame trackId written by trackerService.
+  { key: 'trackId', coerce: coerceNonEmptyString },
+  // Preserve editor-set label so renames survive subsequent reads.
+  { key: 'name', coerce: coerceNonEmptyString },
+] as const;
 
 export interface ParsedPolygonResult {
   polygons: Polygon[];
@@ -311,26 +369,24 @@ export const PolygonValidator = {
       validatedPolygon.area = polygonObj.area;
     }
 
-    // Preserve polyline fields (sperm model)
+    // Preserve polyline geometry (sperm / microtubule). 'polygon' is the
+    // implicit default and never stored explicitly.
     if (polygonObj.geometry === 'polyline') {
-      (validatedPolygon as any).geometry = 'polyline';
+      validatedPolygon.geometry = 'polyline';
     }
-    // partClass accepts both sperm parts (head/midpiece/tail) and 'core' for
-    // ASPP spheroid core polygons; older code only validated SpermPartClass
-    // which silently stripped 'core' during polygon JSON load.
-    if (isValidPolygonPartClass(polygonObj.partClass)) {
-      (validatedPolygon as any).partClass = polygonObj.partClass;
-    }
-    if (polygonObj.instanceId && typeof polygonObj.instanceId === 'string') {
-      (validatedPolygon as any).instanceId = polygonObj.instanceId;
-    }
-    // Preserve cross-frame trackId written by trackerService.
-    if (polygonObj.trackId && typeof polygonObj.trackId === 'string') {
-      validatedPolygon.trackId = polygonObj.trackId;
-    }
-    // Preserve editor-set label so renames survive subsequent reads.
-    if (polygonObj.name && typeof polygonObj.name === 'string') {
-      validatedPolygon.name = polygonObj.name;
+
+    // Copy every registered optional metadata field via the SSOT table. This
+    // is the ONLY place that needs editing to admit a new optional field; the
+    // per-field whitelist preserves the untrusted-input security boundary.
+    const validatedRecord = validatedPolygon as unknown as Record<
+      string,
+      unknown
+    >;
+    for (const field of OPTIONAL_POLYGON_FIELDS) {
+      const coerced = field.coerce(polygonObj[field.key]);
+      if (coerced !== undefined) {
+        validatedRecord[field.key] = coerced;
+      }
     }
 
     return validatedPolygon;


### PR DESCRIPTION
## Summary

Adding a new optional polygon metadata field used to require editing **5+ "stages" by hand** — the most failure-prone data path in the repo. This PR makes it a ~1-2 edit change while preserving the untrusted-input security boundary.

## What changed

**`backend/src/utils/polygonValidation.ts`** — introduces a single `OPTIONAL_POLYGON_FIELDS` table (field name → per-field `coerce`/validate fn) that `validateSinglePolygon` iterates. This is the SSOT. The per-field whitelist is preserved because this validator runs on **untrusted ML output**: unknown/junk fields are still dropped, and `_embedding` is still never admitted through this path.

**`backend/src/services/segmentationService.ts`** — the three field-by-field rebuilds (`saveSegmentationResultsInternal`, `updateSegmentationResults`, the `getSegmentationResults` response builder) plus the `getBatchSegmentationResults` mapper now use two shared helpers:
- `toDbPolygon` — `{...spread}` + collapse `parentIds[]` → `parent_id`
- `toApiPolygon` — `{...spread}` + promote `parent_id` → `parentIds[]` + strip `EDITOR_OMITTED_POLYGON_FIELDS`

These operate on already-validated internal data, so the spread is safe. `_embedding` is stripped at the serve boundary only (the ~30-40 MB saving on a 100-frame microtubule video) via a single named `EDITOR_OMITTED_POLYGON_FIELDS = ['_embedding']` constant.

**`src/lib/api.ts`** + **backend `SegmentationPolygon`** — the two typed contracts now cross-reference each other and the SSOT.

## Net result

Adding an optional polygon field now requires **2 edits**: one entry in `OPTIONAL_POLYGON_FIELDS` + the explicit field on the two `SegmentationPolygon` type decls. The mappers pass it through automatically.

## Tests

New `segmentationService.ssot.test.ts` proves the SSOT property:
- a polygon carrying every optional field (`partClass`, `instanceId`, `trackId`, `name`) survives `save → getSegmentationResults` and `updateSegmentationResults → getSegmentationResults` round-trips unchanged
- `_embedding` round-trips internally but is stripped on serve
- `parentIds` ↔ `parent_id` converts both directions
- the validator rejects unknown/junk fields (security property preserved)

`tsc --noEmit` clean (BE + FE, via pre-commit hook). Polygon/segmentation/tracker suites green: validator + SSOT 62, segmentation + tracker 238 passed, FE transform/api-segmentation 48.

## ⚠️ Behavior-change note (one intentional)

The original save/update mappers **dropped `_embedding`** before the DB write, even though the worker folds embeddings onto polygons so the cross-frame tracker can read them back from the DB, and the serve boundary strips `_embedding` (which only makes sense if it is in the DB). The spread-based mappers now **persist `_embedding`** to the segmentation row — correcting a pre-existing latent bug where the tracker was reading null embeddings on a manual re-save. This matches the documented intent of both the worker and the serve-boundary strip. All other fields are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional polygon metadata fields (`geometry`, `partClass`, `instanceId`) with centralized validation and preservation across database save and serve operations.

* **Bug Fixes**
  * Ensured internal embedding data is consistently stripped from polygon responses and that unknown/junk fields are rejected during validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michalprusek/cell-segmentation-hub/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->