### PR TITLE
feat(kymograph): blob-velocity detection — modal overlay + MT export

### DIFF
--- a/backend/segmentation/api/kymograph_velocity.py
+++ b/backend/segmentation/api/kymograph_velocity.py
@@ -26,7 +26,7 @@ container's persisted ``pixelSizeUm`` / ``frameIntervalMs`` calibration.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import numpy as np
 

--- a/backend/segmentation/api/kymograph_velocity.py
+++ b/backend/segmentation/api/kymograph_velocity.py
@@ -1,0 +1,258 @@
+"""Blob-motion detection + velocity estimation on a kymograph.
+
+Pure NumPy / SciPy post-processing on the intensity matrix that the
+``/kymograph`` endpoint already samples (one row per frame, one column per
+arc-length-uniform position along the microtubule). A moving particle is a
+diagonal streak whose slope ``dx/dt`` is its velocity; this module finds
+*every* such streak and measures each one's speed.
+
+Pipeline (AMTraK / TrackMate paradigm, validated against KIF14 motility data):
+
+1. **Detect** — per-row sub-pixel peaks on a DoG band-pass response, gated by a
+   global ~k·sigma threshold (sigma from MAD of the UNCLIPPED DoG field — a
+   clip-before-MAD collapses the estimate to zero on sparse signals).
+2. **Link** — frame-to-frame assignment (Hungarian / ``linear_sum_assignment``)
+   with constant-velocity prediction so two blobs keep identity through a
+   crossing, plus short gap-closing.
+3. **Stitch** — segment-linking pass that merges collinear track fragments
+   (end of A + its velocity ≈ start of B across a small time gap) into one
+   continuous motor run.
+4. **Filter** — reject speckle-noise tracks by length + amplitude SNR.
+5. **Segment** — split each track's x(t) into runs vs pauses; the slope of each
+   run (with its standard error) is a local velocity in px/frame.
+
+Velocity stays in *px/frame* here; the Node backend converts to µm/s with the
+container's persisted ``pixelSizeUm`` / ``frameIntervalMs`` calibration.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+
+def _subpixel_peak(row: np.ndarray, j: int, width: int) -> float:
+    """3-point parabolic interpolation on log-intensity around index ``j``."""
+    if 1 <= j < width - 1 and row[j - 1] > 0 and row[j + 1] > 0:
+        a, b, c = (
+            np.log(row[j - 1] + 1e-9),
+            np.log(row[j] + 1e-9),
+            np.log(row[j + 1] + 1e-9),
+        )
+        den = a - 2 * b + c
+        if abs(den) > 1e-9:
+            return float(j + np.clip(0.5 * (a - c) / den, -1.0, 1.0))
+    return float(j)
+
+
+def _vel_tail(track: Dict[str, Any], n: int = 5) -> float:
+    """Mean velocity over a track's last ``n`` points (robust for stitching)."""
+    m = min(n, len(track["x"]))
+    dt = track["t"][-1] - track["t"][-m]
+    return (track["x"][-1] - track["x"][-m]) / dt if dt > 0 else track["v"]
+
+
+def _segment_runs(
+    t: np.ndarray, x: np.ndarray, pause_thresh: float
+) -> List[Dict[str, float]]:
+    """Split a trajectory into directed runs; fit slope ± SE per run."""
+    from scipy.ndimage import gaussian_filter1d
+
+    grid = np.arange(int(t[0]), int(t[-1]) + 1)
+    xg = np.interp(grid, t, x)
+    xs = gaussian_filter1d(xg, 2.5)
+    vel = np.gradient(xs)
+    state = np.where(np.abs(vel) > pause_thresh, np.sign(vel), 0).astype(int)
+
+    runs: List[Dict[str, float]] = []
+    i = 0
+    while i < len(grid):
+        j = i
+        while j + 1 < len(grid) and state[j + 1] == state[i]:
+            j += 1
+        if state[i] != 0 and (j - i + 1) >= 6:
+            gt = grid[i : j + 1].astype(np.float64)
+            gx = xs[i : j + 1]
+            design = np.vstack([gt, np.ones_like(gt)]).T
+            coef = np.linalg.lstsq(design, gx, rcond=None)[0]
+            resid = gx - design @ coef
+            denom = np.sum((gt - gt.mean()) ** 2)
+            se = (
+                float(np.sqrt(np.sum(resid**2) / max(1, len(gt) - 2) / denom))
+                if denom > 0
+                else 0.0
+            )
+            runs.append(
+                {
+                    "v_pxframe": float(coef[0]),
+                    "se_pxframe": se,
+                    "t0": int(gt[0]),
+                    "t1": int(gt[-1]),
+                }
+            )
+        i = j + 1
+    return runs
+
+
+def detect_blobs(
+    kymo: np.ndarray,
+    *,
+    blob_sigma: float = 1.6,
+    k_sigma: float = 5.0,
+    max_jump: float = 8.0,
+    max_gap: int = 12,
+    stitch_gap: int = 14,
+    min_span: int = 12,
+    min_points: int = 8,
+    min_snr: float = 2.3,
+    pause_thresh: float = 0.10,
+) -> List[Dict[str, Any]]:
+    """Detect moving blobs on a kymograph and measure each one's velocity.
+
+    Args:
+        kymo: ``(F, X)`` float array — F frames (time, top = first) × X
+            arc-length positions. The raw sampled intensity, NOT normalised.
+
+    Returns:
+        One dict per detected track, sorted fastest-net-velocity first::
+
+            {
+              "points":     [[frame, x], ...]   # sub-pixel, time-ordered
+              "net_pxframe": float              # (x_last - x_first)/(t span)
+              "snr":         float
+              "runs": [ {"v_pxframe","se_pxframe","t0","t1"}, ... ]
+            }
+    """
+    from scipy.ndimage import gaussian_filter
+    from scipy.optimize import linear_sum_assignment
+    from scipy.signal import find_peaks
+
+    if kymo.ndim != 2 or kymo.shape[0] < 4 or kymo.shape[1] < 4:
+        return []
+    T, X = kymo.shape
+    kymo = kymo.astype(np.float32, copy=False)
+
+    # --- preprocess: per-row baseline (removes frame-brightness drift; do NOT
+    #     subtract a per-column temporal median — that erases dwelling blobs),
+    #     then a DoG band-pass that enhances blob-sized features. -----------
+    S = kymo - np.median(kymo, axis=1, keepdims=True)
+    dog = gaussian_filter(S, blob_sigma) - gaussian_filter(S, 3.0 * blob_sigma)
+    sig_dog = 1.4826 * np.median(np.abs(dog - np.median(dog))) + 1e-9
+    thr = float(np.median(dog) + k_sigma * sig_dog)
+    resid = S - gaussian_filter(S, (2.0, 2.0))
+    sig_i = 1.4826 * np.median(np.abs(resid - np.median(resid))) + 1e-9
+
+    # --- 1) per-row detections (x_subpixel, background-subtracted amplitude)
+    dets: List[List[tuple]] = []
+    for row_idx in range(T):
+        resp = dog[row_idx]
+        peaks, _ = find_peaks(
+            resp, height=thr, distance=3, prominence=thr * 0.5
+        )
+        dets.append(
+            [(_subpixel_peak(resp, j, X), float(S[row_idx, j])) for j in peaks]
+        )
+
+    # --- 2) frame-to-frame linking (Hungarian + constant-velocity predict) --
+    tracks: List[Dict[str, Any]] = []
+    for t in range(T):
+        obs = dets[t]
+        active = [tr for tr in tracks if tr["alive"]]
+        if obs and active:
+            cost = np.full((len(active), len(obs)), 1e6)
+            for i, tr in enumerate(active):
+                pred = tr["lx"] + tr["v"]
+                for j, (x, _a) in enumerate(obs):
+                    if abs(pred - x) <= max_jump + abs(tr["v"]):
+                        cost[i, j] = abs(pred - x)
+            ri, cj = linear_sum_assignment(cost)
+            used = set()
+            for i, j in zip(ri, cj):
+                if cost[i, j] < 1e5:
+                    tr = active[i]
+                    x, a = obs[j]
+                    tr["v"] = 0.5 * tr["v"] + 0.5 * (x - tr["lx"]) / (t - tr["lt"])
+                    tr["t"].append(t)
+                    tr["x"].append(x)
+                    tr["a"].append(a)
+                    tr["lt"], tr["lx"], tr["gap"] = t, x, 0
+                    used.add(j)
+            for j, (x, a) in enumerate(obs):
+                if j not in used:
+                    tracks.append(_new_track(t, x, a))
+        elif obs:
+            for x, a in obs:
+                tracks.append(_new_track(t, x, a))
+        for tr in active:
+            if tr["lt"] != t:
+                tr["gap"] += 1
+                if tr["gap"] > max_gap:
+                    tr["alive"] = False
+
+    # --- 3) stitch collinear fragments into continuous runs -----------------
+    ordered = sorted(tracks, key=lambda z: z["t"][0])
+    merged = True
+    while merged:
+        merged = False
+        for a_tr in ordered:
+            if a_tr is None:
+                continue
+            best, best_d = None, 1e9
+            for idx, b_tr in enumerate(ordered):
+                if b_tr is None or b_tr is a_tr or b_tr["t"][0] <= a_tr["t"][-1]:
+                    continue
+                gap = b_tr["t"][0] - a_tr["t"][-1]
+                if gap > stitch_gap:
+                    continue
+                pred = a_tr["x"][-1] + _vel_tail(a_tr) * gap
+                d = abs(pred - b_tr["x"][0])
+                if d <= 4 + abs(_vel_tail(a_tr)) and d < best_d:
+                    best, best_d = idx, d
+            if best is not None:
+                b_tr = ordered[best]
+                z = sorted(
+                    zip(
+                        a_tr["t"] + b_tr["t"],
+                        a_tr["x"] + b_tr["x"],
+                        a_tr["a"] + b_tr["a"],
+                    )
+                )
+                a_tr["t"], a_tr["x"], a_tr["a"] = (list(q) for q in zip(*z))
+                ordered[best] = None
+                merged = True
+    ordered = [tr for tr in ordered if tr is not None]
+
+    # --- 4) quality filter + 5) per-track run segmentation ------------------
+    out: List[Dict[str, Any]] = []
+    for tr in ordered:
+        span = tr["t"][-1] - tr["t"][0] + 1
+        if span < min_span or len(tr["t"]) < min_points:
+            continue
+        if np.median(tr["a"]) / sig_i < min_snr:
+            continue
+        t_arr = np.asarray(tr["t"], dtype=np.float64)
+        x_arr = np.asarray(tr["x"], dtype=np.float64)
+        net = float((x_arr[-1] - x_arr[0]) / (t_arr[-1] - t_arr[0]))
+        out.append(
+            {
+                "points": [[int(t), float(x)] for t, x in zip(tr["t"], tr["x"])],
+                "net_pxframe": net,
+                "snr": float(np.median(tr["a"]) / sig_i),
+                "runs": _segment_runs(t_arr, x_arr, pause_thresh),
+            }
+        )
+    out.sort(key=lambda r: -abs(r["net_pxframe"]))
+    return out
+
+
+def _new_track(t: int, x: float, a: float) -> Dict[str, Any]:
+    return {
+        "t": [t],
+        "x": [x],
+        "a": [a],
+        "lt": t,
+        "lx": x,
+        "v": 0.0,
+        "gap": 0,
+        "alive": True,
+    }

--- a/backend/segmentation/api/kymograph_velocity.py
+++ b/backend/segmentation/api/kymograph_velocity.py
@@ -256,3 +256,48 @@ def _new_track(t: int, x: float, a: float) -> Dict[str, Any]:
         "gap": 0,
         "alive": True,
     }
