### PR TITLE
chore(video): guard storage path segments against traversal

### DIFF
--- a/backend/src/services/videoUploadService.ts
+++ b/backend/src/services/videoUploadService.ts
@@ -500,10 +500,9 @@ export async function uploadVideoFromFile(options: {
 
     // The multi-position source ND2 has been fully split into per-position
     // frames + TIFF originals; drop it so it isn't counted/served as position
-    // 0's original (its key now points at position 0's TIFF).
-    await fs
-      .rm(path.join(baseDir, originalFileName), { force: true })
-      .catch(() => undefined);
+    // 0's original (its key now points at position 0's TIFF). ``originalPath``
+    // is the same join computed when the source was first persisted.
+    await fs.rm(originalPath, { force: true }).catch(() => undefined);
 
     reportProgress('completed', 1.0, 'Video ready');
     logger.info('Multi-position video upload complete', 'VideoUploadService', {

--- a/backend/src/services/videoUploadService.ts
+++ b/backend/src/services/videoUploadService.ts
@@ -36,6 +36,7 @@ import sharp from 'sharp';
 import { prisma } from '../db/prismaClient';
 import { config } from '../utils/config';
 import { logger } from '../utils/logger';
+import { assertSafeStorageSegment } from '../utils/storagePath';
 import { extractVideoSafe } from './video/videoExtractor';
 import type {
   ChannelMeta,
@@ -75,7 +76,12 @@ function videoContainerStorageKey(
   projectId: string,
   containerId: string
 ): string {
-  return path.posix.join('projects', projectId, 'images', containerId);
+  return path.posix.join(
+    'projects',
+    assertSafeStorageSegment(projectId, 'projectId'),
+    'images',
+    assertSafeStorageSegment(containerId, 'containerId')
+  );
 }
 
 /** Absolute filesystem path for the container directory — UPLOAD_DIR
@@ -85,9 +91,9 @@ function videoContainerDir(projectId: string, containerId: string): string {
   return path.join(
     config.UPLOAD_DIR,
     'projects',
-    projectId,
+    assertSafeStorageSegment(projectId, 'projectId'),
     'images',
-    containerId
+    assertSafeStorageSegment(containerId, 'containerId')
   );
 }
 
@@ -105,7 +111,7 @@ function frameStorageKey(
     videoContainerStorageKey(projectId, containerId),
     'frames',
     String(frameIndex).padStart(4, '0'),
-    `${channelName}.png`
+    `${assertSafeStorageSegment(channelName, 'channel')}.png`
   );
 }
 
@@ -165,7 +171,9 @@ async function moveFile(srcPath: string, destPath: string): Promise<void> {
     return;
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
-    if (e.code !== 'EXDEV') throw err;
+    if (e.code !== 'EXDEV') {
+      throw err;
+    }
     await fs.copyFile(srcPath, destPath);
     await fs.unlink(srcPath).catch(() => undefined);
   }
@@ -180,7 +188,9 @@ async function moveDir(srcDir: string, destDir: string): Promise<void> {
     return;
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
-    if (e.code !== 'EXDEV') throw err;
+    if (e.code !== 'EXDEV') {
+      throw err;
+    }
     await fs.cp(srcDir, destDir, { recursive: true });
     await fs.rm(srcDir, { recursive: true, force: true }).catch(() => undefined);
   }
@@ -212,10 +222,14 @@ async function finalizeContainer(params: {
 }): Promise<void> {
   const { containerId, baseDir, projectId, displayName, result } = params;
 
-  const defaultChannel =
+  // Channel names originate in source metadata (ND2/OME-TIFF); guard before
+  // they reach the thumbnail read-path and the frame storage keys.
+  const defaultChannel = assertSafeStorageSegment(
     result.channels.find(c => c.isSegmentationSource)?.name ??
-    result.channels[0]?.name ??
-    'video';
+      result.channels[0]?.name ??
+      'video',
+    'channel'
+  );
 
   const thumbnailPath = path.join(baseDir, 'thumbnail.jpg');
   await generateContainerThumbnail(
@@ -306,7 +320,7 @@ export async function uploadVideoFromFile(options: {
     phase: VideoUploadProgressEvent['phase'],
     progress: number,
     message?: string
-  ) => {
+  ): void => {
     onProgress?.({
       videoContainerId: containerId,
       filename: originalName,
@@ -338,8 +352,14 @@ export async function uploadVideoFromFile(options: {
     // 2. Move multer's temp file into the canonical location.
     reportProgress('saving', 0.05, 'Persisting original');
     await fs.mkdir(baseDir, { recursive: true });
+    // ``ext`` comes from the user-supplied filename — guard the canonical
+    // ``original.<ext>`` leaf name once and reuse it everywhere below.
     const ext = path.extname(originalName) || '.bin';
-    const originalPath = path.join(baseDir, `original${ext}`);
+    const originalFileName = assertSafeStorageSegment(
+      `original${ext}`,
+      'original file'
+    );
+    const originalPath = path.join(baseDir, originalFileName);
     await moveFile(tempFilePath, originalPath);
 
     // Storage key of the moved source file. Used as-is for an ordinary
@@ -347,7 +367,7 @@ export async function uploadVideoFromFile(options: {
     // container its own per-position TIFF and deletes this source afterward.
     const sourceOriginalKey = path.posix.join(
       videoContainerStorageKey(projectId, containerId),
-      `original${ext}`
+      originalFileName
     );
 
     // 3. Run the extractor end-to-end.
@@ -409,6 +429,17 @@ export async function uploadVideoFromFile(options: {
     for (let i = 0; i < positions.length; i++) {
       const pos = positions[i];
       const label = positionLabel(pos);
+      // The extractor names these (``pos_%04d`` / ``original.tif``), but guard
+      // before they enter filesystem paths so a future extractor change can't
+      // silently introduce traversal.
+      const framesSubdir = assertSafeStorageSegment(
+        pos.framesSubdir,
+        'framesSubdir'
+      );
+      const originalFile = assertSafeStorageSegment(
+        pos.originalFile,
+        'originalFile'
+      );
 
       let cid: string;
       let cBaseDir: string;
@@ -437,10 +468,10 @@ export async function uploadVideoFromFile(options: {
       // Relocate this position's frames + its single-position TIFF original
       // into the container dir, then drop the now-empty pos_<NNNN> staging
       // subdir.
-      const stagingDir = path.join(baseDir, pos.framesSubdir);
+      const stagingDir = path.join(baseDir, framesSubdir);
       await moveDir(path.join(stagingDir, 'frames'), path.join(cBaseDir, 'frames'));
-      const originalDest = path.join(cBaseDir, pos.originalFile);
-      await moveFile(path.join(stagingDir, pos.originalFile), originalDest);
+      const originalDest = path.join(cBaseDir, originalFile);
+      await moveFile(path.join(stagingDir, originalFile), originalDest);
       await fs
         .rm(stagingDir, { recursive: true, force: true })
         .catch(() => undefined);
@@ -454,7 +485,7 @@ export async function uploadVideoFromFile(options: {
         result: pos.result,
         originalStorageKey: path.posix.join(
           videoContainerStorageKey(projectId, cid),
-          pos.originalFile
+          originalFile
         ),
         fileSize: Number(originalStat.size),
         mimeType: 'image/tiff',
@@ -471,7 +502,7 @@ export async function uploadVideoFromFile(options: {
     // frames + TIFF originals; drop it so it isn't counted/served as position
     // 0's original (its key now points at position 0's TIFF).
     await fs
-      .rm(path.join(baseDir, `original${ext}`), { force: true })
+      .rm(path.join(baseDir, originalFileName), { force: true })
       .catch(() => undefined);
 
     reportProgress('completed', 1.0, 'Video ready');

--- a/backend/src/utils/__tests__/storagePath.test.ts
+++ b/backend/src/utils/__tests__/storagePath.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assertSafeStorageSegment,
+  UnsafeStorageSegmentError,
+} from '../storagePath';
+
+describe('assertSafeStorageSegment', () => {
+  describe('accepts the leaf names this codebase actually produces', () => {
+    const valid = [
+      '550e8400-e29b-41d4-a716-446655440000', // container / project UUID
+      'pos_0000', // multi-position ND2 frames subdir
+      'pos_0042',
+      '0000', // zero-padded frame index
+      'frames',
+      'original.tif',
+      'original.nd2',
+      'thumbnail.jpg',
+      'GFP.png', // channel-derived frame file
+      'DAPI',
+      'Channel 0', // ND2 channel name with a space
+      'a..b', // embedded dots are harmless without a separator
+    ];
+
+    it.each(valid)('passes %j through unchanged', segment => {
+      expect(assertSafeStorageSegment(segment)).toBe(segment);
+    });
+  });
+
+  describe('rejects path-traversal and malformed segments', () => {
+    const invalid: Array<[string, unknown]> = [
+      ['empty string', ''],
+      ['parent reference', '..'],
+      ['current-dir reference', '.'],
+      ['posix traversal', '../etc/passwd'],
+      ['windows traversal', '..\\windows\\system32'],
+      ['nested posix separator', 'a/b'],
+      ['nested windows separator', 'a\\b'],
+      ['leading slash (absolute)', '/etc/passwd'],
+      ['NUL byte', 'original\0.tif'],
+      ['non-string', 42],
+      ['null', null],
+      ['undefined', undefined],
+    ];
+
+    it.each(invalid)('throws on %s', (_label, segment) => {
+      expect(() =>
+        assertSafeStorageSegment(segment as string)
+      ).toThrow(UnsafeStorageSegmentError);
+    });
+  });
+
+  it('includes the supplied label in the error message', () => {
+    expect(() => assertSafeStorageSegment('../x', 'containerId')).toThrow(
+      /containerId/
+    );
+  });
+
+  it('defaults the label when none is supplied', () => {
+    expect(() => assertSafeStorageSegment('a/b')).toThrow(/path segment/);
+  });
+});

--- a/backend/src/utils/storagePath.ts
+++ b/backend/src/utils/storagePath.ts
@@ -1,0 +1,72 @@
+import path from 'path';
+
+/**
+ * Thrown when a value that is about to be used as a storage path component
+ * fails validation. Distinct error type so callers (and tests) can assert on
+ * the failure mode rather than matching message text.
+ */
+export class UnsafeStorageSegmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeStorageSegmentError';
+  }
+}
+
+/**
+ * Assert that ``segment`` is safe to use as a SINGLE path component when
+ * building a storage path with ``path.join`` / ``path.posix.join``, and
+ * return it unchanged so callers can inline the check:
+ *
+ * ```ts
+ * path.join(base, assertSafeStorageSegment(containerId, 'containerId'));
+ * ```
+ *
+ * A storage segment is a leaf name — a UUID, a zero-padded index, a channel
+ * name, ``frames``, ``original.tif`` — that must never span directories. The
+ * multi-position ND2 upload path builds filesystem paths from values that
+ * originate (transitively) in the request, so a crafted source file or
+ * malformed metadata could otherwise smuggle ``../`` into a path and escape
+ * the project's upload directory. This guard makes that impossible at the
+ * point of use.
+ *
+ * Rejected: empty strings, NUL bytes, the directory references ``.`` and
+ * ``..``, absolute paths, and anything containing a POSIX (``/``) or Windows
+ * (``\``) separator. Both separators are checked regardless of host OS so the
+ * guard stays correct on every deploy target. Server-generated UUIDs,
+ * ``pos_%04d`` indices and ordinary channel names all pass untouched.
+ *
+ * @throws {UnsafeStorageSegmentError} if ``segment`` could escape its parent.
+ */
+export function assertSafeStorageSegment(
+  segment: string,
+  label = 'path segment'
+): string {
+  if (typeof segment !== 'string' || segment.length === 0) {
+    throw new UnsafeStorageSegmentError(`${label} must be a non-empty string`);
+  }
+  // NUL truncates paths in many syscalls — never valid in a storage segment.
+  if (segment.includes('\0')) {
+    throw new UnsafeStorageSegmentError(`${label} contains a NUL byte`);
+  }
+  // '.' / '..' are directory references: '..' escapes upward, '.' is a no-op
+  // that signals corrupt input. Neither is ever a legitimate leaf name.
+  if (segment === '.' || segment === '..') {
+    throw new UnsafeStorageSegmentError(
+      `${label} is a directory reference ("${segment}")`
+    );
+  }
+  // A single component must not span directories. Reject both separators (not
+  // just the host's) and absolute paths. With no separator present, an
+  // embedded ".." (e.g. "a..b") cannot traverse, so substring checks aren't
+  // needed beyond the exact "." / ".." cases handled above.
+  if (
+    segment.includes('/') ||
+    segment.includes('\\') ||
+    path.isAbsolute(segment)
+  ) {
+    throw new UnsafeStorageSegmentError(
+      `${label} must be a single path component, got "${segment}"`
+    );
+  }
+  return segment;
+}


### PR DESCRIPTION
## What

Adds `assertSafeStorageSegment()` — a small, reusable guard that validates any value used as a **single path component** when building a storage path — and routes every request/metadata-derived value in `videoUploadService.ts` through it.

## Why

CodeQL flagged **11 new high-severity `js/path-injection` alerts** on the multi-position ND2 upload added in #236, all in `videoUploadService.ts`. I traced every one to its source: each flagged path component is server-controlled — a generated UUID, a `pos_%04d` index dir, or a constant filename (`original.tif`). The genuinely attacker-controllable value (the ND2 position name from metadata) is deliberately kept out of all filesystem paths and only used for DB display fields. **So all 11 are false positives.**

Rather than dismiss them, this guard makes traversal *impossible at the point of use* — defense in depth. If a future extractor change ever derived a path segment from attacker-controllable metadata, the upload fails loudly instead of writing outside the project's upload dir. It also legitimately clears the recurring CodeQL noise.

## How

`assertSafeStorageSegment(segment, label)` throws `UnsafeStorageSegmentError` on empty / NUL byte / `.` / `..` / POSIX or Windows separator / absolute path, and returns the validated segment so it inlines at the sink:

```ts
path.join(base, assertSafeStorageSegment(containerId, 'containerId'))
```

Applied in: `videoContainerStorageKey`, `videoContainerDir`, `frameStorageKey` (channel), `finalizeContainer` (`defaultChannel`), the `original.<ext>` source leaf, and the per-position `framesSubdir` / `originalFile`.

Also folds in **3 pre-existing lint fixes** in the touched file (curly braces on two single-line `if`s; explicit `: void` on `reportProgress`) that landed unlinted when #236 merged via GitHub — needed so `lint-staged` passes on the file.

## Tests

New `storagePath.test.ts` — 26 cases (valid leaf names this service produces + every traversal vector).

## Verification

Run in a one-off container off the `cell-segmentation-hub-backend` image with the working tree mounted (the live container is the baked prod image):
- `tsc --noEmit` → clean
- `vitest run` storagePath + videoUploadService → **31/31 pass**
- `eslint --max-warnings=0` on changed files → clean
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened storage path validation during video uploads to prevent path traversal vulnerabilities. Unsafe path segments are now validated before file system operations.

* **Tests**
  * Added comprehensive test coverage for path segment validation, including edge cases and malicious input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->