### PR TITLE
perf(upload): stream + parallelise ND2 frame extraction (1.9× faster, 2.5× less RAM)

### DIFF
--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -27,11 +27,27 @@ result-JSON object on its own line.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
+
+
+def _extract_workers() -> int:
+    """Thread count for parallel PNG encoding. PIL's PNG save releases the GIL
+    during zlib compression, so threads genuinely parallelise the CPU-bound
+    encode. Default to the box's core count (capped at 4 so a single upload
+    doesn't monopolise a shared host); override with ``ND2_EXTRACT_WORKERS``."""
+    try:
+        env = int(os.getenv("ND2_EXTRACT_WORKERS", "0"))
+    except ValueError:
+        env = 0
+    if env > 0:
+        return env
+    return min(4, os.cpu_count() or 2)
 
 
 # A 1536-well plate is the practical ceiling for microscopy; anything past
@@ -69,7 +85,10 @@ def _to_png_dtype(arr: np.ndarray) -> np.ndarray:
 
 def _save_png(arr: np.ndarray, path: Path) -> None:
     from PIL import Image
-    Image.fromarray(_to_png_dtype(arr)).save(path, format="PNG", optimize=True)
+    # Materialise any lazy (dask) slice before PIL, which needs a real ndarray.
+    Image.fromarray(_to_png_dtype(np.asarray(arr))).save(
+        path, format="PNG", optimize=True
+    )
 
 
 def _sanitize_name(name: str | None, fallback: str) -> str:
@@ -384,19 +403,39 @@ def _save_position_tiff(arr_tcyx: np.ndarray, path: Path) -> None:
     )
 
 
