### PR TITLE
fix(microcapsule): correct Feret-guide formulas, ovality guard, border test

### DIFF
--- a/backend/segmentation/tests/test_microcapsule_model.py
+++ b/backend/segmentation/tests/test_microcapsule_model.py
@@ -55,15 +55,21 @@ def test_touches_border_edge_polygon_is_incomplete(poly):
 
 
 def test_touches_border_respects_margin():
-    from models.microcapsule import _touches_border
+    from models.microcapsule import _touches_border, _BORDER_MARGIN_PX
 
-    # Default margin is 2 px: a vertex AT x=2 is cut off, an inset that clears
-    # 2 px on every edge is complete. Pixels run 0..199, so the far thresholds
-    # are width-1-margin = 197 / height-1-margin = 197.
-    near = np.array([[2, 40], [60, 40], [60, 120], [2, 120]], np.float32)
+    # Default margin is 20 px: a capsule reaching within 20 px of any edge is cut
+    # off; an inset that clears 20 px on every edge is complete. Pixels run
+    # 0..199, so the far thresholds are width-1-margin = 179 / height-1 = 179.
+    assert _BORDER_MARGIN_PX == 20
+    near = np.array([[18, 40], [60, 40], [60, 120], [18, 120]], np.float32)
     assert _touches_border(near, height=200, width=200) is True
-    clear = np.array([[3, 3], [196, 3], [196, 196], [3, 196]], np.float32)
+    clear = np.array([[25, 25], [174, 25], [174, 174], [25, 174]], np.float32)
     assert _touches_border(clear, height=200, width=200) is False
+    # Boundary: exactly at the margin is cut off; one px further in is complete.
+    at_margin = np.array([[20, 40], [174, 40], [174, 174], [20, 174]], np.float32)
+    assert _touches_border(at_margin, height=200, width=200) is True
+    just_clear = np.array([[21, 40], [174, 40], [174, 174], [21, 174]], np.float32)
+    assert _touches_border(just_clear, height=200, width=200) is False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -135,33 +135,34 @@ capsule is one closed polygon and gets **one row** of size and shape descriptors
 ### Columns
 
 Every metric is derived from the capsule's **polygon contour** — the ordered
