### PR TITLE
fix(upload): PR #246 review — NaN guard, FE/nginx ceiling parity, doc fixes

### DIFF
--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -282,10 +282,16 @@ server {
     # Video uploads (Nikon ND2 / multi-page TIFF stacks). The single POST
     # carries the multi-GB file transfer AND blocks on synchronous server-side
     # frame extraction, so both the body read (slow links) and the upstream
-    # response (long extraction) need a generous window. The default /api 600s
-    # read timeout 504'd large 2048x2048 stacks mid-extraction; the per-chunk
-    # body timeout must also tolerate a slow multi-GB upload. Must precede the
-    # /api/images/upload + /api prefix locations (regex wins over prefix).
+    # response (long extraction) need a generous window. Under the generic /api
+    # block this path gets a 600s read timeout, which WOULD 504 a large 2048×2048
+    # stack mid-extraction once the transfer succeeded (the observed failure was a
+    # client-side abort during transfer; this prevents the second failure mode).
+    # read/send timeouts match the FE 4h videoUploadTimeoutMs ceiling so the
+    # client, not nginx, owns the end-to-end cap. A plain (~) regex location wins
+    # over the /api + /api/feedback prefix blocks regardless of file order, so
+    # placement vs those is immaterial — only order against OTHER regex locations
+    # matters (none today overlap /api/projects/<id>/videos). A future "^~ /api"
+    # prefix WOULD override it (see the note at the frame-data location above).
     location ~ ^/api/projects/[^/]+/videos$ {
         limit_req zone=upload burst=10 nodelay;
         client_max_body_size 100G;
@@ -299,9 +305,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Environment "production";
 
-        proxy_read_timeout 3600s;
+        proxy_read_timeout 14400s; # 4h — matches FE videoUploadTimeoutMs cap
         proxy_connect_timeout 75s;
-        proxy_send_timeout 3600s;
+        proxy_send_timeout 14400s;
 
         proxy_request_buffering off;
     }

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -30,18 +30,22 @@ describe('constants', () => {
     });
 
     it('scales above the floor for large files (~1 MB/s + 1.5x headroom)', () => {
-      // 3 GB → 3072 s × 1.5 = 4608 s = 4_608_000 ms, well above the floor.
+      // 3 GB → 3072 s × 1.5 = 4608 s = 4_608_000 ms (exact, no rounding).
       const threeGb = 3 * 1024 * 1024 * 1024;
-      expect(videoUploadTimeoutMs(threeGb)).toBeCloseTo(3072 * 1000 * 1.5, -3);
-      expect(videoUploadTimeoutMs(threeGb)).toBeGreaterThan(MIN);
+      expect(videoUploadTimeoutMs(threeGb)).toBe(3072 * 1000 * 1.5);
     });
 
     it('caps at 4 hours for very large files', () => {
       expect(videoUploadTimeoutMs(50 * 1024 * 1024 * 1024)).toBe(MAX); // 50 GB
     });
 
-    it('handles negative/NaN sizes by falling back to the floor', () => {
+    it('falls back to the floor for negative, NaN, and non-finite sizes', () => {
+      // A non-finite timeout would reach axios as "no timeout" — guard it.
       expect(videoUploadTimeoutMs(-1)).toBe(MIN);
+      expect(videoUploadTimeoutMs(NaN)).toBe(MIN);
+      expect(videoUploadTimeoutMs(Infinity)).toBe(MIN);
+      // @ts-expect-error — exercise a careless non-number caller at runtime.
+      expect(videoUploadTimeoutMs(undefined)).toBe(MIN);
     });
   });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,13 +70,17 @@ export const TIMEOUTS = {
  * Budget a conservative effective-throughput floor (~1 MB/s) plus 1.5× headroom
  * for extraction, with a 20-min floor for small clips and a 4-hour hard ceiling
  * so a genuinely stuck request still fails eventually. */
-const VIDEO_UPLOAD_MIN_BYTES_PER_SEC = 1024 * 1024; // ~8 Mbps effective floor
+const VIDEO_UPLOAD_MIN_BYTES_PER_SEC = 1024 * 1024; // 1 MiB/s ≈ 8 Mbps
 const VIDEO_UPLOAD_TIMEOUT_FLOOR_MS = 20 * 60 * 1000; // 20 min
 const VIDEO_UPLOAD_TIMEOUT_MAX_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 export function videoUploadTimeoutMs(fileSizeBytes: number): number {
-  const sizeBudgetMs =
-    (Math.max(0, fileSizeBytes) / VIDEO_UPLOAD_MIN_BYTES_PER_SEC) * 1000 * 1.5;
+  // Coerce non-finite / negative input (NaN, undefined, Infinity, <0) to 0 so the
+  // result is always a valid finite timeout. A NaN here would otherwise reach
+  // axios as `timeout: NaN` — treated as NO timeout, the exact unbounded-request
+  // failure this helper exists to prevent.
+  const bytes = Number.isFinite(fileSizeBytes) ? Math.max(0, fileSizeBytes) : 0;
+  const sizeBudgetMs = (bytes / VIDEO_UPLOAD_MIN_BYTES_PER_SEC) * 1000 * 1.5;
   return Math.min(
     VIDEO_UPLOAD_TIMEOUT_MAX_MS,
     Math.max(VIDEO_UPLOAD_TIMEOUT_FLOOR_MS, sizeBudgetMs)


### PR DESCRIPTION
Follow-up to #246, addressing a 3-agent review (code / tests / comments).

## Important
- **NaN safety** — `videoUploadTimeoutMs(NaN)` returned `NaN`, which axios treats as *no timeout* (an unbounded request — the exact failure the helper prevents). Unreachable today (`File.size` is always finite) but the export is general-purpose. Now coerces non-finite/negative input to `0`; the test asserts `NaN`/`Infinity`/`undefined` → floor (it was titled "negative/NaN" but only covered `-1`).
- **FE/nginx ceiling parity** — the FE advertised a 4 h ceiling but the nginx video location capped the *extraction* wait at 1 h (`proxy_read_timeout 3600s`), so a >1 h extraction would 504 despite the FE waiting 4 h. Raised nginx read/send to `14400s` so the client owns the end-to-end cap. Validated with `nginx -t`.

## Doc / test polish
- nginx comment fixes: "504'd … mid-extraction" → preventive "would 504" (the observed failure was a client-side transfer abort); corrected the "regex wins over prefix" rationale (a `~` regex wins regardless of file order — only regex-vs-regex order matters).
- Dropped the loose "effective" from the `~8 Mbps` annotation.
- Test: exact `toBe(4_608_000)` instead of `toBeCloseTo`; dropped a redundant `toBeGreaterThan`.

## Verification
`nginx -t` ok; 30 constants tests pass; `make ci` green; nginx + frontend redeployed, `production-healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed time for large video uploads so long-running uploads are less likely to fail.
  * Improved handling of invalid upload size values to ensure timeouts stay finite and consistent.
  * Clarified upload timeout behavior in server configuration to better align with frontend limits and routing behavior.

* **Tests**
  * Updated timeout coverage to verify exact behavior for large files and invalid or non-finite inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->