### PR TITLE
fix(metrics): de-staircase contour perimeter so circularity/compactness aren't deflated

### DIFF
--- a/backend/segmentation/tests/unit/test_characteristic_functions.py
+++ b/backend/segmentation/tests/unit/test_characteristic_functions.py
@@ -82,6 +82,21 @@ class TestPerimeterFromContour:
         perim = calculate_perimeter_from_contour(square_contour)
         assert abs(perim - 320.0) < 5.0, f"Expected ~320, got {perim}"
 
+    def test_perimeter_staircase_circle_close_to_true(self):
+        """Regression: a circle traced from a rasterized mask has a pixel
+        staircase boundary whose raw arc length over-counts the perimeter by
+        ~12%. The de-staircased measurement must approximate 2πr instead."""
+        mask = np.zeros((400, 400), np.uint8)
+        cv2.circle(mask, (200, 200), 150, 1, -1)
+        cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        cnt = max(cnts, key=cv2.contourArea)
+        assert len(cnt) > 200, "expected a genuine pixel-staircase boundary"
+        perim = calculate_perimeter_from_contour(cnt)
+        true_perim = 2 * np.pi * 150
+        assert abs(perim - true_perim) / true_perim < 0.05, (
+            f"Perimeter should be within 5% of 2πr={true_perim:.0f}, got {perim:.0f}"
+        )
+
 
 @pytest.mark.unit
 class TestCircularityFromContour:
@@ -107,6 +122,21 @@ class TestCircularityFromContour:
         circularity = calculate_circularity_from_contour(square_contour)
         assert 0.6 <= circularity <= 0.9, (
             f"Square circularity should be in [0.6, 0.9], got {circularity:.4f}"
+        )
+
+    def test_circularity_staircase_circle_not_deflated(self):
+        """Regression: before de-staircasing the perimeter, a round object
+        traced from a rasterized mask read circularity ~0.80 (the pixel
+        staircase inflated P, and circularity ∝ 1/P²). A genuinely round shape
+        must now read close to 1.0."""
+        mask = np.zeros((400, 400), np.uint8)
+        cv2.circle(mask, (200, 200), 150, 1, -1)
+        cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        cnt = max(cnts, key=cv2.contourArea)
+        assert len(cnt) > 200, "expected a genuine pixel-staircase boundary"
+        circularity = calculate_circularity_from_contour(cnt)
+        assert circularity >= 0.95, (
+            f"Staircase circle should read ~1.0 after de-staircasing, got {circularity:.4f}"
         )
 
 

--- a/backend/segmentation/utils/characteristic_functions.py
+++ b/backend/segmentation/utils/characteristic_functions.py
@@ -1,9 +1,37 @@
 import cv2
 import numpy as np
+
+# Contours traced from a segmentation mask follow every pixel step, so summing
+# the raw arc length over-counts the boundary by the staircase effect (~12% for
+# a smooth object). Since Circularity/Compactness scale as 1/P², that inflation
+# deflates a genuinely round shape to ~0.80 instead of ~1.0. Measure length on a
+# Douglas-Peucker-simplified COPY of the contour: this removes sub-pixel
+# staircase noise while preserving real concavities (a truly dented object still
+# reads low). The stored/display polygon is never touched — only the length
+# measurement. eps is in pixels and applied in pixel space (metrics are scaled to
+# µm afterward in the Node layer). eps=2.0 px makes a round capsule read ~0.996.
+_PERIMETER_SIMPLIFY_EPS_PX = 2.0
+
+
+def _perimeter_contour(contour):
+    """Douglas-Peucker-simplified copy of ``contour`` for length measurement.
+
+    Returns the original contour unchanged when it is too small to simplify
+    safely (a degenerate <3-point result would measure zero length).
+    """
+    c = np.asarray(contour, dtype=np.float32)
+    if c.ndim == 2:
+        c = c.reshape(-1, 1, 2)
+    if len(c) < 3:
+        return contour
+    approx = cv2.approxPolyDP(c, _PERIMETER_SIMPLIFY_EPS_PX, True)
+    return approx if len(approx) >= 3 else contour
+
+
 def calculate_area_from_contour(contour):
     return cv2.contourArea(contour)
 def calculate_perimeter_from_contour(contour):
