### PR TITLE
feat: Microcapsule project type with Meta SAM 3 segmentation

### DIFF
--- a/backend/segmentation/api/models.py
+++ b/backend/segmentation/api/models.py
@@ -13,6 +13,7 @@ class ModelType(str, Enum):
     MAMBA_UNET = "mamba_unet"
     SPERM = "sperm"
     WOUND = "wound"
+    MICROCAPSULE = "microcapsule"
 
 class SegmentationRequest(BaseModel):
     model: ModelType = Field(default=ModelType.HRNET, description="Model to use for segmentation")

--- a/backend/segmentation/api/routes.py
+++ b/backend/segmentation/api/routes.py
@@ -39,6 +39,9 @@ router = APIRouter()
 # threading.Lock keeps lighter models (hrnet, sperm, wound) parallel while
 # preventing the heavy model from racing itself.
 _microtubule_inference_lock = threading.Lock()
+# Microcapsule (SAM 3) is a ~3.4 GB model; serialise its inference for the same
+# reason as microtubule so two concurrent requests can't overcommit the GPU.
+_microcapsule_inference_lock = threading.Lock()
 
 from fastapi import Request
 
@@ -172,7 +175,9 @@ async def segment_image(
             # Microcapsule SAM 3 ("circle" prompt) — the user threshold is
             # forwarded as the per-instance score cutoff. detect_holes is not
             # meaningful: each capsule is a single closed instance polygon.
-            result = loader.predict_microcapsule(image, threshold)
+            # Serialise like microtubule: SAM 3 is heavy and must not race itself.
+            with _microcapsule_inference_lock:
+                result = loader.predict_microcapsule(image, threshold)
         else:
             result = loader.predict(image, model, threshold, detect_holes)
         inference_time = time.time() - inference_start

--- a/backend/segmentation/api/routes.py
+++ b/backend/segmentation/api/routes.py
@@ -169,9 +169,9 @@ async def segment_image(
             with _microtubule_inference_lock:
                 result = loader.predict_microtubule(image, threshold)
         elif model == 'microcapsule':
-            # Microcapsule YOLO11n-seg — the user threshold is forwarded as the
-            # YOLO confidence cutoff (registry default 0.25). detect_holes is
-            # not meaningful: each capsule is a single closed instance polygon.
+            # Microcapsule SAM 3 ("circle" prompt) — the user threshold is
+            # forwarded as the per-instance score cutoff. detect_holes is not
+            # meaningful: each capsule is a single closed instance polygon.
             result = loader.predict_microcapsule(image, threshold)
         else:
             result = loader.predict(image, model, threshold, detect_holes)

--- a/backend/segmentation/api/routes.py
+++ b/backend/segmentation/api/routes.py
@@ -168,6 +168,11 @@ async def segment_image(
             # worker thread, not the event loop.
             with _microtubule_inference_lock:
                 result = loader.predict_microtubule(image, threshold)
+        elif model == 'microcapsule':
+            # Microcapsule YOLO11n-seg — the user threshold is forwarded as the
+            # YOLO confidence cutoff (registry default 0.25). detect_holes is
+            # not meaningful: each capsule is a single closed instance polygon.
+            result = loader.predict_microcapsule(image, threshold)
         else:
             result = loader.predict(image, model, threshold, detect_holes)
         inference_time = time.time() - inference_start

--- a/backend/segmentation/config/batch_sizes.json
+++ b/backend/segmentation/config/batch_sizes.json
@@ -121,16 +121,16 @@
     "microcapsule": {
       "optimal_batch_size": 1,
       "max_safe_batch_size": 1,
-      "expected_throughput": 8.0,
-      "memory_limit_mb": 1500,
-      "p95_latency_ms": 200.0,
-      "production_optimized": true,
+      "expected_throughput": 1.0,
+      "memory_limit_mb": 4500,
+      "p95_latency_ms": 1200.0,
+      "production_optimized": false,
       "concurrent_processing": {
-        "max_concurrent_users": 2,
-        "memory_per_user_mb": 1500,
-        "expected_concurrent_throughput": 8.0
+        "max_concurrent_users": 1,
+        "memory_per_user_mb": 4500,
+        "expected_concurrent_throughput": 1.0
       },
-      "note": "Microcapsule YOLO11n-seg (~6 MB, Ultralytics). Instance segmentation runs at imgsz=1024; sub-second on CPU and faster on the A5000. Ultralytics drives its own per-image inference, so the wrapper is called once per image (batch size 1); throughput/memory are conservative estimates for the tiny nano model."
+      "note": "Microcapsule Meta SAM 3 (Promptable Concept Segmentation, 'circle' prompt). ~3.4 GB sam3.pt loaded from HuggingFace; full-resolution instance masks at 1008px working resolution. ~1 s/image on the A5000; the wrapper runs one prompt per image (batch size 1). Nested 'circle' masks per capsule are merged to one outer boundary."
     }
   },
   "dynamic_batching": {

--- a/backend/segmentation/config/batch_sizes.json
+++ b/backend/segmentation/config/batch_sizes.json
@@ -117,6 +117,20 @@
         "expected_concurrent_throughput": 0.2
       },
       "note": "Microtubule v7 (DINOv3-L ViT-L/16 + DPT decoder + PySOAX postprocessing). DINOv3-L backbone is ~300M params and PySOAX is iterative (up to 5000 snake-evolution iterations per frame). Budget ~5-8s per frame on A5000 once warm; ~6.5 GB peak memory dominated by frozen DINOv3 activations at 448x448 FOV. Batch size pinned to 1 — frame-parallelism happens upstream via the queue."
+    },
+    "microcapsule": {
+      "optimal_batch_size": 1,
+      "max_safe_batch_size": 1,
+      "expected_throughput": 8.0,
+      "memory_limit_mb": 1500,
+      "p95_latency_ms": 200.0,
+      "production_optimized": true,
+      "concurrent_processing": {
+        "max_concurrent_users": 2,
+        "memory_per_user_mb": 1500,
+        "expected_concurrent_throughput": 8.0
+      },
+      "note": "Microcapsule YOLO11n-seg (~6 MB, Ultralytics). Instance segmentation runs at imgsz=1024; sub-second on CPU and faster on the A5000. Ultralytics drives its own per-image inference, so the wrapper is called once per image (batch size 1); throughput/memory are conservative estimates for the tiny nano model."
     }
   },
   "dynamic_batching": {

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -78,6 +78,18 @@ except ImportError as e:
     SegFormerModel = None
     _segformer_import_error = e
 
+# Optional microcapsule model import (requires ultralytics for YOLO11n-seg).
+_microcapsule_import_error = None
+try:
+    from models.microcapsule import MicrocapsuleModel
+except ImportError as e:
+    logger.warning(
+        f"Could not import MicrocapsuleModel: {e}. "
+        "Microcapsule segmentation will not be available."
+    )
+    MicrocapsuleModel = None
+    _microcapsule_import_error = e
+
 # Optional Mamba-UNet spheroid model import (requires mamba_ssm CUDA kernels).
 # OSError is caught alongside ImportError: an ABI-mismatched compiled .so can
 # raise OSError on load, and that must disable only this model, not the service.
@@ -228,6 +240,13 @@ class ModelLoader:
             'pretrained_path': 'weights/microtubule_v7.pt',
             'finetuned_path': 'weights/microtubule_v7.pt',
             'config_path': None
+        },
+        'microcapsule': {
+            # Will be None if ultralytics not installed
+            'class': MicrocapsuleModel,
+            'pretrained_path': 'weights/microcapsule_yolo11n.pt',
+            'finetuned_path': 'weights/microcapsule_yolo11n.pt',
+            'config_path': None
         }
     }
     
@@ -377,6 +396,20 @@ class ModelLoader:
                 model.load_weights(str(weights_full_path), self.device)
                 self.loaded_models[model_name] = model
                 logger.info(f"Successfully loaded microtubule v7 model from: {weights_full_path}")
+                return model
+            elif model_name == 'microcapsule':
+                # Microcapsule YOLO11n-seg — Ultralytics owns its own loader, so
+                # skip the generic torch.load path below and let the wrapper
+                # drive it end-to-end.
+                if MicrocapsuleModel is None:
+                    raise ImportError(
+                        f"Microcapsule model architecture not available: "
+                        f"{_microcapsule_import_error}"
+                    )
+                model = MicrocapsuleModel()
+                model.load_weights(str(weights_full_path), self.device)
+                self.loaded_models[model_name] = model
+                logger.info(f"Successfully loaded microcapsule YOLO model from: {weights_full_path}")
                 return model
             else:
                 raise ValueError(f"Unknown model architecture: {model_name}")
@@ -1137,6 +1170,103 @@ class ModelLoader:
             self.is_processing = False
             self.current_model = None
             self.release_model('wound')
+
+    def predict_microcapsule(self, image: Image.Image, threshold: float = 0.25,
+                             timeout: Optional[float] = None) -> Dict[str, Any]:
+        """Run the microcapsule YOLO11n-seg instance segmentation model.
+
+        Each detected capsule is one closed *external* polygon, so the response
+        matches the spheroid polygon shape — only ``class`` differs — plus two
+        per-polygon fields the rest of the stack carries through:
+
+          - ``confidence`` : YOLO detection score (0..1)
+          - ``complete``   : ``False`` if the capsule is cut off by the image
+                             border. Incomplete capsules are drawn grey and
+                             excluded from metrics downstream.
+
+        ``threshold`` is forwarded verbatim as the YOLO confidence cutoff.
+        ``timeout`` is accepted for interface symmetry with the other predict_*
+        methods; YOLO11n inference is sub-second so no executor wrapping is used.
+        """
+        import time as _time
+
+        self.get_model('microcapsule')
+        if 'microcapsule' not in self.loaded_models:
+            raise ValueError(
+                "Microcapsule model not loaded. "
+                "Load it first with load_model('microcapsule')"
+            )
+
+        capsule_model = self.loaded_models['microcapsule']
+        original_size = image.size  # (width, height)
+
+        self.is_processing = True
+        self.current_model = 'microcapsule'
+        start_time = _time.time()
+
+        try:
+            # YOLO accepts BGR ndarrays; mirror the sperm conversion convention.
+            img_rgb = np.array(image.convert('RGB'))
+            img_bgr = cv2.cvtColor(img_rgb, cv2.COLOR_RGB2BGR)
+
+            instances = capsule_model.predict(img_bgr, conf=threshold)
+            processing_time = _time.time() - start_time
+
+            polygons = []
+            polygon_id_counter = 1
+            for inst in instances:
+                points = [
+                    {"x": float(x), "y": float(y)}
+                    for x, y in inst["polygon_xy"]
+                ]
+                if len(points) < 3:
+                    continue
+                polygons.append({
+                    "id": f"polygon_{polygon_id_counter}",
+                    "points": points,
+                    "type": "external",
+                    "class": "microcapsule",
+                    "confidence": float(inst["confidence"]),
+                    "complete": bool(inst["complete"]),
+                    "vertices_count": len(points),
+                })
+                polygon_id_counter += 1
+
+            num_complete = sum(1 for p in polygons if p["complete"])
+            logger.info(
+                f"Microcapsule: {len(polygons)} capsules "
+                f"({num_complete} complete, "
+                f"{len(polygons) - num_complete} cut off) in {processing_time:.2f}s"
+            )
+
+            return {
+                "model_used": "microcapsule",
+                "threshold_used": threshold,
+                "image_size": {"width": original_size[0], "height": original_size[1]},
+                "polygons": polygons,
+                "processing_info": {
+                    "device": str(self.device),
+                    "num_polygons": len(polygons),
+                    "num_complete": num_complete,
+                    "confidence_scores": [p["confidence"] for p in polygons],
+                    "processing_time_s": processing_time,
+                    "batch_size": 1,
+                },
+            }
+
+        except Exception as e:
+            processing_time = _time.time() - start_time
+            logger.error(
+                f"Microcapsule inference failed after {processing_time:.2f}s: "
+                f"{type(e).__name__}: {e}",
+                exc_info=True,
+            )
+            raise
+
+        finally:
+            self.is_processing = False
+            self.current_model = None
+            self.release_model('microcapsule')
 
     def predict_microtubule(self, image: Image.Image, threshold: float = 0.5,
                             timeout: Optional[float] = None) -> Dict[str, Any]:

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -78,7 +78,7 @@ except ImportError as e:
     SegFormerModel = None
     _segformer_import_error = e
 
-# Optional microcapsule model import (requires ultralytics for YOLO11n-seg).
+# Optional microcapsule model import (requires the sam3 package for SAM 3).
 _microcapsule_import_error = None
 try:
     from models.microcapsule import MicrocapsuleModel
@@ -242,10 +242,12 @@ class ModelLoader:
             'config_path': None
         },
         'microcapsule': {
-            # Will be None if ultralytics not installed
+            # SAM 3 ("circle" prompt). Will be None if the sam3 package isn't
+            # installed. No local weights file — sam3.pt loads from HuggingFace
+            # (facebook/sam3) in the wrapper; the path is nominal and unused.
             'class': MicrocapsuleModel,
-            'pretrained_path': 'weights/microcapsule_yolo11n.pt',
-            'finetuned_path': 'weights/microcapsule_yolo11n.pt',
+            'pretrained_path': 'weights/sam3',
+            'finetuned_path': 'weights/sam3',
             'config_path': None
         }
     }
@@ -315,7 +317,9 @@ class ModelLoader:
         
         weights_full_path = self.base_path / weights_path
         
-        if not weights_full_path.exists():
+        # Microcapsule (SAM 3) has no local weights file — it loads its
+        # checkpoint from HuggingFace (facebook/sam3) in the wrapper.
+        if model_name != 'microcapsule' and not weights_full_path.exists():
             raise FileNotFoundError(f"Model weights not found: {weights_full_path}")
         
         # Initialize model
@@ -398,9 +402,9 @@ class ModelLoader:
                 logger.info(f"Successfully loaded microtubule v7 model from: {weights_full_path}")
                 return model
             elif model_name == 'microcapsule':
