### PR TITLE
fix(metrics): clamp Compactness to >= 1.0 (isoperimetric bound)

### DIFF
--- a/backend/segmentation/tests/unit/test_characteristic_functions.py
+++ b/backend/segmentation/tests/unit/test_characteristic_functions.py
@@ -214,6 +214,25 @@ class TestCalculateAll:
             "PerimeterWithHoles should be larger when holes are provided"
         )
 
+    def test_compactness_never_below_one_for_tiny_contour(self):
+        """Regression: de-staircasing the perimeter with a 2px tolerance can
+        over-shorten a TINY few-point contour's boundary (approxPolyDP cuts
+        area-contributing vertices while Area stays measured on the original),
+        pushing P²/4πA below the isoperimetric bound of 1.0. This 5-point
+        fragment — taken from a real spheroid export — yields raw compactness
+        ~0.87; calculate_all must clamp it to >= 1.0, mirroring the
+        Circularity <= 1.0 clamp so the reciprocal metrics stay consistent."""
+        cnt = np.array(
+            [[[4, 1]], [[1, 3]], [[1, 6]], [[4, 7]], [[6, 4]]], dtype=np.int32
+        )
+        data = calculate_all(cnt)
+        assert data["Compactness"] >= 1.0, (
+            f"Compactness must not violate the isoperimetric bound, got {data['Compactness']:.4f}"
+        )
+        assert data["Circularity"] <= 1.0, (
+            f"Circularity must stay <= 1.0, got {data['Circularity']:.4f}"
+        )
+
 
 @pytest.mark.unit
 class TestDegenerateContourSafety:

--- a/backend/segmentation/utils/characteristic_functions.py
+++ b/backend/segmentation/utils/characteristic_functions.py
@@ -171,8 +171,15 @@ def calculate_all(contour, hole_contours=None):
     feret_max_orthogonal_distance = calculate_orthogonal_diameter(contour)
     major_axis_length, minor_axis_length = calculate_diameters_from_contour(contour)
 
-    # Use correct compactness formula: P²/(4πA)
-    compactness = calculate_compactness_from_contour(contour)
+    # Compactness = P²/(4πA), the reciprocal of circularity (1.0 = circle, larger
+    # = more irregular). The isoperimetric inequality guarantees P² ≥ 4πA, so the
+    # true value is ≥ 1; clamp to mirror the Circularity ≤ 1.0 clamp above. This
+    # absorbs the rare case where de-staircasing a TINY contour (area ≲ 30 px²,
+    # where the 2px tolerance is large relative to the object) shortens the
+    # perimeter just below the bound. Real-sized objects are unaffected — their
+    # value is already ≥ 1 — and Circularity already reports a clamped 1.0 for
+    # these fragments, so this keeps the two reciprocal metrics consistent.
+    compactness = max(1.0, calculate_compactness_from_contour(contour))
 
     # Convexity uses perimeter with holes for boundary smoothness measure
     hull = cv2.convexHull(contour)


### PR DESCRIPTION
Follow-up to #252. Verifying compactness on a **spheroid_invasive** export (project `b6b2f933`, 67,968 polygons) surfaced **18 polygons reading Compactness (`P²/4πA`) < 1.0** — mathematically impossible (isoperimetric inequality `P² ≥ 4πA`).

## Cause
All 18 were tiny few-point fragments (area ~10–26 px²). De-staircasing the perimeter (#252) with the 2px `approxPolyDP` tolerance cuts area-contributing vertices, so the simplified perimeter falls below the isoperimetric bound while **Area is still measured on the original contour**. Before #252 the staircase *inflated* P, so compactness was always >1 and the clamp was never needed.

`Circularity` was already clamped to ≤1.0 for the same reason (and these fragments already reported a clamped Circularity of 1.0) — the reciprocal `Compactness` simply lacked the symmetric ≥1.0 clamp.

## Fix
`compactness = max(1.0, P²/4πA)` in `calculate_all`. Real-sized objects are unaffected (already ≥1); only the degenerate fragments snap to the 1.0 "perfect circle" sentinel, keeping Compactness and Circularity consistent (both report 1.0 for an unmeasurable fragment).

## Discrimination preserved
The metric still ranges 1.0 → ~79 across the spheroid project (round ~1.0, irregular higher) — it is **not** pinned to 1.0.

## Test
Regression test uses a **real 5-point spheroid fragment** (`[[4,1],[1,3],[1,6],[4,7],[6,4]]`) whose raw compactness is 0.87 → clamped 1.0, so it genuinely fails without the clamp. Full suite (17 assertions) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)