-    return cv2.arcLength(contour, True)
+    return cv2.arcLength(_perimeter_contour(contour), True)
 
 def calculate_equivalent_diameter_from_contour(contour):
     area = calculate_area_from_contour(contour)
@@ -126,11 +154,13 @@ def calculate_all(contour, hole_contours=None):
     area = calculate_area_from_contour(contour)
     perimeter = calculate_perimeter_from_contour(contour)
 
-    # Calculate perimeter with holes if provided
+    # Calculate perimeter with holes if provided. Holes are de-staircased the
+    # same way as the outer contour so PerimeterWithHoles / Circularity stay
+    # consistent with the simplified outer perimeter above.
     perimeter_with_holes = perimeter
     if hole_contours:
         for hole in hole_contours:
-            perimeter_with_holes += cv2.arcLength(hole, True)
+            perimeter_with_holes += cv2.arcLength(_perimeter_contour(hole), True)
 
     eq_diam = calculate_equivalent_diameter_from_contour(contour)
     # Use perimeter with holes for circularity calculation (ImageJ convention)


### PR DESCRIPTION
## Problem
Round microcapsules exported with **Compactness ≈ 0.79** instead of ~1.0. Diagnosed on a real capsule (`341.tiff`, stored polygon = **1132 points** = full pixel contour).

`circularity = 4π·Area / Perimeter²`, with `Perimeter = cv2.arcLength(raw_contour)`. The raw contour follows every pixel step, so its summed arc length **over-counts a smooth boundary by ~12%** (staircase effect). Because circularity ∝ 1/P², that inflation deflates a genuinely round shape to ~0.80. The effect grew after the microcapsule model dropped `approxPolyDP` (#249), producing ~1100-vertex pixel contours.

Measured on the real capsule:

| Perimeter method | P (px) | Circularity |
|---|---|---|
| **Raw arcLength (1132 pts) — before** | 2342.8 | **0.796** |
| approxPolyDP eps=2.0 — after | 2094.8 | **0.996** |
| Ideal circle (same area) | 2090.1 | 1.000 |

## Fix
Measure perimeter on a **Douglas-Peucker-simplified copy** of the contour (`approxPolyDP`, eps=2.0 px) inside the shared `calculate_perimeter_from_contour`, plus the hole perimeters in `calculate_all`. The **stored/display polygon, Area and Feret are untouched** — only the length measurement changes.

This is the single source of truth for perimeter, so **circularity, compactness, sphericity and convexity all become consistent and accurate** in one place — applied **globally (all project types)** per the chosen scope. Metrics are computed fresh at export time (not persisted), so no migration is needed; every project's next export picks up the corrected values.

## Verification
- Real capsule (1132-pt contour): circularity **0.796 → 0.996**, perimeter 2342.8 → 2094.8.
- Safe across radii 8..330 px — tiny blobs improve (0.80→0.93) without distortion; minor >1.0 overshoots clamped by the existing `min(1.0, …)` in `calculate_all`.
- Existing unit tests unaffected (square ~0.785, rectangle <0.5, smooth circle ≥0.70).
- New regression tests: a rasterized-disk contour (genuine pixel staircase, >200 pts) must measure perimeter within 5% of 2πr and circularity ≥0.95 (was ~0.80–0.89). These fail before the fix, pass after.
- Deploying `spheroseg-ml` (metric endpoint) + re-exporting to confirm the live Compactness column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved perimeter measurements for pixel-based shapes so jagged edges no longer inflate results.
  * Updated circularity calculations to better match expected values for rasterized circles.
  * Refined measurements for shapes with holes to keep perimeter results consistent across all contours.
* **Tests**
  * Added regression coverage for perimeter and circularity on staircase-like circular contours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->