### PR TITLE
fix(upload): scale video-upload timeout to file size + nginx headroom

### DIFF
--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -279,6 +279,33 @@ server {
         add_header Expires "0";
     }
 
+    # Video uploads (Nikon ND2 / multi-page TIFF stacks). The single POST
+    # carries the multi-GB file transfer AND blocks on synchronous server-side
+    # frame extraction, so both the body read (slow links) and the upstream
+    # response (long extraction) need a generous window. The default /api 600s
+    # read timeout 504'd large 2048x2048 stacks mid-extraction; the per-chunk
+    # body timeout must also tolerate a slow multi-GB upload. Must precede the
+    # /api/images/upload + /api prefix locations (regex wins over prefix).
+    location ~ ^/api/projects/[^/]+/videos$ {
+        limit_req zone=upload burst=10 nodelay;
+        client_max_body_size 100G;
+        client_body_timeout 3600s;
+
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Environment "production";
+
+        proxy_read_timeout 3600s;
+        proxy_connect_timeout 75s;
+        proxy_send_timeout 3600s;
+
+        proxy_request_buffering off;
+    }
+
     # Upload endpoints with special handling
     location /api/images/upload {
         limit_req zone=upload burst=10 nodelay;

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -16,9 +16,35 @@ import {
   VALIDATION,
   getTimeout,
   getRetryAttempts,
+  videoUploadTimeoutMs,
 } from '../constants';
 
 describe('constants', () => {
+  describe('videoUploadTimeoutMs', () => {
+    const MIN = 20 * 60 * 1000; // 20 min floor
+    const MAX = 4 * 60 * 60 * 1000; // 4 h ceiling
+
+    it('applies the 20-min floor to small clips', () => {
+      expect(videoUploadTimeoutMs(5 * 1024 * 1024)).toBe(MIN); // 5 MB
+      expect(videoUploadTimeoutMs(0)).toBe(MIN);
+    });
+
+    it('scales above the floor for large files (~1 MB/s + 1.5x headroom)', () => {
+      // 3 GB → 3072 s × 1.5 = 4608 s = 4_608_000 ms, well above the floor.
+      const threeGb = 3 * 1024 * 1024 * 1024;
+      expect(videoUploadTimeoutMs(threeGb)).toBeCloseTo(3072 * 1000 * 1.5, -3);
+      expect(videoUploadTimeoutMs(threeGb)).toBeGreaterThan(MIN);
+    });
+
+    it('caps at 4 hours for very large files', () => {
+      expect(videoUploadTimeoutMs(50 * 1024 * 1024 * 1024)).toBe(MAX); // 50 GB
+    });
+
+    it('handles negative/NaN sizes by falling back to the floor', () => {
+      expect(videoUploadTimeoutMs(-1)).toBe(MIN);
+    });
+  });
+
   describe('Constants Export Integrity', () => {
     it('should export all timeout configurations', () => {
       expect(TIMEOUTS).toBeDefined();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,7 +9,7 @@ import {
 } from '@/types';
 import { logger } from '@/lib/logger';
 import config from '@/lib/config';
-import { TIMEOUTS, FILE_LIMITS } from '@/lib/constants';
+import { TIMEOUTS, FILE_LIMITS, videoUploadTimeoutMs } from '@/lib/constants';
 import { retryWithBackoff, RETRY_CONFIGS } from '@/lib/retryUtils';
 import {
   chunkFiles,
@@ -1222,10 +1222,11 @@ class ApiClient {
       formData,
       {
         headers: { 'Content-Type': 'multipart/form-data' },
-        // Server-side extraction can take minutes for a 1 GB ND2 stack.
-        // Bias toward the high end; for typical small videos the request
-        // returns well before this.
-        timeout: TIMEOUTS.FILE_UPLOAD_LARGE * 4,
+        // Transfer + server-side extraction must both fit in this one request.
+        // Scale the timeout to the file size (a fixed 20-min cap was timing out
+        // multi-GB ND2 uploads mid-transfer); small clips still get a 20-min
+        // floor, huge files up to a 4-hour ceiling.
+        timeout: videoUploadTimeoutMs(payload.size),
         onUploadProgress: progressEvent => {
           if (onProgress && progressEvent.total) {
             const percentCompleted = Math.round(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -61,6 +61,28 @@ export const TIMEOUTS = {
   METRICS_COLLECTION: 60000,
 } as const;
 
+/** Video-upload request timeout, scaled to file size.
+ *
+ * A single video POST carries the file transfer AND blocks on server-side
+ * ND2/TIFF frame extraction, so both must fit in one request timeout. A fixed
+ * 20-min cap timed out legitimate multi-GB microscopy ND2 uploads mid-transfer
+ * (a 2048×2048 stack is easily several GB, and uploads are limited to 100 GB).
+ * Budget a conservative effective-throughput floor (~1 MB/s) plus 1.5× headroom
+ * for extraction, with a 20-min floor for small clips and a 4-hour hard ceiling
+ * so a genuinely stuck request still fails eventually. */
+const VIDEO_UPLOAD_MIN_BYTES_PER_SEC = 1024 * 1024; // ~8 Mbps effective floor
+const VIDEO_UPLOAD_TIMEOUT_FLOOR_MS = 20 * 60 * 1000; // 20 min
+const VIDEO_UPLOAD_TIMEOUT_MAX_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+export function videoUploadTimeoutMs(fileSizeBytes: number): number {
+  const sizeBudgetMs =
+    (Math.max(0, fileSizeBytes) / VIDEO_UPLOAD_MIN_BYTES_PER_SEC) * 1000 * 1.5;
+  return Math.min(
+    VIDEO_UPLOAD_TIMEOUT_MAX_MS,
+    Math.max(VIDEO_UPLOAD_TIMEOUT_FLOOR_MS, sizeBudgetMs)
+  );
+}
+
 /**
  * Retry attempt configurations for different operation types
  */


### PR DESCRIPTION
## Problem

A user's large microscopy ND2 upload failed with `timeout of 1200000ms exceeded` (client-side axios, 20 min). Diagnosis on production:

- The failed `…000.nd2` left **no container row, no file on disk** — while its single-frame `_IRM` companion (2048×2048, 8.5 MB) uploaded instantly.
- `uploadVideoFromFile` creates the container row *before* extraction, and `cleanupOnFailure` removes dirs but **not** rows. So "no row" ⇒ the request died during the **multer transfer**, before extraction.
- The video upload is a **single blocking POST** whose one axios timeout covers transfer **+** synchronous frame extraction. A multi-GB 2048×2048 stack (38× the pixels/frame of files that work — the known-good `e199f011` is only 242×332) exceeds 20 min on a normal link.

## Fix (two layers)

**Frontend** — `src/lib/constants.ts`, `src/lib/api.ts`:
Replace the fixed `TIMEOUTS.FILE_UPLOAD_LARGE * 4` (20 min) with `videoUploadTimeoutMs(file.size)`: a ~1 MB/s effective-throughput budget × 1.5 headroom, floored at 20 min for small clips, capped at 4 h so a genuinely stuck request still fails.

**nginx** — `docker/nginx/nginx.production.conf`:
The video endpoint had no dedicated location and fell into generic `/api` (600s `proxy_read_timeout`) — which would 504 a large file mid-**extraction** even if the transfer succeeded. Added `location ~ ^/api/projects/[^/]+/videos$` (100 GB body, 3600s body/read/send, `proxy_request_buffering off`), mirroring the feedback-upload location.

## Verification
- `videoUploadTimeoutMs` unit test (floor / size-scaling / 4 h cap / negative input) — 30 constants tests pass.
- `make ci` green (TS + ESLint 0 + i18n 6×1530).
- nginx config validated with `nginx -t` (throwaway container joined to both networks); recreated; `production-healthy`.
- Frontend rebuilt + deployed; 4 h-cap literal confirmed in the live minified bundle.

## Not fully verifiable
The original failed file is gone and I don't have a multi-GB ND2 to reproduce a slow transfer end-to-end. The config change is validated and live; the reporter should re-try their actual upload to confirm.

## Follow-up (noted, not in this PR)
`extract_nd2.py` single-position path materializes the entire `T×C×Y×X` array (`np.asarray`, ~line 465) before writing any frame — a latent multi-GB RAM/OOM risk for very large high-res stacks. The multi-position path already slices lazily; the single-position path should stream per-frame too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)