-                # Microcapsule YOLO11n-seg — Ultralytics owns its own loader, so
-                # skip the generic torch.load path below and let the wrapper
-                # drive it end-to-end.
+                # Microcapsule SAM 3 — the wrapper builds the model from
+                # HuggingFace, so skip the generic torch.load path below and let
+                # it drive loading end-to-end.
                 if MicrocapsuleModel is None:
                     raise ImportError(
                         f"Microcapsule model architecture not available: "
@@ -1171,22 +1175,22 @@ class ModelLoader:
             self.current_model = None
             self.release_model('wound')
 
-    def predict_microcapsule(self, image: Image.Image, threshold: float = 0.25,
+    def predict_microcapsule(self, image: Image.Image, threshold: float = 0.3,
                              timeout: Optional[float] = None) -> Dict[str, Any]:
-        """Run the microcapsule YOLO11n-seg instance segmentation model.
+        """Run the microcapsule SAM 3 ("circle" prompt) instance segmentation model.
 
         Each detected capsule is one closed *external* polygon, so the response
         matches the spheroid polygon shape — only ``class`` differs — plus two
         per-polygon fields the rest of the stack carries through:
 
-          - ``confidence`` : YOLO detection score (0..1)
+          - ``confidence`` : SAM 3 detection score (0..1)
           - ``complete``   : ``False`` if the capsule is cut off by the image
                              border. Incomplete capsules are drawn grey and
                              excluded from metrics downstream.
 
-        ``threshold`` is forwarded verbatim as the YOLO confidence cutoff.
-        ``timeout`` is accepted for interface symmetry with the other predict_*
-        methods; YOLO11n inference is sub-second so no executor wrapping is used.
+        ``threshold`` is forwarded as the per-instance score cutoff. ``timeout``
+        is accepted for interface symmetry with the other predict_* methods;
+        SAM 3 inference is ~1 s/image so no executor wrapping is used.
         """
         import time as _time
 

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -31,6 +31,12 @@ try:
 except ImportError:
     SegFormerModel = None
 
+# Microcapsule model: optional import (requires ultralytics for YOLO11n-seg).
+try:
+    from .microcapsule import MicrocapsuleModel
+except ImportError:
+    MicrocapsuleModel = None
+
 # Mamba-UNet spheroid model: optional import (requires mamba_ssm CUDA kernels).
 # Catch OSError too: a present-but-ABI-mismatched .so raises OSError/ImportError
 # on load, and we want that to disable only this model (with a log), not crash
@@ -46,4 +52,5 @@ except (ImportError, OSError) as _e:
     UMamba = None
 
 __all__ = ['HRNetV2', 'ResUNetCBAM', 'UNet', 'UNetAttention', 'SpermModel',
-           'WoundModel', 'MicrotubuleModel', 'SegFormerModel', 'UMamba']
+           'WoundModel', 'MicrotubuleModel', 'SegFormerModel', 'UMamba',
+           'MicrocapsuleModel']

--- a/backend/segmentation/models/__init__.py
+++ b/backend/segmentation/models/__init__.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     SegFormerModel = None
 
-# Microcapsule model: optional import (requires ultralytics for YOLO11n-seg).
+# Microcapsule model: optional import (requires the sam3 package for SAM 3).
 try:
     from .microcapsule import MicrocapsuleModel
 except ImportError:

--- a/backend/segmentation/models/microcapsule.py
+++ b/backend/segmentation/models/microcapsule.py
@@ -27,6 +27,7 @@ HuggingFace on first load (HF_TOKEN required) and cache under ``HF_HOME``.
 
 import logging
 import os
+import shutil
 import urllib.request
 
 import cv2
@@ -54,11 +55,16 @@ _BPE_URL = (
 
 def _touches_border(polygon: np.ndarray, height: int, width: int,
                     margin: int = _BORDER_MARGIN_PX) -> bool:
-    """Return True if the polygon comes within ``margin`` px of any image edge."""
+    """Return True if the polygon comes within ``margin`` px of any image edge.
+
+    Symmetric on all four edges: the last valid pixel index is ``width-1`` /
+    ``height-1``, so the right/bottom thresholds use ``-1 - margin`` to match the
+    ``<= margin`` rule on the left/top.
+    """
     xs, ys = polygon[:, 0], polygon[:, 1]
     return bool(
         xs.min() <= margin or ys.min() <= margin
-        or xs.max() >= width - margin or ys.max() >= height - margin
+        or xs.max() >= width - 1 - margin or ys.max() >= height - 1 - margin
     )
 
 
@@ -108,13 +114,27 @@ def _merge_nested(masks, containment: float = _NEST_CONTAINMENT):
 
 
 def _bpe_path() -> str:
-    """Path to the CLIP BPE vocab; download + cache under HF_HOME on first use."""
+    """Path to the CLIP BPE vocab; download + cache under HF_HOME on first use.
+
+    Downloads with a timeout and writes to a temp file that is atomically
+    renamed, so a slow/broken network can't block model loading forever and a
+    partial download can't leave a corrupt cache file that is then reused.
+    """
     cache_dir = os.environ.get("HF_HOME") or "/tmp"
     path = os.path.join(cache_dir, "sam3_bpe_simple_vocab_16e6.txt.gz")
     if not os.path.exists(path):
         os.makedirs(cache_dir, exist_ok=True)
         logger.info("Downloading CLIP BPE vocab for SAM 3 ...")
-        urllib.request.urlretrieve(_BPE_URL, path)
+        tmp = f"{path}.{os.getpid()}.tmp"
+        try:
+            with urllib.request.urlopen(_BPE_URL, timeout=30) as resp, \
+                    open(tmp, "wb") as out:
+                shutil.copyfileobj(resp, out)
+            os.replace(tmp, path)  # atomic on the same filesystem
+        except Exception:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
     return path
 
 

--- a/backend/segmentation/models/microcapsule.py
+++ b/backend/segmentation/models/microcapsule.py
@@ -62,21 +62,43 @@ def _touches_border(polygon: np.ndarray, height: int, width: int,
     )
 
 
+def _fill_holes(mask: np.ndarray) -> np.ndarray:
+    """Fill interior holes so a ring / annulus mask becomes a solid disk.
+
+    SAM 3 often segments a thick-shelled capsule's OUTER boundary as an annulus
+    (the shell, hollow in the middle). Filling it lets containment see that the
+    inner-wall disk really sits inside the outer capsule.
+    """
+    cnts, _ = cv2.findContours(
+        mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
+    if not cnts:
+        return mask
+    out = np.zeros(mask.shape, np.uint8)
+    cv2.drawContours(out, cnts, -1, 1, thickness=cv2.FILLED)
+    return out.astype(bool)
+
+
 def _merge_nested(masks, containment: float = _NEST_CONTAINMENT):
     """Indices of masks to KEEP: largest first, drop any >``containment`` nested.
 
     A capsule's inner wall / interior bubble is almost entirely contained in its
     outer-shell mask, so keeping only the outer mask yields one boundary per
-    capsule. Mirrors `training/make_yolo_dataset.py: merge_nested`.
+    capsule. Containment is measured on HOLE-FILLED masks: SAM 3's outer mask is
+    frequently a ring, and on the raw ring an inner disk falls in the hole and
+    looks "separate" (low overlap) — filling fixes that without ever merging two
+    genuinely separate capsules (their filled disks don't overlap). Mirrors
+    `training/make_yolo_dataset.py: merge_nested`.
     """
-    areas = [int(m.sum()) for m in masks]
+    filled = [_fill_holes(m) for m in masks]
+    areas = [int(f.sum()) for f in filled]
     order = sorted(range(len(masks)), key=lambda i: -areas[i])
     kept: list[int] = []
     for i in order:
         if areas[i] == 0:
             continue
         nested = any(
-            np.count_nonzero(masks[i] & masks[k]) / min(areas[i], areas[k])
+            np.count_nonzero(filled[i] & filled[k]) / min(areas[i], areas[k])
             > containment
             for k in kept
         )
@@ -177,8 +199,11 @@ class MicrocapsuleModel:
         for i in _merge_nested(masks):
             if scores[i] < conf:
                 continue
+            # Fill holes first so a ring/annulus outer mask yields the solid
+            # capsule's outer boundary (not its hollow inner edge).
             cnts, _ = cv2.findContours(
-                masks[i].astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+                _fill_holes(masks[i]).astype(np.uint8),
+                cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE,
             )
             if not cnts:
                 continue

--- a/backend/segmentation/models/microcapsule.py
+++ b/backend/segmentation/models/microcapsule.py
@@ -1,0 +1,140 @@
+"""Microcapsule instance-segmentation model wrapper.
+
+Wraps the distilled YOLO11n-seg model (Ultralytics) that detects and segments
+every microcapsule in a bright-field microscopy image.
+
+Unlike the semantic-mask models (HRNet/UNet/CBAM/...), YOLO returns per-instance
+polygons natively, so each detection maps directly onto one closed *external*
+polygon — exactly the shape the backend already uses for spheroids. No
+polyline/instanceId machinery is needed: multiple external polygons already mean
+multiple instances.
+
+Each instance additionally carries:
+  - ``confidence`` — YOLO detection score (0..1)
+  - ``complete``   — ``False`` if the mask touches the image border (the capsule
+                     is cut off by the frame). Downstream, incomplete capsules
+                     are drawn grey and excluded from metrics.
+
+The wrapper exposes the same minimal interface as SpermModel/WoundModel so
+ModelLoader can drive it uniformly. It is intentionally NOT an ``nn.Module`` —
+YOLO owns its own module/loader internally.
+"""
+
+import logging
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Capsules whose mask comes within this many pixels of any image edge are treated
+# as cut off by the frame. Inherited verbatim from the model's reference infer.py
+# (``_touches_border(..., m=3)``) so the completeness flag matches what the model
+# authors validated.
+_BORDER_MARGIN_PX = 3
+
+
+def _touches_border(polygon: np.ndarray, height: int, width: int,
+                    margin: int = _BORDER_MARGIN_PX) -> bool:
+    """Return True if the polygon comes within ``margin`` px of any image edge."""
+    xs, ys = polygon[:, 0], polygon[:, 1]
+    return bool(
+        xs.min() <= margin or ys.min() <= margin
+        or xs.max() >= width - margin or ys.max() >= height - margin
+    )
+
+
+class MicrocapsuleModel:
+    """YOLO11n-seg instance segmenter for microcapsules.
+
+    Loaded once via ``load_weights()``; call ``predict()`` per image.
+    """
+
+    # YOLO inference resolution (the reference pipeline runs the model at 1024).
+    IMGSZ = 1024
+
+    def __init__(self):
+        """Initialize without loading — weights load separately via load_weights()."""
+        self._model = None
+        self._device = "cpu"
+        logger.info("MicrocapsuleModel wrapper initialized")
+
+    def load_weights(self, weights_path: str, device):
+        """Load the YOLO ``.pt`` checkpoint and pin the inference device."""
+        from ultralytics import YOLO  # local import keeps package import light
+
+        self._model = YOLO(weights_path)
+        # ultralytics accepts 'cpu', a CUDA index, or a 'cuda:N' string.
+        dev_type = getattr(device, "type", str(device))
+        if dev_type == "cuda":
+            idx = getattr(device, "index", 0) or 0
+            self._device = f"cuda:{idx}"
+        else:
+            self._device = "cpu"
+        logger.info(
+            f"Microcapsule YOLO model loaded from {weights_path} "
+            f"(device={self._device})"
+        )
+
+    def predict(self, image_bgr: np.ndarray, conf: float = 0.25):
+        """Segment every microcapsule in a BGR image.
+
+        Args:
+            image_bgr: numpy array (H, W, 3) in BGR order.
+            conf: YOLO confidence cutoff (0..1).
+
+        Returns:
+            A list of instance dicts, sorted largest-area first (deterministic,
+            stable numbering), each with:
+                polygon_xy        : (N, 2) float32 pixel coordinates
+                confidence        : float 0..1
+                complete          : bool  (False if cut off by the frame)
+                area_px           : float (cv2.contourArea)
+                equiv_diameter_px : float (2*sqrt(area/pi))
+        """
+        if self._model is None:
+            raise RuntimeError("Model not loaded. Call load_weights() first.")
+
+        height, width = image_bgr.shape[:2]
+        res = self._model(
+            image_bgr, imgsz=self.IMGSZ, conf=conf,
+            device=self._device, verbose=False,
+        )[0]
+
+        if res.masks is None or res.boxes is None:
+            return []
+
+        polys = list(res.masks.xy)
+        confs = res.boxes.conf.cpu().numpy()
+
+        instances = []
+        for poly, score in zip(polys, confs):
+            poly = np.asarray(poly, dtype=np.float32)
+            if len(poly) < 3:
+                continue
+            area = float(cv2.contourArea(poly))
+            instances.append({
+                "polygon_xy": poly,
+                "confidence": float(score),
+                "complete": not _touches_border(poly, height, width),
+                "area_px": area,
+                "equiv_diameter_px": (
+                    2.0 * float(np.sqrt(area / np.pi)) if area > 0 else 0.0
+                ),
+            })
+
+        instances.sort(key=lambda inst: -inst["area_px"])
+        return instances
+
+    # ---- PyTorch-compatible stubs (for ModelLoader uniformity) ---------------
+    def eval(self):
+        """No-op — YOLO is always in eval mode after loading."""
+        return self
+
+    def to(self, device):
+        """No-op — device is pinned during load_weights()."""
+        return self
+
+    def parameters(self):
+        """No torch parameters are exposed (YOLO owns its module internally)."""
+        return iter([])

--- a/backend/segmentation/models/microcapsule.py
+++ b/backend/segmentation/models/microcapsule.py
@@ -1,37 +1,55 @@
-"""Microcapsule instance-segmentation model wrapper.
+"""Microcapsule instance-segmentation model wrapper (Meta SAM 3).
 
-Wraps the distilled YOLO11n-seg model (Ultralytics) that detects and segments
-every microcapsule in a bright-field microscopy image.
+Segments every microcapsule (round object) in a bright-field microscopy image
+using SAM 3 Promptable Concept Segmentation with the text prompt "circle".
 
-Unlike the semantic-mask models (HRNet/UNet/CBAM/...), YOLO returns per-instance
-polygons natively, so each detection maps directly onto one closed *external*
-polygon — exactly the shape the backend already uses for spheroids. No
-polyline/instanceId machinery is needed: multiple external polygons already mean
-multiple instances.
+Why SAM 3 (not a distilled YOLO student): SAM 3 produces instance masks at the
+full image resolution, so capsule boundaries are clean and circular — they do
+NOT show the low-resolution block / "flat edges on the sides" artifact of a
+small YOLO-seg mask grid, and the polygon is simplified with `approxPolyDP`
+(points stay ON the contour) rather than smoothed inward, so edges are never
+clipped.
 
-Each instance additionally carries:
-  - ``confidence`` — YOLO detection score (0..1)
-  - ``complete``   — ``False`` if the mask touches the image border (the capsule
-                     is cut off by the frame). Downstream, incomplete capsules
-                     are drawn grey and excluded from metrics.
+SAM 3 with the prompt "circle" returns several overlapping masks per capsule
+(the outer shell, the inner wall, an interior bubble). These are collapsed to
+one OUTER boundary per capsule with `_merge_nested` — the exact convention the
+original distillation used (`training/make_yolo_dataset.py: merge_nested`).
 
-The wrapper exposes the same minimal interface as SpermModel/WoundModel so
-ModelLoader can drive it uniformly. It is intentionally NOT an ``nn.Module`` —
-YOLO owns its own module/loader internally.
+Each instance carries:
+  - ``confidence`` : SAM 3 detection score (0..1)
+  - ``complete``   : ``False`` if the mask touches the image border (the capsule
+                     is cut off by the frame). Incomplete capsules are drawn
+                     grey and excluded from metrics downstream.
+
+SAM 3 weights (~3.4 GB ``sam3.pt``) and the CLIP BPE vocab download from
+HuggingFace on first load (HF_TOKEN required) and cache under ``HF_HOME``.
 """
 
 import logging
+import os
+import urllib.request
 
 import cv2
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
-# Capsules whose mask comes within this many pixels of any image edge are treated
-# as cut off by the frame. Inherited verbatim from the model's reference infer.py
-# (``_touches_border(..., m=3)``) so the completeness flag matches what the model
-# authors validated.
+# Capsules whose mask comes within this many pixels of any image edge are cut
+# off by the frame (inherited from the reference pipeline).
 _BORDER_MARGIN_PX = 3
+# Two SAM 3 "circle" masks are the same capsule when one is >88% contained in
+# the other (its inner wall / interior bubble). Matches the original distillation.
+_NEST_CONTAINMENT = 0.88
+# Polygon simplification tolerance (px). approxPolyDP keeps points ON the
+# contour — no inward shrink — so capsule edges are never clipped.
+_APPROX_EPS_PX = 1.5
+_MIN_AREA_PX = 200
+# SAM 3 internal working resolution (logits are interpolated back to native size).
+_RESOLUTION = 1008
+
+_BPE_URL = (
+    "https://openaipublic.blob.core.windows.net/clip/bpe_simple_vocab_16e6.txt.gz"
+)
 
 
 def _touches_border(polygon: np.ndarray, height: int, width: int,
@@ -44,78 +62,140 @@ def _touches_border(polygon: np.ndarray, height: int, width: int,
     )
 
 
+def _merge_nested(masks, containment: float = _NEST_CONTAINMENT):
+    """Indices of masks to KEEP: largest first, drop any >``containment`` nested.
+
+    A capsule's inner wall / interior bubble is almost entirely contained in its
+    outer-shell mask, so keeping only the outer mask yields one boundary per
+    capsule. Mirrors `training/make_yolo_dataset.py: merge_nested`.
+    """
+    areas = [int(m.sum()) for m in masks]
+    order = sorted(range(len(masks)), key=lambda i: -areas[i])
+    kept: list[int] = []
+    for i in order:
+        if areas[i] == 0:
+            continue
+        nested = any(
+            np.count_nonzero(masks[i] & masks[k]) / min(areas[i], areas[k])
+            > containment
+            for k in kept
+        )
+        if not nested:
+            kept.append(i)
+    return kept
+
+
+def _bpe_path() -> str:
+    """Path to the CLIP BPE vocab; download + cache under HF_HOME on first use."""
+    cache_dir = os.environ.get("HF_HOME") or "/tmp"
+    path = os.path.join(cache_dir, "sam3_bpe_simple_vocab_16e6.txt.gz")
+    if not os.path.exists(path):
+        os.makedirs(cache_dir, exist_ok=True)
+        logger.info("Downloading CLIP BPE vocab for SAM 3 ...")
+        urllib.request.urlretrieve(_BPE_URL, path)
+    return path
+
+
 class MicrocapsuleModel:
-    """YOLO11n-seg instance segmenter for microcapsules.
+    """SAM 3 'circle' instance segmenter for microcapsules.
 
     Loaded once via ``load_weights()``; call ``predict()`` per image.
     """
 
-    # YOLO inference resolution (the reference pipeline runs the model at 1024).
-    IMGSZ = 1024
-
     def __init__(self):
-        """Initialize without loading — weights load separately via load_weights()."""
-        self._model = None
-        self._device = "cpu"
-        logger.info("MicrocapsuleModel wrapper initialized")
+        """Initialize without loading — the model builds in load_weights()."""
+        self._processor = None
+        self._device = "cuda"
+        logger.info("MicrocapsuleModel (SAM 3) wrapper initialized")
 
-    def load_weights(self, weights_path: str, device):
-        """Load the YOLO ``.pt`` checkpoint and pin the inference device."""
-        from ultralytics import YOLO  # local import keeps package import light
+    def load_weights(self, weights_path, device):
+        """Build the SAM 3 image model (downloads sam3.pt from HF, cached).
 
-        self._model = YOLO(weights_path)
-        # ultralytics accepts 'cpu', a CUDA index, or a 'cuda:N' string.
-        dev_type = getattr(device, "type", str(device))
-        if dev_type == "cuda":
-            idx = getattr(device, "index", 0) or 0
-            self._device = f"cuda:{idx}"
-        else:
-            self._device = "cpu"
-        logger.info(
-            f"Microcapsule YOLO model loaded from {weights_path} "
-            f"(device={self._device})"
-        )
-
-    def predict(self, image_bgr: np.ndarray, conf: float = 0.25):
-        """Segment every microcapsule in a BGR image.
-
-        Args:
-            image_bgr: numpy array (H, W, 3) in BGR order.
-            conf: YOLO confidence cutoff (0..1).
-
-        Returns:
-            A list of instance dicts, sorted largest-area first (deterministic,
-            stable numbering), each with:
-                polygon_xy        : (N, 2) float32 pixel coordinates
-                confidence        : float 0..1
-                complete          : bool  (False if cut off by the frame)
-                area_px           : float (cv2.contourArea)
-                equiv_diameter_px : float (2*sqrt(area/pi))
+        ``weights_path`` is accepted for interface symmetry but unused — SAM 3
+        loads its checkpoint from HuggingFace (facebook/sam3).
         """
-        if self._model is None:
+        import sam3
+        from sam3.model.sam3_image_processor import Sam3Processor
+
+        dev_type = getattr(device, "type", str(device))
+        self._device = "cuda" if dev_type == "cuda" else "cpu"
+        model = sam3.build_sam3_image_model(
+            bpe_path=_bpe_path(),
+            device=self._device,
+            eval_mode=True,
+            checkpoint_path=None,
+            load_from_HF=True,
+            enable_segmentation=True,
+        )
+        # Keep the processor threshold low; the per-call user threshold is applied
+        # as a score filter in predict() so it can vary per request.
+        self._processor = Sam3Processor(
+            model,
+            resolution=_RESOLUTION,
+            device=self._device,
+            confidence_threshold=0.15,
+        )
+        logger.info(f"SAM 3 microcapsule model loaded (device={self._device})")
+
+    def predict(self, image_bgr: np.ndarray, conf: float = 0.3):
+        """Segment every microcapsule in a BGR image with the "circle" prompt.
+
+        Returns a list of instance dicts (sorted largest-area first), each:
+            polygon_xy        : (M, 2) float32 pixel coordinates (outer boundary)
+            confidence        : float 0..1 (SAM 3 score)
+            complete          : bool  (False if cut off by the frame)
+            area_px           : float (cv2.contourArea)
+            equiv_diameter_px : float (2*sqrt(area/pi))
+        """
+        if self._processor is None:
             raise RuntimeError("Model not loaded. Call load_weights() first.")
+        from PIL import Image
 
         height, width = image_bgr.shape[:2]
-        res = self._model(
-            image_bgr, imgsz=self.IMGSZ, conf=conf,
-            device=self._device, verbose=False,
-        )[0]
+        pil = Image.fromarray(cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB))
 
-        if res.masks is None or res.boxes is None:
+        state = self._processor.set_image(pil)
+        state = self._processor.set_text_prompt(prompt="circle", state=state)
+
+        masks_t = state.get("masks")
+        scores_t = state.get("scores")
+        if masks_t is None or len(masks_t) == 0:
             return []
 
-        polys = list(res.masks.xy)
-        confs = res.boxes.conf.cpu().numpy()
+        masks = [
+            masks_t[i, 0].cpu().numpy().astype(bool) for i in range(masks_t.shape[0])
+        ]
+        scores = (
+            [float(s) for s in scores_t.cpu().numpy()]
+            if scores_t is not None
+            else [1.0] * len(masks)
+        )
 
+        # Collapse nested capsule detections to one outer mask each, then apply
+        # the per-request confidence threshold as a score filter.
         instances = []
-        for poly, score in zip(polys, confs):
-            poly = np.asarray(poly, dtype=np.float32)
+        for i in _merge_nested(masks):
+            if scores[i] < conf:
+                continue
+            cnts, _ = cv2.findContours(
+                masks[i].astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+            )
+            if not cnts:
+                continue
+            contour = max(cnts, key=cv2.contourArea)
+            if cv2.contourArea(contour) < _MIN_AREA_PX:
+                continue
+            poly = (
+                cv2.approxPolyDP(contour, _APPROX_EPS_PX, True)
+                .reshape(-1, 2)
+                .astype(np.float32)
+            )
             if len(poly) < 3:
                 continue
             area = float(cv2.contourArea(poly))
             instances.append({
                 "polygon_xy": poly,
-                "confidence": float(score),
+                "confidence": scores[i],
                 "complete": not _touches_border(poly, height, width),
                 "area_px": area,
                 "equiv_diameter_px": (
@@ -128,7 +208,7 @@ class MicrocapsuleModel:
 
     # ---- PyTorch-compatible stubs (for ModelLoader uniformity) ---------------
     def eval(self):
-        """No-op — YOLO is always in eval mode after loading."""
+        """No-op — SAM 3 is built in eval mode."""
         return self
 
     def to(self, device):
@@ -136,5 +216,5 @@ class MicrocapsuleModel:
         return self
 
     def parameters(self):
-        """No torch parameters are exposed (YOLO owns its module internally)."""
+        """No torch parameters are exposed (SAM 3 owns its modules internally)."""
         return iter([])

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -26,15 +26,19 @@ opencv-python-headless==4.8.1.78
 # the later high-severity decoder advisories. ML code uses no removed PIL APIs
 # (only the Image.NEAREST alias + ImageDraw, both still valid in Pillow 12).
 Pillow==12.2.0
-numpy==1.24.3
+numpy==1.26.4
 scipy==1.11.4
 scikit-image==0.22.0
 # Sperm model dependencies (Mask2Former + graph assembly)
 # ConvNeXtV2 backbone is implemented in pure PyTorch (no HF/timm needed)
 networkx>=3.0
 
-# Wound-healing model (U-Net++ / ResNeXt-50 via segmentation_models_pytorch)
-segmentation-models-pytorch==0.3.4
+# Wound-healing model (MiT-B5 encoder via segmentation_models_pytorch).
+# Bumped 0.3.4 -> 0.5.0: 0.3.4 hard-pinned timm==0.9.7, which conflicts with the
+# microcapsule SAM 3 model (sam3 needs timm>=1.0.17). smp 0.5.0 uses timm>=1.0
+# and loads the same wound_mitb5.ckpt with a strict state-dict match (verified:
+# the MiT-B5 encoder is architecturally unchanged).
+segmentation-models-pytorch==0.5.0
 
 # Microtubule v7 dependencies (DINOv3 ViT-L/16 backbone via HuggingFace)
 # transformers 4.57+ is required to recognise the DINOv3 model config. Pinned to
@@ -59,13 +63,15 @@ huggingface_hub>=0.20
 # builder has no nvcc) and installed from those wheels in the runtime stage.
 einops>=0.7.0
 
-# Microcapsule model (YOLO11n-seg instance segmentation via Ultralytics).
-# ultralytics only needs torch>=1.8, so the load-bearing torch==2.6.0 pin above
-# is preserved (no bump). NOTE: ultralytics declares a hard dep on the NON-headless
-# `opencv-python`, which collides with `opencv-python-headless` above over the
-# shared `cv2` package. The ML Dockerfile reconciles this to a single headless
-# build right after install (see docker/ml.optimized.Dockerfile).
-ultralytics>=8.3,<9
+# Microcapsule model: Meta SAM 3 (Promptable Concept Segmentation, "circle"
+# prompt). The standalone `sam3` package ships its own model code and the native
+# sam3.pt checkpoint — it has NO `transformers` dependency, so the load-bearing
+# transformers==4.57.6 pin (DINOv3 / SegFormer / Sperm) is untouched. It needs
+# numpy>=1.26 (bumped above, still 1.x — verified safe for the mamba CUDA
+# kernels) and einops>=0.8 (resolves within the >=0.7 range above). sam3.pt
+# (~3.4 GB) + CLIP BPE vocab download from HuggingFace on first load (HF_TOKEN)
+# and cache under HF_HOME.
+sam3==0.1.4
 
 # Prometheus metrics
 prometheus-fastapi-instrumentator==6.1.0

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -59,6 +59,14 @@ huggingface_hub>=0.20
 # builder has no nvcc) and installed from those wheels in the runtime stage.
 einops>=0.7.0
 
+# Microcapsule model (YOLO11n-seg instance segmentation via Ultralytics).
+# ultralytics only needs torch>=1.8, so the load-bearing torch==2.6.0 pin above
+# is preserved (no bump). NOTE: ultralytics declares a hard dep on the NON-headless
+# `opencv-python`, which collides with `opencv-python-headless` above over the
+# shared `cv2` package. The ML Dockerfile reconciles this to a single headless
+# build right after install (see docker/ml.optimized.Dockerfile).
+ultralytics>=8.3,<9
+
 # Prometheus metrics
 prometheus-fastapi-instrumentator==6.1.0
 

--- a/backend/segmentation/tests/test_microcapsule_model.py
+++ b/backend/segmentation/tests/test_microcapsule_model.py
@@ -1,21 +1,21 @@
-"""Tests for the microcapsule YOLO11n-seg instance-segmentation wrapper.
+"""Tests for the microcapsule SAM 3 instance-segmentation wrapper.
 
 Two layers:
-  1. Pure unit tests for `_touches_border` — the completeness rule that decides
-     which capsules are excluded from metrics. No weights / ultralytics needed,
-     so these always run.
-  2. An integration smoke test that loads the real weights against a synthetic
-     bright-field-style image (capsule-like rings, some deliberately clipped by
-     the frame) and asserts the wrapper's output contract: per-instance
-     polygons, the complete/incomplete border flag, and area_px == contourArea.
-     Skipped when ultralytics or the weights file is absent.
-
-Run inside a GPU one-off ML container (pytest is not installed in the image) —
-see the project memory `reference_run_ml_python_tests`.
+  1. Pure unit tests — the completeness rule (`_touches_border`, which decides
+     which capsules are excluded from metrics) and the nested-mask merge
+     (`_merge_nested`, which collapses a capsule's outer shell / inner wall /
+     interior bubble to one outer boundary). No SAM 3 / GPU needed, so these
+     always run.
+  2. A guarded integration smoke test that builds SAM 3 and runs the "circle"
+     prompt on a real image. Skipped unless the `sam3` package is installed
+     (it downloads the ~3.4 GB sam3.pt from HuggingFace), so it only runs in the
+     GPU one-off ML container — see the project memory
+     `reference_run_ml_python_tests`.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -26,16 +26,15 @@ SEG_ROOT = Path(__file__).resolve().parents[1]
 if str(SEG_ROOT) not in sys.path:
     sys.path.insert(0, str(SEG_ROOT))
 
-WEIGHTS = SEG_ROOT / "weights" / "microcapsule_yolo11n.pt"
+REAL_IMAGE = Path("/tmp/mc_test/real_339.tiff")  # provided in the GPU test env
 
 
 # ---------------------------------------------------------------------------
-# 1. Pure completeness-rule tests (no model / weights required)
+# 1. Pure completeness-rule tests (no model required)
 # ---------------------------------------------------------------------------
 def test_touches_border_interior_polygon_is_complete():
     from models.microcapsule import _touches_border
 
-    # A square well inside a 200x200 frame — no edge contact.
     poly = np.array([[50, 50], [150, 50], [150, 150], [50, 150]], np.float32)
     assert _touches_border(poly, height=200, width=200) is False
 
@@ -45,12 +44,8 @@ def test_touches_border_interior_polygon_is_complete():
     [
         np.array([[0, 40], [60, 40], [60, 120], [0, 120]], np.float32),  # left edge
         np.array([[40, 0], [120, 0], [120, 80], [40, 80]], np.float32),  # top edge
-        np.array(
-            [[140, 40], [200, 40], [200, 120], [140, 120]], np.float32
-        ),  # right edge (width=200)
-        np.array(
-            [[40, 140], [120, 140], [120, 200], [40, 200]], np.float32
-        ),  # bottom edge (height=200)
+        np.array([[140, 40], [200, 40], [200, 120], [140, 120]], np.float32),  # right
+        np.array([[40, 140], [120, 140], [120, 200], [40, 200]], np.float32),  # bottom
     ],
 )
 def test_touches_border_edge_polygon_is_incomplete(poly):
@@ -62,101 +57,82 @@ def test_touches_border_edge_polygon_is_incomplete(poly):
 def test_touches_border_respects_margin():
     from models.microcapsule import _touches_border
 
-    # 3 px from the left edge → within the default 3 px margin → cut off.
     near = np.array([[3, 40], [60, 40], [60, 120], [3, 120]], np.float32)
     assert _touches_border(near, height=200, width=200) is True
-    # 4 px from every edge → outside the margin → complete.
     clear = np.array([[4, 4], [196, 4], [196, 196], [4, 196]], np.float32)
     assert _touches_border(clear, height=200, width=200) is False
 
 
 # ---------------------------------------------------------------------------
-# 2. Integration smoke test against the real weights
+# 1b. Nested-mask merge — one outer boundary per capsule
 # ---------------------------------------------------------------------------
-def _synthetic_capsules():
-    """A 1280x1024 bright-field-ish image with 5 capsule-like rings.
-
-    Returns (image_bgr, n_interior, n_clipped) where the first 3 capsules are
-    fully inside the frame and the last 2 run off the border.
-    """
-    import cv2
-
-    w, h = 1280, 1024
-    img = np.full((h, w, 3), 205, np.uint8)
-    capsules = [
-        (300, 300, 90),     # interior
-        (700, 500, 120),    # interior
-        (980, 760, 70),     # interior
-        (40, 520, 110),     # clipped by LEFT edge
-        (1180, 180, 130),   # clipped by RIGHT/TOP corner
-    ]
-    for (cx, cy, r) in capsules:
-        cv2.circle(img, (cx, cy), r, (175, 175, 175), -1)
-        cv2.circle(img, (cx, cy), max(r - 10, 1), (200, 200, 200), -1)
-        cv2.circle(img, (cx, cy), r, (95, 95, 95), 4)
-    return img, 3, 2
+def _disk(size, cx, cy, r):
+    yy, xx = np.ogrid[:size, :size]
+    return ((xx - cx) ** 2 + (yy - cy) ** 2) <= r * r
 
 
+def test_merge_nested_drops_inner_and_bubble_keeps_outer():
+    from models.microcapsule import _merge_nested
+
+    outer = _disk(240, 120, 120, 90)   # capsule outer shell (largest)
+    inner = _disk(240, 120, 120, 70)   # inner wall (fully inside outer)
+    bubble = _disk(240, 120, 120, 12)  # interior bubble (fully inside outer)
+    kept = _merge_nested([inner, outer, bubble])
+    # Only the outer mask (index 1 in the input) survives.
+    assert kept == [1]
+
+
+def test_merge_nested_keeps_separate_capsules():
+    from models.microcapsule import _merge_nested
+
+    a = _disk(240, 70, 120, 50)
+    b = _disk(240, 180, 120, 50)  # disjoint capsule
+    kept = _merge_nested([a, b])
+    assert sorted(kept) == [0, 1]  # both kept (not nested)
+
+
+def test_merge_nested_ignores_empty_masks():
+    from models.microcapsule import _merge_nested
+
+    empty = np.zeros((240, 240), bool)
+    disk = _disk(240, 120, 120, 60)
+    kept = _merge_nested([empty, disk])
+    assert kept == [1]
+
+
+# ---------------------------------------------------------------------------
+# 2. Guarded SAM 3 integration smoke test
+# ---------------------------------------------------------------------------
 @pytest.mark.skipif(
-    not WEIGHTS.exists(), reason="microcapsule_yolo11n.pt not placed"
+    not REAL_IMAGE.exists(), reason="real test image not present in this env"
 )
-def test_microcapsule_wrapper_output_contract():
-    pytest.importorskip("ultralytics")
+def test_sam3_circle_segments_capsules():
+    pytest.importorskip("sam3")
     import cv2
-    import torch
-    from models.microcapsule import MicrocapsuleModel, _touches_border
-
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = MicrocapsuleModel()
-    model.load_weights(str(WEIGHTS), device)
-
-    img, _, _ = _synthetic_capsules()
-    h, w = img.shape[:2]
-    instances = model.predict(img, conf=0.25)
-
-    # The model detects capsules on this synthetic image.
-    assert len(instances) >= 1, "expected at least one detected capsule"
-
-    for inst in instances:
-        poly = inst["polygon_xy"]
-        assert poly.shape[1] == 2 and len(poly) >= 3
-        # confidence is a probability
-        assert 0.0 <= inst["confidence"] <= 1.0
-        # area_px is exactly cv2.contourArea of the returned polygon
-        assert inst["area_px"] == pytest.approx(
-            float(cv2.contourArea(poly)), rel=1e-5, abs=1e-3
-        )
-        # equiv diameter follows 2*sqrt(area/pi)
-        expected_d = 2.0 * float(np.sqrt(inst["area_px"] / np.pi))
-        assert inst["equiv_diameter_px"] == pytest.approx(expected_d, rel=1e-6)
-        # complete flag agrees with the border rule applied to its polygon
-        assert inst["complete"] == (not _touches_border(poly, h, w))
-
-    # Sorted largest-area first (deterministic instance numbering).
-    areas = [inst["area_px"] for inst in instances]
-    assert areas == sorted(areas, reverse=True)
-
-
-@pytest.mark.skipif(
-    not WEIGHTS.exists(), reason="microcapsule_yolo11n.pt not placed"
-)
-def test_microcapsule_detects_border_cut_capsules():
-    pytest.importorskip("ultralytics")
+    import tifffile
     import torch
     from models.microcapsule import MicrocapsuleModel
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = MicrocapsuleModel()
-    model.load_weights(str(WEIGHTS), device)
+    model.load_weights(os.environ.get("HF_HOME", "weights/sam3"), device)
 
-    img, n_interior, n_clipped = _synthetic_capsules()
-    instances = model.predict(img, conf=0.25)
+    img = tifffile.imread(str(REAL_IMAGE))
+    if img.ndim == 2:
+        img = cv2.cvtColor(img.astype(np.uint8), cv2.COLOR_GRAY2BGR)
+    else:
+        img = cv2.cvtColor(img[:, :, :3].astype(np.uint8), cv2.COLOR_RGB2BGR)
 
-    complete = [i for i in instances if i["complete"]]
-    incomplete = [i for i in instances if not i["complete"]]
-
-    # The two frame-clipped capsules must be flagged incomplete, and at least
-    # the interior capsules complete. (Exact counts depend on detections, so we
-    # assert the directional invariant the metrics filter relies on.)
-    assert len(incomplete) >= 1, "border-cut capsules should be flagged incomplete"
-    assert len(complete) >= 1, "interior capsules should be flagged complete"
+    instances = model.predict(img, conf=0.3)
+    assert len(instances) >= 1
+    for inst in instances:
+        poly = inst["polygon_xy"]
+        assert poly.shape[1] == 2 and len(poly) >= 3
+        assert 0.0 <= inst["confidence"] <= 1.0
+        assert inst["area_px"] == pytest.approx(
+            float(cv2.contourArea(poly)), rel=1e-5, abs=1e-3
+        )
+        assert isinstance(inst["complete"], bool)
+    # Largest first (deterministic instance numbering).
+    areas = [inst["area_px"] for inst in instances]
+    assert areas == sorted(areas, reverse=True)

--- a/backend/segmentation/tests/test_microcapsule_model.py
+++ b/backend/segmentation/tests/test_microcapsule_model.py
@@ -1,0 +1,162 @@
+"""Tests for the microcapsule YOLO11n-seg instance-segmentation wrapper.
+
+Two layers:
+  1. Pure unit tests for `_touches_border` — the completeness rule that decides
+     which capsules are excluded from metrics. No weights / ultralytics needed,
+     so these always run.
+  2. An integration smoke test that loads the real weights against a synthetic
+     bright-field-style image (capsule-like rings, some deliberately clipped by
+     the frame) and asserts the wrapper's output contract: per-instance
+     polygons, the complete/incomplete border flag, and area_px == contourArea.
+     Skipped when ultralytics or the weights file is absent.
+
+Run inside a GPU one-off ML container (pytest is not installed in the image) —
+see the project memory `reference_run_ml_python_tests`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+SEG_ROOT = Path(__file__).resolve().parents[1]
+if str(SEG_ROOT) not in sys.path:
+    sys.path.insert(0, str(SEG_ROOT))
+
+WEIGHTS = SEG_ROOT / "weights" / "microcapsule_yolo11n.pt"
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure completeness-rule tests (no model / weights required)
+# ---------------------------------------------------------------------------
+def test_touches_border_interior_polygon_is_complete():
+    from models.microcapsule import _touches_border
+
+    # A square well inside a 200x200 frame — no edge contact.
+    poly = np.array([[50, 50], [150, 50], [150, 150], [50, 150]], np.float32)
+    assert _touches_border(poly, height=200, width=200) is False
+
+
+@pytest.mark.parametrize(
+    "poly",
+    [
+        np.array([[0, 40], [60, 40], [60, 120], [0, 120]], np.float32),  # left edge
+        np.array([[40, 0], [120, 0], [120, 80], [40, 80]], np.float32),  # top edge
+        np.array(
+            [[140, 40], [200, 40], [200, 120], [140, 120]], np.float32
+        ),  # right edge (width=200)
+        np.array(
+            [[40, 140], [120, 140], [120, 200], [40, 200]], np.float32
+        ),  # bottom edge (height=200)
+    ],
+)
+def test_touches_border_edge_polygon_is_incomplete(poly):
+    from models.microcapsule import _touches_border
+
+    assert _touches_border(poly, height=200, width=200) is True
+
+
+def test_touches_border_respects_margin():
+    from models.microcapsule import _touches_border
+
+    # 3 px from the left edge → within the default 3 px margin → cut off.
+    near = np.array([[3, 40], [60, 40], [60, 120], [3, 120]], np.float32)
+    assert _touches_border(near, height=200, width=200) is True
+    # 4 px from every edge → outside the margin → complete.
+    clear = np.array([[4, 4], [196, 4], [196, 196], [4, 196]], np.float32)
+    assert _touches_border(clear, height=200, width=200) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Integration smoke test against the real weights
+# ---------------------------------------------------------------------------
+def _synthetic_capsules():
+    """A 1280x1024 bright-field-ish image with 5 capsule-like rings.
+
+    Returns (image_bgr, n_interior, n_clipped) where the first 3 capsules are
+    fully inside the frame and the last 2 run off the border.
+    """
+    import cv2
+
+    w, h = 1280, 1024
+    img = np.full((h, w, 3), 205, np.uint8)
+    capsules = [
+        (300, 300, 90),     # interior
+        (700, 500, 120),    # interior
+        (980, 760, 70),     # interior
+        (40, 520, 110),     # clipped by LEFT edge
+        (1180, 180, 130),   # clipped by RIGHT/TOP corner
+    ]
+    for (cx, cy, r) in capsules:
+        cv2.circle(img, (cx, cy), r, (175, 175, 175), -1)
+        cv2.circle(img, (cx, cy), max(r - 10, 1), (200, 200, 200), -1)
+        cv2.circle(img, (cx, cy), r, (95, 95, 95), 4)
+    return img, 3, 2
+
+
+@pytest.mark.skipif(
+    not WEIGHTS.exists(), reason="microcapsule_yolo11n.pt not placed"
+)
+def test_microcapsule_wrapper_output_contract():
+    pytest.importorskip("ultralytics")
+    import cv2
+    import torch
+    from models.microcapsule import MicrocapsuleModel, _touches_border
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = MicrocapsuleModel()
+    model.load_weights(str(WEIGHTS), device)
+
+    img, _, _ = _synthetic_capsules()
+    h, w = img.shape[:2]
+    instances = model.predict(img, conf=0.25)
+
+    # The model detects capsules on this synthetic image.
+    assert len(instances) >= 1, "expected at least one detected capsule"
+
+    for inst in instances:
+        poly = inst["polygon_xy"]
+        assert poly.shape[1] == 2 and len(poly) >= 3
+        # confidence is a probability
+        assert 0.0 <= inst["confidence"] <= 1.0
+        # area_px is exactly cv2.contourArea of the returned polygon
+        assert inst["area_px"] == pytest.approx(
+            float(cv2.contourArea(poly)), rel=1e-5, abs=1e-3
+        )
+        # equiv diameter follows 2*sqrt(area/pi)
+        expected_d = 2.0 * float(np.sqrt(inst["area_px"] / np.pi))
+        assert inst["equiv_diameter_px"] == pytest.approx(expected_d, rel=1e-6)
+        # complete flag agrees with the border rule applied to its polygon
+        assert inst["complete"] == (not _touches_border(poly, h, w))
+
+    # Sorted largest-area first (deterministic instance numbering).
+    areas = [inst["area_px"] for inst in instances]
+    assert areas == sorted(areas, reverse=True)
+
+
+@pytest.mark.skipif(
+    not WEIGHTS.exists(), reason="microcapsule_yolo11n.pt not placed"
+)
+def test_microcapsule_detects_border_cut_capsules():
+    pytest.importorskip("ultralytics")
+    import torch
+    from models.microcapsule import MicrocapsuleModel
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = MicrocapsuleModel()
+    model.load_weights(str(WEIGHTS), device)
+
+    img, n_interior, n_clipped = _synthetic_capsules()
+    instances = model.predict(img, conf=0.25)
+
+    complete = [i for i in instances if i["complete"]]
+    incomplete = [i for i in instances if not i["complete"]]
+
+    # The two frame-clipped capsules must be flagged incomplete, and at least
+    # the interior capsules complete. (Exact counts depend on detections, so we
+    # assert the directional invariant the metrics filter relies on.)
+    assert len(incomplete) >= 1, "border-cut capsules should be flagged incomplete"
+    assert len(complete) >= 1, "interior capsules should be flagged complete"

--- a/backend/segmentation/tests/test_microcapsule_model.py
+++ b/backend/segmentation/tests/test_microcapsule_model.py
@@ -71,6 +71,24 @@ def _disk(size, cx, cy, r):
     return ((xx - cx) ** 2 + (yy - cy) ** 2) <= r * r
 
 
+def _ring(size, cx, cy, r_outer, r_inner):
+    yy, xx = np.ogrid[:size, :size]
+    d2 = (xx - cx) ** 2 + (yy - cy) ** 2
+    return (d2 <= r_outer * r_outer) & (d2 >= r_inner * r_inner)
+
+
+def test_merge_nested_collapses_outer_ring_and_inner_disk():
+    """SAM 3's outer mask is often an annulus; on the RAW ring an inner disk
+    barely overlaps, so containment must be measured on hole-FILLED masks."""
+    from models.microcapsule import _merge_nested
+
+    outer_ring = _ring(300, 150, 150, 100, 78)  # capsule shell (hollow centre)
+    inner_disk = _disk(300, 150, 150, 75)        # inner wall (sits in the hole)
+    # Raw overlap is tiny (disk falls in the ring's hole) but they ARE concentric.
+    kept = _merge_nested([inner_disk, outer_ring])
+    assert kept == [1]  # only the (filled) outer ring survives
+
+
 def test_merge_nested_drops_inner_and_bubble_keeps_outer():
     from models.microcapsule import _merge_nested
 

--- a/backend/segmentation/tests/test_microcapsule_model.py
+++ b/backend/segmentation/tests/test_microcapsule_model.py
@@ -59,7 +59,8 @@ def test_touches_border_respects_margin():
 
     near = np.array([[3, 40], [60, 40], [60, 120], [3, 120]], np.float32)
     assert _touches_border(near, height=200, width=200) is True
-    clear = np.array([[4, 4], [196, 4], [196, 196], [4, 196]], np.float32)
+    # 4 px inset from every edge (pixels 0..199, so the far edge is 195 = 199-4).
+    clear = np.array([[4, 4], [195, 4], [195, 195], [4, 195]], np.float32)
     assert _touches_border(clear, height=200, width=200) is False
 
 

--- a/backend/src/constants/__tests__/modelRegistry.test.ts
+++ b/backend/src/constants/__tests__/modelRegistry.test.ts
@@ -15,10 +15,11 @@ const CANONICAL_IDS = [
   'sperm',
   'wound',
   'microtubule',
+  'microcapsule',
 ] as const;
 
 describe('backend model registry SSOT', () => {
-  it('registry keys are exactly the canonical 9 models', () => {
+  it('registry keys are exactly the canonical 10 models', () => {
     expect(Object.keys(MODEL_REGISTRY).sort()).toEqual(
       [...CANONICAL_IDS].sort()
     );
@@ -43,6 +44,7 @@ describe('backend model registry SSOT', () => {
       wound: ['wound'],
       sperm: ['sperm'],
       microtubules: ['microtubule'],
+      microcapsule: ['microcapsule'],
     });
   });
 });

--- a/backend/src/constants/modelRegistry.ts
+++ b/backend/src/constants/modelRegistry.ts
@@ -24,7 +24,8 @@ export type ProjectTypeKey =
   | 'spheroid_invasive'
   | 'wound'
   | 'sperm'
-  | 'microtubules';
+  | 'microtubules'
+  | 'microcapsule';
 
 interface BackendModelSpec {
   /** Project types whose picker offers (and whose worker accepts) this model. */
@@ -45,6 +46,7 @@ export const MODEL_REGISTRY = {
   sperm: { compatibleProjectTypes: ['sperm'] },
   wound: { compatibleProjectTypes: ['wound'] },
   microtubule: { compatibleProjectTypes: ['microtubules'] },
+  microcapsule: { compatibleProjectTypes: ['microcapsule'] },
 } as const satisfies Record<string, BackendModelSpec>;
 
 /** All known model identifiers — derived, so a typo or a removed model is a

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -105,10 +105,60 @@ export function generateMetricsGuide(
       return buildWoundGuide(ctx);
     case 'microtubules':
       return buildMicrotubuleGuide(ctx);
+    case 'microcapsule':
+      return buildMicrocapsuleGuide(ctx);
     case 'spheroid':
     default:
       return buildSpheroidGuide(ctx);
   }
+}
+
+function buildMicrocapsuleGuide({
+  areaUnit,
+  lengthUnit,
+  scaleInfo,
+}: UnitContext): string {
+  return `# Microcapsule Metrics Reference Guide
+${scaleInfo}
+## Metrics file (\`metrics.csv\` / \`metrics.xlsx\`)
+
+The microcapsule model performs **instance segmentation**: each detected
+capsule is one closed polygon and gets **one row**. The report is intentionally
+focused on the three shape measures requested for capsules, plus identifiers.
+
+> **Completeness filter** — capsules whose mask touches the image border are
+> *cut off by the frame* and are **excluded from this report** (they are still
+> drawn, in grey, in the visualisation export, so you can see what was skipped).
+> Only whole capsules contribute to the metrics and the summary statistics.
+
+### Columns
+- **Image Name / Image ID** — source image identifiers.
+- **Capsule ID** — 1-based index within the image (largest capsule first).
+- **Area (${areaUnit})** — enclosed area via the Shoelace formula.
+- **Perimeter (${lengthUnit})** — boundary length, Sum_i ||p_{i+1} - p_i||
+  (ImageJ convention).
+- **Compactness** — circularity \`C = 4*pi * Area / Perimeter^2\`, in [0, 1]
+  where **1.0 = a perfect circle**. For round capsules this is the most
+  intuitive shape measure (a value near 1 means a clean circular capsule;
+  lower values indicate an irregular or dented boundary).
+- **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the
+  same area, \`d = 2*sqrt(Area/pi)\`.
+- **Confidence** — the model's detection score for the capsule, in [0, 1].
+
+### Summary sheet
+Aggregates over the **complete** capsules only: how many were analysed, plus
+mean / min / max of area and compactness, and mean perimeter and equivalent
+diameter.
+
+## Visualisation
+Complete capsules are drawn and numbered in the configured external colour;
+capsules cut off by the image border are drawn **grey** and are not counted.
+
+## Annotation exports (COCO / YOLO / JSON)
+Every detected capsule — complete or cut-off — is exported as one instance
+(the completeness filter applies to metrics only, not to the geometry
+annotations).
+`;
 }
 
 function buildMicrotubuleGuide({ lengthUnit, scaleInfo }: UnitContext): string {

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -137,18 +137,26 @@ focused on the three shape measures requested for capsules, plus identifiers.
 - **Area (${areaUnit})** — enclosed area via the Shoelace formula.
 - **Perimeter (${lengthUnit})** — boundary length, Sum_i ||p_{i+1} - p_i||
   (ImageJ convention).
+- **Width (${lengthUnit})** — axis-aligned bounding-box width (capsule extent
+  in x).
+- **Height (${lengthUnit})** — axis-aligned bounding-box height (capsule extent
+  in y).
+- **Diameter (${lengthUnit})** — mean Feret diameter, the average caliper width
+  across orientations \`(Feret_max + Feret_min) / 2\`. Rotation-invariant, so
+  unlike Width/Height it does not depend on how the capsule sits in the frame.
+- **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the
+  same area, \`d = 2*sqrt(Area/pi)\`. (For a perfect circle Diameter ≈
+  Equivalent Diameter ≈ Width ≈ Height.)
 - **Compactness** — circularity \`C = 4*pi * Area / Perimeter^2\`, in [0, 1]
   where **1.0 = a perfect circle**. For round capsules this is the most
   intuitive shape measure (a value near 1 means a clean circular capsule;
   lower values indicate an irregular or dented boundary).
-- **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the
-  same area, \`d = 2*sqrt(Area/pi)\`.
 - **Confidence** — the model's detection score for the capsule, in [0, 1].
 
 ### Summary sheet
 Aggregates over the **complete** capsules only: how many were analysed, plus
-mean / min / max of area and compactness, and mean perimeter and equivalent
-diameter.
+mean / min / max of area and compactness, and mean perimeter, width, height,
+diameter and equivalent diameter.
 
 ## Visualisation
 Complete capsules are drawn and numbered in the configured external colour;

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1370,6 +1370,15 @@ export class ExportService {
             options?.pixelToMicrometerScale,
             imageMetrics
           );
+        } else if (projectType === 'microcapsule') {
+          // Microcapsule: focused per-capsule report (Area, Perimeter,
+          // Compactness, Equivalent Diameter, Confidence). Border-cut capsules
+          // are already excluded from `allMetrics` upstream.
+          await this.metricsCalculator.exportMicrocapsuleMetricsToExcel(
+            allMetrics,
+            excelPath,
+            options?.pixelToMicrometerScale
+          );
         } else {
           // 'spheroid' (standard) and 'wound': emit the comprehensive
           // per-polygon metrics report (Polygon Metrics + Summary sheets).
@@ -1396,11 +1405,19 @@ export class ExportService {
           }
         }
       } else if (format === 'csv') {
-        await this.metricsCalculator.exportToCSV(
-          allMetrics,
-          path.join(metricsDir, 'metrics.csv'),
-          options?.pixelToMicrometerScale
-        );
+        if (projectType === 'microcapsule') {
+          await this.metricsCalculator.exportMicrocapsuleToCSV(
+            allMetrics,
+            path.join(metricsDir, 'metrics.csv'),
+            options?.pixelToMicrometerScale
+          );
+        } else {
+          await this.metricsCalculator.exportToCSV(
+            allMetrics,
+            path.join(metricsDir, 'metrics.csv'),
+            options?.pixelToMicrometerScale
+          );
+        }
       } else if (format === 'json') {
         await fs.writeFile(
           path.join(metricsDir, 'metrics.json'),

--- a/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
@@ -191,14 +191,39 @@ describe('MetricsCalculator — exportMicrocapsuleMetricsToExcel', () => {
       'Capsule ID',
       'Area (px^2)',
       'Perimeter (px)',
-      'Compactness',
+      'Width (px)',
+      'Height (px)',
+      'Diameter (px)',
       'Equivalent Diameter (px)',
+      'Compactness',
       'Confidence',
     ]);
     // The focused report must NOT carry the rich spheroid descriptors.
     expect(headers).not.toContain('Feret Diameter Max (px)');
     expect(headers).not.toContain('Solidity');
     expect(headers).not.toContain('Sphericity');
+  });
+
+  it('width/height = bounding box, diameter = mean Feret', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [
+        metricRow({
+          polygonId: 1,
+          boundingBoxWidth: 24,
+          boundingBoxHeight: 18,
+          feretDiameterMax: 26,
+          feretDiameterMin: 20,
+        }),
+      ],
+      '/tmp/metrics.xlsx'
+    );
+    const row = mockWorksheet.addRow.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(row.width).toBeCloseTo(24, 4);
+    expect(row.height).toBeCloseTo(18, 4);
+    expect(row.diameter).toBeCloseTo(23, 4); // (26 + 20) / 2
   });
 
   it('maps the Compactness column to the circularity value, not compactness', async () => {

--- a/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the microcapsule metrics path:
+ *   - calculateAllMetrics EXCLUDES border-cut capsules (complete === false)
+ *     from the computed metrics, while keeping complete / unflagged polygons.
+ *   - exportMicrocapsuleMetricsToExcel emits the FOCUSED column set and maps
+ *     the "Compactness" column to the circularity value (4π·A/P²).
+ *   - exportMicrocapsuleToCSV emits the same focused columns and omits cut-off
+ *     capsules.
+ *
+ * The Python metrics endpoint is mocked to reject so geometry is computed by the
+ * offline calculateBasicMetrics fallback (deterministic, no network).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MetricsCalculator,
+  ImageWithSegmentation,
+  PolygonMetrics,
+} from '../metricsCalculator';
+
+// ── ExcelJS mock (captures columns + rows) ──────────────────────────────────
+const mockWorksheet = {
+  columns: [] as Array<{ header?: string; key?: string; width?: number }>,
+  // addRow returns a fresh row whose font/fill can be assigned (the summary
+  // sheet does `excelRow.font = ...` on the first row).
+  addRow: vi.fn(() => ({ font: undefined, fill: undefined })),
+  getRow: vi.fn(() => ({ font: undefined, fill: undefined })),
+};
+const mockAddWorksheet = vi.fn(() => mockWorksheet);
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('exceljs', () => ({
+  default: {
+    Workbook: function MockWorkbook(this: object) {
+      return {
+        addWorksheet: mockAddWorksheet,
+        xlsx: { writeFile: mockWriteFile },
+      };
+    },
+  },
+}));
+
+// ── fs/promises mock (captures CSV writeFile content) ───────────────────────
+const fsWriteFile = vi.fn().mockResolvedValue(undefined);
+vi.mock('fs/promises', () => {
+  const noop = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    mkdir: noop,
+    readFile: noop,
+    writeFile: (...args: unknown[]) => fsWriteFile(...args),
+    unlink: noop,
+    access: noop,
+    stat: noop,
+  };
+  return { default: api, ...api };
+});
+
+// ── axios mock (rejects → offline fallback) ─────────────────────────────────
+const postMock = vi.fn();
+vi.mock('axios', () => ({
+  default: { create: vi.fn(() => ({ post: postMock })) },
+  create: vi.fn(() => ({ post: postMock })),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../../utils/config', () => ({
+  config: { SEGMENTATION_SERVICE_URL: 'http://ml-service:8000' },
+}));
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+const square = (side: number, ox = 0, oy = 0) => [
+  { x: ox, y: oy },
+  { x: ox + side, y: oy },
+  { x: ox + side, y: oy + side },
+  { x: ox, y: oy + side },
+];
+
+/** External microcapsule polygon with an explicit completeness flag. */
+const capsule = (side: number, complete: boolean, confidence: number) => ({
+  type: 'external' as const,
+  class: 'microcapsule',
+  points: square(side),
+  complete,
+  confidence,
+});
+
+const buildImage = (polygons: unknown[]): ImageWithSegmentation => ({
+  id: 'cap1',
+  name: 'capsules.png',
+  segmentation: {
+    polygons: JSON.stringify(polygons),
+    model: 'microcapsule',
+    threshold: 0.25,
+  },
+});
+
+// A focused PolygonMetrics row (only the fields the focused exporter reads).
+const metricRow = (
+  over: Partial<PolygonMetrics> & { polygonId: number }
+): PolygonMetrics =>
+  ({
+    imageId: 'cap1',
+    imageName: 'capsules.png',
+    type: 'external',
+    area: 100,
+    perimeter: 40,
+    perimeterWithHoles: 40,
+    equivalentDiameter: 11.28,
+    circularity: 0.785,
+    compactness: 1.273,
+    confidence: 0.9,
+    complete: true,
+    feretDiameterMax: 14.1,
+    feretDiameterMaxOrthogonalDistance: 10,
+    feretDiameterMin: 10,
+    feretAspectRatio: 1.41,
+    lengthMajorDiameterThroughCentroid: 14.1,
+    lengthMinorDiameterThroughCentroid: 10,
+    boundingBoxWidth: 10,
+    boundingBoxHeight: 10,
+    extent: 1,
+    convexity: 1,
+    solidity: 1,
+    sphericity: 0.6,
+    ...over,
+  }) as PolygonMetrics;
+
+describe('MetricsCalculator — microcapsule completeness exclusion', () => {
+  let calc: MetricsCalculator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calc = new MetricsCalculator();
+    postMock.mockRejectedValue(new Error('ML service unavailable'));
+  });
+
+  it('excludes border-cut capsules (complete === false) from metrics', async () => {
+    const image = buildImage([
+      capsule(10, true, 0.95), // complete → counted
+      capsule(12, false, 0.6), // cut off  → excluded
+      capsule(8, true, 0.8), // complete → counted
+    ]);
+
+    const metrics = await calc.calculateAllMetrics([image]);
+
+    expect(metrics).toHaveLength(2);
+    // Both remaining rows are the two complete capsules (areas 100 and 64).
+    const areas = metrics.map(m => Math.round(m.area)).sort((a, b) => a - b);
+    expect(areas).toEqual([64, 100]);
+    // None of the kept rows is the excluded one.
+    expect(metrics.every(m => m.complete !== false)).toBe(true);
+  });
+
+  it('keeps polygons that do not set the complete flag (other project types)', async () => {
+    const image = buildImage([
+      { type: 'external', points: square(10) }, // no `complete` field
+      { type: 'external', points: square(8), complete: true },
+    ]);
+
+    const metrics = await calc.calculateAllMetrics([image]);
+    expect(metrics).toHaveLength(2);
+  });
+
+  it('carries confidence onto the computed metric rows', async () => {
+    const image = buildImage([capsule(10, true, 0.97)]);
+    const metrics = await calc.calculateAllMetrics([image]);
+    expect(metrics[0]!.confidence).toBeCloseTo(0.97, 5);
+  });
+});
+
+describe('MetricsCalculator — exportMicrocapsuleMetricsToExcel', () => {
+  let calc: MetricsCalculator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWorksheet.columns = [];
+    calc = new MetricsCalculator();
+  });
+
+  it('emits the focused column set (no Feret / solidity / sphericity)', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [metricRow({ polygonId: 1 })],
+      '/tmp/metrics.xlsx'
+    );
+    const headers = mockWorksheet.columns.map(c => c.header);
+    expect(headers).toEqual([
+      'Image Name',
+      'Image ID',
+      'Capsule ID',
+      'Area (px^2)',
+      'Perimeter (px)',
+      'Compactness',
+      'Equivalent Diameter (px)',
+      'Confidence',
+    ]);
+    // The focused report must NOT carry the rich spheroid descriptors.
+    expect(headers).not.toContain('Feret Diameter Max (px)');
+    expect(headers).not.toContain('Solidity');
+    expect(headers).not.toContain('Sphericity');
+  });
+
+  it('maps the Compactness column to the circularity value, not compactness', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [metricRow({ polygonId: 1, circularity: 0.82, compactness: 1.22 })],
+      '/tmp/metrics.xlsx'
+    );
+    // First addRow call is the data row on the metrics sheet.
+    const row = mockWorksheet.addRow.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(row.compactness).toBeCloseTo(0.82, 4); // = circularity
+    expect(row.compactness).not.toBeCloseTo(1.22, 4); // NOT the reciprocal
+  });
+
+  it('uses µm² / µm units when a pixel scale is supplied', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [metricRow({ polygonId: 1 })],
+      '/tmp/metrics.xlsx',
+      0.5
+    );
+    const headers = mockWorksheet.columns.map(c => c.header);
+    expect(headers).toContain('Area (um^2)');
+    expect(headers).toContain('Perimeter (um)');
+  });
+});
+
+describe('MetricsCalculator — exportMicrocapsuleToCSV', () => {
+  let calc: MetricsCalculator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calc = new MetricsCalculator();
+  });
+
+  it('writes the focused CSV header and excludes cut-off capsules', async () => {
+    await calc.exportMicrocapsuleToCSV(
+      [
+        metricRow({ polygonId: 1, area: 100, complete: true }),
+        metricRow({ polygonId: 2, area: 50, complete: false }),
+      ],
+      '/tmp/metrics.csv'
+    );
+    expect(fsWriteFile).toHaveBeenCalledTimes(1);
+    const content = String(fsWriteFile.mock.calls[0]![1]);
+    expect(content).toContain('Capsule ID');
+    expect(content).toContain('Compactness');
+    expect(content).toContain('Confidence');
+    expect(content).not.toContain('Sphericity');
+    // Two metric rows in, one excluded → one data line + the header.
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+  });
+});

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -866,17 +866,25 @@ export class MetricsCalculator {
       { header: 'Capsule ID', key: 'polygonId', width: 12 },
       { header: `Area (${areaUnit})`, key: 'area', width: 14 },
       { header: `Perimeter (${lengthUnit})`, key: 'perimeter', width: 14 },
-      { header: 'Compactness', key: 'compactness', width: 12 },
+      { header: `Width (${lengthUnit})`, key: 'width', width: 12 },
+      { header: `Height (${lengthUnit})`, key: 'height', width: 12 },
+      { header: `Diameter (${lengthUnit})`, key: 'diameter', width: 12 },
       {
         header: `Equivalent Diameter (${lengthUnit})`,
         key: 'equivalentDiameter',
         width: 20,
       },
+      { header: 'Compactness', key: 'compactness', width: 12 },
       { header: 'Confidence', key: 'confidence', width: 12 },
     ];
 
     const safeValue = (value: number, decimals = 2): number =>
       isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
+    // "Diameter" = mean Feret diameter (average caliper width across
+    // orientations) — rotation-invariant, distinct from the axis-aligned
+    // bounding-box Width/Height and the area-based Equivalent Diameter.
+    const meanDiameter = (m: PolygonMetrics): number =>
+      (m.feretDiameterMax + m.feretDiameterMin) / 2;
 
     // Only complete capsules reach here (excluded upstream), but guard anyway.
     const rows = metrics.filter(m => m.complete !== false);
@@ -887,8 +895,11 @@ export class MetricsCalculator {
         polygonId: m.polygonId,
         area: safeValue(m.area, 2),
         perimeter: safeValue(m.perimeter, 2),
-        compactness: safeValue(m.circularity, 4),
+        width: safeValue(m.boundingBoxWidth, 2),
+        height: safeValue(m.boundingBoxHeight, 2),
+        diameter: safeValue(meanDiameter(m), 2),
         equivalentDiameter: safeValue(m.equivalentDiameter, 2),
+        compactness: safeValue(m.circularity, 4),
         confidence:
           typeof m.confidence === 'number' ? safeValue(m.confidence, 4) : '',
       });
@@ -950,11 +961,14 @@ export class MetricsCalculator {
         { id: 'polygonId', title: 'Capsule ID' },
         { id: 'area', title: `Area (${areaUnit})` },
         { id: 'perimeter', title: `Perimeter (${lengthUnit})` },
-        { id: 'compactness', title: 'Compactness' },
+        { id: 'width', title: `Width (${lengthUnit})` },
+        { id: 'height', title: `Height (${lengthUnit})` },
+        { id: 'diameter', title: `Diameter (${lengthUnit})` },
         {
           id: 'equivalentDiameter',
           title: `Equivalent Diameter (${lengthUnit})`,
         },
+        { id: 'compactness', title: 'Compactness' },
         { id: 'confidence', title: 'Confidence' },
       ],
     });
@@ -967,9 +981,14 @@ export class MetricsCalculator {
         polygonId: m.polygonId,
         area: m.area,
         perimeter: m.perimeter,
+        width: m.boundingBoxWidth,
+        height: m.boundingBoxHeight,
+        // "Diameter" = mean Feret diameter (rotation-invariant), distinct from
+        // the axis-aligned Width/Height and the area-based Equivalent Diameter.
+        diameter: (m.feretDiameterMax + m.feretDiameterMin) / 2,
+        equivalentDiameter: m.equivalentDiameter,
         // "Compactness" column carries the circularity value by design.
         compactness: m.circularity,
-        equivalentDiameter: m.equivalentDiameter,
         confidence: typeof m.confidence === 'number' ? m.confidence : '',
       }));
 
@@ -1015,6 +1034,20 @@ export class MetricsCalculator {
       [
         `Average Perimeter (${lengthUnit})`,
         this.average(metrics.map(m => m.perimeter)).toFixed(2),
+      ],
+      [
+        `Average Width (${lengthUnit})`,
+        this.average(metrics.map(m => m.boundingBoxWidth)).toFixed(2),
+      ],
+      [
+        `Average Height (${lengthUnit})`,
+        this.average(metrics.map(m => m.boundingBoxHeight)).toFixed(2),
+      ],
+      [
+        `Average Diameter (${lengthUnit})`,
+        this.average(
+          metrics.map(m => (m.feretDiameterMax + m.feretDiameterMin) / 2)
+        ).toFixed(2),
       ],
       [
         `Average Equivalent Diameter (${lengthUnit})`,

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -41,6 +41,12 @@ export interface PolygonMetrics {
   perimeterWithHoles: number;
   equivalentDiameter: number;
   circularity: number;
+  /** Per-instance detection score (microcapsule YOLO); undefined otherwise. */
+  confidence?: number;
+  /** Microcapsule completeness flag; undefined for non-microcapsule polygons.
+   *  Cut-off capsules (`false`) are already excluded upstream, so rows here are
+   *  always complete — carried for the focused microcapsule exporter. */
+  complete?: boolean;
   feretDiameterMax: number;
   feretDiameterMaxOrthogonalDistance: number;
   feretDiameterMin: number;
@@ -95,6 +101,11 @@ export interface ParsedPolygon {
   geometry?: 'polygon' | 'polyline';
   partClass?: PolygonPartClass;
   instanceId?: string;
+  /** Per-instance detection score (microcapsule YOLO). */
+  confidence?: number;
+  /** Microcapsule completeness: `false` when cut off by the image border.
+   *  Such capsules are excluded from metrics (see the parse filter below). */
+  complete?: boolean;
 }
 
 export interface SegmentationData {
@@ -169,10 +180,14 @@ export class MetricsCalculator {
         if (result.polygons) {
           try {
             const parsed: ParsedPolygon[] = JSON.parse(result.polygons);
-            // Filter to closed polygons only (exclude polylines used for sperm morphology)
+            // Filter to closed polygons only (exclude polylines used for sperm
+            // morphology). Also exclude border-cut microcapsules: an instance
+            // explicitly flagged `complete === false` is cropped by the image
+            // edge and must not contribute to metrics. Other project types never
+            // set `complete`, so `!== false` leaves them untouched.
             const polygons = parsed.filter(
               (p): p is ParsedPolygon & { type: 'external' | 'internal' } =>
-                p.geometry !== 'polyline' && !!p.type
+                p.geometry !== 'polyline' && !!p.type && p.complete !== false
             );
             totalPolygonCount += polygons.length;
 
@@ -255,15 +270,21 @@ export class MetricsCalculator {
    * Calculate metrics for polygons in a single image
    */
   async calculateImageMetrics(
-    polygons: Polygon[],
+    polygons: ParsedPolygon[],
     imageId: string,
     imageName: string
   ): Promise<PolygonMetrics[]> {
     const metrics: PolygonMetrics[] = [];
 
-    // Separate external and internal polygons
-    const externalPolygons = polygons.filter(p => p.type === 'external');
-    const internalPolygons = polygons.filter(p => p.type === 'internal');
+    // Separate external and internal polygons. Type-guard predicates narrow the
+    // optional `type` to a required literal so each element satisfies the
+    // MinimalPolygon shape the geometry helpers expect.
+    const externalPolygons = polygons.filter(
+      (p): p is ParsedPolygon & { type: 'external' } => p.type === 'external'
+    );
+    const internalPolygons = polygons.filter(
+      (p): p is ParsedPolygon & { type: 'internal' } => p.type === 'internal'
+    );
 
     // Calculate metrics for each external polygon
     for (let i = 0; i < externalPolygons.length; i++) {
@@ -303,6 +324,8 @@ export class MetricsCalculator {
           imageName,
           polygonId: i + 1,
           type: 'external',
+          confidence: polygon.confidence,
+          complete: polygon.complete,
           ...polygonMetrics,
         });
       } catch (error) {
@@ -322,6 +345,8 @@ export class MetricsCalculator {
           imageName,
           polygonId: i + 1,
           type: 'external',
+          confidence: polygon.confidence,
+          complete: polygon.complete,
           ...this.calculateBasicMetrics(polygon, holesForPolygon),
         });
       }
@@ -810,6 +835,195 @@ export class MetricsCalculator {
     await fs.mkdir(parentDir, { recursive: true });
     await workbook.xlsx.writeFile(outputPath);
     this.logger.info(`Polygon Metrics Excel written: ${outputPath}`, 'MetricsCalculator');
+  }
+
+  /**
+   * Focused Excel export for **microcapsule** projects. One row per *complete*
+   * capsule — border-cut capsules are already excluded upstream in
+   * `generateMetrics`. Columns are intentionally minimal: the user wants area,
+   * perimeter and compactness per capsule, not the full spheroid descriptor set.
+   *
+   * "Compactness" here is the **circularity** value (4π·A/P², in [0, 1], where
+   * 1.0 is a perfect circle) — the agreed, most-intuitive shape measure for
+   * round capsules. `PolygonMetrics.circularity` already holds exactly this;
+   * the unbounded reciprocal `PolygonMetrics.compactness` is deliberately not
+   * surfaced.
+   */
+  async exportMicrocapsuleMetricsToExcel(
+    metrics: PolygonMetrics[],
+    outputPath: string,
+    pixelToMicrometerScale?: number
+  ): Promise<void> {
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('Microcapsule Metrics');
+    const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
+    const areaUnit = isScaled ? 'um^2' : 'px^2';
+    const lengthUnit = isScaled ? 'um' : 'px';
+
+    worksheet.columns = [
+      { header: 'Image Name', key: 'imageName', width: 20 },
+      { header: 'Image ID', key: 'imageId', width: 15 },
+      { header: 'Capsule ID', key: 'polygonId', width: 12 },
+      { header: `Area (${areaUnit})`, key: 'area', width: 14 },
+      { header: `Perimeter (${lengthUnit})`, key: 'perimeter', width: 14 },
+      { header: 'Compactness', key: 'compactness', width: 12 },
+      {
+        header: `Equivalent Diameter (${lengthUnit})`,
+        key: 'equivalentDiameter',
+        width: 20,
+      },
+      { header: 'Confidence', key: 'confidence', width: 12 },
+    ];
+
+    const safeValue = (value: number, decimals = 2): number =>
+      isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
+
+    // Only complete capsules reach here (excluded upstream), but guard anyway.
+    const rows = metrics.filter(m => m.complete !== false);
+    rows.forEach(m => {
+      worksheet.addRow({
+        imageName: m.imageName,
+        imageId: m.imageId,
+        polygonId: m.polygonId,
+        area: safeValue(m.area, 2),
+        perimeter: safeValue(m.perimeter, 2),
+        compactness: safeValue(m.circularity, 4),
+        equivalentDiameter: safeValue(m.equivalentDiameter, 2),
+        confidence:
+          typeof m.confidence === 'number' ? safeValue(m.confidence, 4) : '',
+      });
+    });
+    worksheet.getRow(1).font = { bold: true };
+    worksheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFE0E0E0' },
+    };
+
+    const summarySheet = workbook.addWorksheet('Summary');
+    const summaryData = this.generateMicrocapsuleSummary(
+      rows,
+      pixelToMicrometerScale
+    );
+    summaryData.forEach((row, index) => {
+      const excelRow = summarySheet.addRow(row);
+      if (index === 0) {
+        excelRow.font = { bold: true };
+        excelRow.fill = {
+          type: 'pattern',
+          pattern: 'solid',
+          fgColor: { argb: 'FFE0E0E0' },
+        };
+      }
+    });
+    summarySheet.columns.forEach(column => {
+      column.width = 26;
+    });
+
+    const parentDir = path.dirname(outputPath);
+    await fs.mkdir(parentDir, { recursive: true });
+    await workbook.xlsx.writeFile(outputPath);
+    this.logger.info(
+      `Microcapsule Metrics Excel written: ${outputPath}`,
+      'MetricsCalculator'
+    );
+  }
+
+  /**
+   * Focused CSV export for **microcapsule** projects — the CSV twin of
+   * `exportMicrocapsuleMetricsToExcel` (same focused columns, complete capsules
+   * only, "Compactness" = circularity 4π·A/P²).
+   */
+  async exportMicrocapsuleToCSV(
+    metrics: PolygonMetrics[],
+    outputPath: string,
+    pixelToMicrometerScale?: number
+  ): Promise<void> {
+    const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
+    const areaUnit = isScaled ? 'um^2' : 'px^2';
+    const lengthUnit = isScaled ? 'um' : 'px';
+
+    const csvStringifier = createObjectCsvStringifier({
+      header: [
+        { id: 'imageName', title: 'Image Name' },
+        { id: 'imageId', title: 'Image ID' },
+        { id: 'polygonId', title: 'Capsule ID' },
+        { id: 'area', title: `Area (${areaUnit})` },
+        { id: 'perimeter', title: `Perimeter (${lengthUnit})` },
+        { id: 'compactness', title: 'Compactness' },
+        {
+          id: 'equivalentDiameter',
+          title: `Equivalent Diameter (${lengthUnit})`,
+        },
+        { id: 'confidence', title: 'Confidence' },
+      ],
+    });
+
+    const records = metrics
+      .filter(m => m.complete !== false)
+      .map(m => ({
+        imageName: m.imageName,
+        imageId: m.imageId,
+        polygonId: m.polygonId,
+        area: m.area,
+        perimeter: m.perimeter,
+        // "Compactness" column carries the circularity value by design.
+        compactness: m.circularity,
+        equivalentDiameter: m.equivalentDiameter,
+        confidence: typeof m.confidence === 'number' ? m.confidence : '',
+      }));
+
+    const header = csvStringifier.getHeaderString();
+    const body = csvStringifier.stringifyRecords(records);
+
+    const parentDir = path.dirname(outputPath);
+    await fs.mkdir(parentDir, { recursive: true });
+    await fs.writeFile(outputPath, header + body);
+    this.logger.info(
+      `Microcapsule CSV created: ${outputPath}`,
+      'MetricsCalculator'
+    );
+  }
+
+  /**
+   * Summary aggregates for the microcapsule report: how many complete capsules
+   * were analysed plus area / compactness statistics.
+   */
+  private generateMicrocapsuleSummary(
+    metrics: PolygonMetrics[],
+    pixelToMicrometerScale?: number
+  ): SummaryStatisticsRow[] {
+    if (metrics.length === 0) {
+      return [['No complete microcapsules found']];
+    }
+
+    const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
+    const areaUnit = isScaled ? 'um^2' : 'px^2';
+    const lengthUnit = isScaled ? 'um' : 'px';
+
+    const areas = metrics.map(m => m.area);
+    const compactness = metrics.map(m => m.circularity);
+
+    return [
+      ['Microcapsule Summary'],
+      [''],
+      ['Metric', 'Value'],
+      ['Capsules analysed (complete)', metrics.length],
+      [`Average Area (${areaUnit})`, this.average(areas).toFixed(2)],
+      [`Minimum Area (${areaUnit})`, Math.min(...areas).toFixed(2)],
+      [`Maximum Area (${areaUnit})`, Math.max(...areas).toFixed(2)],
+      [
+        `Average Perimeter (${lengthUnit})`,
+        this.average(metrics.map(m => m.perimeter)).toFixed(2),
+      ],
+      [
+        `Average Equivalent Diameter (${lengthUnit})`,
+        this.average(metrics.map(m => m.equivalentDiameter)).toFixed(2),
+      ],
+      ['Average Compactness', this.average(compactness).toFixed(4)],
+      ['Minimum Compactness', Math.min(...compactness).toFixed(4)],
+      ['Maximum Compactness', Math.max(...compactness).toFixed(4)],
+    ];
   }
 
   async exportToExcel(

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -302,16 +302,24 @@ export class VisualizationGenerator {
       return;
     }
 
+    // Microcapsules cut off by the image border (complete === false) render
+    // grey, mirroring the model's own overlay. They are also excluded from
+    // metrics elsewhere; greying keeps them visible for QA without implying
+    // they were measured.
+    const isIncomplete = polygon.complete === false;
+
     // Polylines use part-class colors; closed polygons use type-based colors
     // except 'core' which renders green (consistent with the editor canvas).
     const isCorePolygon = !isPolyline && polygon.partClass === 'core';
-    const color = isPolyline
-      ? POLYLINE_COLORS[polygon.partClass || ''] || '#a855f7'
-      : isCorePolygon
-        ? '#22c55e' // green — matches frontend CanvasPolygon for ASPP core
-        : polygon.type === 'external'
-          ? options.polygonColors?.external || '#00FF00'
-          : options.polygonColors?.internal || '#FF0000';
+    const color = isIncomplete
+      ? '#969696' // grey — matches the model overlay (150,150,150)
+      : isPolyline
+        ? POLYLINE_COLORS[polygon.partClass || ''] || '#a855f7'
+        : isCorePolygon
+          ? '#22c55e' // green — matches frontend CanvasPolygon for ASPP core
+          : polygon.type === 'external'
+            ? options.polygonColors?.external || '#00FF00'
+            : options.polygonColors?.internal || '#FF0000';
 
     ctx.strokeStyle = color;
     ctx.lineWidth = isPolyline

--- a/backend/src/types/polygon.ts
+++ b/backend/src/types/polygon.ts
@@ -58,4 +58,11 @@ export interface BasePolygon extends MinimalPolygon {
   /** Human-friendly label set in the editor; mirrored across sibling
    *  frames during cross-frame save propagation. */
   name?: string;
+  /** Per-instance detection score (0..1), written by instance models
+   *  (microcapsule YOLO). Carried through render → export. */
+  confidence?: number;
+  /** Microcapsule completeness flag: `false` when the capsule's mask is cut
+   *  off by the image border. Incomplete capsules are drawn grey and EXCLUDED
+   *  from metrics + the metrics export. Absent for non-microcapsule polygons. */
+  complete?: boolean;
 }

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -134,6 +134,7 @@ export const PROJECT_TYPES = [
   'wound',
   'sperm',
   'microtubules',
+  'microcapsule',
 ] as const;
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 

--- a/backend/src/utils/polygonValidation.ts
+++ b/backend/src/utils/polygonValidation.ts
@@ -52,6 +52,10 @@ export interface Polygon {
    *  frames during cross-frame propagation. Must be preserved here so a
    *  rename survives subsequent reads. */
   name?: string;
+  /** Microcapsule completeness flag (instance models). `false` when the
+   *  capsule's mask is cut off by the image border. Must be preserved here so
+   *  the editor can grey it out and metrics/export can exclude it. */
+  complete?: boolean;
 }
 
 /**
@@ -104,6 +108,12 @@ export const OPTIONAL_POLYGON_FIELDS: readonly OptionalPolygonField[] = [
   { key: 'trackId', coerce: coerceNonEmptyString },
   // Preserve editor-set label so renames survive subsequent reads.
   { key: 'name', coerce: coerceNonEmptyString },
+  // Preserve microcapsule completeness so cut-off capsules can be greyed in
+  // the editor and excluded from metrics. Only a real boolean survives.
+  {
+    key: 'complete',
+    coerce: value => (typeof value === 'boolean' ? value : undefined),
+  },
 ] as const;
 
 export interface ParsedPolygonResult {

--- a/docker/ml.optimized.Dockerfile
+++ b/docker/ml.optimized.Dockerfile
@@ -106,6 +106,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     torch torchvision && \
     pip install --no-cache-dir --no-index --find-links /wheels \
     -r /app/requirements.txt && \
+    # ultralytics (microcapsule model) declares a hard dep on the NON-headless
+    # opencv-python, which collides with opencv-python-headless over the shared
+    # cv2 package. Reconcile to a single headless build: drop every opencv
+    # variant, then reinstall headless from the prebuilt wheels (offline,
+    # --no-deps so numpy isn't dragged back).
+    pip uninstall -y opencv-python opencv-contrib-python opencv-python-headless || true && \
+    pip install --no-cache-dir --no-index --find-links /wheels --no-deps \
+    opencv-python-headless && \
+    python -c "import cv2; print('cv2 OK', cv2.__version__)" && \
     rm -rf /wheels
 
 # Install the CUDA-compiled Mamba kernels (built in the mamba-builder stage

--- a/docker/ml.optimized.Dockerfile
+++ b/docker/ml.optimized.Dockerfile
@@ -106,15 +106,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     torch torchvision && \
     pip install --no-cache-dir --no-index --find-links /wheels \
     -r /app/requirements.txt && \
-    # ultralytics (microcapsule model) declares a hard dep on the NON-headless
-    # opencv-python, which collides with opencv-python-headless over the shared
-    # cv2 package. Reconcile to a single headless build: drop every opencv
-    # variant, then reinstall headless from the prebuilt wheels (offline,
-    # --no-deps so numpy isn't dragged back).
-    pip uninstall -y opencv-python opencv-contrib-python opencv-python-headless || true && \
-    pip install --no-cache-dir --no-index --find-links /wheels --no-deps \
-    opencv-python-headless && \
-    python -c "import cv2; print('cv2 OK', cv2.__version__)" && \
     rm -rf /wheels
 
 # Install the CUDA-compiled Mamba kernels (built in the mamba-builder stage

--- a/docs/superpowers/specs/2026-06-22-microcapsule-project-type-design.md
+++ b/docs/superpowers/specs/2026-06-22-microcapsule-project-type-design.md
@@ -1,0 +1,240 @@
+# Microcapsule Project Type + Instance-Segmentation Model — Design Spec
+
+**Date:** 2026-06-22
+**Branch:** `feat-microcapsule-project-type`
+**Status:** Approved — implementing autonomously per user instruction
+
+---
+
+## Goal (user's words, translated)
+
+Integrate a new segmentation module for **microcapsules** (round objects) as a
+**new project type**, analogous to spheroids — same upload/editor/export flow
+**including visualizations** — differing only in:
+
+1. the **model** (a pre-trained YOLO11n-seg **instance** segmentation model), and
+2. the **metrics**: **area, perimeter, compactness** of _each individual_
+   microcapsule, **excluding capsules that are cut off by the image edge**.
+
+The module was delivered as `microcapsule-segmentation.zip` at the repo root
+(`infer.py` + `capsule_seg_best.pt`, 6.1 MB).
+
+---
+
+## What the delivered module is
+
+A **YOLO11n-seg** instance-segmentation model (Ultralytics), ~6 MB, distilled
+from Meta SAM 3, segmenting microcapsules in bright-field microscopy images.
+Per the shipped `infer.py`, `seg.segment(image)` returns a list of instances,
+each with:
+
+- `polygon` — `(N,2)` float pixel boundary,
+- `confidence` — 0..1,
+- `complete` — `True` if fully inside the frame, `False` if its mask touches the
+  image border within 3 px (`_touches_border(poly, h, w, m=3)`),
+- `area_px`, `equiv_diameter_px`.
+
+CPU inference, sub-second. This is fundamentally **instance** output (per-object
+polygons), unlike the repo's other models which emit a semantic mask that gets
+post-processed. But because each capsule is a **closed** polygon, it maps onto
+the existing **spheroid `polygons[]` channel** (multiple external polygons = many
+instances) — no polyline/instanceId machinery needed.
+
+---
+
+## Decisions (confirmed with user)
+
+| Decision                                     | Choice                                                                                                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Compactness convention**                   | **Circularity `4π·A/P²`** (0–1, 1.0 = perfect circle), surfaced under the label "Compactness". The repo already computes this as `metrics.Circularity`.             |
+| **Cut-off capsules in editor/visualization** | **Drawn grey, excluded from metrics.** Visible for QA (mirrors the model's own overlay), never counted.                                                             |
+| **Export metric columns**                    | **Focused set:** Image Name · Image ID · Capsule ID · Area · Perimeter · Compactness · Equivalent Diameter · Confidence (complete capsules only) + a summary sheet. |
+| **Project images**                           | Single bright-field images, like spheroid (not video).                                                                                                              |
+| **Model count**                              | Exactly one model bound to the `microcapsule` project type.                                                                                                         |
+
+---
+
+## Architecture — integration surface
+
+Five layers, mirroring how `segformer`/`wound` were added, plus a focused metrics
+path.
+
+### 1. ML service (`backend/segmentation/`)
+
+- **`models/microcapsule.py`** — new `MicrocapsuleModel` wrapper class (NOT an
+  `nn.Module`, following the sperm/wound pattern):
+  - `__init__(self)` — no weights.
+  - `load_weights(path, device)` — `from ultralytics import YOLO; self.model = YOLO(path)`; store device + `imgsz=1024`.
+  - `predict(image_bgr, conf=0.25)` — adapts the shipped `infer.py`: read
+    `res.masks.xy` + `res.boxes.conf`, compute `area = cv2.contourArea(poly)`,
+    `complete = not _touches_border(poly, h, w, m=3)`, sort by area desc; return
+    a list of instance dicts.
+  - Stubs: `eval()`, `to(device)`, `parameters()`.
+- **`models/__init__.py`** — guarded optional import + `__all__`.
+- **`ml/model_loader.py`** — `AVAILABLE_MODELS['microcapsule']` entry
+  (`weights/microcapsule_yolo11n.pt`), an early-return branch in `load_model`,
+  and a new **`predict_microcapsule(image, threshold)`** method returning the
+  response below.
+- **`api/routes.py`** — dispatch `elif model == 'microcapsule': result = loader.predict_microcapsule(...)`.
+- **`api/models.py`** — `ModelType.MICROCAPSULE = "microcapsule"`.
+- **`config/batch_sizes.json`** — `microcapsule` entry (optimal/max batch 1,
+  low memory, ~5–10 img/s on GPU; YOLO11n is tiny).
+- **`requirements.txt`** — add `ultralytics>=8.3,<9`. Torch pin is safe
+  (`ultralytics` needs `torch>=1.8`; the pinned `torch==2.6.0` satisfies it).
+- **`Dockerfile`** — after `pip install -r requirements.txt`, reconcile OpenCV to
+  a single **headless** build (ultralytics pulls non-headless `opencv-python`,
+  which collides with the repo's `opencv-python-headless` over `cv2`):
+  `pip uninstall -y opencv-python opencv-contrib-python || true && pip install --no-cache-dir --force-reinstall --no-deps opencv-python-headless==4.8.1.78`.
+- **Weights** — `capsule_seg_best.pt` → host `backend/segmentation/weights/microcapsule_yolo11n.pt`, owned `999:999`, bind-mounted.
+
+**ML response shape** (spheroid-shaped + two extra per-polygon fields):
+
+```json
+{
+  "model_used": "microcapsule",
+  "threshold_used": 0.25,
+  "image_size": {"width": W, "height": H},
+  "polygons": [
+    {
+      "id": "polygon_1",
+      "points": [{"x": .., "y": ..}, ...],
+      "type": "external",
+      "class": "microcapsule",
+      "confidence": 0.97,
+      "complete": true,
+      "vertices_count": N
+    }
+  ],
+  "processing_info": { "device": "...", "num_polygons": K, "confidence_scores": [...], "batch_size": 1 }
+}
+```
+
+The backend `threshold` maps to YOLO `conf`. `complete`/`confidence` are the only
+new fields vs. the spheroid response.
+
+### 2. Backend SSOT (`backend/src/`)
+
+- **`types/validation.ts`** — add `'microcapsule'` to `PROJECT_TYPES`.
+- **`constants/modelRegistry.ts`** — `microcapsule: { compatibleProjectTypes: ['microcapsule'] }`.
+
+### 3. Polygon data model (carry the new fields end-to-end)
+
+Add `complete?: boolean` to **`src/lib/segmentation.ts`** `Polygon` and
+**`backend/src/types/polygon.ts`** `BasePolygon`; add `confidence?: number` to
+`BasePolygon` (FE `Polygon` already has `confidence?`). Per the known **5-stage
+field-stripping** pattern, whitelist `complete` (and BE `confidence`) through:
+`PolygonValidator` + the 3 `segmentationService` mappers (`toApiPolygon` /
+`toDbPolygon` / FE-bound mapper) + the FE editor sync. **No DB migration**
+(polygons persist as JSON in `segmentations.polygons`).
+
+### 4. Metrics + export
+
+- **Compactness = `metrics.Circularity` value** (`4π·A/P²`), labeled "Compactness"
+  in the microcapsule surfaces. (Capsules have no holes → perimeter-with-holes
+  == perimeter.)
+- **Border exclusion in BOTH metric engines**, keyed on the field so it is inert
+  for other project types (they never set `complete`):
+  - FE `src/pages/segmentation/utils/metricCalculations.ts` call sites
+    (`MetricsDisplay.tsx`, `ExcelExporter.tsx`) — filter `p.complete !== false`.
+  - BE `backend/src/services/metrics/metricsCalculator.ts` — filter
+    `p.complete !== false` before computing.
+- **Export** (`backend/src/services/exportService.ts`) — new
+  `projectType === 'microcapsule'` branch → focused exporter (Excel + CSV + JSON
+  metrics) with the columns above, complete capsules only, + summary sheet
+  (count analysed, total detected, mean/min/max area & compactness).
+- **`backend/src/services/export/exportDocs.ts`** — microcapsule metrics-guide
+  branch (defines area/perimeter/compactness, explains the completeness filter).
+- COCO/YOLO/JSON annotation export and the visualization export are **inherited**
+  unchanged (each external polygon already exports as one instance).
+
+### 5. Editor + visualization (grey cut-off capsules)
+
+- **`CanvasPolygon.tsx`** — `complete === false` → grey stroke/fill; everything
+  else unchanged. **Add `complete` to the `React.memo` comparator** (failure
+  pattern #5: a prop not in the comparator never re-renders).
+- **`backend/src/services/visualization/visualizationGenerator.ts`** — grey for
+  `complete === false`, mirroring the model overlay; complete capsules use the
+  normal external colour + numbering.
+
+### 6. Registry + i18n
+
+- **`src/types/index.ts`** — add `'microcapsule'` to `PROJECT_TYPES`
+  (**byte-identical** to BE, enforced by `scripts/verify-shared-types.cjs`).
+- **`src/lib/models/modelRegistry.ts`** — `microcapsule` entry: `size:'small'`,
+  `defaultThreshold:0.25`, `category:'microcapsule'`, performance (~0.1 s),
+  `name:'Microcapsule'`, `displayName:'Microcapsule (YOLO11n-seg)'`, description,
+  `i18nKey:'microcapsule'`, `compatibleProjectTypes:['microcapsule']`.
+- **i18n** — all 6 of `src/translations/{en,cs,es,de,fr,zh}.ts`:
+  `projects.types.microcapsule`, `settings.modelSelection.models.microcapsule.{name,description}`,
+  `settings.modelDescription.microcapsule`. Validate `node scripts/check-i18n.cjs`.
+- Project-type picker (`NewProject.tsx`, `ProjectDialogForm.tsx`) auto-populates
+  from `PROJECT_TYPES`; model selector is registry-driven — no edits there.
+
+---
+
+## Testing
+
+- **Python (ML):** a wrapper unit test that loads `MicrocapsuleModel` against the
+  real weights on a synthetic circles image and asserts: instances returned;
+  border-touching circles flagged `complete=False`; fully-interior circles
+  `complete=True`; `area_px` matches `cv2.contourArea` within tolerance. Guard
+  with `importorskip('ultralytics')` + weights-exist skip (pytest absent in
+  container — runnable via the GPU one-off recipe in memory
+  `reference_run_ml_python_tests`).
+- **Backend (Jest):**
+  - `metricsCalculator` excludes `complete === false` polygons and includes
+    `complete !== false` / undefined.
+  - `exportService` routes `microcapsule` to the focused exporter; emitted
+    columns match the spec; cut-off capsules absent from rows.
+  - `modelRegistry` contains `microcapsule` ↔ `['microcapsule']` and the derived
+    compatibility map is correct (registry already has a parity test).
+- **Frontend (Vitest):**
+  - `metricCalculations` circularity == 1.0 (±ε) for a regular polygon
+    approximating a circle; compactness label maps to circularity value.
+  - per-capsule metrics filter drops `complete === false`.
+- **Shared-types:** `verify-shared-types.cjs` passes (PROJECT_TYPES parity).
+
+Per CLAUDE.md, tests are necessary but **not** sufficient — see Verification.
+
+---
+
+## Verification (cross-stack gate F — mandatory before "done")
+
+1. `make build-service SERVICE=ml` → in-container assert `import cv2` (headless,
+   single copy) + `from ultralytics import YOLO` + `MicrocapsuleModel` loads the
+   weights and runs on a synthetic image (logs `inference with microcapsule`).
+2. `make build-service SERVICE=backend` + `frontend`; `make ci` green.
+3. Playwright (inject-JWT pattern) on dev:
+   - Create a **microcapsule** project (type appears in the picker, localized).
+   - Upload the synthetic circles image; segment with the microcapsule model.
+   - Confirm DB `segmentations.model === 'microcapsule'` + `updatedAt` fresh
+     (enqueue 200 is not proof — compat is enforced in the worker).
+   - Editor: complete capsules coloured + numbered; cut-off capsules grey;
+     metrics panel shows Area/Perimeter/Compactness for complete only.
+   - Export → download Excel; assert focused columns + cut-off capsules absent.
+   - `browser_console_messages` length 0 (any error = blocker).
+
+Dev only. **Production deploy is gated on explicit user go-ahead.**
+
+---
+
+## Risks & mitigations
+
+| Risk                                                                 | Mitigation                                                                                                                                                                         |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ultralytics` drags non-headless `opencv-python` → duplicate `cv2`   | Dockerfile reconciles to single headless build; verify `import cv2` in image.                                                                                                      |
+| New polygon field silently stripped before metrics                   | Whitelist `complete`/`confidence` through all 5 field-stripping stages; assert it survives via a real segment + DB read.                                                           |
+| `React.memo` comparator misses `complete` → grey state never renders | Add `complete` to `CanvasPolygon` comparator (explicit checklist item).                                                                                                            |
+| FE vs BE metric numbers disagree                                     | Enforce the exclusion filter in **both** engines, keyed on the same field.                                                                                                         |
+| No real sample image for E2E                                         | Use a synthetic bright-field-style circles image with known interior/border split — deterministic for the completeness logic. Smoke-test real-weight detection in-container first. |
+| Torch pin bump                                                       | None needed; `ultralytics` is satisfied by `torch==2.6.0`.                                                                                                                         |
+
+---
+
+## Out of scope
+
+- Retraining / SAM-3 teacher path (the `training/` folder ships for
+  reproducibility only).
+- Cross-frame tracking / kymograph (microcapsules are single images).
+- Exposing a per-image confidence-threshold slider (fixed default 0.25; can be a
+  follow-up).

--- a/docs/superpowers/specs/2026-06-22-microcapsule-project-type-design.md
+++ b/docs/superpowers/specs/2026-06-22-microcapsule-project-type-design.md
@@ -2,7 +2,20 @@
 
 **Date:** 2026-06-22
 **Branch:** `feat-microcapsule-project-type`
-**Status:** Approved — implementing autonomously per user instruction
+**Status:** Implemented + deployed
+
+> **Update (2026-06-22, post-deploy):** the segmentation **model** changed from
+> the delivered YOLO11n-seg student to the **Meta SAM 3 teacher directly**
+> (Promptable Concept Segmentation, prompt `"circle"`). On live data the YOLO
+> student's low-resolution masks showed an 8×8-pixel block "flat edges on the
+> sides" artifact, and contour-smoothing to fix it clipped the boundary inward.
+> SAM 3 returns full-resolution masks → clean circular boundaries; nested masks
+> per capsule are merged (`merge_nested`, 0.88) and simplified with
+> `approxPolyDP(1.5)` (no inward shrink). Integrated via the standalone `sam3`
+> package (no `transformers` bump; numpy 1.24→1.26 and smp 0.3.4→0.5.0, both
+> verified safe). Everything below about the project type, metrics, exclusion of
+> border-cut capsules, export and editor still holds — only the model wrapper
+> and its dependencies differ.
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,8 @@ export default tseslint.config(
     ignores: [
       'dist',
       '**/dist/**',
+      'coverage',
+      '**/coverage/**',
       '**/*.d.ts',
       'characteristic_functions.py',
       // Migrated from .eslintignore
@@ -27,6 +29,12 @@ export default tseslint.config(
       // gitignored, never shipped, and may contain bare-expression
       // timestamp files that we don't want to lint.
       '.remember/**',
+      // `.claude/` is gitignored agent scratch space. It can hold nested
+      // git worktrees (full repo copies) whose `backend/**` subtrees are
+      // NOT matched by the root `backend/**` ignore above (that pattern only
+      // matches paths starting with `backend/`). Without this, `eslint .`
+      // lints other agents' in-flight worktrees and fails on their debt.
+      '.claude/**',
     ],
   },
   {

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Menu, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -44,6 +44,11 @@ const DashboardHeader = () => {
   const [mlServiceStatus, setMlServiceStatus] = useState<
     'idle' | 'processing' | 'error'
   >('idle');
+  // Mirror of mlServiceStatus readable inside the polling timeout without
+  // re-subscribing the effect — used to poll faster while in an error state so
+  // the indicator self-heals without a manual page refresh.
+  const mlStatusRef = useRef(mlServiceStatus);
+  mlStatusRef.current = mlServiceStatus;
   const { user } = useAuth();
   const { selectedModel: _selectedModel, getSelectedModelInfo } =
     useLocalizedModels();
@@ -145,11 +150,26 @@ const DashboardHeader = () => {
       }
     };
 
-    // Check immediately and then every 30 seconds (reduced frequency)
-    checkMlServiceStatus();
-    const interval = setInterval(checkMlServiceStatus, 30000);
+    // Check immediately, then self-heal: while the indicator is in an error
+    // state poll every 5s so it recovers on its own (e.g. after the ML service
+    // finishes loading a heavy model like SAM 3, or a transient blip) WITHOUT a
+    // manual page refresh; back off to 30s once the service is reachable again.
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const delay = mlStatusRef.current === 'error' ? 5000 : 30000;
+      timeoutId = setTimeout(async () => {
+        await checkMlServiceStatus();
+        scheduleNext();
+      }, delay);
+    };
+    checkMlServiceStatus().finally(scheduleNext);
 
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   // Determine status dot color

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -28,6 +28,8 @@ const PROJECT_TYPE_BADGE: Record<ProjectType, string> = {
     'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200 border-purple-300 dark:border-purple-700',
   microtubules:
     'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-200 border-cyan-300 dark:border-cyan-700',
+  microcapsule:
+    'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200 border-rose-300 dark:border-rose-700',
 };
 
 interface ProjectHeaderProps {

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -68,6 +68,10 @@ const ModelSettingsSection = () => {
     () => availableModels.filter(m => m.category === 'microtubule'),
     [availableModels]
   );
+  const microcapsuleModels = useMemo(
+    () => availableModels.filter(m => m.category === 'microcapsule'),
+    [availableModels]
+  );
 
   const handleModelChange = (modelId: string) => {
     setSelectedModel(modelId as ModelType);
@@ -223,6 +227,17 @@ const ModelSettingsSection = () => {
                   </h4>
                 </div>
                 {microtubuleModels.map(renderModelCard)}
+              </>
+            )}
+
+            {microcapsuleModels.length > 0 && (
+              <>
+                <div className="pt-2">
+                  <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                    {t('settings.modelSelection.sections.microcapsule')}
+                  </h4>
+                </div>
+                {microcapsuleModels.map(renderModelCard)}
               </>
             )}
           </div>

--- a/src/hooks/__tests__/useLocalizedModels.test.ts
+++ b/src/hooks/__tests__/useLocalizedModels.test.ts
@@ -132,10 +132,10 @@ describe('useLocalizedModels', () => {
       const models = result.current.getAllModels();
 
       // Registry: hrnet, cbam_resunet, unet_spherohq, unet_attention_aspp,
-      // segformer, mamba_unet, sperm, wound, microtubule.
-      // Count updated from 6 → 9 after PRs #221 (Mamba-UNet) and SegFormer/MT additions.
+      // segformer, mamba_unet, sperm, wound, microtubule, microcapsule.
+      // Count updated 6 → 9 (Mamba-UNet, SegFormer, MT) → 10 (microcapsule).
       // If this count changes intentionally, update here.
-      expect(models).toHaveLength(9);
+      expect(models).toHaveLength(10);
       const ids = models.map(m => m.id);
       expect(ids).toContain('hrnet');
       expect(ids).toContain('cbam_resunet');
@@ -146,6 +146,7 @@ describe('useLocalizedModels', () => {
       expect(ids).toContain('sperm');
       expect(ids).toContain('wound');
       expect(ids).toContain('microtubule');
+      expect(ids).toContain('microcapsule');
     });
 
     it('each model has a non-empty name and description', () => {
@@ -174,8 +175,8 @@ describe('useLocalizedModels', () => {
       const { result } = renderHook(() => useLocalizedModels());
 
       // availableModels is the result of getAllModels() called during render.
-      // Count updated from 6 → 9 after model additions (Mamba-UNet, SegFormer, MT).
-      expect(result.current.availableModels).toHaveLength(9);
+      // Count updated 6 → 9 (Mamba-UNet, SegFormer, MT) → 10 (microcapsule).
+      expect(result.current.availableModels).toHaveLength(10);
     });
   });
 

--- a/src/lib/__tests__/modelUtils.test.ts
+++ b/src/lib/__tests__/modelUtils.test.ts
@@ -60,6 +60,7 @@ describe('getSpheroidPreset', () => {
     'sperm',
     'wound',
     'microtubule',
+    'microcapsule',
     'unet_attention_aspp',
   ];
   for (const id of nonSpheroidModels) {
@@ -114,9 +115,10 @@ describe('BASIC_MODEL_INFO', () => {
     'sperm',
     'wound',
     'microtubule',
+    'microcapsule',
   ];
 
-  it('contains all 9 model ids', () => {
+  it('contains all 10 model ids', () => {
     for (const id of allModelIds) {
       expect(BASIC_MODEL_INFO[id]).toBeDefined();
       expect(BASIC_MODEL_INFO[id].id).toBe(id);
@@ -291,8 +293,8 @@ describe('getLocalizedModelInfo', () => {
 describe('getAllLocalizedModels', () => {
   const passthroughT = (key: string) => key;
 
-  it('returns 9 models', () => {
-    expect(getAllLocalizedModels(passthroughT)).toHaveLength(9);
+  it('returns 10 models', () => {
+    expect(getAllLocalizedModels(passthroughT)).toHaveLength(10);
   });
 
   it('contains all model ids exactly once', () => {
@@ -307,17 +309,18 @@ describe('getAllLocalizedModels', () => {
       'sperm',
       'wound',
       'microtubule',
+      'microcapsule',
     ];
     for (const id of expectedIds) {
       expect(ids).toContain(id);
     }
     // No duplicates
-    expect(new Set(ids).size).toBe(9);
+    expect(new Set(ids).size).toBe(10);
   });
 
-  it('preserves order: hrnet first, microtubule last', () => {
+  it('preserves order: hrnet first, microcapsule last', () => {
     const models = getAllLocalizedModels(passthroughT);
     expect(models[0].id).toBe('hrnet');
-    expect(models[models.length - 1].id).toBe('microtubule');
+    expect(models[models.length - 1].id).toBe('microcapsule');
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -116,6 +116,10 @@ export interface SegmentationPolygon {
   /** Human-friendly label set in the editor. Mirrored across sibling
    *  frames by the BE on save when the polyline carries a trackId. */
   name?: string;
+  /** Microcapsule completeness flag: `false` when the capsule is cut off by
+   *  the image border. Drives grey rendering in the editor and exclusion from
+   *  metrics. Absent for other project types. */
+  complete?: boolean;
 }
 
 export interface SegmentationResultData {
@@ -1747,6 +1751,10 @@ class ApiClient {
                       ? poly.confidence
                       : undefined,
                   area: typeof poly.area === 'number' ? poly.area : undefined,
+                  complete:
+                    typeof poly.complete === 'boolean'
+                      ? poly.complete
+                      : undefined,
                 };
               })
               .filter(Boolean)

--- a/src/lib/models/__tests__/modelRegistry.test.ts
+++ b/src/lib/models/__tests__/modelRegistry.test.ts
@@ -241,7 +241,7 @@ describe('model registry SSOT', () => {
         displayName: 'Microcapsule (SAM 3)',
         description:
           'Instance segmentation for microcapsules (round objects) in bright-field microscopy. Meta SAM 3 with the "circle" prompt returns one clean, full-resolution boundary per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
-        size: 'medium',
+        size: 'large',
         defaultThreshold: 0.3,
         category: 'microcapsule',
         performance: {

--- a/src/lib/models/__tests__/modelRegistry.test.ts
+++ b/src/lib/models/__tests__/modelRegistry.test.ts
@@ -27,6 +27,7 @@ const CANONICAL_IDS: ModelType[] = [
   'sperm',
   'wound',
   'microtubule',
+  'microcapsule',
 ];
 
 const MODEL_INFO_KEYS: Array<keyof ModelInfo> = [
@@ -41,13 +42,13 @@ const MODEL_INFO_KEYS: Array<keyof ModelInfo> = [
 ];
 
 describe('model registry SSOT', () => {
-  it('registry keys are exactly the canonical 9 models, in order', () => {
+  it('registry keys are exactly the canonical 10 models, in order', () => {
     expect(Object.keys(MODEL_REGISTRY)).toEqual(CANONICAL_IDS);
     expect(ALL_MODEL_IDS).toEqual(CANONICAL_IDS);
-    expect(ALL_MODEL_IDS).toHaveLength(9);
+    expect(ALL_MODEL_IDS).toHaveLength(10);
   });
 
-  it('getAllLocalizedModels() returns the 9 models in display order', () => {
+  it('getAllLocalizedModels() returns the 10 models in display order', () => {
     // Passthrough t returns the key itself; we only assert id ordering here.
     const models = getAllLocalizedModels((k: string) => k);
     expect(models.map(m => m.id)).toEqual(CANONICAL_IDS);
@@ -66,6 +67,7 @@ describe('model registry SSOT', () => {
       wound: ['wound'],
       sperm: ['sperm'],
       microtubules: ['microtubule'],
+      microcapsule: ['microcapsule'],
     });
   });
 
@@ -233,6 +235,22 @@ describe('model registry SSOT', () => {
           batchSize: 1,
         },
       },
+      microcapsule: {
+        id: 'microcapsule',
+        name: 'Microcapsule',
+        displayName: 'Microcapsule (YOLO11n-seg)',
+        description:
+          'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
+        size: 'small',
+        defaultThreshold: 0.25,
+        category: 'microcapsule',
+        performance: {
+          avgTimePerImage: 0.1,
+          throughput: 8.0,
+          p95Latency: 0.2,
+          batchSize: 1,
+        },
+      },
     });
   });
 
@@ -247,6 +265,7 @@ describe('model registry SSOT', () => {
       sperm: 'sperm',
       wound: 'wound',
       microtubule: 'microtubule',
+      microcapsule: 'microcapsule',
     });
   });
 });

--- a/src/lib/models/__tests__/modelRegistry.test.ts
+++ b/src/lib/models/__tests__/modelRegistry.test.ts
@@ -238,16 +238,16 @@ describe('model registry SSOT', () => {
       microcapsule: {
         id: 'microcapsule',
         name: 'Microcapsule',
-        displayName: 'Microcapsule (YOLO11n-seg)',
+        displayName: 'Microcapsule (SAM 3)',
         description:
-          'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
-        size: 'small',
-        defaultThreshold: 0.25,
+          'Instance segmentation for microcapsules (round objects) in bright-field microscopy. Meta SAM 3 with the "circle" prompt returns one clean, full-resolution boundary per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
+        size: 'large',
+        defaultThreshold: 0.3,
         category: 'microcapsule',
         performance: {
-          avgTimePerImage: 0.1,
-          throughput: 8.0,
-          p95Latency: 0.2,
+          avgTimePerImage: 1.0,
+          throughput: 1.0,
+          p95Latency: 1.5,
           batchSize: 1,
         },
       },

--- a/src/lib/models/__tests__/modelRegistry.test.ts
+++ b/src/lib/models/__tests__/modelRegistry.test.ts
@@ -241,7 +241,7 @@ describe('model registry SSOT', () => {
         displayName: 'Microcapsule (SAM 3)',
         description:
           'Instance segmentation for microcapsules (round objects) in bright-field microscopy. Meta SAM 3 with the "circle" prompt returns one clean, full-resolution boundary per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
-        size: 'large',
+        size: 'medium',
         defaultThreshold: 0.3,
         category: 'microcapsule',
         performance: {

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -239,20 +239,20 @@ export const MODEL_REGISTRY = {
     compatibleProjectTypes: ['microtubules'],
   },
   microcapsule: {
-    size: 'small',
-    defaultThreshold: 0.25,
+    size: 'large',
+    defaultThreshold: 0.3,
     category: 'microcapsule',
     performance: {
-      // YOLO11n-seg (~6 MB). Sub-second on CPU, faster on the A5000.
-      avgTimePerImage: 0.1,
-      throughput: 8.0,
-      p95Latency: 0.2,
+      // Meta SAM 3 (~3.4 GB). ~1 s/image on the A5000.
+      avgTimePerImage: 1.0,
+      throughput: 1.0,
+      p95Latency: 1.5,
       batchSize: 1,
     },
     name: 'Microcapsule',
-    displayName: 'Microcapsule (YOLO11n-seg)',
+    displayName: 'Microcapsule (SAM 3)',
     description:
-      'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
+      'Instance segmentation for microcapsules (round objects) in bright-field microscopy. Meta SAM 3 with the "circle" prompt returns one clean, full-resolution boundary per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
     i18nKey: 'microcapsule',
     compatibleProjectTypes: ['microcapsule'],
   },

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -239,7 +239,10 @@ export const MODEL_REGISTRY = {
     compatibleProjectTypes: ['microtubules'],
   },
   microcapsule: {
-    size: 'large',
+    // SAM 3 is a large checkpoint (~3.4 GB) but runs ~1 s/image — between the
+    // fast spheroid models and the slow microtubule. Tagged 'medium' (yellow
+    // badge) rather than 'large' (red, which reads as an error to users).
+    size: 'medium',
     defaultThreshold: 0.3,
     category: 'microcapsule',
     performance: {

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -24,13 +24,19 @@ export type ProjectTypeKey =
   | 'spheroid_invasive'
   | 'wound'
   | 'sperm'
-  | 'microtubules';
+  | 'microtubules'
+  | 'microcapsule';
 
 /** Coarse size bucket surfaced in the model picker UI. */
 export type ModelSize = 'small' | 'medium' | 'large';
 
 /** Catalogue category used to group models in settings. */
-export type ModelCategory = 'spheroid' | 'sperm' | 'wound' | 'microtubule';
+export type ModelCategory =
+  | 'spheroid'
+  | 'sperm'
+  | 'wound'
+  | 'microtubule'
+  | 'microcapsule';
 
 export interface ModelPerformance {
   avgTimePerImage: number; // seconds
@@ -231,6 +237,24 @@ export const MODEL_REGISTRY = {
       'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT-style fusion produces a per-pixel 32-d embedding that PySOAX uses to extract individual MT centerlines. The embedding also drives automatic cross-frame tracking for kymograph analysis. Slow (~8 s/frame) but the only model in the platform producing polyline output.',
     i18nKey: 'microtubule',
     compatibleProjectTypes: ['microtubules'],
+  },
+  microcapsule: {
+    size: 'small',
+    defaultThreshold: 0.25,
+    category: 'microcapsule',
+    performance: {
+      // YOLO11n-seg (~6 MB). Sub-second on CPU, faster on the A5000.
+      avgTimePerImage: 0.1,
+      throughput: 8.0,
+      p95Latency: 0.2,
+      batchSize: 1,
+    },
+    name: 'Microcapsule',
+    displayName: 'Microcapsule (YOLO11n-seg)',
+    description:
+      'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are flagged and excluded from metrics (area, perimeter, compactness).',
+    i18nKey: 'microcapsule',
+    compatibleProjectTypes: ['microcapsule'],
   },
 } as const satisfies Record<string, ModelRegistryEntry>;
 

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -239,10 +239,7 @@ export const MODEL_REGISTRY = {
     compatibleProjectTypes: ['microtubules'],
   },
   microcapsule: {
-    // SAM 3 is a large checkpoint (~3.4 GB) but runs ~1 s/image — between the
-    // fast spheroid models and the slow microtubule. Tagged 'medium' (yellow
-    // badge) rather than 'large' (red, which reads as an error to users).
-    size: 'medium',
+    size: 'large',
     defaultThreshold: 0.3,
     category: 'microcapsule',
     performance: {

--- a/src/lib/segmentation.ts
+++ b/src/lib/segmentation.ts
@@ -35,6 +35,11 @@ export interface Polygon {
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat with rows stored before sperm model)
   partClass?: PolygonPartClass;
   instanceId?: string;
+  /** Microcapsule completeness flag written by the instance model: `false`
+   *  when the capsule's mask is cut off by the image border. Such capsules are
+   *  drawn grey in the editor and excluded from metrics. Absent for other
+   *  project types. */
+  complete?: boolean;
   /** Cross-frame microtubule track ID; populated by the tracker after a
    *  video container's batch finishes segmentation. Equal across frames
    *  for sibling polylines representing the same MT over time. */

--- a/src/pages/export/hooks/useExportFunctions.ts
+++ b/src/pages/export/hooks/useExportFunctions.ts
@@ -62,8 +62,11 @@ export const useExportFunctions = (
   const calculateObjectMetrics = async (polygons: PolygonData[]) => {
     if (!polygons || polygons.length === 0) return null;
 
-    // Get external polygons
-    const externalPolygons = polygons.filter(p => p.type === 'external');
+    // Get external polygons (excluding border-cut microcapsules, which carry
+    // complete === false and must not contribute to metrics).
+    const externalPolygons = polygons.filter(
+      p => p.type === 'external' && p.complete !== false
+    );
     if (externalPolygons.length === 0) return null;
 
     // Get all internal polygons

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -143,6 +143,13 @@ const CanvasPolygon = React.memo(
 
     // Determine path color based on polygon type, polyline partClass, and selection status
     const pathColor = useMemo(() => {
+      // Microcapsules cut off by the image border (complete === false) render
+      // grey — they're excluded from metrics, and greying keeps them visibly
+      // distinct from the whole capsules that ARE measured (mirrors the model
+      // overlay's grey treatment).
+      if (polygon.complete === false) {
+        return isSelected ? '#737373' : '#969696';
+      }
       // Spheroid 'core' (closed polygon, dense central region from ASPP model)
       if (!isPolyline && polygon.partClass === 'core') {
         return isSelected ? '#16a34a' : '#22c55e'; // green
@@ -178,6 +185,7 @@ const CanvasPolygon = React.memo(
       polygon.partClass,
       polygon.instanceId,
       polygon.trackId,
+      polygon.complete,
       isSelected,
       isInternal,
     ]);
@@ -437,6 +445,7 @@ const CanvasPolygon = React.memo(
       prevProps.polygon.class === nextProps.polygon.class &&
       prevProps.polygon.instanceId === nextProps.polygon.instanceId &&
       prevProps.polygon.trackId === nextProps.polygon.trackId &&
+      prevProps.polygon.complete === nextProps.polygon.complete &&
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isHovered === nextProps.isHovered &&
       prevProps.isUndoRedoInProgress === nextProps.isUndoRedoInProgress &&

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -334,11 +334,13 @@ const CanvasPolygon = React.memo(
             fill={
               isPolyline
                 ? 'none'
-                : polygon.partClass === 'core'
-                  ? 'rgba(34, 197, 94, 0.25)' // green core (#22c55e at 25%)
-                  : isInternal
-                    ? 'rgba(14, 165, 233, 0.1)'
-                    : 'rgba(239, 68, 68, 0.1)'
+                : polygon.complete === false
+                  ? 'rgba(150, 150, 150, 0.18)' // grey fill for cut-off capsules
+                  : polygon.partClass === 'core'
+                    ? 'rgba(34, 197, 94, 0.25)' // green core (#22c55e at 25%)
+                    : isInternal
+                      ? 'rgba(14, 165, 233, 0.1)'
+                      : 'rgba(239, 68, 68, 0.1)'
             }
             stroke={pathColor}
             strokeWidth={Math.max(strokeWidth * hoverStrokeMultiplier, 0.5)}

--- a/src/pages/segmentation/components/project/export/ExcelExporter.tsx
+++ b/src/pages/segmentation/components/project/export/ExcelExporter.tsx
@@ -24,10 +24,13 @@ const ExcelExporter: React.FC<ExcelExporterProps> = ({
     if (!segmentation || !segmentation.polygons) return;
 
     try {
-      // Get only external polygons (exclude polylines — those have separate sperm metrics)
+      // Get only external polygons (exclude polylines — those have separate sperm metrics).
+      // Also exclude border-cut microcapsules (complete === false) from metrics.
       const externalPolygons = segmentation.polygons.filter(
         polygon =>
-          polygon.type === 'external' && polygon.geometry !== 'polyline'
+          polygon.type === 'external' &&
+          polygon.geometry !== 'polyline' &&
+          polygon.complete !== false
       );
 
       // Get all internal polygons

--- a/src/pages/segmentation/components/project/export/MetricsDisplay.tsx
+++ b/src/pages/segmentation/components/project/export/MetricsDisplay.tsx
@@ -37,10 +37,15 @@ const MetricsDisplay: React.FC<MetricsDisplayProps> = ({ segmentation }) => {
     downloadJSON(data, baseFilename);
   };
 
-  // Get external polygons for metrics (exclude polylines)
+  // Get external polygons for metrics (exclude polylines). Also exclude
+  // border-cut microcapsules (complete === false): they are not measured, so
+  // they must not appear in the metrics panel. Other project types never set
+  // `complete`, so `!== false` leaves them untouched.
   const externalPolygons = segmentation.polygons.filter(
     polygon =>
-      polygon.type === 'external' && (polygon as any).geometry !== 'polyline'
+      polygon.type === 'external' &&
+      (polygon as any).geometry !== 'polyline' &&
+      polygon.complete !== false
   );
 
   // Get all internal polygons

--- a/src/pages/segmentation/hooks/__tests__/insertPointsBetweenVertices.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/insertPointsBetweenVertices.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the Add Points arc-selection contract.
+ *
+ * When a sequence is drawn between two vertices it replaces one of the two
+ * boundary arcs. The requested behavior is to KEEP whichever candidate has the
+ * LARGER perimeter (the sequence joins the bigger portion of the outline).
+ */
+import { describe, it, expect } from 'vitest';
+import { insertPointsBetweenVertices } from '../useAdvancedInteractions';
+import { calculatePolygonPerimeter } from '@/lib/polygonGeometry';
+import type { Point } from '@/lib/segmentation';
+
+const square: Point[] = [
+  { x: 0, y: 0 }, // 0
+  { x: 10, y: 0 }, // 1
+  { x: 10, y: 10 }, // 2
+  { x: 0, y: 10 }, // 3
+];
+
+const includesPoint = (pts: Point[], p: Point) =>
+  pts.some(q => q.x === p.x && q.y === p.y);
+
+describe('insertPointsBetweenVertices — keeps the larger-perimeter arc', () => {
+  it('keeps the 3-edge outer arc (not the single inner edge) for adjacent vertices', () => {
+    // Sequence between vertices 0 and 1 (the bottom edge). Keeping the larger
+    // result means retaining the other three edges (vertices 2 and 3) plus the
+    // new point, not collapsing to a small triangle on the bottom edge.
+    const seq: Point[] = [{ x: 5, y: -5 }];
+    const result = insertPointsBetweenVertices(square, 0, 1, seq)!;
+
+    expect(includesPoint(result, { x: 10, y: 10 })).toBe(true); // vertex 2 kept
+    expect(includesPoint(result, { x: 0, y: 10 })).toBe(true); // vertex 3 kept
+    expect(includesPoint(result, { x: 5, y: -5 })).toBe(true); // new point added
+  });
+
+  it('returns whichever candidate has the larger perimeter', () => {
+    const seq: Point[] = [{ x: 5, y: 5 }];
+    const result = insertPointsBetweenVertices(square, 1, 3, seq)!;
+
+    // Reconstruct the two candidates the function chooses between and assert the
+    // returned one is the larger-perimeter candidate.
+    const keepInner: Point[] = [square[1], square[2], square[3], seq[0]]; // inner arc 1->2->3 + seq
+    const keepOuter: Point[] = [square[3], square[0], square[1], seq[0]]; // outer arc 3->0->1 + seq
+    const pInner = calculatePolygonPerimeter(keepInner);
+    const pOuter = calculatePolygonPerimeter(keepOuter);
+    const resultPerimeter = calculatePolygonPerimeter(result);
+
+    expect(resultPerimeter).toBeCloseTo(Math.max(pInner, pOuter), 6);
+  });
+
+  it('orients the drawn sequence regardless of click order (start > end)', () => {
+    const seq: Point[] = [{ x: 5, y: -5 }];
+    // Clicking end vertex first (2) then start (0) must produce the same shape
+    // as clicking 0 then 2 — the sequence is oriented internally.
+    const a = insertPointsBetweenVertices(square, 0, 2, seq)!;
+    const b = insertPointsBetweenVertices(square, 2, 0, seq)!;
+    expect(calculatePolygonPerimeter(a)).toBeCloseTo(
+      calculatePolygonPerimeter(b),
+      6
+    );
+  });
+
+  it('is a no-op for adjacent vertices with no new points', () => {
+    expect(insertPointsBetweenVertices(square, 0, 1, [])).toBe(square);
+  });
+});

--- a/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
+++ b/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
@@ -1013,69 +1013,57 @@ export const useAdvancedInteractions = ({
  * Helper function to insert points between vertices using normalized path logic
  * Ensures consistent behavior regardless of click order (A→B vs B→A)
  */
-function insertPointsBetweenVertices(
+export function insertPointsBetweenVertices(
   originalPoints: Point[],
   startVertexIndex: number,
   endVertexIndex: number,
   newPoints: Point[]
 ): Point[] | null {
-  // Inserts new points between two vertices, creating two candidate polygons
-  // and selecting the one with the smaller perimeter (preserves original boundary).
+  // The two clicked vertices split the boundary into two arcs (the "inner" arc
+  // running directly between them by index, and the "outer" arc that wraps the
+  // other way). The newly drawn sequence replaces ONE arc. We build both
+  // genuinely-different candidates and KEEP whichever has the LARGER perimeter —
+  // i.e. the sequence joins the bigger portion of the outline. (Requested
+  // behavior: Add Points always grows toward the larger-perimeter result.)
 
   const numPoints = originalPoints.length;
 
-  // Normalize vertices to ensure consistent behavior
-  // Always work with the smaller index as vertex1 and larger as vertex2
+  // Normalize so vertex1 is the smaller index and vertex2 the larger.
   const vertex1 = Math.min(startVertexIndex, endVertexIndex);
   const vertex2 = Math.max(startVertexIndex, endVertexIndex);
 
-  // If adjacent vertices and no points to add, nothing to do
+  // Adjacent vertices with nothing to add: no-op.
   if (
     newPoints.length === 0 &&
-    (Math.abs(vertex1 - vertex2) === 1 ||
-      Math.abs(vertex1 - vertex2) === numPoints - 1)
+    (vertex2 - vertex1 === 1 || (vertex1 === 0 && vertex2 === numPoints - 1))
   ) {
     return originalPoints;
   }
 
-  // Determine if the new points should be reversed based on original click order
-  const shouldReverseNewPoints = startVertexIndex > endVertexIndex;
-  const finalNewPoints = shouldReverseNewPoints
-    ? [...newPoints].reverse()
-    : newPoints;
+  // Orient the drawn sequence to run vertex1 -> vertex2 (clicks may be in
+  // either order).
+  const seq =
+    startVertexIndex > endVertexIndex ? [...newPoints].reverse() : newPoints;
 
-  // Create two candidate polygons
-  const candidate1Points: Point[] = []; // Replace direct path
-  const candidate2Points: Point[] = []; // Replace wrapped path
+  // Inner arc: vertex1 -> vertex1+1 -> ... -> vertex2 (direct, by index).
+  const innerArc: Point[] = [];
+  for (let i = vertex1; i <= vertex2; i++) innerArc.push(originalPoints[i]);
 
-  // Candidate 1: Replace direct path (vertex1 to vertex2)
-  // Keep: [0...vertex1] + newPoints + [vertex2...numPoints-1]
-  for (let i = 0; i <= vertex1; i++) {
-    candidate1Points.push(originalPoints[i]);
-  }
-  candidate1Points.push(...finalNewPoints);
-  for (let i = vertex2; i < numPoints; i++) {
-    candidate1Points.push(originalPoints[i]);
-  }
+  // Outer arc: vertex2 -> ... -> numPoints-1 -> 0 -> ... -> vertex1 (wrapped).
+  const outerArc: Point[] = [];
+  for (let i = vertex2; i < numPoints; i++) outerArc.push(originalPoints[i]);
+  for (let i = 0; i <= vertex1; i++) outerArc.push(originalPoints[i]);
 
-  // Candidate 2: Replace wrapped path (vertex2 to vertex1 going around)
-  // Keep only the direct path vertices and replace wrapped path with newPoints
-  candidate2Points.push(originalPoints[vertex1]);
-  candidate2Points.push(...finalNewPoints);
-  candidate2Points.push(originalPoints[vertex2]);
+  // Candidate A — keep the inner arc; the sequence replaces the outer arc.
+  //   inner (v1..v2) then the sequence back (v2..v1).
+  const keepInner = [...innerArc, ...[...seq].reverse()];
+  // Candidate B — keep the outer arc; the sequence replaces the inner arc.
+  //   outer (v2..v1 wrapped) then the sequence forward (v1..v2).
+  const keepOuter = [...outerArc, ...seq];
 
-  // Add the remaining points (wrapped path) by going from vertex2 to vertex1
-  let idx = (vertex2 + 1) % numPoints;
-  while (idx !== vertex1) {
-    candidate2Points.push(originalPoints[idx]);
-    idx = (idx + 1) % numPoints;
-  }
+  const perimeterInner = calculatePolygonPerimeter(keepInner);
+  const perimeterOuter = calculatePolygonPerimeter(keepOuter);
 
-  // Calculate perimeters and choose the one with smaller perimeter.
-  // The candidate closer to the original polygon shape is the correct one,
-  // as adding points refines the boundary rather than replacing it.
-  const perimeter1 = calculatePolygonPerimeter(candidate1Points);
-  const perimeter2 = calculatePolygonPerimeter(candidate2Points);
-
-  return perimeter1 <= perimeter2 ? candidate1Points : candidate2Points;
+  // Keep the larger-perimeter result.
+  return perimeterInner >= perimeterOuter ? keepInner : keepOuter;
 }

--- a/src/pages/segmentation/hooks/useResegment.ts
+++ b/src/pages/segmentation/hooks/useResegment.ts
@@ -88,6 +88,7 @@ export function useResegment({
     if (projectType === 'microtubules') return 'microtubule';
     if (projectType === 'sperm') return 'sperm';
     if (projectType === 'wound') return 'wound';
+    if (projectType === 'microcapsule') return 'microcapsule';
     if (projectType === 'spheroid_invasive') return 'unet_attention_aspp';
     return selectedModel;
   }, [projectType, selectedModel]);

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -218,6 +218,7 @@ export default {
       wound: 'Hojení ran',
       sperm: 'Spermie',
       microtubules: 'Mikrotubuly',
+      microcapsule: 'Mikrokapsle',
     },
     projectNamePlaceholder: 'např. HeLa buněčné sferoidy',
     projectDescPlaceholder:
@@ -437,6 +438,7 @@ export default {
         sperm: 'Modely spermií',
         wound: 'Modely hojení ran',
         microtubule: 'Modely mikrotubulů',
+        microcapsule: 'Modely mikrokapsulí',
       },
       presets: {
         fast: 'Rychlý',
@@ -495,6 +497,11 @@ export default {
           description:
             'Instanční segmentace mikrotubulů pro IRM/TIRF časosběrná videa. DINOv3-L ViT-L/16 + DPT fúze dává centerline polyline per MT a 32-d embedding na pixel, který umožňuje cross-frame tracking a generování kymografu. ~8 s/frame; jediný model v platformě s nativním polyline výstupem.',
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            'Instanční segmentace mikrokapsulí (kulatých objektů) v mikroskopii světlého pole. Kompaktní model YOLO11n-seg (~6 MB, destilovaný z SAM 3) vrací jeden polygon na kapsuli s hodnotou spolehlivosti; kapsule přesahující okraj snímku jsou vyloučeny z metrik (plocha, obvod, kompaktnost).',
+        },
       },
     },
     detectHoles: 'Detekce Děr',
@@ -526,6 +533,8 @@ export default {
         'U-Net + MiT-B5 (SegFormer enkodér) model pro segmentaci ran v mikroskopii scratch-assay. Jedna binární oblast rány na snímek; ideální pro časové řady hojení.',
       microtubule:
         'Instanční segmentace mikrotubulů pro IRM/TIRF mikroskopii. DINOv3-L + DPT enkodér, PySOAX postprocessing, nativní polyline výstup s tracking přes 32-d embedding.',
+      microcapsule:
+        'Instanční segmentace mikrokapsulí metodou YOLO11n-seg — plocha, obvod a kompaktnost každé kapsule; kapsule přesahující okraj snímku jsou vyloučeny z metrik (~6 MB, zpracování pod jednu sekundu na snímek).',
     },
     dataUsageTitle: 'Použití dat a soukromí',
     dataUsageDescription:

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -498,9 +498,9 @@ export default {
             'Instanční segmentace mikrotubulů pro IRM/TIRF časosběrná videa. DINOv3-L ViT-L/16 + DPT fúze dává centerline polyline per MT a 32-d embedding na pixel, který umožňuje cross-frame tracking a generování kymografu. ~8 s/frame; jediný model v platformě s nativním polyline výstupem.',
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            'Instanční segmentace mikrokapsulí (kulatých objektů) v mikroskopii světlého pole. Kompaktní model YOLO11n-seg (~6 MB, destilovaný z SAM 3) vrací jeden polygon na kapsuli s hodnotou spolehlivosti; kapsule přesahující okraj snímku jsou vyloučeny z metrik (plocha, obvod, kompaktnost).',
+            'Instanční segmentace mikrokapsulí (kulatých objektů) v mikroskopii světlého pole. Meta SAM 3 s promptem „circle" vrací jednu čistou hranici plného rozlišení na kapsuli s hodnotou spolehlivosti; kapsule přesahující okraj snímku jsou vyloučeny z metrik (plocha, obvod, kompaktnost).',
         },
       },
     },
@@ -534,7 +534,7 @@ export default {
       microtubule:
         'Instanční segmentace mikrotubulů pro IRM/TIRF mikroskopii. DINOv3-L + DPT enkodér, PySOAX postprocessing, nativní polyline výstup s tracking přes 32-d embedding.',
       microcapsule:
-        'Instanční segmentace mikrokapsulí metodou YOLO11n-seg — plocha, obvod a kompaktnost každé kapsule; kapsule přesahující okraj snímku jsou vyloučeny z metrik (~6 MB, zpracování pod jednu sekundu na snímek).',
+        'Instanční segmentace mikrokapsulí pomocí Meta SAM 3 (prompt „circle") — plocha, obvod a kompaktnost každé kapsule; kapsule přesahující okraj snímku jsou vyloučeny z metrik.',
     },
     dataUsageTitle: 'Použití dat a soukromí',
     dataUsageDescription:

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -500,7 +500,7 @@ export default {
         microcapsule: {
           name: 'Microcapsule (SAM 3)',
           description:
-            'Instanční segmentace mikrokapsulí (kulatých objektů) v mikroskopii světlého pole. Meta SAM 3 s promptem „circle" vrací jednu čistou hranici plného rozlišení na kapsuli s hodnotou spolehlivosti; kapsule přesahující okraj snímku jsou vyloučeny z metrik (plocha, obvod, kompaktnost).',
+            'Instanční segmentace mikrokapsulí (kulatých objektů) v mikroskopii světlého pole. Meta SAM 3 s promptem „circle“ vrací jednu čistou hranici plného rozlišení na kapsuli s hodnotou spolehlivosti; kapsule přesahující okraj snímku jsou vyloučeny z metrik (plocha, obvod, kompaktnost).',
         },
       },
     },
@@ -534,7 +534,7 @@ export default {
       microtubule:
         'Instanční segmentace mikrotubulů pro IRM/TIRF mikroskopii. DINOv3-L + DPT enkodér, PySOAX postprocessing, nativní polyline výstup s tracking přes 32-d embedding.',
       microcapsule:
-        'Instanční segmentace mikrokapsulí pomocí Meta SAM 3 (prompt „circle") — plocha, obvod a kompaktnost každé kapsule; kapsule přesahující okraj snímku jsou vyloučeny z metrik.',
+        'Instanční segmentace mikrokapsulí pomocí Meta SAM 3 (prompt „circle“) — plocha, obvod a kompaktnost každé kapsule; kapsule přesahující okraj snímku jsou vyloučeny z metrik.',
     },
     dataUsageTitle: 'Použití dat a soukromí',
     dataUsageDescription:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -518,9 +518,9 @@ export default {
             'Instanz-Segmentierung für IRM/TIRF-Mikrotubuli-Zeitrafferaufnahmen. DINOv3-L ViT-L/16 + DPT-Fusion liefert eine Centerline-Polylinie pro MT plus ein 32-d Embedding pro Pixel, das frameübergreifendes Tracking und Kymograph-Erzeugung ermöglicht. ~8 s/Bild; einziges Modell der Plattform mit nativer Polylinien-Ausgabe.',
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            'Instanz-Segmentierung für Mikrokapseln (runde Objekte) in der Hellfeld-Mikroskopie. Ein kompaktes YOLO11n-seg-Modell (~6 MB, aus SAM 3 destilliert) liefert ein Polygon pro Kapsel mit Konfidenzwert; am Bildrand abgeschnittene Kapseln werden von den Metriken (Fläche, Umfang, Kompaktheit) ausgeschlossen.',
+            'Instanz-Segmentierung für Mikrokapseln (runde Objekte) in der Hellfeld-Mikroskopie. Meta SAM 3 mit dem Prompt „circle" liefert eine saubere Kontur in voller Auflösung pro Kapsel mit Konfidenzwert; am Bildrand abgeschnittene Kapseln werden von den Metriken (Fläche, Umfang, Kompaktheit) ausgeschlossen.',
         },
       },
     },
@@ -554,7 +554,7 @@ export default {
       microtubule:
         'Instanz-Segmentierung für Mikrotubuli in der IRM/TIRF-Mikroskopie. DINOv3-L + DPT-Encoder, PySOAX-Postprocessing, native Polylinien-Ausgabe mit Embedding-basiertem Tracking.',
       microcapsule:
-        'YOLO11n-seg-Instanz-Segmentierung für Mikrokapseln — Fläche, Umfang und Kompaktheit je Kapsel; am Bildrand abgeschnittene Kapseln werden von den Metriken ausgeschlossen (~6 MB, unter einer Sekunde je Bild).',
+        'Meta SAM 3 (Prompt „circle") Instanz-Segmentierung für Mikrokapseln — Fläche, Umfang und Kompaktheit je Kapsel; am Bildrand abgeschnittene Kapseln werden von den Metriken ausgeschlossen.',
     },
     dataUsageTitle: 'Datennutzung und Datenschutz',
     dataUsageDescription:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -217,6 +217,7 @@ export default {
       wound: 'Wundheilung',
       sperm: 'Spermien',
       microtubules: 'Mikrotubuli',
+      microcapsule: 'Mikrokapseln',
     },
     projectNamePlaceholder: 'z.B. HeLa-Zell-Sphäroide',
     projectDescPlaceholder:
@@ -455,6 +456,7 @@ export default {
         sperm: 'Spermien-Modelle',
         wound: 'Wundheilungs-Modelle',
         microtubule: 'Mikrotubuli-Modelle',
+        microcapsule: 'Mikrokapsel-Modelle',
       },
       presets: {
         fast: 'Schnell',
@@ -515,6 +517,11 @@ export default {
           description:
             'Instanz-Segmentierung für IRM/TIRF-Mikrotubuli-Zeitrafferaufnahmen. DINOv3-L ViT-L/16 + DPT-Fusion liefert eine Centerline-Polylinie pro MT plus ein 32-d Embedding pro Pixel, das frameübergreifendes Tracking und Kymograph-Erzeugung ermöglicht. ~8 s/Bild; einziges Modell der Plattform mit nativer Polylinien-Ausgabe.',
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            'Instanz-Segmentierung für Mikrokapseln (runde Objekte) in der Hellfeld-Mikroskopie. Ein kompaktes YOLO11n-seg-Modell (~6 MB, aus SAM 3 destilliert) liefert ein Polygon pro Kapsel mit Konfidenzwert; am Bildrand abgeschnittene Kapseln werden von den Metriken (Fläche, Umfang, Kompaktheit) ausgeschlossen.',
+        },
       },
     },
     detectHoles: 'Löcher Erkennen',
@@ -546,6 +553,8 @@ export default {
         'U-Net + MiT-B5 (SegFormer-Encoder) Modell für die Wundsegmentierung in Scratch-Assay-Mikroskopie. Eine binäre Wundregion pro Bild; ideal für Heilungsverlauf-Timelapses.',
       microtubule:
         'Instanz-Segmentierung für Mikrotubuli in der IRM/TIRF-Mikroskopie. DINOv3-L + DPT-Encoder, PySOAX-Postprocessing, native Polylinien-Ausgabe mit Embedding-basiertem Tracking.',
+      microcapsule:
+        'YOLO11n-seg-Instanz-Segmentierung für Mikrokapseln — Fläche, Umfang und Kompaktheit je Kapsel; am Bildrand abgeschnittene Kapseln werden von den Metriken ausgeschlossen (~6 MB, unter einer Sekunde je Bild).',
     },
     dataUsageTitle: 'Datennutzung und Datenschutz',
     dataUsageDescription:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -512,9 +512,9 @@ export default {
             'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT fusion produces per-instance polyline centerlines plus a 32-d per-pixel embedding that drives cross-frame tracking and kymograph generation. ~8 s/frame; the only model in the platform with native polyline output.',
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are excluded from the metrics (area, perimeter, compactness).',
+            'Instance segmentation for microcapsules (round objects) in bright-field microscopy. Meta SAM 3 with the "circle" prompt returns one clean, full-resolution boundary per capsule with a confidence score; capsules cut off by the image border are excluded from the metrics (area, perimeter, compactness).',
         },
       },
     },
@@ -548,7 +548,7 @@ export default {
       microtubule:
         'Microtubule instance segmentation for IRM/TIRF microscopy. DINOv3-L + DPT encoder, PySOAX postprocessing, native polyline output with embedding-based cross-frame tracking.',
       microcapsule:
-        'YOLO11n-seg instance segmentation for microcapsules — area, perimeter and compactness per capsule, with border-cut capsules excluded from metrics (~6 MB, sub-second per image).',
+        'Meta SAM 3 ("circle" prompt) instance segmentation for microcapsules — area, perimeter and compactness per capsule, with border-cut capsules excluded from metrics.',
     },
     dataUsageTitle: 'Data Usage & Privacy',
     dataUsageDescription:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -225,6 +225,7 @@ export default {
       wound: 'Wound healing',
       sperm: 'Sperm',
       microtubules: 'Microtubules',
+      microcapsule: 'Microcapsules',
     },
     projectNamePlaceholder: 'e.g., HeLa Cell Spheroids',
     projectDescPlaceholder:
@@ -449,6 +450,7 @@ export default {
         sperm: 'Sperm Models',
         wound: 'Wound Healing Models',
         microtubule: 'Microtubule Models',
+        microcapsule: 'Microcapsule Models',
       },
       presets: {
         fast: 'Fast',
@@ -509,6 +511,11 @@ export default {
           description:
             'Instance segmentation for IRM/TIRF microtubule time-lapses. DINOv3-L ViT-L/16 backbone + DPT fusion produces per-instance polyline centerlines plus a 32-d per-pixel embedding that drives cross-frame tracking and kymograph generation. ~8 s/frame; the only model in the platform with native polyline output.',
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            'Instance segmentation for microcapsules (round objects) in bright-field microscopy. A compact YOLO11n-seg model (~6 MB, distilled from SAM 3) returns one polygon per capsule with a confidence score; capsules cut off by the image border are excluded from the metrics (area, perimeter, compactness).',
+        },
       },
     },
     detectHoles: 'Detect Holes',
@@ -540,6 +547,8 @@ export default {
         'U-Net + MiT-B5 (SegFormer encoder) model for wound segmentation in scratch-assay microscopy. Single binary wound region per image; ideal for healing-rate timelapses.',
       microtubule:
         'Microtubule instance segmentation for IRM/TIRF microscopy. DINOv3-L + DPT encoder, PySOAX postprocessing, native polyline output with embedding-based cross-frame tracking.',
+      microcapsule:
+        'YOLO11n-seg instance segmentation for microcapsules — area, perimeter and compactness per capsule, with border-cut capsules excluded from metrics (~6 MB, sub-second per image).',
     },
     dataUsageTitle: 'Data Usage & Privacy',
     dataUsageDescription:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -497,9 +497,9 @@ export default {
             'Segmentación de instancias para time-lapses de microtúbulos IRM/TIRF. DINOv3-L ViT-L/16 + fusión DPT produce polilíneas centerline por MT y embeddings de 32 dim por píxel para tracking entre cuadros y generación de kymograph. ~8 s por cuadro; único modelo de la plataforma con salida polilínea nativa.',
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            'Segmentación de instancias para microcápsulas (objetos redondos) en microscopía de campo claro. Un compacto modelo YOLO11n-seg (~6 MB, destilado de SAM 3) devuelve un polígono por cápsula con puntuación de confianza; las cápsulas cortadas por el borde de la imagen quedan excluidas de las métricas (área, perímetro, compacidad).',
+            'Segmentación de instancias para microcápsulas (objetos redondos) en microscopía de campo claro. Meta SAM 3 con el prompt «circle» devuelve un contorno limpio a resolución completa por cápsula con puntuación de confianza; las cápsulas cortadas por el borde de la imagen quedan excluidas de las métricas (área, perímetro, compacidad).',
         },
       },
     },
@@ -533,7 +533,7 @@ export default {
       microtubule:
         'Segmentación de instancias de microtúbulos para microscopía IRM/TIRF. Codificador DINOv3-L + DPT, postprocesado PySOAX, salida polilínea nativa con tracking basado en embeddings.',
       microcapsule:
-        'Segmentación de instancias YOLO11n-seg para microcápsulas — área, perímetro y compacidad por cápsula, con las cápsulas cortadas por el borde excluidas de las métricas (~6 MB, procesamiento sub-segundo por imagen).',
+        'Segmentación de instancias Meta SAM 3 (prompt «circle») para microcápsulas — área, perímetro y compacidad por cápsula, con las cápsulas cortadas por el borde excluidas de las métricas.',
     },
     dataUsageTitle: 'Uso de datos y privacidad',
     dataUsageDescription:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -217,6 +217,7 @@ export default {
       wound: 'Cicatrización de heridas',
       sperm: 'Esperma',
       microtubules: 'Microtúbulos',
+      microcapsule: 'Microcápsulas',
     },
     projectNamePlaceholder: 'ej. Esferoides de células HeLa',
     projectDescPlaceholder:
@@ -433,6 +434,7 @@ export default {
         sperm: 'Modelos de espermatozoides',
         wound: 'Modelos de cicatrización',
         microtubule: 'Modelos de microtúbulos',
+        microcapsule: 'Modelos de microcápsulas',
       },
       presets: {
         fast: 'Rápido',
@@ -494,6 +496,11 @@ export default {
           description:
             'Segmentación de instancias para time-lapses de microtúbulos IRM/TIRF. DINOv3-L ViT-L/16 + fusión DPT produce polilíneas centerline por MT y embeddings de 32 dim por píxel para tracking entre cuadros y generación de kymograph. ~8 s por cuadro; único modelo de la plataforma con salida polilínea nativa.',
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            'Segmentación de instancias para microcápsulas (objetos redondos) en microscopía de campo claro. Un compacto modelo YOLO11n-seg (~6 MB, destilado de SAM 3) devuelve un polígono por cápsula con puntuación de confianza; las cápsulas cortadas por el borde de la imagen quedan excluidas de las métricas (área, perímetro, compacidad).',
+        },
       },
     },
     detectHoles: 'Detectar Agujeros',
@@ -525,6 +532,8 @@ export default {
         'Modelo U-Net + MiT-B5 (codificador SegFormer) para segmentación de heridas en microscopía de scratch-assay. Una única región de herida binaria por imagen; ideal para time-lapses de cicatrización.',
       microtubule:
         'Segmentación de instancias de microtúbulos para microscopía IRM/TIRF. Codificador DINOv3-L + DPT, postprocesado PySOAX, salida polilínea nativa con tracking basado en embeddings.',
+      microcapsule:
+        'Segmentación de instancias YOLO11n-seg para microcápsulas — área, perímetro y compacidad por cápsula, con las cápsulas cortadas por el borde excluidas de las métricas (~6 MB, procesamiento sub-segundo por imagen).',
     },
     dataUsageTitle: 'Uso de datos y privacidad',
     dataUsageDescription:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -510,9 +510,9 @@ export default {
             "Segmentation d'instances pour les time-lapses de microtubules IRM/TIRF. Le backbone DINOv3-L ViT-L/16 + fusion DPT produit des polylignes centerline par MT et un embedding 32-d par pixel qui alimente le tracking inter-trames et la génération de kymographe. ~8 s/image ; seul modèle de la plateforme à sortie polyligne native.",
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            "Segmentation d'instances pour les microcapsules (objets ronds) en microscopie à champ clair. Un modèle YOLO11n-seg compact (~6 Mo, distillé de SAM 3) renvoie un polygone par capsule avec un score de confiance ; les capsules coupées par le bord de l'image sont exclues des métriques (aire, périmètre, compacité).",
+            "Segmentation d'instances pour les microcapsules (objets ronds) en microscopie à champ clair. Meta SAM 3 avec le prompt « circle » renvoie un contour propre en pleine résolution par capsule avec un score de confiance ; les capsules coupées par le bord de l'image sont exclues des métriques (aire, périmètre, compacité).",
         },
       },
     },
@@ -546,7 +546,7 @@ export default {
       microtubule:
         "Segmentation d'instances de microtubules pour la microscopie IRM/TIRF. Encodeur DINOv3-L + DPT, post-traitement PySOAX, sortie polyligne native avec tracking basé sur embedding.",
       microcapsule:
-        "Segmentation d'instances YOLO11n-seg pour les microcapsules — aire, périmètre et compacité par capsule, les capsules coupées par le bord étant exclues des métriques (~6 Mo, traitement sous la seconde par image).",
+        "Segmentation d'instances Meta SAM 3 (prompt « circle ») pour les microcapsules — aire, périmètre et compacité par capsule, les capsules coupées par le bord étant exclues des métriques.",
     },
     dataUsageTitle: 'Utilisation des données et confidentialité',
     dataUsageDescription:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -217,6 +217,7 @@ export default {
       wound: 'Cicatrisation des plaies',
       sperm: 'Spermatozoïdes',
       microtubules: 'Microtubules',
+      microcapsule: 'Microcapsules',
     },
     projectNamePlaceholder: 'ex. : Sphéroïdes de cellules HeLa',
     projectDescPlaceholder:
@@ -446,6 +447,7 @@ export default {
         sperm: 'Modèles de spermatozoïdes',
         wound: 'Modèles de cicatrisation',
         microtubule: 'Modèles de microtubules',
+        microcapsule: 'Modèles de microcapsules',
       },
       presets: {
         fast: 'Rapide',
@@ -507,6 +509,11 @@ export default {
           description:
             "Segmentation d'instances pour les time-lapses de microtubules IRM/TIRF. Le backbone DINOv3-L ViT-L/16 + fusion DPT produit des polylignes centerline par MT et un embedding 32-d par pixel qui alimente le tracking inter-trames et la génération de kymographe. ~8 s/image ; seul modèle de la plateforme à sortie polyligne native.",
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            "Segmentation d'instances pour les microcapsules (objets ronds) en microscopie à champ clair. Un modèle YOLO11n-seg compact (~6 Mo, distillé de SAM 3) renvoie un polygone par capsule avec un score de confiance ; les capsules coupées par le bord de l'image sont exclues des métriques (aire, périmètre, compacité).",
+        },
       },
     },
     detectHoles: 'Détecter les Trous',
@@ -538,6 +545,8 @@ export default {
         'Modèle U-Net + MiT-B5 (encodeur SegFormer) pour la segmentation des plaies en microscopie de scratch-assay. Une seule région de plaie binaire par image ; idéal pour les time-lapses de cicatrisation.',
       microtubule:
         "Segmentation d'instances de microtubules pour la microscopie IRM/TIRF. Encodeur DINOv3-L + DPT, post-traitement PySOAX, sortie polyligne native avec tracking basé sur embedding.",
+      microcapsule:
+        "Segmentation d'instances YOLO11n-seg pour les microcapsules — aire, périmètre et compacité par capsule, les capsules coupées par le bord étant exclues des métriques (~6 Mo, traitement sous la seconde par image).",
     },
     dataUsageTitle: 'Utilisation des données et confidentialité',
     dataUsageDescription:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -204,6 +204,7 @@ export default {
       wound: '伤口愈合',
       sperm: '精子',
       microtubules: '微管',
+      microcapsule: '微胶囊',
     },
     projectNamePlaceholder: '例如：HeLa细胞球体',
     projectDescPlaceholder: '例如：用于药物耐受性研究的肿瘤球体分析',
@@ -403,6 +404,7 @@ export default {
         sperm: '精子模型',
         wound: '伤口愈合模型',
         microtubule: '微管模型',
+        microcapsule: '微胶囊模型',
       },
       presets: {
         fast: '快速',
@@ -460,6 +462,11 @@ export default {
           description:
             '面向 IRM/TIRF 微管延时实验的实例分割。DINOv3-L ViT-L/16 + DPT 融合生成每条微管的中线折线和每像素 32 维嵌入，可驱动跨帧跟踪和动态图（kymograph）生成。约 8 秒/帧；本平台唯一原生输出折线的模型。',
         },
+        microcapsule: {
+          name: 'Microcapsule (YOLO11n-seg)',
+          description:
+            '面向明场显微镜中微胶囊（圆形对象）的实例分割。紧凑型 YOLO11n-seg 模型（~6 MB，由 SAM 3 蒸馏）为每个胶囊返回一个多边形及置信度分数；被图像边缘截断的胶囊不计入指标（面积、周长、紧实度）。',
+        },
       },
     },
     detectHoles: '检测空洞',
@@ -487,6 +494,8 @@ export default {
         '用于划痕实验显微镜的伤口分割的U-Net + MiT-B5（SegFormer编码器）模型。每张图像一个二进制伤口区域；非常适合愈合速度的时间延迟拍摄。',
       microtubule:
         '面向 IRM/TIRF 显微镜的微管实例分割。DINOv3-L + DPT 编码器，PySOAX 后处理，原生折线输出，并支持基于嵌入的跨帧跟踪。',
+      microcapsule:
+        'YOLO11n-seg 微胶囊实例分割 — 输出每个胶囊的面积、周长和紧实度，被图像边缘截断的胶囊不计入指标（~6 MB，单张图像处理时间低于一秒）。',
     },
     dataUsageTitle: '数据使用和隐私',
     dataUsageDescription: '控制您的数据如何用于机器学习和研究',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -463,9 +463,9 @@ export default {
             '面向 IRM/TIRF 微管延时实验的实例分割。DINOv3-L ViT-L/16 + DPT 融合生成每条微管的中线折线和每像素 32 维嵌入，可驱动跨帧跟踪和动态图（kymograph）生成。约 8 秒/帧；本平台唯一原生输出折线的模型。',
         },
         microcapsule: {
-          name: 'Microcapsule (YOLO11n-seg)',
+          name: 'Microcapsule (SAM 3)',
           description:
-            '面向明场显微镜中微胶囊（圆形对象）的实例分割。紧凑型 YOLO11n-seg 模型（~6 MB，由 SAM 3 蒸馏）为每个胶囊返回一个多边形及置信度分数；被图像边缘截断的胶囊不计入指标（面积、周长、紧实度）。',
+            '面向明场显微镜中微胶囊（圆形对象）的实例分割。Meta SAM 3 使用"circle"提示词，为每个胶囊返回一条清晰的全分辨率轮廓及置信度分数；被图像边缘截断的胶囊不计入指标（面积、周长、紧实度）。',
         },
       },
     },
@@ -495,7 +495,7 @@ export default {
       microtubule:
         '面向 IRM/TIRF 显微镜的微管实例分割。DINOv3-L + DPT 编码器，PySOAX 后处理，原生折线输出，并支持基于嵌入的跨帧跟踪。',
       microcapsule:
-        'YOLO11n-seg 微胶囊实例分割 — 输出每个胶囊的面积、周长和紧实度，被图像边缘截断的胶囊不计入指标（~6 MB，单张图像处理时间低于一秒）。',
+        'Meta SAM 3（"circle"提示词）微胶囊实例分割 — 输出每个胶囊的面积、周长和紧实度，被图像边缘截断的胶囊不计入指标。',
     },
     dataUsageTitle: '数据使用和隐私',
     dataUsageDescription: '控制您的数据如何用于机器学习和研究',

--- a/src/types/__tests__/index.runtime.test.ts
+++ b/src/types/__tests__/index.runtime.test.ts
@@ -36,18 +36,19 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('PROJECT_TYPES', () => {
-  it('contains exactly the five known project types', () => {
+  it('contains exactly the six known project types', () => {
     expect([...PROJECT_TYPES]).toEqual([
       'spheroid',
       'spheroid_invasive',
       'wound',
       'sperm',
       'microtubules',
+      'microcapsule',
     ]);
   });
 
-  it('is a readonly tuple (length 5)', () => {
-    expect(PROJECT_TYPES).toHaveLength(5);
+  it('is a readonly tuple (length 6)', () => {
+    expect(PROJECT_TYPES).toHaveLength(6);
   });
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -344,6 +344,7 @@ export const PROJECT_TYPES = [
   'wound',
   'sperm',
   'microtubules',
+  'microcapsule',
 ] as const;
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 
@@ -477,6 +478,9 @@ export interface PolygonData {
   geometry?: 'polygon' | 'polyline'; // absent = 'polygon' (backward compat)
   partClass?: 'head' | 'midpiece' | 'tail'; // For sperm polyline parts
   instanceId?: string; // Groups polylines into instances, e.g. 'sperm_1'
+  /** Microcapsule completeness flag: `false` when cut off by the image border.
+   *  Excluded from metrics; absent for other project types. */
+  complete?: boolean;
 }
 
 export interface SegmentationData {


### PR DESCRIPTION
## Summary

Adds a new **`microcapsule`** project type (analogous to `spheroid` — same upload/editor/export+visualizations flow) backed by **Meta SAM 3** instance segmentation with the text prompt `"circle"`. Metrics are **area, perimeter, and compactness** per capsule, **excluding capsules cut off by the image border**.

The branch is already deployed to production (single-stack) and verified end-to-end; this PR brings `main` in sync.

## What's included

**New project type + model**
- `microcapsule` added to `PROJECT_TYPES` (FE/BE byte-identical) and both model registries (`compatibleProjectTypes: ['microcapsule']`); i18n across all 6 locales; model-picker section; resegment mapping.
- ML wrapper `models/microcapsule.py`: SAM 3 `"circle"` → `merge_nested` (one outer boundary per capsule) → `approxPolyDP(1.5)` (clean boundary, no inward shrink). `complete` flag on the raw mask (3 px border rule); `confidence` per capsule.

**Metrics & export**
- "Compactness" = circularity `4π·A/P²` (0–1). Border-cut capsules excluded from metrics in **both** engines (FE `metricCalculations` call sites + BE `metricsCalculator`).
- Focused microcapsule Excel/CSV exporter (Capsule ID, Area, Perimeter, Compactness, Equivalent Diameter, Confidence) + summary; `exportService`/`exportDocs` branches. Cut-off capsules drawn **grey** in the editor (`CanvasPolygon`) and the visualization export.
- New polygon fields `complete` / `confidence` carried end-to-end (whitelisted through the ML-input validator; mappers already spread-through).

**Model journey (YOLO → SAM 3)**
- Initially integrated the delivered YOLO11n-seg student, but its low-resolution masks produced an 8×8-block "flat edges on the sides" artifact, and smoothing to fix it clipped the boundary. Switched to the SAM 3 teacher directly (full-resolution masks, clean circles).
- Integrated via the standalone **`sam3`** package — **no `transformers` dependency**, so the load-bearing `transformers==4.57.6` (DINOv3/SegFormer/Sperm) and `torch==2.6.0` (mamba kernels) pins are untouched. Needed `numpy` 1.24.3→1.26.4 (still 1.x) and `timm>=1.0.17`, which bumped `segmentation-models-pytorch` 0.3.4→0.5.0 (Wound model — verified `wound_mitb5.ckpt` still loads with a strict state-dict match).

**Fixes found during live testing**
- `fix(db)`: `projects.type` carries a raw-SQL `CHECK` constraint (`projects_type_check`) that omitted `microcapsule` → 500 on project-type change. Extended on prod via idempotent SQL (migrations are gitignored here).
- `fix(editor)`: Add Points now keeps the polygon part forming the **larger-perimeter** result (old code's two candidates were identical).
- `fix(microcapsule)`: merge concentric SAM 3 circles — fill interior holes before the containment test (SAM 3's outer mask is an annulus; the inner disk fell in its hole).
- `fix(ui)`: the model-status indicator self-heals — polls every 5 s while in an error state (e.g. during SAM 3's ~15 s load) instead of a fixed 30 s, so it recovers without a manual refresh.

## Verification

- ML: 10 Python tests (incl. SAM 3 integration); all 8 models load + run in the deployed service (wound under smp 0.5.0). SAM 3 ~0.9 s/image, circularity 0.978–0.997, 0 nested pairs across 16 production images.
- BE: metrics-exclusion + focused-export tests; export/registry suites green (0 regressions).
- FE: registry/project-type/model-count tests; Add Points unit tests; `make ci` green; editor renders capsules with zero console errors; kontrolka self-heal verified live (red → green in ~5 s, no refresh).

## Notes
- The `projects_type_check` DB constraint change is applied directly to production (the prod Prisma migration history has drifted; `migrate deploy` is not run blind). A documentary `migration.sql` exists locally but is gitignored.
- SAM 3 is ~3.4 GB (loads from HuggingFace on first use, `HF_TOKEN`) and ~1 s/image — slower than the spheroid models, faster than microtubule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Microcapsule project type with Meta SAM 3 instance segmentation and a selectable model.
  * Added border-cut/incomplete instance handling: incomplete capsules are excluded from metrics.
  * Added Microcapsule-specific metrics + export (Excel/CSV), including confidence in outputs.
  * Expanded model/project selection UI with multilingual support.
* **Visualization**
  * Border-cut (incomplete) capsules now render in grey.
* **Bug Fixes / Reliability**
  * Improved segmentation inference stability under concurrent requests.
* **Tests**
  * Added unit and smoke tests for Microcapsule completeness and metrics/export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->