-boundary points \`p_0 … p_{n-1}\` (each \`p_i = (x_i, y_i)\`) that the segmentation
-produced, in ${lengthUnit}.
+boundary points \`p_0 … p_{n-1}\` (each \`p_i = (x_i, y_i)\`), in ${lengthUnit}.
+Values are computed by the metrics service with OpenCV directly on that contour
+(a pure-JS convex-hull fallback is used only if that service is unavailable).
 
 - **Image Name / Image ID** — source image identifiers.
 - **Capsule ID** — 1-based index within the image (largest capsule first).
-- **Area (${areaUnit})** — enclosed area via the **Shoelace formula**:
-  \`A = ½·|Σ_i (x_i·y_{i+1} − x_{i+1}·y_i)|\`.
-- **Perimeter (${lengthUnit})** — summed edge lengths around the contour:
-  \`P = Σ_i ||p_{i+1} − p_i||\` (ImageJ convention).
-- **Width (${lengthUnit})** — axis-aligned bounding box: \`max_i(x_i) − min_i(x_i)\`.
-- **Height (${lengthUnit})** — axis-aligned bounding box: \`max_i(y_i) − min_i(y_i)\`.
-  (Width/Height depend on how the capsule is oriented in the frame.)
-- **Diameter (${lengthUnit})** — mean Feret diameter, the average caliper width
-  across orientations \`(Feret_max + Feret_min) / 2\`. Rotation-invariant.
-- **Feret Max (${lengthUnit})** — maximum caliper / **longest** diameter (the
-  *thickest* part): the largest distance between any two contour points,
-  \`Feret_max = max_{i,j} ||p_i − p_j||\` (evaluated on the convex hull).
-- **Feret Min (${lengthUnit})** — minimum caliper / **narrowest** width (the
-  *thinnest* part): the smallest distance between two parallel lines that just
-  enclose the contour. Via rotating calipers on the convex hull — for each hull
-  edge take the farthest vertex's perpendicular distance, then
-  \`Feret_min = min over hull edges of that distance\`.
+- **Area (${areaUnit})** — enclosed contour area (\`cv2.contourArea\`), equivalent
+  to the **Shoelace formula** \`A = ½·|Σ_i (x_i·y_{i+1} − x_{i+1}·y_i)|\`.
+- **Perimeter (${lengthUnit})** — closed-contour length (\`cv2.arcLength\`),
+  \`P = Σ_i ||p_{i+1} − p_i||\` (Euclidean sum over the boundary edges).
+- **Width / Height (${lengthUnit})** — axis-aligned bounding box
+  (\`cv2.boundingRect\`): the pixel-inclusive \`max(x)−min(x)+1\` and
+  \`max(y)−min(y)+1\`. Depend on how the capsule is oriented in the frame.
+- **Diameter (${lengthUnit})** — mean of the max and min Feret diameters (below),
+  \`(Feret_max + Feret_min) / 2\`. Rotation-invariant.
+- **Feret Max (${lengthUnit})** — **longest** diameter (the capsule's long axis):
+  the **longer side of the minimum-area bounding rectangle** of the contour
+  (\`cv2.minAreaRect\`), \`Feret_max = max(w_rect, h_rect)\`.
+- **Feret Min (${lengthUnit})** — **narrowest** width (the short axis): the
+  **shorter side of that same minimum-area rectangle**, \`Feret_min = min(w_rect,
+  h_rect)\`. (It is the min-*area* rectangle — a close approximation of the true
+  minimum caliper width, not the exact min-width rectangle.)
 - **Equivalent Diameter (${lengthUnit})** — diameter of the circle with the same
-  area: \`d_eq = 2·sqrt(Area / π)\`. (For a perfect circle Diameter ≈ Equivalent
+  area, \`d_eq = 2·sqrt(Area / π)\`. (For a round capsule Diameter ≈ Equivalent
   Diameter ≈ Width ≈ Height.)
-- **Compactness** — circularity \`C = 4π·Area / Perimeter²\`, in [0, 1] where
-  **1.0 = a perfect circle**; lower values indicate an irregular/dented boundary.
+- **Compactness** — circularity \`C = 4π·Area / Perimeter²\`, clamped to [0, 1]
+  where **1.0 = a perfect circle**; lower values indicate an irregular/dented
+  boundary.
 - **Ovality** — elongation \`Ovality = Feret_max / Feret_min\` (≥ 1; **1.0 = a
   perfectly round capsule**, larger = more elongated/oval).
 - **Confidence** — the model's detection score for the capsule, in [0, 1].

--- a/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
@@ -221,6 +221,36 @@ describe('MetricsCalculator — exportMicrocapsuleMetricsToExcel', () => {
     expect(row.ovality).toBeCloseTo(1.5, 4); // 30 / 20
   });
 
+  it('ovality falls back to the neutral 1 (not 0) when feretMin <= 0', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [metricRow({ polygonId: 1, feretDiameterMax: 30, feretDiameterMin: 0 })],
+      '/tmp/metrics.xlsx'
+    );
+    const row = mockWorksheet.addRow.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    // Degenerate (unreachable for a real capsule) → 1.0, in-range [1,∞); a 0
+    // would be out-of-range and drag the summary Average Ovality below 1.
+    expect(row.ovality).toBe(1);
+  });
+
+  it('summary Average Ovality is the mean of per-capsule ratios', async () => {
+    await calc.exportMicrocapsuleMetricsToExcel(
+      [
+        metricRow({ polygonId: 1, feretDiameterMax: 30, feretDiameterMin: 20 }), // 1.5
+        metricRow({ polygonId: 2, feretDiameterMax: 50, feretDiameterMin: 20 }), // 2.5
+      ],
+      '/tmp/metrics.xlsx'
+    );
+    // Summary rows are arrays pushed to the shared mock after the data rows.
+    const ovalityRow = mockWorksheet.addRow.mock.calls
+      .map(c => c[0])
+      .find(r => Array.isArray(r) && r[0] === 'Average Ovality') as unknown[];
+    expect(ovalityRow).toBeDefined();
+    expect(parseFloat(String(ovalityRow[1]))).toBeCloseTo(2.0, 4); // mean(1.5, 2.5)
+  });
+
   it('width/height = bounding box, diameter = mean Feret', async () => {
     await calc.exportMicrocapsuleMetricsToExcel(
       [
@@ -294,5 +324,29 @@ describe('MetricsCalculator — exportMicrocapsuleToCSV', () => {
     // Two metric rows in, one excluded → one data line + the header.
     const lines = content.trim().split('\n');
     expect(lines).toHaveLength(2);
+  });
+
+  it('emits Feret Max / Feret Min / Ovality columns with correct values', async () => {
+    await calc.exportMicrocapsuleToCSV(
+      [
+        metricRow({
+          polygonId: 1,
+          feretDiameterMax: 30,
+          feretDiameterMin: 20,
+          complete: true,
+        }),
+      ],
+      '/tmp/metrics.csv'
+    );
+    const content = String(fsWriteFile.mock.calls[0]![1]);
+    const [headerLine, dataLine] = content.trim().split('\n');
+    const headers = headerLine.split(',');
+    const vals = dataLine.split(',');
+    const valOf = (prefix: string): number =>
+      parseFloat(vals[headers.findIndex(h => h.startsWith(prefix))]);
+    expect(valOf('Feret Max')).toBeCloseTo(30, 4);
+    expect(valOf('Feret Min')).toBeCloseTo(20, 4);
+    expect(valOf('Ovality')).toBeCloseTo(1.5, 4); // 30 / 20 — guards the CSV
+    // copy of the ovality logic against drifting from the Excel path.
   });
 });

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -126,6 +126,25 @@ export interface ImageWithSegmentation {
 
 export type SummaryStatisticsRow = (string | number)[];
 
+/** Mean of the max and min Feret diameters — the microcapsule export's
+ *  "Diameter" column. Rotation-invariant, distinct from the axis-aligned
+ *  Width/Height and the area-based Equivalent Diameter. */
+function meanFeretDiameter(m: PolygonMetrics): number {
+  return (m.feretDiameterMax + m.feretDiameterMin) / 2;
+}
+
+/** Ovality = Feret Max / Feret Min elongation ratio (≥ 1; 1.0 = round). Shared
+ *  by the CSV, Excel and summary exports so the value + degenerate handling stay
+ *  identical. ``feretDiameterMin`` is always > 0 for a real capsule (the shorter
+ *  side of a ≥ _MIN_AREA_PX min-area rectangle), so the guard returns the neutral
+ *  in-range 1.0 only for a degenerate zero-width polygon that can't reach export
+ *  — never the out-of-range 0 that would drag the summary average below 1. */
+function microcapsuleOvality(m: PolygonMetrics): number {
+  return m.feretDiameterMin > 0
+    ? m.feretDiameterMax / m.feretDiameterMin
+    : 1;
+}
+
 export class MetricsCalculator {
   private pythonApiUrl: string;
   private http: AxiosInstance;
@@ -883,17 +902,6 @@ export class MetricsCalculator {
 
     const safeValue = (value: number, decimals = 2): number =>
       isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
-    // "Diameter" = mean Feret diameter (average caliper width across
-    // orientations) — rotation-invariant, distinct from the axis-aligned
-    // bounding-box Width/Height and the area-based Equivalent Diameter.
-    const meanDiameter = (m: PolygonMetrics): number =>
-      (m.feretDiameterMax + m.feretDiameterMin) / 2;
-    // Ovality = max-caliper / min-caliper Feret ratio (≥ 1; 1.0 = circular,
-    // larger = more elongated). NaN/Inf guarded to 0 by safeValue.
-    const ovality = (m: PolygonMetrics): number =>
-      m.feretDiameterMin > 0
-        ? m.feretDiameterMax / m.feretDiameterMin
-        : 0;
 
     // Only complete capsules reach here (excluded upstream), but guard anyway.
     const rows = metrics.filter(m => m.complete !== false);
@@ -906,12 +914,12 @@ export class MetricsCalculator {
         perimeter: safeValue(m.perimeter, 2),
         width: safeValue(m.boundingBoxWidth, 2),
         height: safeValue(m.boundingBoxHeight, 2),
-        diameter: safeValue(meanDiameter(m), 2),
+        diameter: safeValue(meanFeretDiameter(m), 2),
         feretMax: safeValue(m.feretDiameterMax, 2),
         feretMin: safeValue(m.feretDiameterMin, 2),
         equivalentDiameter: safeValue(m.equivalentDiameter, 2),
         compactness: safeValue(m.circularity, 4),
-        ovality: safeValue(ovality(m), 4),
+        ovality: safeValue(microcapsuleOvality(m), 4),
         confidence:
           typeof m.confidence === 'number' ? safeValue(m.confidence, 4) : '',
       });
@@ -1000,19 +1008,15 @@ export class MetricsCalculator {
         height: m.boundingBoxHeight,
         // "Diameter" = mean Feret diameter (rotation-invariant), distinct from
         // the axis-aligned Width/Height and the area-based Equivalent Diameter.
-        diameter: (m.feretDiameterMax + m.feretDiameterMin) / 2,
-        // Feret Max/Min = longest / shortest caliper width (thickest / narrowest
-        // part of the capsule).
+        diameter: meanFeretDiameter(m),
+        // Feret Max/Min = longer / shorter side of the min-area bounding rect
+        // (the capsule's long axis / narrowest width).
         feretMax: m.feretDiameterMax,
         feretMin: m.feretDiameterMin,
         equivalentDiameter: m.equivalentDiameter,
         // "Compactness" column carries the circularity value by design.
         compactness: m.circularity,
-        // Ovality = Feret Max / Feret Min (≥ 1; 1.0 = circular).
-        ovality:
-          m.feretDiameterMin > 0
-            ? m.feretDiameterMax / m.feretDiameterMin
-            : 0,
+        ovality: microcapsuleOvality(m),
         confidence: typeof m.confidence === 'number' ? m.confidence : '',
       }));
 
@@ -1069,9 +1073,7 @@ export class MetricsCalculator {
       ],
       [
         `Average Diameter (${lengthUnit})`,
-        this.average(
-          metrics.map(m => (m.feretDiameterMax + m.feretDiameterMin) / 2)
-        ).toFixed(2),
+        this.average(metrics.map(meanFeretDiameter)).toFixed(2),
       ],
       [
         `Average Feret Max (${lengthUnit})`,
@@ -1090,13 +1092,7 @@ export class MetricsCalculator {
       ['Maximum Compactness', Math.max(...compactness).toFixed(4)],
       [
         'Average Ovality',
-        this.average(
-          metrics.map(m =>
-            m.feretDiameterMin > 0
-              ? m.feretDiameterMax / m.feretDiameterMin
-              : 0
-          )
-        ).toFixed(4),
+        this.average(metrics.map(microcapsuleOvality)).toFixed(4),
       ],
     ];
   }


### PR DESCRIPTION
Follow-up review fixes for **PR #250** (microcapsule Feret Max/Min + Ovality export, 20px edge margin). A 3-agent review of the #250 diff (comment-accuracy, test-coverage, silent-failure) surfaced three real issues that no compile-time gate catches:

## Fixes

### 1. `metrics_guide.md` Feret formulas were wrong (comment-analyzer)
The guide documented Feret Max/Min as **convex-hull rotating calipers** (max pairwise distance / min caliper width). But `metricsCalculator.calculatePolygonMetrics` POSTs to the Python metrics service (`/api/calculate-metrics`), which computes them from **`cv2.minAreaRect` sides**. These diverge for elongated shapes — for a square, the hull's max pairwise distance is the diagonal `s√2` vs the rect side `s` (~41% gap). The JS convex-hull path is only a *fallback* used when the service is unavailable.
- Rewrote the guide to describe the production cv2 path: `cv2.minAreaRect` (Feret), `cv2.contourArea` (Area), `cv2.arcLength` (Perimeter), pixel-inclusive `cv2.boundingRect` (Width/Height), and a lead-in noting the JS fallback.

### 2. Ovality degenerate guard returned an out-of-range `0` (silent-failure-hunter)
Ovality ∈ `[1, ∞)` (1.0 = round). The `feretMin <= 0` guard returned `0`, which would silently drag the summary **Average Ovality** below 1. Now returns the neutral in-range `1.0`.
- Factored the diameter + ovality math into shared `meanFeretDiameter` / `microcapsuleOvality` helpers so the CSV, Excel and summary exports can't drift.

### 3. `test_touches_border_respects_margin` broke at margin=20 (pr-test-analyzer)
The margin 2→20 change in #250 broke this test — its old `clear` polygon inset only 3px, so `3 <= 20` now reads as "touches border". Rewrote for `_BORDER_MARGIN_PX == 20` with exact at-margin / just-clear boundary cases.
- Added TS coverage: degenerate ovality → 1, summary Average Ovality = mean of per-capsule ratios, and the CSV Feret Max/Min/Ovality column values.

## Verification
- Python border tests (interior / 4 edge cases / at-margin / just-clear): ✅ pass via the in-container import-shim runner (pytest not installed in the ML container).
- TS Vitest `metricsCalculator.microcapsule.test.ts` + `exportDocs.test.ts`: ✅ 27/27.
- `make ci` (TS + ESLint 0 warnings + i18n): ✅ pass.
- Backend image rebuilt; deploying + verifying corrected export against the live test account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microcapsule exports and summaries now use consistent diameter and ovality calculations across CSV, Excel, and summary views.
  * Ovality now handles edge cases more reliably when minimum Feret values are invalid, preventing misleading results.
  * Boundary-related checks were updated to match the current margin behavior, improving consistency around edge-touching shapes.

* **Documentation**
  * Updated the microcapsule metrics guide to better describe how metric values are calculated and how key columns should be interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->