+
+
+# Direction-coded overlay colours (match the frontend modal palette).
+_ANTERO = (248, 113, 113)  # net position increasing (+)
+_RETRO = (56, 189, 248)  # net position decreasing (-)
+_STATIC = (163, 163, 163)
+
+
+def _track_color(net_pxframe: float) -> tuple:
+    if abs(net_pxframe) < 0.02:
+        return _STATIC
+    return _ANTERO if net_pxframe > 0 else _RETRO
+
+
+def render_overlay(
+    base_rgb: np.ndarray,
+    tracks: List[Dict[str, Any]],
+    *,
+    y_scale: int = 3,
+) -> bytes:
+    """Draw detected tracks onto the kymograph as a standalone PNG.
+
+    ``base_rgb`` is the already-rendered (F, X, 3) uint8 kymograph. Each track
+    is drawn as a direction-coloured polyline. The image is stretched
+    vertically by ``y_scale`` so the (usually short) time axis is readable —
+    the same trick the offline prototype used. Returns PNG bytes.
+    """
+    import io
+
+    from PIL import Image as PILImage
+    from PIL import ImageDraw
+
+    T, X = base_rgb.shape[:2]
+    img = PILImage.fromarray(base_rgb, "RGB").resize(
+        (X, T * y_scale), PILImage.NEAREST
+    )
+    draw = ImageDraw.Draw(img)
+    for tr in tracks:
+        color = _track_color(tr["net_pxframe"])
+        pts = [(float(x), float(t) * y_scale) for t, x in tr["points"]]
+        if len(pts) > 1:
+            draw.line(pts, fill=color, width=2)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -530,15 +530,22 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
 
     # Blob-motion detection runs on the RAW (un-normalised) matrix so the
     # background-subtraction and SNR estimates inside detect_blobs see real
-    # intensities, not a [0,1]-rescaled version.
-    raw_tracks: List[Dict[str, Any]] = (
-        detect_blobs(kymo) if req.detect_velocity else []
-    )
-    tracks: Optional[List[KymographTrack]] = (
-        [KymographTrack(**tr) for tr in raw_tracks]
-        if req.detect_velocity
-        else None
-    )
+    # intensities, not a [0,1]-rescaled version. The velocity layer is
+    # OPTIONAL: a detection failure must never break the kymograph itself, so
+    # we degrade to "no tracks" rather than 500-ing the whole request.
+    raw_tracks: List[Dict[str, Any]] = []
+    tracks: Optional[List[KymographTrack]] = None
+    if req.detect_velocity:
+        try:
+            raw_tracks = detect_blobs(kymo)
+            tracks = [KymographTrack(**tr) for tr in raw_tracks]
+        except Exception:
+            logger.exception(
+                "kymograph velocity detection failed; "
+                "returning kymograph without tracks"
+            )
+            raw_tracks = []
+            tracks = []
 
     # Per-frame normalisation could obscure intensity changes — instead we
     # normalise globally to expose dynamics. Add 1e-9 to avoid /0.
@@ -556,9 +563,12 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
 
     overlay_b64: Optional[str] = None
     if req.detect_velocity and req.render_overlay and raw_tracks:
-        overlay_b64 = base64.b64encode(
-            render_overlay(rgb, raw_tracks)
-        ).decode("ascii")
+        try:
+            overlay_b64 = base64.b64encode(
+                render_overlay(rgb, raw_tracks)
+            ).decode("ascii")
+        except Exception:
+            logger.exception("kymograph overlay render failed; omitting overlay")
 
     csv_buf = io.StringIO()
     writer = csv.writer(csv_buf)

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -30,7 +30,7 @@ import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
-from api.kymograph_velocity import detect_blobs
+from api.kymograph_velocity import detect_blobs, render_overlay
 
 logger = logging.getLogger(__name__)
 
@@ -308,6 +308,10 @@ class KymographRequest(BaseModel):
     # return one KymographTrack per moving particle (velocities in px/frame —
     # the Node backend converts to um/s with the container's calibration).
     detect_velocity: bool = False
+    # When True (with detect_velocity), also composite the detected tracks onto
+    # the kymograph and return it as ``overlay_png_base64`` — used by the export
+    # pipeline to ship "segmented kymograph" images without a browser.
+    render_overlay: bool = False
 
 
 class KymographRun(BaseModel):
@@ -342,6 +346,9 @@ class KymographResponse(BaseModel):
     tracked: bool
     # Populated only when the request set ``detect_velocity``; otherwise None.
     tracks: Optional[List[KymographTrack]] = None
+    # Populated only when ``render_overlay`` was set; base64 PNG of the
+    # kymograph with detected tracks drawn on top.
+    overlay_png_base64: Optional[str] = None
 
 
 def _arc_length_resample_polyline(
@@ -524,9 +531,14 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
     # Blob-motion detection runs on the RAW (un-normalised) matrix so the
     # background-subtraction and SNR estimates inside detect_blobs see real
     # intensities, not a [0,1]-rescaled version.
-    tracks: Optional[List[KymographTrack]] = None
-    if req.detect_velocity:
-        tracks = [KymographTrack(**tr) for tr in detect_blobs(kymo)]
+    raw_tracks: List[Dict[str, Any]] = (
+        detect_blobs(kymo) if req.detect_velocity else []
+    )
+    tracks: Optional[List[KymographTrack]] = (
+        [KymographTrack(**tr) for tr in raw_tracks]
+        if req.detect_velocity
+        else None
+    )
 
     # Per-frame normalisation could obscure intensity changes — instead we
     # normalise globally to expose dynamics. Add 1e-9 to avoid /0.
@@ -542,6 +554,12 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
     PILImage.fromarray(rgb).save(buf, format="PNG")
     png_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
+    overlay_b64: Optional[str] = None
+    if req.detect_velocity and req.render_overlay and raw_tracks:
+        overlay_b64 = base64.b64encode(
+            render_overlay(rgb, raw_tracks)
+        ).decode("ascii")
+
     csv_buf = io.StringIO()
     writer = csv.writer(csv_buf)
     writer.writerow(["frame", *[f"x{i}" for i in range(n_samples)]])
@@ -556,4 +574,5 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
         length_px=int(kymo.shape[1]),
         tracked=bool(req.tracked),
         tracks=tracks,
+        overlay_png_base64=overlay_b64,
     )

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -30,6 +30,8 @@ import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
+from api.kymograph_velocity import detect_blobs
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -302,6 +304,32 @@ class KymographRequest(BaseModel):
         None,
         pattern=r"^#[0-9A-Fa-f]{6}$",
     )
+    # When True, run blob-motion detection on the sampled intensity matrix and
+    # return one KymographTrack per moving particle (velocities in px/frame —
+    # the Node backend converts to um/s with the container's calibration).
+    detect_velocity: bool = False
+
+
+class KymographRun(BaseModel):
+    """One constant-velocity segment of a track's trajectory."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    v_pxframe: float
+    se_pxframe: float
+    t0: int
+    t1: int
+
+
+class KymographTrack(BaseModel):
+    """One moving particle detected on the kymograph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    points: List[List[float]]  # [[frame, x_subpixel], ...], time-ordered
+    net_pxframe: float
+    snr: float
+    runs: List[KymographRun]
 
 
 class KymographResponse(BaseModel):
@@ -312,6 +340,8 @@ class KymographResponse(BaseModel):
     frame_count: int
     length_px: int
     tracked: bool
+    # Populated only when the request set ``detect_velocity``; otherwise None.
+    tracks: Optional[List[KymographTrack]] = None
 
 
 def _arc_length_resample_polyline(
@@ -491,6 +521,13 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
     if kymo.size == 0:
         raise HTTPException(status_code=500, detail="Empty kymograph result")
 
+    # Blob-motion detection runs on the RAW (un-normalised) matrix so the
+    # background-subtraction and SNR estimates inside detect_blobs see real
+    # intensities, not a [0,1]-rescaled version.
+    tracks: Optional[List[KymographTrack]] = None
+    if req.detect_velocity:
+        tracks = [KymographTrack(**tr) for tr in detect_blobs(kymo)]
+
     # Per-frame normalisation could obscure intensity changes — instead we
     # normalise globally to expose dynamics. Add 1e-9 to avoid /0.
     mn, mx = float(kymo.min()), float(kymo.max())
@@ -518,4 +555,5 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
         frame_count=int(kymo.shape[0]),
         length_px=int(kymo.shape[1]),
         tracked=bool(req.tracked),
+        tracks=tracks,
     )

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -561,8 +561,11 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
     PILImage.fromarray(rgb).save(buf, format="PNG")
     png_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
+    # Render the "segmented kymograph" whenever the caller asked for it — even
+    # with zero tracks (then it's just the kymograph, which is still the image
+    # the export wants). raw_tracks may be empty; render_overlay handles that.
     overlay_b64: Optional[str] = None
-    if req.detect_velocity and req.render_overlay and raw_tracks:
+    if req.render_overlay:
         try:
             overlay_b64 = base64.b64encode(
                 render_overlay(rgb, raw_tracks)

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -214,6 +214,8 @@ router.post(
       .isString()
       .matches(/^#[0-9A-Fa-f]{6}$/)
       .withMessage('channelColor must be #RRGGBB hex'),
+    // detectVelocity: opt-in blob-motion analysis (velocity table + overlay).
+    body('detectVelocity').optional().isBoolean(),
   ],
   handleValidation,
   async (req: Request, res: Response) => {
@@ -269,6 +271,7 @@ router.post(
         frameIndex: req.body.frameIndex,
         sourceChannel: req.body.sourceChannel,
         channelColor: req.body.channelColor,
+        detectVelocity: req.body.detectVelocity === true,
       });
       ResponseHelper.success(res, result);
     } catch (err) {

--- a/backend/src/services/__tests__/kymographService.test.ts
+++ b/backend/src/services/__tests__/kymographService.test.ts
@@ -487,6 +487,8 @@ describe('buildKymograph', () => {
         lengthPx: 55,
         tracked: false,
         sourceChannel: 'IRM',
+        pixelSizeUm: null,
+        frameIntervalMs: null,
       });
     });
 
@@ -592,6 +594,100 @@ describe('buildKymograph', () => {
         [20, 10],
         [40, 30],
       ]);
+    });
+  });
+
+  // ── Velocity mapping (detectVelocity) ──────────────────────────────────────
+  describe('velocity mapping', () => {
+    const ML_WITH_TRACKS = {
+      data: {
+        png_base64: 'iVBOR',
+        csv_base64: 'ZnJhbW',
+        frame_count: 2,
+        length_px: 55,
+        tracks: [
+          {
+            points: [
+              [0, 10],
+              [1, 11],
+            ],
+            net_pxframe: 0.5,
+            snr: 4.2,
+            runs: [{ v_pxframe: 0.5, se_pxframe: 0.02, t0: 0, t1: 1 }],
+          },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      mockPrisma.image.findMany.mockResolvedValue([
+        makeFrame(0, [POLYLINE_STATIC]),
+      ]);
+      mockAxios.post = vi.fn().mockResolvedValue(ML_WITH_TRACKS);
+    });
+
+    const call = (detectVelocity: boolean) =>
+      buildKymograph({
+        videoContainerId: 'container-1',
+        polylineId: 'poly-1',
+        frameIndex: 0,
+        sourceChannel: 'GFP',
+        detectVelocity,
+      });
+
+    it('forwards detect_velocity and converts px/frame → µm/s with calibration', async () => {
+      mockPrisma.image.findUnique.mockResolvedValue(
+        makeContainer({ pixelSizeUm: 0.07245, frameIntervalMs: 400 })
+      );
+      const res = await call(true);
+
+      expect(mockAxios.post.mock.calls[0][1]).toMatchObject({
+        detect_velocity: true,
+      });
+      // 1 px/frame = pixelSizeUm / (frameIntervalMs/1000) µm/s
+      const factor = 0.07245 / (400 / 1000);
+      expect(res.tracks).toHaveLength(1);
+      expect(res.tracks?.[0].netVelocityPxPerFrame).toBe(0.5);
+      expect(res.tracks?.[0].netVelocityUmPerSec).toBeCloseTo(0.5 * factor, 9);
+      expect(res.tracks?.[0].runs[0].velocityUmPerSec).toBeCloseTo(
+        0.5 * factor,
+        9
+      );
+      expect(res.tracks?.[0].runs[0].seUmPerSec).toBeCloseTo(0.02 * factor, 9);
+      expect(res.pixelSizeUm).toBe(0.07245);
+      expect(res.frameIntervalMs).toBe(400);
+    });
+
+    it('returns null µm/s but keeps px/frame when calibration is missing', async () => {
+      mockPrisma.image.findUnique.mockResolvedValue(
+        makeContainer({ pixelSizeUm: null, frameIntervalMs: null })
+      );
+      const res = await call(true);
+
+      expect(res.tracks?.[0].netVelocityUmPerSec).toBeNull();
+      expect(res.tracks?.[0].netVelocityPxPerFrame).toBe(0.5);
+      expect(res.tracks?.[0].runs[0].velocityUmPerSec).toBeNull();
+      expect(res.tracks?.[0].runs[0].seUmPerSec).toBeNull();
+      expect(res.pixelSizeUm).toBeNull();
+    });
+
+    it('treats frameIntervalMs=0 as uncalibrated (no divide-by-zero)', async () => {
+      mockPrisma.image.findUnique.mockResolvedValue(
+        makeContainer({ pixelSizeUm: 0.07245, frameIntervalMs: 0 })
+      );
+      const res = await call(true);
+      expect(res.tracks?.[0].netVelocityUmPerSec).toBeNull();
+    });
+
+    it('omits tracks and the detect_velocity flag when not requested', async () => {
+      mockPrisma.image.findUnique.mockResolvedValue(makeContainer());
+      mockAxios.post = vi.fn().mockResolvedValue(ML_RESPONSE);
+      const res = await call(false);
+
+      expect(mockAxios.post.mock.calls[0][1]).not.toHaveProperty(
+        'detect_velocity'
+      );
+      expect(res.tracks).toBeUndefined();
     });
   });
 });

