### PR TITLE
feat(microcapsule): Feret max/min + ovality metrics, 20px edge margin, guide formulas

### DIFF
--- a/backend/segmentation/models/microcapsule.py
+++ b/backend/segmentation/models/microcapsule.py
@@ -47,8 +47,11 @@ _ENCODERS = ("timm-mobilenetv3_small_100", "resnet18")
 _WATERSHED_H = 0.3
 # Contours smaller than this (px^2) at native resolution are dropped as noise.
 _MIN_AREA_PX = 60
-# A contour within this many px of any edge is cut off by the frame.
-_BORDER_MARGIN_PX = 2
+# A capsule whose contour comes within this many native px of any image edge is
+# treated as cut off by the frame (``complete=False``) and excluded from the
+# metrics aggregation. 20 px (≈1.5% of the 1280-wide frame) so capsules that
+# only just reach into the border are excluded, not only those flush against it.
+_BORDER_MARGIN_PX = 20
 
 
 def _letterbox(img, size, interp):

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -123,40 +123,53 @@ ${scaleInfo}
 ## Metrics file (\`metrics.csv\` / \`metrics.xlsx\`)
 
 The microcapsule model performs **instance segmentation**: each detected
-capsule is one closed polygon and gets **one row**. The report is intentionally
-focused on the three shape measures requested for capsules, plus identifiers.
+capsule is one closed polygon and gets **one row** of size and shape descriptors
+(below), plus identifiers.
 
-> **Completeness filter** — capsules whose mask touches the image border are
-> *cut off by the frame* and are **excluded from this report** (they are still
-> drawn, in grey, in the visualisation export, so you can see what was skipped).
-> Only whole capsules contribute to the metrics and the summary statistics.
+> **Completeness filter** — capsules whose contour comes within **20 px** of any
+> image border are treated as *cut off by the frame* and are **excluded from this
+> report** (they are still drawn, in grey, in the visualisation export, so you can
+> see what was skipped). Only whole capsules contribute to the metrics and the
+> summary statistics.
 
 ### Columns
