### PR TITLE
fix(monitoring): point Prometheus at live containers + app network

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -13,7 +13,7 @@ services:
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     networks:
-      - blue-network
+      - app-network
     restart: always
     deploy:
       resources:
@@ -33,7 +33,7 @@ services:
     ports:
       - '9090:9090'
     volumes:
-      - ./monitoring/blue-prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/production-prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_monitoring_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -46,7 +46,7 @@ services:
       node-exporter:
         condition: service_healthy
     networks:
-      - blue-network
+      - app-network
     restart: always
     deploy:
       resources:
@@ -94,7 +94,7 @@ services:
       prometheus:
         condition: service_healthy
     networks:
-      - blue-network
+      - app-network
     restart: always
     deploy:
       resources:
@@ -111,9 +111,9 @@ services:
       retries: 3
 
 networks:
-  blue-network:
+  app-network:
     external: true
-    name: spheroseg-blue
+    name: spheroseg
 
 volumes:
   prometheus_monitoring_data:


### PR DESCRIPTION
The monitoring stack scraped stale blue/green hostnames (`blue-backend:3001`, `blue-ml:8000`) and sat on the `spheroseg-blue` network, so the backend + ML Prometheus targets were permanently **down** (no metrics in Grafana; app unaffected).

- Mount `monitoring/production-prometheus.yml` (targets `spheroseg-backend:3001` / `spheroseg-ml:8000`) instead of the deleted `blue-prometheus.yml`.
- Move the monitoring stack onto the live `spheroseg` network (renamed the compose alias `blue-network` → `app-network`) so those container names resolve.

Verified after recreate: **backend + ml-service targets UP**, node-exporter + prometheus UP.

> postgres/redis targets stay down — their exporter containers aren't deployed; a separate pre-existing gap, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)