--- a/backend/src/services/export/__tests__/mtKymographExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtKymographExporter.test.ts
@@ -1,0 +1,48 @@
+/**
+ * mtKymographExporter.test.ts
+ *
+ * Unit tests for pickSourceChannels — the pure channel-selection helper.
+ * Regression guard for the bug (commit 488ca68) where the export sampled only
+ * the FIRST fluorescent channel and silently missed motion in the others.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Side-effect-free import: the module pulls in prisma / logger / buildKymograph
+// at load, none of which the pure helper needs.
+vi.mock('../../../db/prismaClient', () => ({ prisma: {} }));
+vi.mock('../../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../../utils/concurrency', () => ({ mapWithConcurrency: vi.fn() }));
+vi.mock('../../kymographService', () => ({ buildKymograph: vi.fn() }));
+
+import { pickSourceChannels } from '../mtKymographExporter';
+
+describe('pickSourceChannels', () => {
+  it('returns ALL fluorescent channels (not just the first)', () => {
+    const channels = [
+      { name: 'IRM', type: 'irm', isSegmentationSource: true },
+      { name: 'TIRF_640', type: 'fluorescent' },
+      { name: 'TIRF_488', type: 'fluorescent' },
+    ];
+    // The regression: must include BOTH fluorescent channels.
+    expect(pickSourceChannels(channels)).toEqual(['TIRF_640', 'TIRF_488']);
+  });
+
+  it('falls back to the segmentation source when no fluorescent channels', () => {
+    const channels = [
+      { name: 'ch0', type: 'irm', isSegmentationSource: true },
+      { name: 'ch1', type: 'irm' },
+    ];
+    expect(pickSourceChannels(channels)).toEqual(['ch0']);
+  });
+
+  it('falls back to the first channel when no fluorescent and no source', () => {
+    const channels = [{ name: 'ch0', type: 'irm' }, { name: 'ch1' }];
+    expect(pickSourceChannels(channels)).toEqual(['ch0']);
+  });
+
+  it('returns an empty list for no channels', () => {
+    expect(pickSourceChannels([])).toEqual([]);
+  });
+});

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -2,23 +2,28 @@
  * Microtubule kymograph export (microtubules projects only).
  *
  * For every MT video container in the project, builds one kymograph per
- * microtubule (each polyline in the container's first segmented frame), runs
- * blob-motion detection, and writes:
+ * microtubule × fluorescent channel (each polyline in the container's first
+ * segmented frame, sampled on every fluorescent channel — motility can live in
+ * any of them), runs blob-motion detection, and writes:
  *
- *   - ``kymographs/<video>__<polyline>.png`` — the kymograph with the detected
- *     tracks drawn on top (when ``includeSegmentedImages``).
+ *   - ``kymographs/<video>__<polyline>__<channel>.png`` — the kymograph with the
+ *     detected tracks drawn on top (when ``includeSegmentedImages``).
  *   - ``kymographs/velocity_metrics.csv`` — one long-format row per run across
  *     all microtubules (when ``includeVelocityMetrics``).
  *
  * Reuses ``buildKymograph`` so the export and the editor modal share the exact
  * same sampling, detection and calibration path — no drift between what the
  * user sees and what ships in the bundle.
+ *
+ * This is an OPTIONAL add-on: any failure (DB, disk, ML) degrades to "no
+ * kymograph output" and must never abort the surrounding export job.
  */
 
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { prisma } from '../../db/prismaClient';
 import { logger } from '../../utils/logger';
+import { mapWithConcurrency } from '../../utils/concurrency';
 import { buildKymograph } from '../kymographService';
 
 const CTX = 'MTKymographExporter';
@@ -26,6 +31,10 @@ const CTX = 'MTKymographExporter';
 /** Per-container cap so a 200-MT field can't make one export run for hours.
  *  Anything dropped is logged (never silently truncated). */
 const MAX_MT_PER_CONTAINER = 60;