+
+Every metric is derived from the capsule's **polygon contour** — the ordered
+boundary points \`p_0 … p_{n-1}\` (each \`p_i = (x_i, y_i)\`) that the segmentation
+produced, in ${lengthUnit}.
+
 - **Image Name / Image ID** — source image identifiers.
 - **Capsule ID** — 1-based index within the image (largest capsule first).
-- **Area (${areaUnit})** — enclosed area via the Shoelace formula.
-- **Perimeter (${lengthUnit})** — boundary length, Sum_i ||p_{i+1} - p_i||
-  (ImageJ convention).
-- **Width (${lengthUnit})** — axis-aligned bounding-box width (capsule extent
-  in x).
-- **Height (${lengthUnit})** — axis-aligned bounding-box height (capsule extent
-  in y).
+- **Area (${areaUnit})** — enclosed area via the **Shoelace formula**:
+  \`A = ½·|Σ_i (x_i·y_{i+1} − x_{i+1}·y_i)|\`.
+- **Perimeter (${lengthUnit})** — summed edge lengths around the contour:
+  \`P = Σ_i ||p_{i+1} − p_i||\` (ImageJ convention).
+- **Width (${lengthUnit})** — axis-aligned bounding box: \`max_i(x_i) − min_i(x_i)\`.
+- **Height (${lengthUnit})** — axis-aligned bounding box: \`max_i(y_i) − min_i(y_i)\`.
+  (Width/Height depend on how the capsule is oriented in the frame.)
 - **Diameter (${lengthUnit})** — mean Feret diameter, the average caliper width
-  across orientations \`(Feret_max + Feret_min) / 2\`. Rotation-invariant, so
-  unlike Width/Height it does not depend on how the capsule sits in the frame.
-- **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the
-  same area, \`d = 2*sqrt(Area/pi)\`. (For a perfect circle Diameter ≈
-  Equivalent Diameter ≈ Width ≈ Height.)
-- **Compactness** — circularity \`C = 4*pi * Area / Perimeter^2\`, in [0, 1]
-  where **1.0 = a perfect circle**. For round capsules this is the most
-  intuitive shape measure (a value near 1 means a clean circular capsule;
-  lower values indicate an irregular or dented boundary).
+  across orientations \`(Feret_max + Feret_min) / 2\`. Rotation-invariant.
+- **Feret Max (${lengthUnit})** — maximum caliper / **longest** diameter (the
+  *thickest* part): the largest distance between any two contour points,
+  \`Feret_max = max_{i,j} ||p_i − p_j||\` (evaluated on the convex hull).
+- **Feret Min (${lengthUnit})** — minimum caliper / **narrowest** width (the
+  *thinnest* part): the smallest distance between two parallel lines that just
+  enclose the contour. Via rotating calipers on the convex hull — for each hull
+  edge take the farthest vertex's perpendicular distance, then
+  \`Feret_min = min over hull edges of that distance\`.
+- **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the same
+  area: \`d_eq = 2·sqrt(Area / π)\`. (For a perfect circle Diameter ≈ Equivalent
+  Diameter ≈ Width ≈ Height.)
+- **Compactness** — circularity \`C = 4π·Area / Perimeter²\`, in [0, 1] where
+  **1.0 = a perfect circle**; lower values indicate an irregular/dented boundary.
+- **Ovality** — elongation \`Ovality = Feret_max / Feret_min\` (≥ 1; **1.0 = a
+  perfectly round capsule**, larger = more elongated/oval).
 - **Confidence** — the model's detection score for the capsule, in [0, 1].
 
 ### Summary sheet
 Aggregates over the **complete** capsules only: how many were analysed, plus
 mean / min / max of area and compactness, and mean perimeter, width, height,
-diameter and equivalent diameter.
+diameter, Feret max, Feret min, equivalent diameter and ovality.
 
 ## Visualisation
 Complete capsules are drawn and numbered in the configured external colour;

--- a/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
@@ -194,14 +194,31 @@ describe('MetricsCalculator — exportMicrocapsuleMetricsToExcel', () => {
       'Width (px)',
       'Height (px)',
       'Diameter (px)',
+      'Feret Max (px)',
+      'Feret Min (px)',
       'Equivalent Diameter (px)',
       'Compactness',
+      'Ovality',
       'Confidence',
     ]);
     // The focused report must NOT carry the rich spheroid descriptors.
     expect(headers).not.toContain('Feret Diameter Max (px)');
     expect(headers).not.toContain('Solidity');
     expect(headers).not.toContain('Sphericity');
+  });
+
+  it('exports Feret max/min and ovality = max/min per capsule', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [metricRow({ polygonId: 1, feretDiameterMax: 30, feretDiameterMin: 20 })],
+      '/tmp/metrics.xlsx'
+    );
+    const row = mockWorksheet.addRow.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(row.feretMax).toBeCloseTo(30, 4);
+    expect(row.feretMin).toBeCloseTo(20, 4);
+    expect(row.ovality).toBeCloseTo(1.5, 4); // 30 / 20
   });
 
   it('width/height = bounding box, diameter = mean Feret', async () => {

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -869,12 +869,15 @@ export class MetricsCalculator {
       { header: `Width (${lengthUnit})`, key: 'width', width: 12 },
       { header: `Height (${lengthUnit})`, key: 'height', width: 12 },
       { header: `Diameter (${lengthUnit})`, key: 'diameter', width: 12 },
+      { header: `Feret Max (${lengthUnit})`, key: 'feretMax', width: 14 },
+      { header: `Feret Min (${lengthUnit})`, key: 'feretMin', width: 14 },
       {
         header: `Equivalent Diameter (${lengthUnit})`,
         key: 'equivalentDiameter',
         width: 20,
       },
       { header: 'Compactness', key: 'compactness', width: 12 },
+      { header: 'Ovality', key: 'ovality', width: 10 },
       { header: 'Confidence', key: 'confidence', width: 12 },
     ];
 
@@ -885,6 +888,12 @@ export class MetricsCalculator {
     // bounding-box Width/Height and the area-based Equivalent Diameter.
     const meanDiameter = (m: PolygonMetrics): number =>
       (m.feretDiameterMax + m.feretDiameterMin) / 2;
+    // Ovality = max-caliper / min-caliper Feret ratio (≥ 1; 1.0 = circular,
+    // larger = more elongated). NaN/Inf guarded to 0 by safeValue.
+    const ovality = (m: PolygonMetrics): number =>
+      m.feretDiameterMin > 0
+        ? m.feretDiameterMax / m.feretDiameterMin
+        : 0;
 
     // Only complete capsules reach here (excluded upstream), but guard anyway.
     const rows = metrics.filter(m => m.complete !== false);
@@ -898,8 +907,11 @@ export class MetricsCalculator {
         width: safeValue(m.boundingBoxWidth, 2),
         height: safeValue(m.boundingBoxHeight, 2),
         diameter: safeValue(meanDiameter(m), 2),
+        feretMax: safeValue(m.feretDiameterMax, 2),
+        feretMin: safeValue(m.feretDiameterMin, 2),
         equivalentDiameter: safeValue(m.equivalentDiameter, 2),
         compactness: safeValue(m.circularity, 4),
+        ovality: safeValue(ovality(m), 4),
         confidence:
           typeof m.confidence === 'number' ? safeValue(m.confidence, 4) : '',
       });
@@ -964,11 +976,14 @@ export class MetricsCalculator {
         { id: 'width', title: `Width (${lengthUnit})` },
         { id: 'height', title: `Height (${lengthUnit})` },
         { id: 'diameter', title: `Diameter (${lengthUnit})` },
+        { id: 'feretMax', title: `Feret Max (${lengthUnit})` },
+        { id: 'feretMin', title: `Feret Min (${lengthUnit})` },
         {
           id: 'equivalentDiameter',
           title: `Equivalent Diameter (${lengthUnit})`,
         },
         { id: 'compactness', title: 'Compactness' },
+        { id: 'ovality', title: 'Ovality' },
         { id: 'confidence', title: 'Confidence' },
       ],
     });
@@ -986,9 +1001,18 @@ export class MetricsCalculator {
         // "Diameter" = mean Feret diameter (rotation-invariant), distinct from
         // the axis-aligned Width/Height and the area-based Equivalent Diameter.
         diameter: (m.feretDiameterMax + m.feretDiameterMin) / 2,
+        // Feret Max/Min = longest / shortest caliper width (thickest / narrowest
+        // part of the capsule).
+        feretMax: m.feretDiameterMax,
+        feretMin: m.feretDiameterMin,
         equivalentDiameter: m.equivalentDiameter,
         // "Compactness" column carries the circularity value by design.
         compactness: m.circularity,
+        // Ovality = Feret Max / Feret Min (≥ 1; 1.0 = circular).
+        ovality:
+          m.feretDiameterMin > 0
+            ? m.feretDiameterMax / m.feretDiameterMin
+            : 0,
         confidence: typeof m.confidence === 'number' ? m.confidence : '',
       }));
 
@@ -1050,12 +1074,30 @@ export class MetricsCalculator {
         ).toFixed(2),
       ],
       [
+        `Average Feret Max (${lengthUnit})`,
+        this.average(metrics.map(m => m.feretDiameterMax)).toFixed(2),
+      ],
+      [
+        `Average Feret Min (${lengthUnit})`,
+        this.average(metrics.map(m => m.feretDiameterMin)).toFixed(2),
+      ],
+      [
         `Average Equivalent Diameter (${lengthUnit})`,
         this.average(metrics.map(m => m.equivalentDiameter)).toFixed(2),
       ],
       ['Average Compactness', this.average(compactness).toFixed(4)],
       ['Minimum Compactness', Math.min(...compactness).toFixed(4)],
       ['Maximum Compactness', Math.max(...compactness).toFixed(4)],
+      [
+        'Average Ovality',
+        this.average(
+          metrics.map(m =>
+            m.feretDiameterMin > 0
+              ? m.feretDiameterMax / m.feretDiameterMin
+              : 0
+          )
+        ).toFixed(4),
+      ],
     ];
   }
 


### PR DESCRIPTION
Three microcapsule-export improvements, all verified end-to-end on production.

## 1. Edge margin 2 px → 20 px
Capsules whose contour comes within **20 px** of any image border are now flagged cut-off (`complete=False`) and excluded from the metrics aggregation — capsules that only just reach the border are dropped, not only those flush against it. Measured impact across the 101 real capsules: exclusions 55 → 68. (`microcapsule.py`; drives the stored `complete` flag at segmentation time, so it applies on re-segmentation.)

## 2. Feret Max + Feret Min + Ovality
New columns in the microcapsule CSV + Excel export and the summary averages:
- **Feret Max** — longest caliper diameter (thickest part).
- **Feret Min** — minimum caliper width (narrowest part).
- **Ovality** = Feret Max / Feret Min (≥ 1; 1.0 = round).

Values reuse the existing convex-hull rotating-calipers (`geometricPrimitives.ts`; `feretDiameterMax/Min` already on `PolygonMetrics`). Computed from the stored contour → applies on next export, no re-segmentation needed.

## 3. metrics_guide.md formulas
Every microcapsule metric is now documented with its contour-based formula: Shoelace area, perimeter sum, convex-hull Feret max/min (rotating calipers), circularity 4π·A/P², ovality = Feret_max/Feret_min, equivalent diameter — plus the 20 px completeness rule.

## Verification
Re-segmented + exported a real 1280×1024 capsule via the full pipeline: `metrics.csv` carries Feret Max=623, Feret Min=616, Ovality=1.011; `documentation/metrics_guide.md` renders all formulas. Tests updated (column set + ovality=max/min); 9/9 microcapsule tests + `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capsule completeness detection so objects near the image border are more reliably marked as incomplete.
  * Capsules that only slightly enter the border are now excluded from metrics, while still appearing in exports as greyed-out items.

* **New Features**
  * Added new shape measurements to microcapsule exports and summaries, including Feret Max, Feret Min, Equivalent Diameter, Compactness, and Ovality.
  * Updated Excel/CSV outputs and summary statistics to include the new metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->