### PR TITLE
chore(deps): patch reachable security advisories + dep hygiene

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,7 +28,7 @@
         "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^9.0.1",
         "prom-client": "^15.1.3",
         "rate-limit-redis": "^4.2.0",
         "redis": "^4.7.0",
@@ -2470,9 +2470,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10130,9 +10130,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,7 @@
     "ioredis": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.1",
     "prom-client": "^15.1.3",
     "rate-limit-redis": "^4.2.0",
     "redis": "^4.7.0",

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -8,8 +8,10 @@ pydantic==2.5.0
 requests==2.33.0
 # python-multipart 0.0.30 fixes CVE-2024-24762 (Content-Type header ReDoS),
 # CVE-2024-53981 (multipart boundary DoS), CVE-2026-24486 (arbitrary file
-# write), and the later high-severity multipart-parsing advisory.
-python-multipart==0.0.30
+# write), and the later high-severity multipart-parsing advisory. 0.0.31 adds
+# the negative Content-Length parse_form buffer fix (GHSA, low). In-range
+# patch; FastAPI 0.104.1 only requires python-multipart>=0.0.5.
+python-multipart==0.0.31
 psutil==5.9.5
 
 # ML dependencies (CUDA variant specified in Dockerfiles)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8564,9 +8564,9 @@
       "license": "MIT"
     },
     "node_modules/depcheck/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Patches the **reachable, safely in-range** Dependabot advisories. Load-bearing / non-exploitable / dev-only alerts are risk-accepted and dismissed separately (see below), per maintainer decision.

### Fixed in this PR
| Advisory | Change | Severity |
|---|---|---|
| nodemailer raw-option bypasses `disableFileAccess` | `^8.0.5 → ^9.0.1` (resolved 9.0.3) | **HIGH** |
| js-yaml quadratic merge-key DoS | `3.14.2 → 3.15.0` (both lockfiles, transitive) | MEDIUM ×2 |
| python-multipart negative Content-Length buffer | `0.0.30 → 0.0.31` | LOW |

### Verification
- nodemailer is API-compatible for our usage (`createTransport` + `sendMail` + `attachments`; the `raw` option the CVE concerns is never used). Verified: backend `type-check`, **62 email unit tests**, transporter-construction smoke test.
- js-yaml/python-multipart are transitive/in-range patches.
- Production `vite build` clean (lockfile change doesn't break the prod bundle).

### Handled outside this PR (maintainer-approved)
- **Dismissed (tolerable risk / not reachable):** `torch` + `transformers` (load-bearing — mamba CUDA kernels built against torch 2.6.0, DINOv3 needs transformers 4.57.x; 2 torch CVEs have no upstream fix), `exceljs→uuid` (uuid v4 path, not the vulnerable v3/5/6+buf), `vite`/`esbuild` (dev-server only; Windows-path CVE, we run Linux).
- **Dismissed 20 `js/path-injection` CodeQL alerts** on `videoUploadService.ts` as false-positive (all segments sanitized by `assertSafeStorageSegment`; CodeQL doesn't model the custom sanitizer).
- **Closed 17 stale `[nightly-drift]` auto-issues** (none since 2026-05-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a mail-sending dependency to a newer release for improved reliability and security.
  * Refreshed a request-handling package to address known vulnerability fixes and strengthen backend stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->