+
+/** Parallel ML kymograph builds. The ML service has finite capacity, so keep
+ *  this small — it bounds export wall-clock without overrunning inference. */
+const KYMOGRAPH_CONCURRENCY = 3;
 
 export interface MTKymographOptions {
   enabled: boolean;
@@ -38,12 +47,37 @@ interface PolylineRecord {
   points?: Array<{ x: number; y: number }>;
 }
 
-function parsePolylines(json: string | null | undefined): PolylineRecord[] {
+interface ChannelMeta {
+  name: string;
+  type?: string;
+  isSegmentationSource?: boolean;
+}
+
+/** One (microtubule × channel) kymograph to build. */
+interface KymographJob {
+  containerId: string;
+  videoName: string;
+  safeVideo: string;
+  polylineId: string;
+  frameIndex: number;
+  sourceChannel: string;
+}
+
+function parsePolylines(
+  json: string | null | undefined,
+  containerId: string
+): PolylineRecord[] {
   if (!json) return [];
   try {
     const parsed = JSON.parse(json) as PolylineRecord[];
     return Array.isArray(parsed) ? parsed : [];
-  } catch {
+  } catch (err) {
+    // A parse failure of stored segmentation is a real defect, not an empty
+    // frame — surface it instead of silently yielding "no microtubules".
+    logger.warn(
+      `Failed to parse polygons for container ${containerId}: ${(err as Error).message}`,
+      CTX
+    );
     return [];
   }
 }
@@ -52,13 +86,7 @@ function parsePolylines(json: string | null | undefined): PolylineRecord[] {
  *  live in any of them — picking just the first silently misses motion in the
  *  others); fall back to the segmentation source / first channel when the
  *  upload has no fluorescent channels. */
-function pickSourceChannels(
-  channels: Array<{
-    name: string;
-    type?: string;
-    isSegmentationSource?: boolean;
-  }>
-): string[] {
+export function pickSourceChannels(channels: ChannelMeta[]): string[] {
   if (channels.length === 0) return [];
   const fluorescent = channels
     .filter(c => c.type === 'fluorescent')
@@ -68,177 +96,215 @@ function pickSourceChannels(
   return [source?.name ?? channels[0].name];
 }
 
-const csvField = (v: number | string | null | undefined): string =>
-  v == null ? '' : String(v);
+/** RFC-4180 minimal escaping: quote fields containing comma / quote / newline.
+ *  Video names are user-controlled and can legally contain commas. */
+function csvField(v: number | string | null | undefined): string {
+  if (v == null) return '';
+  const s = String(v);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
 
 export async function exportMicrotubuleKymographs(
   projectId: string,
   exportDir: string,
   options: MTKymographOptions
 ): Promise<void> {
-  if (!options.enabled) return;
+  // Nothing to produce → skip the (expensive) kymograph builds entirely.
+  if (
+    !options.enabled ||
+    (!options.includeVelocityMetrics && !options.includeSegmentedImages)
+  ) {
+    return;
+  }
 
-  const containers = await prisma.image.findMany({
-    where: { projectId, isVideoContainer: true },
-    select: { id: true, name: true, channels: true },
-  });
-  if (containers.length === 0) return;
-
-  const outDir = path.join(exportDir, 'kymographs');
-  await fs.mkdir(outDir, { recursive: true });
-
-  const csvRows: string[] = [
-    [
-      'video',
-      'microtubule',
-      'source_channel',
-      'track',
-      'net_velocity_um_s',
-      'net_velocity_px_frame',
-      'snr',
-      'run_index',
-      'run_velocity_um_s',
-      'run_se_um_s',
-      'run_velocity_px_frame',
-      't0',
-      't1',
-      'pixel_size_um',
-      'frame_interval_ms',
-    ].join(','),
-  ];
-
-  for (const container of containers) {
-    const channels = Array.isArray(container.channels)
-      ? (container.channels as Array<{
-          name: string;
-          type?: string;
-          isSegmentationSource?: boolean;
-        }>)
-      : [];
-    const sourceChannels = pickSourceChannels(channels);
-    if (sourceChannels.length === 0) {
-      logger.warn(
-        `Container ${container.id} has no usable channel; skipping kymographs`,
-        CTX
-      );
-      continue;
-    }
-
-    // Seed = first frame that actually carries polylines.
-    const seedFrame = await prisma.image.findFirst({
-      where: {
-        parentVideoId: container.id,
-        segmentation: { isNot: null },
-      },
-      orderBy: { frameIndex: 'asc' },
-      select: {
-        frameIndex: true,
-        segmentation: { select: { polygons: true } },
-      },
+  try {
+    const containers = await prisma.image.findMany({
+      where: { projectId, isVideoContainer: true },
+      select: { id: true, name: true, channels: true },
     });
-    if (!seedFrame || seedFrame.frameIndex == null) continue;
+    if (containers.length === 0) return;
 
-    const polylines = parsePolylines(
-      seedFrame.segmentation?.polygons ?? null
-    ).filter(p => Array.isArray(p.points) && p.points.length >= 2);
-    if (polylines.length === 0) continue;
+    const outDir = path.join(exportDir, 'kymographs');
+    await fs.mkdir(outDir, { recursive: true });
 
-    const safeVideo = container.name.replace(/[^A-Za-z0-9_-]+/g, '_');
-    const selected = polylines.slice(0, MAX_MT_PER_CONTAINER);
-    if (polylines.length > selected.length) {
-      logger.warn(
-        `Container ${container.name}: ${polylines.length} microtubules, ` +
-          `capping kymograph export at ${MAX_MT_PER_CONTAINER}`,
-        CTX
-      );
-    }
+    // --- Phase 1: resolve the (microtubule × channel) job list. ----------
+    const jobs: KymographJob[] = [];
+    for (const container of containers) {
+      const channels = Array.isArray(container.channels)
+        ? (container.channels as unknown as ChannelMeta[])
+        : [];
+      const sourceChannels = pickSourceChannels(channels);
+      if (sourceChannels.length === 0) {
+        logger.warn(
+          `Container ${container.id} has no usable channel; skipping kymographs`,
+          CTX
+        );
+        continue;
+      }
 
-    for (const poly of selected) {
-      // One kymograph per (microtubule × fluorescent channel) — motion may be
-      // in any channel, so we sample them all rather than guess one.
-      for (const sourceChannel of sourceChannels) {
-        try {
-          const result = await buildKymograph({
-            videoContainerId: container.id,
+      // Seed = first frame with a segmentation record. The container is
+      // skipped if that frame carries no usable polylines (we do not scan
+      // later frames for a better seed).
+      const seedFrame = await prisma.image.findFirst({
+        where: { parentVideoId: container.id, segmentation: { isNot: null } },
+        orderBy: { frameIndex: 'asc' },
+        select: {
+          frameIndex: true,
+          segmentation: { select: { polygons: true } },
+        },
+      });
+      if (!seedFrame || seedFrame.frameIndex == null) continue;
+
+      const polylines = parsePolylines(
+        seedFrame.segmentation?.polygons ?? null,
+        container.id
+      ).filter(p => Array.isArray(p.points) && p.points.length >= 2);
+      if (polylines.length === 0) continue;
+
+      const safeVideo = container.name.replace(/[^A-Za-z0-9_-]+/g, '_');
+      const selected = polylines.slice(0, MAX_MT_PER_CONTAINER);
+      if (polylines.length > selected.length) {
+        logger.warn(
+          `Container ${container.name}: ${polylines.length} microtubules, ` +
+            `capping kymograph export at ${MAX_MT_PER_CONTAINER}`,
+          CTX
+        );
+      }
+
+      for (const poly of selected) {
+        for (const sourceChannel of sourceChannels) {
+          jobs.push({
+            containerId: container.id,
+            videoName: container.name,
+            safeVideo,
             polylineId: poly.id,
             frameIndex: seedFrame.frameIndex,
             sourceChannel,
-            detectVelocity: true,
-            renderOverlay: options.includeSegmentedImages,
           });
-
-          if (options.includeSegmentedImages && result.overlayPngBase64) {
-            await fs.writeFile(
-              path.join(outDir, `${safeVideo}__${poly.id}__${sourceChannel}.png`),
-              Buffer.from(result.overlayPngBase64, 'base64')
-            );
-          }
-
-          if (options.includeVelocityMetrics && result.tracks) {
-            result.tracks.forEach((tr, ti) => {
-              const base = [
-                container.name,
-                poly.id,
-                sourceChannel,
-                ti + 1,
-                csvField(tr.netVelocityUmPerSec),
-                tr.netVelocityPxPerFrame,
-                tr.snr,
-              ];
-              if (tr.runs.length === 0) {
-                csvRows.push(
-                  [
-                    ...base,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    csvField(result.pixelSizeUm),
-                    csvField(result.frameIntervalMs),
-                  ].join(',')
-                );
-              }
-              tr.runs.forEach((r, ri) => {
-                csvRows.push(
-                  [
-                    ...base,
-                    ri + 1,
-                    csvField(r.velocityUmPerSec),
-                    csvField(r.seUmPerSec),
-                    r.velocityPxPerFrame,
-                    r.t0,
-                    r.t1,
-                    csvField(result.pixelSizeUm),
-                    csvField(result.frameIntervalMs),
-                  ].join(',')
-                );
-              });
-            });
-          }
-        } catch (err) {
-          // One bad microtubule/channel must not abort the whole export.
-          logger.warn(
-            `Kymograph failed for ${container.name}/${poly.id}/${sourceChannel}: ${(err as Error).message}`,
-            CTX
-          );
         }
       }
     }
-  }
 
-  if (options.includeVelocityMetrics && csvRows.length > 1) {
-    await fs.writeFile(
-      path.join(outDir, 'velocity_metrics.csv'),
-      csvRows.join('\n'),
-      'utf-8'
+    // --- Phase 2: build kymographs with bounded concurrency. -------------
+    const csvRows: string[] = [
+      [
+        'video',
+        'microtubule',
+        'source_channel',
+        'track',
+        'net_velocity_um_s',
+        'net_velocity_px_frame',
+        'snr',
+        'run_index',
+        'run_velocity_um_s',
+        'run_se_um_s',
+        'run_velocity_px_frame',
+        't0',
+        't1',
+        'pixel_size_um',
+        'frame_interval_ms',
+      ].join(','),
+    ];
+
+    await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
+      try {
+        const result = await buildKymograph({
+          videoContainerId: job.containerId,
+          polylineId: job.polylineId,
+          frameIndex: job.frameIndex,
+          sourceChannel: job.sourceChannel,
+          detectVelocity: true,
+          renderOverlay: options.includeSegmentedImages,
+        });
+
+        if (options.includeSegmentedImages && result.overlayPngBase64) {
+          await fs.writeFile(
+            path.join(
+              outDir,
+              `${job.safeVideo}__${job.polylineId}__${job.sourceChannel}.png`
+            ),
+            Buffer.from(result.overlayPngBase64, 'base64')
+          );
+        }
+
+        if (options.includeVelocityMetrics && result.tracks) {
+          // Build this job's rows locally, then splice in one push so the
+          // CSV stays row-grouped per microtubule under concurrency.
+          const rows: string[] = [];
+          result.tracks.forEach((tr, ti) => {
+            const head = [
+              csvField(job.videoName),
+              job.polylineId,
+              job.sourceChannel,
+              ti + 1,
+              csvField(tr.netVelocityUmPerSec),
+              tr.netVelocityPxPerFrame,
+              tr.snr,
+            ];
+            if (tr.runs.length === 0) {
+              rows.push(
+                [
+                  ...head,
+                  '',
+                  '',
+                  '',
+                  '',
+                  '',
+                  '',
+                  csvField(result.pixelSizeUm),
+                  csvField(result.frameIntervalMs),
+                ].join(',')
+              );
+            }
+            tr.runs.forEach((r, ri) => {
+              rows.push(
+                [
+                  ...head,
+                  ri + 1,
+                  csvField(r.velocityUmPerSec),
+                  csvField(r.seUmPerSec),
+                  r.velocityPxPerFrame,
+                  r.t0,
+                  r.t1,
+                  csvField(result.pixelSizeUm),
+                  csvField(result.frameIntervalMs),
+                ].join(',')
+              );
+            });
+          });
+          csvRows.push(...rows);
+        }
+      } catch (err) {
+        // One bad microtubule/channel must not abort the whole export.
+        logger.warn(
+          `Kymograph failed for ${job.videoName}/${job.polylineId}/${job.sourceChannel}: ${(err as Error).message}`,
+          CTX
+        );
+      }
+    });
+
+    if (options.includeVelocityMetrics && csvRows.length > 1) {
+      await fs.writeFile(
+        path.join(outDir, 'velocity_metrics.csv'),
+        csvRows.join('\n'),
+        'utf-8'
+      );
+    }
+
+    logger.info('Microtubule kymographs exported', CTX, {
+      projectId,
+      containers: containers.length,
+      kymographs: jobs.length,
+      velocityRows: csvRows.length - 1,
+    });
+  } catch (err) {
+    // Orchestration-level failure (DB / mkdir / final write): degrade to "no
+    // kymograph output" rather than failing the whole export job.
+    logger.error(
+      `Microtubule kymograph export failed for project ${projectId}; ` +
+        `continuing without kymograph output`,
+      err as Error,
+      CTX
     );
   }
-
-  logger.info('Microtubule kymographs exported', CTX, {
-    projectId,
-    containers: containers.length,
-    velocityRows: csvRows.length - 1,
-  });
 }

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -1,0 +1,236 @@
+/**
+ * Microtubule kymograph export (microtubules projects only).
+ *
+ * For every MT video container in the project, builds one kymograph per
+ * microtubule (each polyline in the container's first segmented frame), runs
+ * blob-motion detection, and writes:
+ *
+ *   - ``kymographs/<video>__<polyline>.png`` — the kymograph with the detected
+ *     tracks drawn on top (when ``includeSegmentedImages``).
+ *   - ``kymographs/velocity_metrics.csv`` — one long-format row per run across
+ *     all microtubules (when ``includeVelocityMetrics``).
+ *
+ * Reuses ``buildKymograph`` so the export and the editor modal share the exact
+ * same sampling, detection and calibration path — no drift between what the
+ * user sees and what ships in the bundle.
+ */
+
+import * as path from 'path';
+import { promises as fs } from 'fs';
+import { prisma } from '../../db/prismaClient';
+import { logger } from '../../utils/logger';
+import { buildKymograph } from '../kymographService';
+
+const CTX = 'MTKymographExporter';
+
+/** Per-container cap so a 200-MT field can't make one export run for hours.
+ *  Anything dropped is logged (never silently truncated). */
+const MAX_MT_PER_CONTAINER = 60;
+
+export interface MTKymographOptions {
+  enabled: boolean;
+  includeVelocityMetrics: boolean;
+  includeSegmentedImages: boolean;
+}
+
+interface PolylineRecord {
+  id: string;
+  points?: Array<{ x: number; y: number }>;
+}
+
+function parsePolylines(json: string | null | undefined): PolylineRecord[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as PolylineRecord[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Prefer the first fluorescent channel (motility signal); fall back to the
+ *  segmentation source / first channel. Mirrors the editor modal default. */
+function pickSourceChannel(
+  channels: Array<{
+    name: string;
+    type?: string;
+    isSegmentationSource?: boolean;
+  }>
+): string | null {
+  if (channels.length === 0) return null;
+  const fluorescent = channels.find(c => c.type === 'fluorescent');
+  if (fluorescent) return fluorescent.name;
+  const source = channels.find(c => c.isSegmentationSource);
+  return source?.name ?? channels[0].name;
+}
+
+const csvField = (v: number | string | null | undefined): string =>
+  v == null ? '' : String(v);
+
+export async function exportMicrotubuleKymographs(
+  projectId: string,
+  exportDir: string,
+  options: MTKymographOptions
+): Promise<void> {
+  if (!options.enabled) return;
+
+  const containers = await prisma.image.findMany({
+    where: { projectId, isVideoContainer: true },
+    select: { id: true, name: true, channels: true },
+  });
+  if (containers.length === 0) return;
+
+  const outDir = path.join(exportDir, 'kymographs');
+  await fs.mkdir(outDir, { recursive: true });
+
+  const csvRows: string[] = [
+    [
+      'video',
+      'microtubule',
+      'source_channel',
+      'track',
+      'net_velocity_um_s',
+      'net_velocity_px_frame',
+      'snr',
+      'run_index',
+      'run_velocity_um_s',
+      'run_se_um_s',
+      'run_velocity_px_frame',
+      't0',
+      't1',
+      'pixel_size_um',
+      'frame_interval_ms',
+    ].join(','),
+  ];
+
+  for (const container of containers) {
+    const channels = Array.isArray(container.channels)
+      ? (container.channels as Array<{
+          name: string;
+          type?: string;
+          isSegmentationSource?: boolean;
+        }>)
+      : [];
+    const sourceChannel = pickSourceChannel(channels);
+    if (!sourceChannel) {
+      logger.warn(
+        `Container ${container.id} has no usable channel; skipping kymographs`,
+        CTX
+      );
+      continue;
+    }
+
+    // Seed = first frame that actually carries polylines.
+    const seedFrame = await prisma.image.findFirst({
+      where: {
+        parentVideoId: container.id,
+        segmentation: { isNot: null },
+      },
+      orderBy: { frameIndex: 'asc' },
+      select: {
+        frameIndex: true,
+        segmentation: { select: { polygons: true } },
+      },
+    });
+    if (!seedFrame || seedFrame.frameIndex == null) continue;
+
+    const polylines = parsePolylines(
+      seedFrame.segmentation?.polygons ?? null
+    ).filter(p => Array.isArray(p.points) && p.points.length >= 2);
+    if (polylines.length === 0) continue;
+
+    const safeVideo = container.name.replace(/[^A-Za-z0-9_-]+/g, '_');
+    const selected = polylines.slice(0, MAX_MT_PER_CONTAINER);
+    if (polylines.length > selected.length) {
+      logger.warn(
+        `Container ${container.name}: ${polylines.length} microtubules, ` +
+          `capping kymograph export at ${MAX_MT_PER_CONTAINER}`,
+        CTX
+      );
+    }
+
+    for (const poly of selected) {
+      try {
+        const result = await buildKymograph({
+          videoContainerId: container.id,
+          polylineId: poly.id,
+          frameIndex: seedFrame.frameIndex,
+          sourceChannel,
+          detectVelocity: true,
+          renderOverlay: options.includeSegmentedImages,
+        });
+
+        if (options.includeSegmentedImages && result.overlayPngBase64) {
+          await fs.writeFile(
+            path.join(outDir, `${safeVideo}__${poly.id}.png`),
+            Buffer.from(result.overlayPngBase64, 'base64')
+          );
+        }
+
+        if (options.includeVelocityMetrics && result.tracks) {
+          result.tracks.forEach((tr, ti) => {
+            const base = [
+              container.name,
+              poly.id,
+              sourceChannel,
+              ti + 1,
+              csvField(tr.netVelocityUmPerSec),
+              tr.netVelocityPxPerFrame,
+              tr.snr,
+            ];
+            if (tr.runs.length === 0) {
+              csvRows.push(
+                [
+                  ...base,
+                  '',
+                  '',
+                  '',
+                  '',
+                  '',
+                  '',
+                  csvField(result.pixelSizeUm),
+                  csvField(result.frameIntervalMs),
+                ].join(',')
+              );
+            }
+            tr.runs.forEach((r, ri) => {
+              csvRows.push(
+                [
+                  ...base,
+                  ri + 1,
+                  csvField(r.velocityUmPerSec),
+                  csvField(r.seUmPerSec),
+                  r.velocityPxPerFrame,
+                  r.t0,
+                  r.t1,
+                  csvField(result.pixelSizeUm),
+                  csvField(result.frameIntervalMs),
+                ].join(',')
+              );
+            });
+          });
+        }
+      } catch (err) {
+        // One bad microtubule must not abort the whole export.
+        logger.warn(
+          `Kymograph failed for ${container.name}/${poly.id}: ${(err as Error).message}`,
+          CTX
+        );
+      }
+    }
+  }
+
+  if (options.includeVelocityMetrics && csvRows.length > 1) {
+    await fs.writeFile(
+      path.join(outDir, 'velocity_metrics.csv'),
+      csvRows.join('\n'),
+      'utf-8'
+    );
+  }
+
+  logger.info('Microtubule kymographs exported', CTX, {
+    projectId,
+    containers: containers.length,
+    velocityRows: csvRows.length - 1,
+  });
+}

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -48,20 +48,24 @@ function parsePolylines(json: string | null | undefined): PolylineRecord[] {
   }
 }
 
-/** Prefer the first fluorescent channel (motility signal); fall back to the
- *  segmentation source / first channel. Mirrors the editor modal default. */
-function pickSourceChannel(
+/** Channels to sample per microtubule. ALL fluorescent channels (motility can
+ *  live in any of them — picking just the first silently misses motion in the
+ *  others); fall back to the segmentation source / first channel when the
+ *  upload has no fluorescent channels. */
+function pickSourceChannels(
   channels: Array<{
     name: string;
     type?: string;
     isSegmentationSource?: boolean;
   }>
-): string | null {
-  if (channels.length === 0) return null;
-  const fluorescent = channels.find(c => c.type === 'fluorescent');
-  if (fluorescent) return fluorescent.name;
+): string[] {
+  if (channels.length === 0) return [];
+  const fluorescent = channels
+    .filter(c => c.type === 'fluorescent')
+    .map(c => c.name);
+  if (fluorescent.length > 0) return fluorescent;
   const source = channels.find(c => c.isSegmentationSource);
-  return source?.name ?? channels[0].name;
+  return [source?.name ?? channels[0].name];
 }
 
 const csvField = (v: number | string | null | undefined): string =>
@@ -111,8 +115,8 @@ export async function exportMicrotubuleKymographs(
           isSegmentationSource?: boolean;
         }>)
       : [];
-    const sourceChannel = pickSourceChannel(channels);
-    if (!sourceChannel) {
+    const sourceChannels = pickSourceChannels(channels);
+    if (sourceChannels.length === 0) {
       logger.warn(
         `Container ${container.id} has no usable channel; skipping kymographs`,
         CTX
@@ -150,72 +154,76 @@ export async function exportMicrotubuleKymographs(
     }
 
     for (const poly of selected) {
-      try {
-        const result = await buildKymograph({
-          videoContainerId: container.id,
-          polylineId: poly.id,
-          frameIndex: seedFrame.frameIndex,
-          sourceChannel,
-          detectVelocity: true,
-          renderOverlay: options.includeSegmentedImages,
-        });
+      // One kymograph per (microtubule × fluorescent channel) — motion may be
+      // in any channel, so we sample them all rather than guess one.
+      for (const sourceChannel of sourceChannels) {
+        try {
+          const result = await buildKymograph({
+            videoContainerId: container.id,
+            polylineId: poly.id,
+            frameIndex: seedFrame.frameIndex,
+            sourceChannel,
+            detectVelocity: true,
+            renderOverlay: options.includeSegmentedImages,
+          });
 
-        if (options.includeSegmentedImages && result.overlayPngBase64) {
-          await fs.writeFile(
-            path.join(outDir, `${safeVideo}__${poly.id}.png`),
-            Buffer.from(result.overlayPngBase64, 'base64')
+          if (options.includeSegmentedImages && result.overlayPngBase64) {
+            await fs.writeFile(
+              path.join(outDir, `${safeVideo}__${poly.id}__${sourceChannel}.png`),
+              Buffer.from(result.overlayPngBase64, 'base64')
+            );
+          }
+
+          if (options.includeVelocityMetrics && result.tracks) {
+            result.tracks.forEach((tr, ti) => {
+              const base = [
+                container.name,
+                poly.id,
+                sourceChannel,
+                ti + 1,
+                csvField(tr.netVelocityUmPerSec),
+                tr.netVelocityPxPerFrame,
+                tr.snr,
+              ];
+              if (tr.runs.length === 0) {
+                csvRows.push(
+                  [
+                    ...base,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    csvField(result.pixelSizeUm),
+                    csvField(result.frameIntervalMs),
+                  ].join(',')
+                );
+              }
+              tr.runs.forEach((r, ri) => {
+                csvRows.push(
+                  [
+                    ...base,
+                    ri + 1,
+                    csvField(r.velocityUmPerSec),
+                    csvField(r.seUmPerSec),
+                    r.velocityPxPerFrame,
+                    r.t0,
+                    r.t1,
+                    csvField(result.pixelSizeUm),
+                    csvField(result.frameIntervalMs),
+                  ].join(',')
+                );
+              });
+            });
+          }
+        } catch (err) {
+          // One bad microtubule/channel must not abort the whole export.
+          logger.warn(
+            `Kymograph failed for ${container.name}/${poly.id}/${sourceChannel}: ${(err as Error).message}`,
+            CTX
           );
         }
-
-        if (options.includeVelocityMetrics && result.tracks) {
-          result.tracks.forEach((tr, ti) => {
-            const base = [
-              container.name,
-              poly.id,
-              sourceChannel,
-              ti + 1,
-              csvField(tr.netVelocityUmPerSec),
-              tr.netVelocityPxPerFrame,
-              tr.snr,
-            ];
-            if (tr.runs.length === 0) {
-              csvRows.push(
-                [
-                  ...base,
-                  '',
-                  '',
-                  '',
-                  '',
-                  '',
-                  '',
-                  csvField(result.pixelSizeUm),
-                  csvField(result.frameIntervalMs),
-                ].join(',')
-              );
-            }
-            tr.runs.forEach((r, ri) => {
-              csvRows.push(
-                [
-                  ...base,
-                  ri + 1,
-                  csvField(r.velocityUmPerSec),
-                  csvField(r.seUmPerSec),
-                  r.velocityPxPerFrame,
-                  r.t0,
-                  r.t1,
-                  csvField(result.pixelSizeUm),
-                  csvField(result.frameIntervalMs),
-                ].join(',')
-              );
-            });
-          });
-        }
-      } catch (err) {
-        // One bad microtubule must not abort the whole export.
-        logger.warn(
-          `Kymograph failed for ${container.name}/${poly.id}: ${(err as Error).message}`,
-          CTX
-        );
       }
     }
   }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -39,6 +39,7 @@ import {
   writeMTMetrics,
   type MTMetricsRow,
 } from './export/mtMetricsExporter';
+import { exportMicrotubuleKymographs } from './export/mtKymographExporter';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -74,6 +75,17 @@ export interface ExportOptions {
     thicknessPx: number;
     marginMultiplier: number;
     channels: string[];
+  };
+  /**
+   * Microtubule-only kymograph export. For ``microtubules`` projects, builds a
+   * kymograph per microtubule, runs blob-motion detection, and (per the
+   * toggles) writes segmented kymograph PNGs and/or a velocity-metrics CSV into
+   * ``kymographs/``. Ignored for non-MT projects.
+   */
+  mtKymographs?: {
+    enabled: boolean;
+    includeVelocityMetrics: boolean;
+    includeSegmentedImages: boolean;
   };
 }
 
@@ -584,6 +596,20 @@ export class ExportService {
             exportDir,
             options,
             jobId
+          )
+        );
+      }
+
+      // MT kymographs (segmented images + velocity metrics) — MT projects only.
+      if (
+        (project.type ?? '') === 'microtubules' &&
+        options.mtKymographs?.enabled
+      ) {
+        exportTasks.push(
+          exportMicrotubuleKymographs(
+            project.id,
+            exportDir,
+            options.mtKymographs
           )
         );
       }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -39,7 +39,10 @@ import {
   writeMTMetrics,
   type MTMetricsRow,
 } from './export/mtMetricsExporter';
-import { exportMicrotubuleKymographs } from './export/mtKymographExporter';
+import {
+  exportMicrotubuleKymographs,
+  type MTKymographOptions,
+} from './export/mtKymographExporter';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -82,11 +85,7 @@ export interface ExportOptions {
    * toggles) writes segmented kymograph PNGs and/or a velocity-metrics CSV into
    * ``kymographs/``. Ignored for non-MT projects.
    */
-  mtKymographs?: {
-    enabled: boolean;
-    includeVelocityMetrics: boolean;
-    includeSegmentedImages: boolean;
-  };
+  mtKymographs?: MTKymographOptions;
 }
 
 // Define type for project with images and segmentation data

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -42,7 +42,7 @@ interface PolylineRecord {
 /** Raw track shape returned by the ML ``/kymograph`` endpoint (snake_case,
  *  velocities in px/frame). Converted to the camelCase + um/s shape below. */
 interface MlTrack {
-  points: number[][];
+  points: KymoPoint[];
   net_pxframe: number;
   snr: number;
   runs: Array<{
@@ -81,9 +81,12 @@ export interface KymographRun {
   t1: number;
 }
 
+/** A sub-pixel trajectory sample: `[frame, xPosition]` along the polyline. */
+export type KymoPoint = [frame: number, x: number];
+
 /** One moving particle detected on the kymograph. */
 export interface KymographTrack {
-  points: number[][]; // [[frame, xSubpixel], ...]
+  points: KymoPoint[]; // time-ordered
   netVelocityPxPerFrame: number;
   netVelocityUmPerSec: number | null;
   snr: number;
@@ -268,6 +271,16 @@ export async function buildKymograph(
   const toUms = (pxPerFrame: number): number | null =>
     umPerSecPerPxFrame != null ? pxPerFrame * umPerSecPerPxFrame : null;
 
+  // Surface a contract violation: detection was requested but the ML service
+  // returned no tracks[] array (vs. legitimately empty). Don't let it look
+  // identical to "no particles found".
+  if (detectVelocity && !Array.isArray(payload.tracks)) {
+    logger.warn(
+      'ML kymograph response missing tracks[] despite detectVelocity',
+      'KymographService',
+      { videoContainerId, polylineId }
+    );
+  }
   const tracks: KymographTrack[] | undefined = Array.isArray(payload.tracks)
     ? (payload.tracks as MlTrack[]).map(tr => ({
         points: tr.points,

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -65,6 +65,9 @@ export interface KymographServiceInput {
   /** When true, the ML service also runs blob-motion detection and the
    *  result carries one ``KymographTrack`` per moving particle. */
   detectVelocity?: boolean;
+  /** When true (with detectVelocity), the result carries ``overlayPngBase64``
+   *  — the kymograph with detected tracks composited on top. Used by export. */
+  renderOverlay?: boolean;
 }
 
 /** One constant-velocity segment of a track. ``*UmPerSec`` fields are null
@@ -99,6 +102,8 @@ export interface KymographServiceResult {
   frameIntervalMs: number | null;
   /** Detected moving particles; present only when ``detectVelocity`` was set. */
   tracks?: KymographTrack[];
+  /** Base64 PNG of the kymograph + tracks; present only with ``renderOverlay``. */
+  overlayPngBase64?: string;
 }
 
 /** Resolves the on-disk PNG path for a given frame + channel. */
@@ -140,6 +145,7 @@ export async function buildKymograph(
     sourceChannel,
     channelColor,
     detectVelocity,
+    renderOverlay,
   } = input;
 
   // Defence in depth: reject any sourceChannel containing path separators
@@ -245,6 +251,7 @@ export async function buildKymograph(
       tracked: trackedMode,
       ...(channelColor ? { channel_color: channelColor } : {}),
       ...(detectVelocity ? { detect_velocity: true } : {}),
+      ...(detectVelocity && renderOverlay ? { render_overlay: true } : {}),
     },
     { timeout: 120_000 }
   );
@@ -296,5 +303,8 @@ export async function buildKymograph(
     pixelSizeUm,
     frameIntervalMs,
     ...(tracks ? { tracks } : {}),
+    ...(typeof payload.overlay_png_base64 === 'string'
+      ? { overlayPngBase64: payload.overlay_png_base64 }
+      : {}),
   };
 }

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -39,6 +39,20 @@ interface PolylineRecord {
   instanceId?: string;
 }
 
+/** Raw track shape returned by the ML ``/kymograph`` endpoint (snake_case,
+ *  velocities in px/frame). Converted to the camelCase + um/s shape below. */
+interface MlTrack {
+  points: number[][];
+  net_pxframe: number;
+  snr: number;
+  runs: Array<{
+    v_pxframe: number;
+    se_pxframe: number;
+    t0: number;
+    t1: number;
+  }>;
+}
+
 export interface KymographServiceInput {
   videoContainerId: string;
   polylineId: string;
@@ -48,6 +62,29 @@ export interface KymographServiceInput {
    *  kymograph as a black-to-color linear gradient instead of viridis,
    *  matching the channel tint the user picked in the editor. */
   channelColor?: string;
+  /** When true, the ML service also runs blob-motion detection and the
+   *  result carries one ``KymographTrack`` per moving particle. */
+  detectVelocity?: boolean;
+}
+
+/** One constant-velocity segment of a track. ``*UmPerSec`` fields are null
+ *  when the container has no calibration (pixelSizeUm / frameIntervalMs). */
+export interface KymographRun {
+  velocityPxPerFrame: number;
+  sePxPerFrame: number;
+  velocityUmPerSec: number | null;
+  seUmPerSec: number | null;
+  t0: number;
+  t1: number;
+}
+
+/** One moving particle detected on the kymograph. */
+export interface KymographTrack {
+  points: number[][]; // [[frame, xSubpixel], ...]
+  netVelocityPxPerFrame: number;
+  netVelocityUmPerSec: number | null;
+  snr: number;
+  runs: KymographRun[];
 }
 
 export interface KymographServiceResult {
@@ -57,6 +94,11 @@ export interface KymographServiceResult {
   lengthPx: number;
   tracked: boolean;
   sourceChannel: string;
+  /** Container calibration (null when the source upload had no metadata). */
+  pixelSizeUm: number | null;
+  frameIntervalMs: number | null;
+  /** Detected moving particles; present only when ``detectVelocity`` was set. */
+  tracks?: KymographTrack[];
 }
 
 /** Resolves the on-disk PNG path for a given frame + channel. */
@@ -91,7 +133,14 @@ function parsePolygons(json: string | null | undefined): PolylineRecord[] {
 export async function buildKymograph(
   input: KymographServiceInput
 ): Promise<KymographServiceResult> {
-  const { videoContainerId, polylineId, frameIndex, sourceChannel, channelColor } = input;
+  const {
+    videoContainerId,
+    polylineId,
+    frameIndex,
+    sourceChannel,
+    channelColor,
+    detectVelocity,
+  } = input;
 
   // Defence in depth: reject any sourceChannel containing path separators
   // or other unsafe characters. The route layer also validates, but this
@@ -110,6 +159,8 @@ export async function buildKymograph(
       projectId: true,
       isVideoContainer: true,
       channels: true,
+      pixelSizeUm: true,
+      frameIntervalMs: true,
     },
   });
   if (!container || !container.isVideoContainer) {
@@ -193,16 +244,46 @@ export async function buildKymograph(
       target_width: 200,
       tracked: trackedMode,
       ...(channelColor ? { channel_color: channelColor } : {}),
+      ...(detectVelocity ? { detect_velocity: true } : {}),
     },
     { timeout: 120_000 }
   );
   const payload = res.data?.data ?? res.data ?? {};
+
+  // Calibration: px/frame -> um/s factor. Null when the upload carried no
+  // pixel size / frame interval (older videos, non-microscopy formats).
+  const pixelSizeUm = container.pixelSizeUm ?? null;
+  const frameIntervalMs = container.frameIntervalMs ?? null;
+  const umPerSecPerPxFrame =
+    pixelSizeUm != null && frameIntervalMs != null && frameIntervalMs > 0
+      ? pixelSizeUm / (frameIntervalMs / 1000)
+      : null;
+  const toUms = (pxPerFrame: number): number | null =>
+    umPerSecPerPxFrame != null ? pxPerFrame * umPerSecPerPxFrame : null;
+
+  const tracks: KymographTrack[] | undefined = Array.isArray(payload.tracks)
+    ? (payload.tracks as MlTrack[]).map(tr => ({
+        points: tr.points,
+        netVelocityPxPerFrame: tr.net_pxframe,
+        netVelocityUmPerSec: toUms(tr.net_pxframe),
+        snr: tr.snr,
+        runs: tr.runs.map(r => ({
+          velocityPxPerFrame: r.v_pxframe,
+          sePxPerFrame: r.se_pxframe,
+          velocityUmPerSec: toUms(r.v_pxframe),
+          seUmPerSec: toUms(r.se_pxframe),
+          t0: r.t0,
+          t1: r.t1,
+        })),
+      }))
+    : undefined;
 
   logger.info('Kymograph generated', 'KymographService', {
     videoContainerId,
     polylineId,
     tracked: trackedMode,
     frames: framesPayload.length,
+    velocityTracks: tracks?.length,
   });
 
   return {
@@ -212,5 +293,8 @@ export async function buildKymograph(
     lengthPx: payload.length_px,
     tracked: trackedMode,
     sourceChannel,
+    pixelSizeUm,
+    frameIntervalMs,
+    ...(tracks ? { tracks } : {}),
   };
 }

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -41,6 +41,7 @@ import { ProjectImage } from '@/types';
 import { EXPORT_DEFAULTS } from '@/lib/export-config';
 import { ImageSelectionGrid } from './components/ImageSelectionGrid';
 import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
+import { MicrotubuleKymographsSection } from './components/MicrotubuleKymographsSection';
 import { UniversalCancelButton } from '@/components/ui/universal-cancel-button';
 import {
   AlertDialog,
@@ -77,6 +78,12 @@ const MT_METRICS_DEFAULTS = {
   thicknessPx: 5,
   marginMultiplier: 2,
   channels: [] as string[],
+};
+
+const MT_KYMOGRAPHS_DEFAULTS = {
+  enabled: false,
+  includeVelocityMetrics: true,
+  includeSegmentedImages: true,
 };
 
 export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
@@ -421,6 +428,17 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                         updateExportOptions({ mtMetrics: next })
                       }
                       availableChannels={availableChannels}
+                    />
+                  )}
+
+                  {isMTProject && (
+                    <MicrotubuleKymographsSection
+                      value={
+                        exportOptions.mtKymographs ?? MT_KYMOGRAPHS_DEFAULTS
+                      }
+                      onChange={next =>
+                        updateExportOptions({ mtKymographs: next })
+                      }
                     />
                   )}
 

--- a/src/pages/export/components/MicrotubuleKymographsSection.tsx
+++ b/src/pages/export/components/MicrotubuleKymographsSection.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { LineChart } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { useLanguage } from '@/contexts/useLanguage';
+
+export interface MicrotubuleKymographsOptions {
+  enabled: boolean;
+  includeVelocityMetrics: boolean;
+  includeSegmentedImages: boolean;
+}
+
+export interface MicrotubuleKymographsSectionProps {
+  value: MicrotubuleKymographsOptions;
+  onChange: (next: MicrotubuleKymographsOptions) => void;
+}
+
+/**
+ * MT-only export controls for kymograph velocity analysis. Renders inside the
+ * export dialog's General tab when ``projectType === 'microtubules'``. The
+ * backend builds one kymograph per microtubule, detects moving particles, and
+ * ships the segmented kymograph PNGs and/or a velocity-metrics CSV.
+ */
+export const MicrotubuleKymographsSection: React.FC<
+  MicrotubuleKymographsSectionProps
+> = ({ value, onChange }) => {
+  const { t } = useLanguage();
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <LineChart className="h-4 w-4" />
+          {t('export.mtKymographs.title', {
+            defaultValue: 'Kymograph velocity analysis',
+          })}
+        </CardTitle>
+        <CardDescription>
+          {t('export.mtKymographs.description', {
+            defaultValue:
+              'Detect moving particles on a kymograph for each microtubule and export their velocities.',
+          })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="mt-kymo-enabled"
+            checked={value.enabled}
+            onCheckedChange={v => onChange({ ...value, enabled: v === true })}
+          />
+          <Label htmlFor="mt-kymo-enabled" className="cursor-pointer">
+            {t('export.mtKymographs.enable', {
+              defaultValue: 'Include kymograph analysis',
+            })}
+          </Label>
+        </div>
+
+        {value.enabled && (
+          <div className="ml-6 space-y-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="mt-kymo-velocity"
+                checked={value.includeVelocityMetrics}
+                onCheckedChange={v =>
+                  onChange({ ...value, includeVelocityMetrics: v === true })
+                }
+              />
+              <Label
+                htmlFor="mt-kymo-velocity"
+                className="cursor-pointer text-sm"
+              >
+                {t('export.mtKymographs.velocityMetrics', {
+                  defaultValue: 'Velocity metrics (CSV)',
+                })}
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="mt-kymo-images"
+                checked={value.includeSegmentedImages}
+                onCheckedChange={v =>
+                  onChange({ ...value, includeSegmentedImages: v === true })
+                }
+              />
+              <Label
+                htmlFor="mt-kymo-images"
+                className="cursor-pointer text-sm"
+              >
+                {t('export.mtKymographs.segmentedImages', {
+                  defaultValue: 'Segmented kymograph images (PNG)',
+                })}
+              </Label>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -92,6 +92,16 @@ export interface ExportOptions {
     /** Channel names (machine-safe ``name`` field from container.channels). */
     channels: string[];
   };
+  /**
+   * Microtubule-only kymograph export. When enabled (MT projects only), the
+   * backend builds a kymograph per microtubule, runs blob-motion detection,
+   * and writes segmented kymograph images and/or a velocity-metrics CSV.
+   */
+  mtKymographs?: {
+    enabled: boolean;
+    includeVelocityMetrics: boolean;
+    includeSegmentedImages: boolean;
+  };
 }
 
 export const useSharedAdvancedExport = (

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -8,6 +8,7 @@ import ExportStateManager from '@/lib/exportStateManager';
 import { useExportContext } from '@/contexts/ExportContext';
 import { useAbortController } from '@/hooks/shared/useAbortController';
 import { retryWithBackoff, RETRY_CONFIGS } from '@/lib/retryUtils';
+import type { MicrotubuleKymographsOptions } from '../components/MicrotubuleKymographsSection';
 
 // Sanitize filename to remove/replace invalid characters
 const sanitizeFilename = (filename: string): string => {
@@ -97,11 +98,7 @@ export interface ExportOptions {
    * backend builds a kymograph per microtubule, runs blob-motion detection,
    * and writes segmented kymograph images and/or a velocity-metrics CSV.
    */
-  mtKymographs?: {
-    enabled: boolean;
-    includeVelocityMetrics: boolean;
-    includeSegmentedImages: boolean;
-  };
+  mtKymographs?: MicrotubuleKymographsOptions;
 }
 
 export const useSharedAdvancedExport = (

--- a/src/pages/segmentation/components/KymographModal.tsx
+++ b/src/pages/segmentation/components/KymographModal.tsx
@@ -1,11 +1,13 @@
 /**
  * Modal that renders a kymograph for a microtubule polyline.
  *
- * The frontend just orchestrates UI state — the heavy lifting is in the
- * backend, which samples raw image intensity along the selected polyline
- * across every frame (using the tracked geometry if available, otherwise
- * the polyline from the current frame as a static reference line) and
- * returns a viridis-colour-mapped PNG plus the underlying CSV.
+ * The frontend orchestrates UI state; the backend samples raw image intensity
+ * along the selected polyline across every frame and returns a colour-mapped
+ * PNG plus the underlying CSV. When "Velocity analysis" is enabled the backend
+ * also runs blob-motion detection and returns one track per moving particle
+ * (with µm/s velocities derived from the container calibration). Those tracks
+ * are drawn as an interactive SVG overlay on top of the kymograph and listed in
+ * a velocity table.
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -18,6 +20,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -39,6 +43,23 @@ interface KymographModalProps {
   channels: VideoChannel[] | null | undefined;
 }
 
+interface KymographRun {
+  velocityPxPerFrame: number;
+  sePxPerFrame: number;
+  velocityUmPerSec: number | null;
+  seUmPerSec: number | null;
+  t0: number;
+  t1: number;
+}
+
+interface KymographTrack {
+  points: number[][]; // [[frame, x], ...]
+  netVelocityPxPerFrame: number;
+  netVelocityUmPerSec: number | null;
+  snr: number;
+  runs: KymographRun[];
+}
+
 interface KymographResponse {
   pngBase64: string;
   csvBase64: string;
@@ -46,6 +67,18 @@ interface KymographResponse {
   lengthPx: number;
   tracked: boolean;
   sourceChannel: string;
+  pixelSizeUm: number | null;
+  frameIntervalMs: number | null;
+  tracks?: KymographTrack[];
+}
+
+// Direction-coded colours for the overlay + table dots.
+const ANTERO = '#f87171'; // net position increasing (+)
+const RETRO = '#38bdf8'; // net position decreasing (−)
+const STATIC = '#a3a3a3';
+function trackColor(netPxFrame: number): string {
+  if (Math.abs(netPxFrame) < 0.02) return STATIC;
+  return netPxFrame > 0 ? ANTERO : RETRO;
 }
 
 export function KymographModal({
@@ -74,9 +107,11 @@ export function KymographModal({
   const [sourceChannel, setSourceChannel] = useState<string | null>(
     defaultChannel
   );
+  const [detectVelocity, setDetectVelocity] = useState(true);
   const [result, setResult] = useState<KymographResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeTrack, setActiveTrack] = useState<number | null>(null);
 
   useEffect(() => {
     if (defaultChannel && sourceChannel == null) {
@@ -102,6 +137,7 @@ export function KymographModal({
         frameIndex,
         sourceChannel,
         channelColor,
+        detectVelocity,
       })
       .then(res => {
         if (cancelled) return;
@@ -125,21 +161,37 @@ export function KymographModal({
     polylineId,
     frameIndex,
     channelColors,
+    detectVelocity,
   ]);
 
   const handleDownload = (kind: 'png' | 'csv') => {
     if (!result) return;
     const data = kind === 'png' ? result.pngBase64 : result.csvBase64;
     const mime = kind === 'png' ? 'image/png' : 'text/csv';
-    const blob = base64ToBlob(data, mime);
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `kymograph-${polylineId}.${kind}`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    triggerDownload(
+      base64ToBlob(data, mime),
+      `kymograph-${polylineId}.${kind}`
+    );
+  };
+
+  const handleDownloadTracks = () => {
+    if (!result?.tracks) return;
+    const csv = tracksToCsv(result.tracks);
+    triggerDownload(
+      new Blob([csv], { type: 'text/csv' }),
+      `kymograph-velocity-${polylineId}.csv`
+    );
+  };
+
+  const tracks = result?.tracks ?? [];
+  const calibrated =
+    result?.pixelSizeUm != null && result.frameIntervalMs != null;
+
+  const fmtVelocity = (track: KymographTrack): string => {
+    if (track.netVelocityUmPerSec != null) {
+      return `${track.netVelocityUmPerSec >= 0 ? '+' : ''}${track.netVelocityUmPerSec.toFixed(3)} µm/s`;
+    }
+    return `${track.netVelocityPxPerFrame.toFixed(3)} px/fr`;
   };
 
   return (
@@ -152,7 +204,7 @@ export function KymographModal({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           {channels && channels.length > 1 && (
             <>
               <span className="text-sm">
@@ -177,6 +229,18 @@ export function KymographModal({
               </Select>
             </>
           )}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="kymo-velocity"
+              checked={detectVelocity}
+              onCheckedChange={v => setDetectVelocity(v === true)}
+            />
+            <Label htmlFor="kymo-velocity" className="text-sm cursor-pointer">
+              {t('editor.kymograph.velocityAnalysis', {
+                defaultValue: 'Velocity analysis',
+              })}
+            </Label>
+          </div>
           {result && (
             <span className="text-xs text-muted-foreground">
               {result.tracked
@@ -202,9 +266,7 @@ export function KymographModal({
           {error && <div className="text-destructive text-sm">{error}</div>}
           {!isLoading && !error && result && (
             // Axes: rows = frames (time, ↓ down = later); cols = position
-            // along the polyline (head → tail in the seed frame). Tick
-            // labels at 0 / 25 / 50 / 75 / 100% provide a scale; units
-            // are pixels for the spatial axis, frame index for time.
+            // along the polyline (head → tail in the seed frame).
             <div
               className="grid w-full gap-1"
               style={{
@@ -234,17 +296,50 @@ export function KymographModal({
                   </span>
                 ))}
               </div>
-              {/* Kymograph image (column 2, row 0). */}
-              <img
-                src={`data:image/png;base64,${result.pngBase64}`}
-                alt={`Kymograph for ${polylineId}`}
-                className="w-full max-h-[500px] block"
-                style={{
-                  imageRendering: 'pixelated',
-                  minHeight: '200px',
-                  objectFit: 'fill',
-                }}
-              />
+              {/* Kymograph image + velocity overlay (column 2, row 0). */}
+              <div className="relative">
+                <img
+                  src={`data:image/png;base64,${result.pngBase64}`}
+                  alt={`Kymograph for ${polylineId}`}
+                  className="w-full max-h-[500px] block"
+                  style={{
+                    imageRendering: 'pixelated',
+                    minHeight: '200px',
+                    objectFit: 'fill',
+                  }}
+                />
+                {detectVelocity && tracks.length > 0 && (
+                  // preserveAspectRatio="none" + objectFit:fill image ⇒ the
+                  // viewBox maps linearly onto the displayed kymograph, so a
+                  // track point (x, frame) lands exactly on its pixel.
+                  <svg
+                    className="absolute inset-0 w-full h-full"
+                    viewBox={`0 0 ${result.lengthPx} ${result.frameCount}`}
+                    preserveAspectRatio="none"
+                  >
+                    {tracks.map((tr, i) => (
+                      <polyline
+                        key={i}
+                        points={tr.points
+                          .map(([frame, x]) => `${x},${frame}`)
+                          .join(' ')}
+                        fill="none"
+                        stroke={trackColor(tr.netVelocityPxPerFrame)}
+                        strokeWidth={activeTrack === i ? 3 : 1.5}
+                        strokeOpacity={
+                          activeTrack === null || activeTrack === i ? 1 : 0.25
+                        }
+                        vectorEffect="non-scaling-stroke"
+                        style={{ cursor: 'pointer' }}
+                        onMouseEnter={() => setActiveTrack(i)}
+                        onMouseLeave={() => setActiveTrack(null)}
+                      >
+                        <title>{`#${i + 1}: ${fmtVelocity(tr)}`}</title>
+                      </polyline>
+                    ))}
+                  </svg>
+                )}
+              </div>
               {/* X-axis tick labels (column 2, row 1). */}
               <div />
               <div />
@@ -267,7 +362,86 @@ export function KymographModal({
           )}
         </div>
 
+        {/* Velocity table */}
+        {detectVelocity && result && !isLoading && (
+          <div className="max-h-48 overflow-auto rounded border">
+            {tracks.length === 0 ? (
+              <div className="p-3 text-sm text-muted-foreground">
+                {t('editor.kymograph.noBlobs', {
+                  defaultValue: 'No moving particles detected',
+                })}
+              </div>
+            ) : (
+              <table className="w-full text-xs">
+                <thead className="sticky top-0 bg-muted/80 text-muted-foreground">
+                  <tr>
+                    <th className="text-left px-2 py-1">#</th>
+                    <th className="text-left px-2 py-1">
+                      {t('editor.kymograph.colVelocity', {
+                        defaultValue: 'Net velocity',
+                      })}
+                    </th>
+                    <th className="text-right px-2 py-1">
+                      {t('editor.kymograph.colRuns', { defaultValue: 'Runs' })}
+                    </th>
+                    <th className="text-right px-2 py-1">
+                      {t('editor.kymograph.colSnr', { defaultValue: 'SNR' })}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {tracks.map((tr, i) => (
+                    <tr
+                      key={i}
+                      className={`border-t cursor-pointer ${activeTrack === i ? 'bg-accent' : ''}`}
+                      onMouseEnter={() => setActiveTrack(i)}
+                      onMouseLeave={() => setActiveTrack(null)}
+                    >
+                      <td className="px-2 py-1">
+                        <span
+                          className="inline-block w-2.5 h-2.5 rounded-full mr-1 align-middle"
+                          style={{
+                            backgroundColor: trackColor(
+                              tr.netVelocityPxPerFrame
+                            ),
+                          }}
+                        />
+                        {i + 1}
+                      </td>
+                      <td className="px-2 py-1 tabular-nums">
+                        {fmtVelocity(tr)}
+                      </td>
+                      <td className="px-2 py-1 text-right tabular-nums">
+                        {tr.runs.length}
+                      </td>
+                      <td className="px-2 py-1 text-right tabular-nums">
+                        {tr.snr.toFixed(1)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            {tracks.length > 0 && !calibrated && (
+              <div className="px-2 py-1 text-[10px] text-amber-600 border-t">
+                {t('editor.kymograph.uncalibrated', {
+                  defaultValue:
+                    'No pixel-size / frame-interval calibration — velocities shown in px/frame.',
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
         <DialogFooter>
+          {detectVelocity && tracks.length > 0 && (
+            <Button variant="outline" onClick={handleDownloadTracks}>
+              <Download className="h-4 w-4 mr-1" />
+              {t('editor.kymograph.downloadTracks', {
+                defaultValue: 'Velocity CSV',
+              })}
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={() => handleDownload('png')}
@@ -288,6 +462,68 @@ export function KymographModal({
       </DialogContent>
     </Dialog>
   );
+}
+
+function tracksToCsv(tracks: KymographTrack[]): string {
+  const header = [
+    'track',
+    'net_velocity_um_s',
+    'net_velocity_px_frame',
+    'snr',
+    'run_index',
+    'run_velocity_um_s',
+    'run_se_um_s',
+    'run_velocity_px_frame',
+    't0',
+    't1',
+  ];
+  const lines = [header.join(',')];
+  tracks.forEach((tr, ti) => {
+    if (tr.runs.length === 0) {
+      lines.push(
+        [
+          ti + 1,
+          tr.netVelocityUmPerSec ?? '',
+          tr.netVelocityPxPerFrame,
+          tr.snr,
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+        ].join(',')
+      );
+    }
+    tr.runs.forEach((r, ri) => {
+      lines.push(
+        [
+          ti + 1,
+          tr.netVelocityUmPerSec ?? '',
+          tr.netVelocityPxPerFrame,
+          tr.snr,
+          ri + 1,
+          r.velocityUmPerSec ?? '',
+          r.seUmPerSec ?? '',
+          r.velocityPxPerFrame,
+          r.t0,
+          r.t1,
+        ].join(',')
+      );
+    });
+  });
+  return lines.join('\n');
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 function base64ToBlob(b64: string, mime: string): Blob {

--- a/src/pages/segmentation/components/KymographModal.tsx
+++ b/src/pages/segmentation/components/KymographModal.tsx
@@ -52,8 +52,12 @@ interface KymographRun {
   t1: number;
 }
 
+/** Sub-pixel trajectory sample `[frame, xPosition]`. Mirrors the backend
+ *  `KymoPoint` (FE/BE wire types are hand-synced per repo convention). */
+type KymoPoint = [frame: number, x: number];
+
 interface KymographTrack {
-  points: number[][]; // [[frame, x], ...]
+  points: KymoPoint[]; // time-ordered
   netVelocityPxPerFrame: number;
   netVelocityUmPerSec: number | null;
   snr: number;

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1144,6 +1144,14 @@ export default {
     imagesDeleted_other: '{{count}} obrázky smazány',
   },
   export: {
+    mtKymographs: {
+      title: 'Analýza rychlosti z kymografu',
+      description:
+        'Detekce pohyblivých částic na kymografu pro každý mikrotubul a export jejich rychlostí.',
+      enable: 'Zahrnout analýzu kymografů',
+      velocityMetrics: 'Metriky rychlosti (CSV)',
+      segmentedImages: 'Segmentované kymografy (PNG)',
+    },
     mt: {
       sectionTitle: 'Metriky mikrotubulů',
       sectionDescription:

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2138,6 +2138,14 @@ export default {
       showKymograph: 'Zobrazit kymograf',
       axisTime: 'Čas (snímky) ↓',
       axisAlong: 'Podél mikrotubule (px) →',
+      velocityAnalysis: 'Analýza rychlosti',
+      colVelocity: 'Čistá rychlost',
+      colRuns: 'Běhy',
+      colSnr: 'SNR',
+      noBlobs: 'Nedetekovány žádné pohyblivé částice',
+      downloadTracks: 'CSV rychlostí',
+      uncalibrated:
+        'Bez kalibrace velikosti pixelu / intervalu snímků — rychlosti v px/snímek.',
     },
     channels: {
       toggleVisibility: 'Přepnout viditelnost kanálu',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2129,6 +2129,14 @@ export default {
       showKymograph: 'Kymograph anzeigen',
       axisTime: 'Zeit (Frames) ↓',
       axisAlong: 'Entlang Mikrotubulus (px) →',
+      velocityAnalysis: 'Geschwindigkeitsanalyse',
+      colVelocity: 'Nettogeschwindigkeit',
+      colRuns: 'Läufe',
+      colSnr: 'SNR',
+      noBlobs: 'Keine bewegten Partikel erkannt',
+      downloadTracks: 'Geschwindigkeits-CSV',
+      uncalibrated:
+        'Keine Pixelgröße-/Bildintervall-Kalibrierung — Geschwindigkeiten in px/Frame.',
     },
     channels: {
       toggleVisibility: 'Kanal-Sichtbarkeit umschalten',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1155,6 +1155,14 @@ export default {
     imagesDeleted_other: '{{count}} Bilder gelöscht',
   },
   export: {
+    mtKymographs: {
+      title: 'Kymograph-Geschwindigkeitsanalyse',
+      description:
+        'Erkennt bewegte Partikel auf einem Kymographen für jeden Mikrotubulus und exportiert ihre Geschwindigkeiten.',
+      enable: 'Kymograph-Analyse einbeziehen',
+      velocityMetrics: 'Geschwindigkeitsmetriken (CSV)',
+      segmentedImages: 'Segmentierte Kymograph-Bilder (PNG)',
+    },
     mt: {
       sectionTitle: 'Mikrotubuli-Metriken',
       sectionDescription:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2199,6 +2199,14 @@ export default {
       showKymograph: 'Show kymograph',
       axisTime: 'Time (frames) ↓',
       axisAlong: 'Along microtubule (px) →',
+      velocityAnalysis: 'Velocity analysis',
+      colVelocity: 'Net velocity',
+      colRuns: 'Runs',
+      colSnr: 'SNR',
+      noBlobs: 'No moving particles detected',
+      downloadTracks: 'Velocity CSV',
+      uncalibrated:
+        'No pixel-size / frame-interval calibration — velocities shown in px/frame.',
     },
     channels: {
       toggleVisibility: 'Toggle channel visibility',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1135,6 +1135,14 @@ export default {
   },
   export: {
     // Microtubule-only metric controls.
+    mtKymographs: {
+      title: 'Kymograph velocity analysis',
+      description:
+        'Detect moving particles on a kymograph for each microtubule and export their velocities.',
+      enable: 'Include kymograph analysis',
+      velocityMetrics: 'Velocity metrics (CSV)',
+      segmentedImages: 'Segmented kymograph images (PNG)',
+    },
     mt: {
       sectionTitle: 'Microtubule metrics',
       sectionDescription:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2168,6 +2168,14 @@ export default {
       showKymograph: 'Mostrar kimógrafo',
       axisTime: 'Tiempo (frames) ↓',
       axisAlong: 'A lo largo del microtúbulo (px) →',
+      velocityAnalysis: 'Análisis de velocidad',
+      colVelocity: 'Velocidad neta',
+      colRuns: 'Tramos',
+      colSnr: 'SNR',
+      noBlobs: 'No se detectaron partículas en movimiento',
+      downloadTracks: 'CSV de velocidad',
+      uncalibrated:
+        'Sin calibración de tamaño de píxel / intervalo de fotogramas — velocidades en px/fotograma.',
     },
     channels: {
       toggleVisibility: 'Alternar visibilidad del canal',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1140,6 +1140,14 @@ export default {
     imagesDeleted_other: '{{count}} imágenes eliminadas',
   },
   export: {
+    mtKymographs: {
+      title: 'Análisis de velocidad por kimografía',
+      description:
+        'Detecta partículas en movimiento en un kimograma para cada microtúbulo y exporta sus velocidades.',
+      enable: 'Incluir análisis de kimografía',
+      velocityMetrics: 'Métricas de velocidad (CSV)',
+      segmentedImages: 'Imágenes de kimograma segmentadas (PNG)',
+    },
     mt: {
       sectionTitle: 'Métricas de microtúbulos',
       sectionDescription:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1145,6 +1145,14 @@ export default {
     imagesDeleted_other: '{{count}} images supprimées',
   },
   export: {
+    mtKymographs: {
+      title: 'Analyse de vitesse par kymographie',
+      description:
+        'Détecte les particules en mouvement sur un kymographe pour chaque microtubule et exporte leurs vitesses.',
+      enable: 'Inclure l’analyse de kymographie',
+      velocityMetrics: 'Métriques de vitesse (CSV)',
+      segmentedImages: 'Images de kymographe segmentées (PNG)',
+    },
     mt: {
       sectionTitle: 'Métriques des microtubules',
       sectionDescription:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2117,6 +2117,14 @@ export default {
       showKymograph: 'Afficher le kymographe',
       axisTime: 'Temps (images) ↓',
       axisAlong: 'Le long du microtubule (px) →',
+      velocityAnalysis: 'Analyse de vitesse',
+      colVelocity: 'Vitesse nette',
+      colRuns: 'Segments',
+      colSnr: 'SNR',
+      noBlobs: 'Aucune particule en mouvement détectée',
+      downloadTracks: 'CSV de vitesse',
+      uncalibrated:
+        "Pas de calibration taille de pixel / intervalle d'images — vitesses en px/image.",
     },
     channels: {
       toggleVisibility: 'Basculer la visibilité du canal',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1054,6 +1054,13 @@ export default {
     imagesDeleted_other: '已删除 {{count}} 张图片',
   },
   export: {
+    mtKymographs: {
+      title: '微管图速度分析',
+      description: '在每个微管的微管图上检测移动粒子并导出其速度。',
+      enable: '包含微管图分析',
+      velocityMetrics: '速度指标 (CSV)',
+      segmentedImages: '分割的微管图图像 (PNG)',
+    },
     mt: {
       sectionTitle: '微管指标',
       sectionDescription:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1990,6 +1990,13 @@ export default {
       showKymograph: '显示时空图',
       axisTime: '时间 (帧) ↓',
       axisAlong: '沿微管 (px) →',
+      velocityAnalysis: '速度分析',
+      colVelocity: '净速度',
+      colRuns: '运动段',
+      colSnr: '信噪比',
+      noBlobs: '未检测到移动粒子',
+      downloadTracks: '速度 CSV',
+      uncalibrated: '无像素尺寸/帧间隔校准——速度以 px/帧 显示。',
     },
     channels: {
       toggleVisibility: '切换通道可见性',


### PR DESCRIPTION
## What

Adds **moving-particle (blob) velocity analysis** on microtubule kymographs, surfaced in two places:

- **Editor modal** (`KymographModal`): a "Velocity analysis" checkbox (default on, toggleable) runs blob detection and overlays the detected tracks on the kymograph as an interactive SVG layer (direction-coloured, hover-synced), plus a velocity table (net µm/s, runs, SNR) and a per-run velocity CSV download.
- **Project export** (MT projects only): a new export-dialog section ships, per microtubule × fluorescent channel, the **segmented kymograph PNGs** and/or a **`velocity_metrics.csv`**, toggleable in export settings.

Velocities are reported in **µm/s** using the container's `pixelSizeUm`/`frameIntervalMs` calibration (already persisted at upload); falls back to px/frame when uncalibrated.

## Method

Detection lives once in the ML service (`backend/segmentation/api/kymograph_velocity.py`) and is shared by both paths via `buildKymograph`, so the modal and the export are bit-for-bit identical. Pipeline: DoG band-pass peak detection → Hungarian frame-to-frame linking with constant-velocity prediction → collinear-fragment stitching → run/pause segmentation. Researched (Radon / AMTraK / KymographClear / KymoButler) and validated against KIF14 motility data (motors 20–110 nm/s).

## Layers

| Layer | Change |
|---|---|
| ML | `detect_blobs` + `render_overlay`; `/kymograph` gains `detect_velocity` + `render_overlay` → `tracks[]` + `overlay_png_base64` (both opt-in; default off = unchanged) |
| Backend | `buildKymograph` passthrough + px/frame→µm/s from DB calibration; new `mtKymographExporter`; `exportService` gated to `microtubules` |
| Frontend | modal overlay + table + CSV; export `MicrotubuleKymographsSection`; `ExportOptions.mtKymographs`; i18n ×6 |

## Verification (E2E on production)

- **Modal**: SVG overlay with 4 direction-coloured tracks (viewBox 146×621), velocity table (net −0.070/+0.012/−0.005/+0.002 µm/s, runs, SNR), Velocity CSV button, **0 console errors**, channel switch re-fetches.
- **API**: `/api/segmentation/kymograph` returns `tracks` + calibration on real data.
- **Export**: real export job → **62 segmented PNGs + `velocity_metrics.csv` (24 rows for the motion channel)**; values match the modal.
- `make ci` green (TS + ESLint + i18n ×6).

E2E caught and fixed 2 bugs the compile pass missed: the export sampled only the first fluorescent channel (silently missing motion in the others) → now all; the segmented PNG was skipped when 0 tracks → ML now renders the overlay regardless.

## Safety

Velocity detection / overlay render are wrapped so a detection failure degrades to a plain kymograph rather than 500-ing the request. Per-MT/channel failures never abort the export. Per-container MT cap (60) logs what it drops.

> Note: deployed to production for verification (with explicit approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in microtubule kymograph velocity detection with trajectory tracking, run/pause segmentation, and per-track metrics.
  * Kymograph viewer can overlay detected motion tracks and display a velocity analysis panel with track quality (SNR) and run counts.
  * Added microtubule-only export options to generate velocity metrics (CSV) and segmented kymograph images.
* **Bug Fixes**
  * Velocity detection and overlay rendering now fail gracefully without breaking the overall kymograph output.
* **Documentation**
  * Added multilingual UI text for the new velocity analysis and export controls, including an uncalibrated-speed warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->