-def _write_frames(arr_tcyx: np.ndarray, frames_root: Path, channel_names: list[str],
+def _write_frames(arr_tcyx, frames_root: Path, channel_names: list[str],
                   on_frame=None) -> None:
     """Write one PNG per (frame, channel) under ``frames_root/<TTTT>/``.
-    ``on_frame()`` is called after each frame for progress accounting."""
-    T = arr_tcyx.shape[0]
-    C = arr_tcyx.shape[1]
-    for t in range(T):
+
+    ``arr_tcyx`` is a dask OR numpy ``(T, C, Y, X)`` array. Frames are streamed
+    one chunk at a time so peak memory is ~chunk frames rather than the whole
+    video (the dask path stays lazy until here), and the CPU-bound PNG encoding
+    is fanned across a thread pool (PIL releases the GIL during zlib). Each
+    chunk's frames are materialised SEQUENTIALLY — one dask compute at a time,
+    since the nd2-backed reader is not assumed thread-safe — then their PNGs are
+    encoded in parallel. ``on_frame()`` is called once per written frame for
+    progress accounting. Output bytes are identical to a sequential write.
+    """
+    T = int(arr_tcyx.shape[0])
+    C = int(arr_tcyx.shape[1])
+    workers = max(1, min(_extract_workers(), T))
+    chunk = max(workers * 2, 4)
+
+    def _write_one(item) -> None:
+        t, frame_cyx = item
         frame_dir = frames_root / f"{t:04d}"
         frame_dir.mkdir(parents=True, exist_ok=True)
         for c in range(C):
-            _save_png(arr_tcyx[t, c], frame_dir / f"{channel_names[c]}.png")
-        if on_frame is not None:
-            on_frame()
+            _save_png(frame_cyx[c], frame_dir / f"{channel_names[c]}.png")
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for start in range(0, T, chunk):
+            stop = min(start + chunk, T)
+            # Sequential per-frame materialisation (read), parallel encode/write.
+            batch = [(t, np.asarray(arr_tcyx[t])) for t in range(start, stop)]
+            for _ in pool.map(_write_one, batch):
+                if on_frame is not None:
+                    on_frame()
 
 
 def _progress(done: int, total: int) -> None:
@@ -462,8 +501,14 @@ def main() -> int:
 
         # ---- Single-position path (historical contract, unchanged) -------
         if p_count <= 1:
-            arr = np.asarray(darr) if use_dask else f.asarray()
-            arr = normalize_to_tcyx(arr, axes)
+            # Keep the array LAZY (dask) through normalisation so _write_frames
+            # streams it frame-by-frame instead of materialising the whole
+            # T×C×Y×X stack (multi-GB for a long 2048² video). Falls back to a
+            # full in-RAM array only when dask was unavailable. normalize_to_tcyx
+            # uses only dask-supported ops (transpose / squeeze / expand_dims /
+            # max), so it stays lazy on a dask input.
+            src = darr if use_dask else f.asarray()
+            arr = normalize_to_tcyx(src, axes)
             T, C, H, W = (int(arr.shape[0]), int(arr.shape[1]),
                           int(arr.shape[2]), int(arr.shape[3]))
 

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_nd2_normalize.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_nd2_normalize.py
@@ -35,7 +35,9 @@ HELPERS_DIR = os.path.abspath(os.path.join(HERE, ".."))
 sys.path.insert(0, HELPERS_DIR)
 
 from extract_nd2 import (  # noqa: E402
+    _extract_workers,
     _position_interval_ms,
+    _write_frames,
     normalize_to_tcyx,
     position_axis,
     select_position,
@@ -188,6 +190,79 @@ def test_missing_yx_rejected():
 def test_axes_ndim_mismatch_rejected():
     # 3-D array described by a 4-char axes string.
     _expect_unsupported("TCYX", (2, 4, 5))
+
+
+# ── streaming + parallel _write_frames (perf optimisation) ─────────────────
+# The extractor streams frames one chunk at a time and encodes PNGs across a
+# thread pool. These pin the load-bearing invariant: the optimisation must not
+# change a single output byte vs a naive sequential write.
+
+import hashlib  # noqa: E402
+import tempfile  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+def _seq_write(arr_tcyx, root, names):
+    """Reference sequential writer matching the pre-optimisation behaviour."""
+    from PIL import Image
+
+    from extract_nd2 import _to_png_dtype
+
+    T, C = arr_tcyx.shape[0], arr_tcyx.shape[1]
+    for t in range(T):
+        fd = root / f"{t:04d}"
+        fd.mkdir(parents=True, exist_ok=True)
+        for c in range(C):
+            Image.fromarray(_to_png_dtype(np.asarray(arr_tcyx[t, c]))).save(
+                fd / f"{names[c]}.png", format="PNG", optimize=True
+            )
+
+
+def _digest(root):
+    h = hashlib.md5()
+    for p in sorted(Path(root).rglob("*.png")):
+        h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def test_write_frames_byte_identical_to_sequential():
+    rng = np.random.RandomState(3)
+    arr = (rng.rand(11, 2, 24, 32) * 4000 + 100).astype(np.uint16)  # T=11,C=2
+    names = ["chA", "chB"]
+    par = Path(tempfile.mkdtemp())
+    seq = Path(tempfile.mkdtemp())
+    _write_frames(arr, par, names)
+    _seq_write(arr, seq, names)
+    assert sorted(p.name for p in par.rglob("*.png")) == sorted(
+        p.name for p in seq.rglob("*.png")
+    )
+    assert _digest(par) == _digest(seq), "parallel write changed the PNG bytes"
+
+
+def test_write_frames_streams_dask_input_identically():
+    # The single-position path now hands _write_frames a LAZY dask array; it must
+    # produce the same bytes as the equivalent numpy array. Skip if dask absent.
+    try:
+        import dask.array as da
+    except ImportError:
+        return
+    rng = np.random.RandomState(5)
+    arr = (rng.rand(9, 1, 20, 20) * 5000).astype(np.uint16)
+    darr = da.from_array(arr, chunks=(1, 1, 20, 20))
+    a = Path(tempfile.mkdtemp())
+    b = Path(tempfile.mkdtemp())
+    _write_frames(darr, a, ["c0"])  # dask (streamed)
+    _write_frames(arr, b, ["c0"])  # numpy
+    assert _digest(a) == _digest(b)
+
+
+def test_write_frames_single_frame_and_workers():
+    # T=1 (the single-frame IRM case) must not divide-by-zero on worker sizing.
+    arr = np.full((1, 1, 16, 16), 300, np.uint16)
+    d = Path(tempfile.mkdtemp())
+    _write_frames(arr, d, ["IRM"])
+    assert (d / "0000" / "IRM.png").exists()
+    assert _extract_workers() >= 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`extract_nd2.py` materialised the **entire** `T×C×Y×X` array into RAM before writing any frame, and encoded PNGs sequentially. For a long 2048² stack that's a multi-GB allocation + minutes of single-threaded zlib.

Two changes, **output byte-for-byte unchanged**:
1. **Stream** — keep the single-position array lazy (dask) through `normalize_to_tcyx` and read it one chunk of frames at a time in `_write_frames`, so peak memory is ~chunk frames instead of the whole video (removes the OOM risk on huge stacks).
2. **Parallelise** — encode each chunk's PNGs across a thread pool (PIL releases the GIL during zlib). Workers = `min(4, cpu_count)`, override via `ND2_EXTRACT_WORKERS`. Reads stay **sequential** (one dask compute at a time — the nd2 reader is not assumed thread-safe); only the encode/write fans out.
3. `optimize=True` is **kept** — dropping it would change the PNG bytes.

## Results (real 621-frame ND2, e199f011)
| | Before | After | Gain |
|--|--|--|--|
| Extract wall-clock | 80s | 43s | **1.9×** |
| Peak RSS | 648 MB | 263 MB | **2.5×** |
| End-to-end upload+extract (prod) | ~81s | 44s | **1.8×** |
| Output | — | **all 1242 frames md5-identical** | ✓ |

The thread speedup caps near 2× because `optimize=True`'s filter-selection holds the GIL for part of each encode; a process pool could push higher but at the cost of pickling 8 MB frames/task — not worth the complexity/risk on production-critical upload code. The memory win (O(whole video) → O(chunk)) is the bigger structural improvement.

## Tests
New regression tests pin the load-bearing invariants: parallel `_write_frames` ≡ sequential (byte-identical), dask-streamed input ≡ numpy input, single-frame (IRM) case doesn't divide-by-zero. All 16 existing normalize tests still pass.

## Verification
A/B old-vs-new on the real ND2 (byte-for-byte + time + peak RSS); end-to-end upload on prod (44s, 621 frames); backend rebuilt + deployed, `production-healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)