### PR TITLE
fix(websocket): auto-recover connection instead of stranding the "Connecting to server..." banner

### DIFF
--- a/src/hooks/__tests__/useWebSocketToasts.test.ts
+++ b/src/hooks/__tests__/useWebSocketToasts.test.ts
@@ -63,16 +63,8 @@ describe('useWebSocketToasts', () => {
         'reconnected',
         expect.any(Function)
       );
-      expect(webSocketEventEmitter.on).toHaveBeenCalledWith(
-        'reconnect_failed',
-        expect.any(Function)
-      );
-      expect(webSocketEventEmitter.on).toHaveBeenCalledWith(
-        'connection_lost',
-        expect.any(Function)
-      );
 
-      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(4);
+      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(2);
     });
 
     it('should unregister event listeners on unmount', () => {
@@ -82,7 +74,7 @@ describe('useWebSocketToasts', () => {
       const onCalls = vi.mocked(webSocketEventEmitter.on).mock.calls;
       const handlers = onCalls.map(call => call[1]);
 
-      expect(handlers).toHaveLength(4);
+      expect(handlers).toHaveLength(2);
 
       unmount();
 
@@ -95,16 +87,8 @@ describe('useWebSocketToasts', () => {
         'reconnected',
         expect.any(Function)
       );
-      expect(webSocketEventEmitter.off).toHaveBeenCalledWith(
-        'reconnect_failed',
-        expect.any(Function)
-      );
-      expect(webSocketEventEmitter.off).toHaveBeenCalledWith(
-        'connection_lost',
-        expect.any(Function)
-      );
 
-      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(4);
+      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(2);
     });
 
     it('should re-register listeners when translation function changes', () => {
@@ -175,28 +159,6 @@ describe('useWebSocketToasts', () => {
       );
     });
 
-    it('should show error toast for reconnect_failed event', () => {
-      const event: WebSocketEvent = { type: 'reconnect_failed' };
-
-      eventHandler(event);
-
-      expect(mockT).toHaveBeenCalledWith('websocket.reconnectFailed');
-      expect(toast.error).toHaveBeenCalledWith(
-        'translated.websocket.reconnectFailed'
-      );
-    });
-
-    it('should show error toast for connection_lost event', () => {
-      const event: WebSocketEvent = { type: 'connection_lost' };
-
-      eventHandler(event);
-
-      expect(mockT).toHaveBeenCalledWith('websocket.connectionLost');
-      expect(toast.error).toHaveBeenCalledWith(
-        'translated.websocket.connectionLost'
-      );
-    });
-
     it('should handle unknown event types gracefully', () => {
       const event = { type: 'unknown_event' } as any;
 
@@ -236,14 +198,13 @@ describe('useWebSocketToasts', () => {
 
       const events: WebSocketEvent[] = [
         { type: 'reconnecting' },
-        { type: 'reconnect_failed' },
         { type: 'reconnecting' },
         { type: 'reconnected' },
       ];
 
       events.forEach(event => eventHandler(event));
 
-      expect(toast.error).toHaveBeenCalledTimes(3); // 2 reconnecting + 1 failed
+      expect(toast.error).toHaveBeenCalledTimes(2); // 2 reconnecting
       expect(toast.success).toHaveBeenCalledTimes(1); // 1 reconnected
     });
 
@@ -272,17 +233,17 @@ describe('useWebSocketToasts', () => {
       const { unmount } = renderHook(() => useWebSocketToasts());
 
       // Initial mount
-      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(4);
+      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(2);
 
       // Unmount
       unmount();
-      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(4);
+      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(2);
 
       vi.clearAllMocks();
 
       // Re-mount with new hook instance
       const { unmount: unmount2 } = renderHook(() => useWebSocketToasts());
-      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(4);
+      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(2);
 
       unmount2();
     });
@@ -321,14 +282,14 @@ describe('useWebSocketToasts', () => {
         instances.push(renderHook(() => useWebSocketToasts()));
       }
 
-      // Should register 4 listeners per instance
-      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(40);
+      // Should register 2 listeners per instance
+      expect(webSocketEventEmitter.on).toHaveBeenCalledTimes(20);
 
       // Unmount all instances
       instances.forEach(instance => instance.unmount());
 
       // Should clean up all listeners
-      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(40);
+      expect(webSocketEventEmitter.off).toHaveBeenCalledTimes(20);
     });
 
     it('should handle high-frequency events without performance issues', () => {

--- a/src/hooks/useWebSocketToasts.ts
+++ b/src/hooks/useWebSocketToasts.ts
@@ -21,14 +21,6 @@ export function useWebSocketToasts() {
           toast.success(t('websocket.reconnected'));
           break;
 
-        case 'reconnect_failed':
-          toast.error(t('websocket.reconnectFailed'));
-          break;
-
-        case 'connection_lost':
-          toast.error(t('websocket.connectionLost'));
-          break;
-
         default:
           break;
       }
@@ -37,15 +29,11 @@ export function useWebSocketToasts() {
     // Subscribe to all websocket events
     webSocketEventEmitter.on('reconnecting', handleWebSocketEvent);
     webSocketEventEmitter.on('reconnected', handleWebSocketEvent);
-    webSocketEventEmitter.on('reconnect_failed', handleWebSocketEvent);
-    webSocketEventEmitter.on('connection_lost', handleWebSocketEvent);
 
     return () => {
       // Cleanup
       webSocketEventEmitter.off('reconnecting', handleWebSocketEvent);
       webSocketEventEmitter.off('reconnected', handleWebSocketEvent);
-      webSocketEventEmitter.off('reconnect_failed', handleWebSocketEvent);
-      webSocketEventEmitter.off('connection_lost', handleWebSocketEvent);
     };
   }, [t]);
 }

--- a/src/lib/__tests__/websocketEvents.test.ts
+++ b/src/lib/__tests__/websocketEvents.test.ts
@@ -35,11 +35,11 @@ describe('WebSocketEventEmitter', () => {
       const listener1 = vi.fn();
       const listener2 = vi.fn();
       const listener3 = vi.fn();
-      const event: WebSocketEvent = { type: 'connection_lost' };
+      const event: WebSocketEvent = { type: 'reconnected' };
 
-      webSocketEventEmitter.on('connection_lost', listener1);
-      webSocketEventEmitter.on('connection_lost', listener2);
-      webSocketEventEmitter.on('connection_lost', listener3);
+      webSocketEventEmitter.on('reconnected', listener1);
+      webSocketEventEmitter.on('reconnected', listener2);
+      webSocketEventEmitter.on('reconnected', listener3);
 
       webSocketEventEmitter.emit(event);
 
@@ -51,18 +51,15 @@ describe('WebSocketEventEmitter', () => {
     it('should not affect listeners of different event types', () => {
       const reconnectingListener = vi.fn();
       const reconnectedListener = vi.fn();
-      const reconnectFailedListener = vi.fn();
 
       webSocketEventEmitter.on('reconnecting', reconnectingListener);
       webSocketEventEmitter.on('reconnected', reconnectedListener);
-      webSocketEventEmitter.on('reconnect_failed', reconnectFailedListener);
 
       const event: WebSocketEvent = { type: 'reconnecting' };
       webSocketEventEmitter.emit(event);
 
       expect(reconnectingListener).toHaveBeenCalledWith(event);
       expect(reconnectedListener).not.toHaveBeenCalled();
-      expect(reconnectFailedListener).not.toHaveBeenCalled();
     });
 
     it('should handle emission when no listeners are registered', () => {
@@ -117,8 +114,6 @@ describe('WebSocketEventEmitter', () => {
       const listeners = {
         reconnecting: vi.fn(),
         reconnected: vi.fn(),
-        reconnect_failed: vi.fn(),
-        connection_lost: vi.fn(),
       };
 
       // Register all listeners
@@ -240,40 +235,11 @@ describe('WebSocketEventEmitter', () => {
       expect(listener).toHaveBeenCalledWith(event);
     });
 
-    it('should handle reconnect_failed events', () => {
-      const listener = vi.fn();
-      webSocketEventEmitter.on('reconnect_failed', listener);
-
-      const event: WebSocketEvent = {
-        type: 'reconnect_failed',
-        data: {
-          attempts: 10,
-          message: 'Max reconnection attempts reached',
-        },
-      };
-
-      webSocketEventEmitter.emit(event);
-      expect(listener).toHaveBeenCalledWith(event);
-    });
-
-    it('should handle connection_lost events', () => {
-      const listener = vi.fn();
-      webSocketEventEmitter.on('connection_lost', listener);
-
-      const event: WebSocketEvent = {
-        type: 'connection_lost',
-        data: { message: 'Connection lost due to network error' },
-      };
-
-      webSocketEventEmitter.emit(event);
-      expect(listener).toHaveBeenCalledWith(event);
-    });
-
     it('should handle events without data payload', () => {
       const listener = vi.fn();
-      webSocketEventEmitter.on('reconnect_failed', listener);
+      webSocketEventEmitter.on('reconnecting', listener);
 
-      const event: WebSocketEvent = { type: 'reconnect_failed' };
+      const event: WebSocketEvent = { type: 'reconnecting' };
 
       webSocketEventEmitter.emit(event);
       expect(listener).toHaveBeenCalledWith(event);
@@ -313,7 +279,7 @@ describe('WebSocketEventEmitter', () => {
     });
 
     it('should handle empty listener arrays without issues', () => {
-      const event: WebSocketEvent = { type: 'reconnect_failed' };
+      const event: WebSocketEvent = { type: 'reconnected' };
 
       // Should not throw when no listeners are registered
       expect(() => webSocketEventEmitter.emit(event)).not.toThrow();
@@ -411,15 +377,11 @@ describe('WebSocketEventEmitter', () => {
       // These should be valid event types
       webSocketEventEmitter.on('reconnecting', listener);
       webSocketEventEmitter.on('reconnected', listener);
-      webSocketEventEmitter.on('reconnect_failed', listener);
-      webSocketEventEmitter.on('connection_lost', listener);
 
       // These events should match the interface
       const validEvents: WebSocketEvent[] = [
         { type: 'reconnecting' },
         { type: 'reconnected', data: { attempts: 1 } },
-        { type: 'reconnect_failed', data: { message: 'Failed' } },
-        { type: 'connection_lost' },
       ];
 
       validEvents.forEach(event => {

--- a/src/lib/websocketEvents.ts
+++ b/src/lib/websocketEvents.ts
@@ -4,7 +4,9 @@
 import { logger } from './logger';
 
 export interface WebSocketEvent {
-  type: 'reconnecting' | 'reconnected' | 'reconnect_failed' | 'connection_lost';
+  // Reconnection never gives up (see webSocketManager), so there is no
+  // terminal "failed"/"lost" event — only the retrying/recovered pair.
+  type: 'reconnecting' | 'reconnected';
   data?: {
     message?: string;
     attempts?: number;

--- a/src/services/__tests__/webSocketIntegration.test.ts
+++ b/src/services/__tests__/webSocketIntegration.test.ts
@@ -12,6 +12,12 @@ vi.mock('socket.io-client', () => ({
 }));
 
 // Mock logger
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    refreshAccessToken: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@/lib/logger', () => ({
   logger: {
     info: vi.fn(),
@@ -649,12 +655,9 @@ describe('WebSocket Integration Tests', () => {
       // Server forcefully disconnects
       mockSocket.__triggerDisconnect('io server disconnect');
 
-      // On first server disconnect, manager starts manual reconnect (not connection_lost).
-      // connection_lost is only emitted after maxReconnectAttempts (10) are exhausted.
-      // Verify that the disconnect was processed (disconnect listener fired)
-      expect(webSocketEventEmitter.emit).not.toHaveBeenCalledWith({
-        type: 'connection_lost',
-      });
+      // The manager retries forever — there is no terminal give-up event,
+      // so nothing may be emitted on a server disconnect.
+      expect(webSocketEventEmitter.emit).not.toHaveBeenCalled();
     });
 
     it('should handle listener exceptions during event processing', async () => {

--- a/src/services/__tests__/webSocketManager.test.ts
+++ b/src/services/__tests__/webSocketManager.test.ts
@@ -5,10 +5,18 @@ import WebSocketManager, {
 } from '@/services/webSocketManager';
 import { io } from 'socket.io-client';
 import { webSocketEventEmitter } from '@/lib/websocketEvents';
+import { apiClient } from '@/lib/api';
 
 // Mock socket.io-client
 vi.mock('socket.io-client', () => ({
   io: vi.fn(),
+}));
+
+// Mock api client (used for auth-cookie refresh on handshake auth failures)
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    refreshAccessToken: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 // Mock logger to prevent console spam in tests
@@ -137,9 +145,9 @@ describe('WebSocketManager', () => {
         withCredentials: true,
         transports: ['websocket', 'polling'],
         reconnection: true,
-        reconnectionAttempts: 10,
+        reconnectionAttempts: Infinity,
         reconnectionDelay: 1000,
-        reconnectionDelayMax: 5000,
+        reconnectionDelayMax: 15000,
         timeout: 10000,
         autoConnect: true,
       });
@@ -545,21 +553,144 @@ describe('WebSocketManager', () => {
       });
     });
 
-    it('should emit reconnect_failed event on failure', async () => {
+    it('should not register a reconnect_failed handler (retries never stop)', async () => {
       const connectPromise = wsManager.connect(mockUser);
       mockSocket.connected = true;
       mockSocket._trigger('connect');
       await connectPromise;
 
-      // Simulate reconnection failure
+      // With reconnectionAttempts: Infinity the engine never emits
+      // reconnect_failed, so no terminal give-up handler exists.
       const reconnectFailedHandler = mockSocket.io.on.mock.calls.find(
         call => call[0] === 'reconnect_failed'
-      )?.[1];
-      reconnectFailedHandler?.();
+      );
+      expect(reconnectFailedHandler).toBeUndefined();
+    });
+  });
 
-      expect(webSocketEventEmitter.emit).toHaveBeenCalledWith({
-        type: 'reconnect_failed',
+  describe('automatic recovery (regression: permanent "Connecting to server..." banner)', () => {
+    const mockUser = { id: 'user-123', token: 'test-token' };
+
+    const connectManager = async () => {
+      const connectPromise = wsManager.connect(mockUser);
+      mockSocket.connected = true;
+      mockSocket._trigger('connect');
+      await connectPromise;
+    };
+
+    it('configures socket.io to never stop reconnecting', async () => {
+      await connectManager();
+
+      expect(io).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          reconnection: true,
+          reconnectionAttempts: Infinity,
+        })
+      );
+    });
+
+    it('refreshes the auth cookie and reconnects on an auth handshake failure', async () => {
+      await connectManager();
+      mockSocket.connected = false;
+      mockSocket.connect.mockClear();
+
+      mockSocket._trigger('connect_error', new Error('Authentication failed'));
+
+      await vi.waitFor(() => {
+        expect(apiClient.refreshAccessToken).toHaveBeenCalledTimes(1);
+        expect(mockSocket.connect).toHaveBeenCalledTimes(1);
       });
+    });
+
+    it('does not refresh the auth cookie for non-auth connection errors', async () => {
+      await connectManager();
+      mockSocket.connected = false;
+
+      mockSocket._trigger('connect_error', new Error('websocket error'));
+
+      // Flush microtasks; no refresh should have been scheduled
+      await Promise.resolve();
+      expect(apiClient.refreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('survives a failing auth refresh and does not force a reconnect', async () => {
+      vi.mocked(apiClient.refreshAccessToken).mockRejectedValueOnce(
+        new Error('offline')
+      );
+      await connectManager();
+      mockSocket.connected = false;
+      mockSocket.connect.mockClear();
+
+      mockSocket._trigger('connect_error', new Error('Authentication failed'));
+
+      await vi.waitFor(() => {
+        expect(apiClient.refreshAccessToken).toHaveBeenCalledTimes(1);
+      });
+      expect(mockSocket.connect).not.toHaveBeenCalled();
+    });
+
+    it('reconnects when the browser regains network connectivity', async () => {
+      await connectManager();
+      mockSocket.connected = false;
+      mockSocket.connect.mockClear();
+
+      window.dispatchEvent(new Event('online'));
+
+      expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects when the tab becomes visible again', async () => {
+      await connectManager();
+      mockSocket.connected = false;
+      mockSocket.connect.mockClear();
+
+      const originalVisibility = Object.getOwnPropertyDescriptor(
+        Document.prototype,
+        'visibilityState'
+      );
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      });
+      try {
+        document.dispatchEvent(new Event('visibilitychange'));
+        expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+      } finally {
+        delete (document as any).visibilityState;
+        if (originalVisibility) {
+          Object.defineProperty(
+            Document.prototype,
+            'visibilityState',
+            originalVisibility
+          );
+        }
+      }
+    });
+
+    it('does not reconnect on online/visibility events while already connected', async () => {
+      await connectManager();
+      mockSocket.connected = true;
+      mockSocket.connect.mockClear();
+
+      window.dispatchEvent(new Event('online'));
+
+      expect(mockSocket.connect).not.toHaveBeenCalled();
+    });
+
+    it('tears down the previous socket before creating a new connection', async () => {
+      await connectManager();
+
+      const oldSocket = mockSocket;
+      // Simulate a re-initialization for the same user while disconnected
+      oldSocket.connected = false;
+      const secondConnect = wsManager.connect(mockUser);
+      mockSocket.connected = true;
+      mockSocket._trigger('connect');
+      await secondConnect;
+
+      expect(oldSocket.removeAllListeners).toHaveBeenCalled();
+      expect(oldSocket.disconnect).toHaveBeenCalled();
     });
   });
 
@@ -852,29 +983,22 @@ describe('WebSocketManager', () => {
 
         vi.clearAllMocks();
 
-        // Mock createConnection to track reconnection attempts
-        const createConnectionSpy = vi
-          .spyOn(wsManager as any, 'createConnection')
-          .mockImplementation(() => {
-            throw new Error('Reconnection failed');
-          });
-
         // First attempt fires after 1000ms (reconnectAttempts=1, delay=1000*2^0=1000)
+        // and reconnects the EXISTING socket (no new socket is created).
         vi.advanceTimersByTime(1000);
-        expect(createConnectionSpy).toHaveBeenCalledTimes(1);
+        expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+        expect(io).not.toHaveBeenCalled();
 
         // No further automatic attempts (Socket.io handles reconnect; handleReconnect only queues one)
         vi.advanceTimersByTime(5000);
-        expect(createConnectionSpy).toHaveBeenCalledTimes(1); // Still 1
-
-        createConnectionSpy.mockRestore();
+        expect(mockSocket.connect).toHaveBeenCalledTimes(1); // Still 1
       } finally {
         vi.clearAllTimers();
         vi.useRealTimers();
       }
     });
 
-    it('should emit connection_lost after max reconnect attempts', async () => {
+    it('should keep retrying server disconnects indefinitely (no give-up)', async () => {
       vi.useFakeTimers();
 
       try {
@@ -888,30 +1012,23 @@ describe('WebSocketManager', () => {
           call => call[0] === 'disconnect'
         )?.[1];
 
-        // Mock createConnection to always fail immediately
-        const createConnectionSpy = vi
-          .spyOn(wsManager as any, 'createConnection')
-          .mockImplementation(() => {
-            throw new Error('Reconnection failed');
-          });
+        vi.clearAllMocks();
 
-        // Simulate maxReconnectAttempts+1 server disconnects to exhaust attempts
-        // Each 'io server disconnect' calls handleReconnect() once.
-        // After maxReconnectAttempts (10) calls, the next one emits connection_lost.
-        const maxAttempts = 10;
-        for (let i = 0; i <= maxAttempts; i++) {
+        // Well past the former 10-attempt budget: every server disconnect
+        // must still schedule a reconnect of the existing socket.
+        const attempts = 15;
+        for (let i = 0; i < attempts; i++) {
           mockSocket.connected = false;
           disconnectHandler?.('io server disconnect');
-          // Advance past the reconnect delay to process the queued attempt
+          // Advance past the (capped) backoff delay to process the attempt
           vi.advanceTimersByTime(30000);
         }
 
-        // Should emit connection_lost after max attempts exhausted
-        expect(webSocketEventEmitter.emit).toHaveBeenCalledWith({
-          type: 'connection_lost',
-        });
-
-        createConnectionSpy.mockRestore();
+        expect(mockSocket.connect).toHaveBeenCalledTimes(attempts);
+        // No terminal give-up event exists any more
+        expect(webSocketEventEmitter.emit).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'connection_lost' })
+        );
       } finally {
         vi.clearAllTimers();
         vi.useRealTimers();
@@ -945,17 +1062,11 @@ describe('WebSocketManager', () => {
         mockSocket.connected = false;
         disconnectHandler?.('io server disconnect');
 
-        const createConnectionSpy = vi
-          .spyOn(wsManager as any, 'createConnection')
-          .mockImplementation(() => {
-            throw new Error('Reconnection failed');
-          });
+        mockSocket.connect.mockClear();
 
         // Should start with 1000ms delay again (not 2000ms)
         vi.advanceTimersByTime(1000);
-        expect(createConnectionSpy).toHaveBeenCalledTimes(1);
-
-        createConnectionSpy.mockRestore();
+        expect(mockSocket.connect).toHaveBeenCalledTimes(1);
       } finally {
         vi.clearAllTimers();
         vi.useRealTimers();
@@ -1032,9 +1143,6 @@ describe('WebSocketManager', () => {
       const reconnectErrorHandler = mockSocket.io.on.mock.calls.find(
         call => call[0] === 'reconnect_error'
       )?.[1];
-      const reconnectFailedHandler = mockSocket.io.on.mock.calls.find(
-        call => call[0] === 'reconnect_failed'
-      )?.[1];
 
       // Test reconnect success
       reconnectHandler?.(3);
@@ -1049,12 +1157,6 @@ describe('WebSocketManager', () => {
       expect(() =>
         reconnectErrorHandler?.(new Error('Reconnect failed'))
       ).not.toThrow();
-
-      // Test reconnect failed
-      reconnectFailedHandler?.();
-      expect(webSocketEventEmitter.emit).toHaveBeenCalledWith({
-        type: 'reconnect_failed',
-      });
     });
 
     it('should handle edge case with empty project ID', async () => {

--- a/src/services/__tests__/webSocketPerformance.test.ts
+++ b/src/services/__tests__/webSocketPerformance.test.ts
@@ -12,6 +12,12 @@ vi.mock('socket.io-client', () => ({
 }));
 
 // Mock logger to prevent console spam
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    refreshAccessToken: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@/lib/logger', () => ({
   logger: {
     info: vi.fn(),

--- a/src/services/__tests__/webSocketRealtimeWorkflows.test.ts
+++ b/src/services/__tests__/webSocketRealtimeWorkflows.test.ts
@@ -15,6 +15,12 @@ vi.mock('socket.io-client', () => ({
 }));
 
 // Mock dependencies
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    refreshAccessToken: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@/lib/logger', () => ({
   logger: {
     info: vi.fn(),

--- a/src/services/webSocketManager.ts
+++ b/src/services/webSocketManager.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 import { logger } from '@/lib/logger';
 import config from '@/lib/config';
+import { apiClient } from '@/lib/api';
 import { TIMEOUTS } from '@/lib/constants';
 import { webSocketEventEmitter } from '@/lib/websocketEvents';
 import type {
@@ -46,12 +47,11 @@ class WebSocketManager {
   private static instance: WebSocketManager | null = null;
   private socket: Socket | null = null;
   private isConnecting = false;
-  private isInitialized = false;
+  private isRefreshingAuth = false;
   private currentUser: { id: string } | null = null;
   private eventListeners: EventListenerRegistry = {};
   private messageQueue: Array<{ event: string; data: unknown }> = [];
   private reconnectAttempts = 0;
-  private maxReconnectAttempts = 10;
   private reconnectDelay = 1000;
   private maxReconnectDelay = 30000;
   private lastToastTime = 0;
@@ -68,6 +68,45 @@ class WebSocketManager {
       disconnect: new Set(),
       connect_error: new Set(),
     };
+
+    // Recover instantly when the network returns or a slept/backgrounded tab
+    // wakes up — the reconnection engine's next scheduled attempt may be
+    // seconds away, and a laptop resume can leave the socket dead until then.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', this.ensureConnected);
+      document.addEventListener(
+        'visibilitychange',
+        this.handleVisibilityChange
+      );
+    }
+  }
+
+  private ensureConnected = (): void => {
+    if (
+      this.currentUser &&
+      this.socket &&
+      !this.socket.connected &&
+      !this.isConnecting
+    ) {
+      logger.info('WebSocket down while session active - forcing reconnect');
+      this.socket.connect();
+    }
+  };
+
+  private handleVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible') {
+      this.ensureConnected();
+    }
+  };
+
+  private removeLifecycleListeners(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('online', this.ensureConnected);
+      document.removeEventListener(
+        'visibilitychange',
+        this.handleVisibilityChange
+      );
+    }
   }
 
   static getInstance(): WebSocketManager {
@@ -155,6 +194,13 @@ class WebSocketManager {
 
     logger.info('Creating WebSocket connection to:', serverUrl);
 
+    // Replace any previous socket wholesale — leaving the old one alive would
+    // duplicate every event and keep a second reconnection engine running.
+    if (this.socket) {
+      this.socket.removeAllListeners();
+      this.socket.disconnect();
+    }
+
     this.socket = io(serverUrl, {
       // Auth travels in the httpOnly access_token cookie, which the browser
       // attaches to the same-origin handshake automatically. withCredentials
@@ -162,15 +208,17 @@ class WebSocketManager {
       withCredentials: true,
       transports: ['websocket', 'polling'],
       reconnection: true, // Enable automatic reconnection
-      reconnectionAttempts: 10,
+      // Never stop retrying: a finite attempt budget leaves the tab
+      // permanently disconnected ("Connecting to server..." banner) after any
+      // outage longer than the budget, and only a manual reload recovers.
+      reconnectionAttempts: Infinity,
       reconnectionDelay: 1000,
-      reconnectionDelayMax: 5000,
+      reconnectionDelayMax: 15000,
       timeout: 10000,
       autoConnect: true,
     });
 
     this.setupEventHandlers();
-    this.isInitialized = true;
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -224,13 +272,19 @@ class WebSocketManager {
       logger.error('WebSocket CONNECTION ERROR:', error.message);
       this.emitToListeners('connect_error', error);
 
+      // The handshake authenticates via the httpOnly access_token cookie
+      // (15 min TTL). Reconnects after the cookie expired fail here forever —
+      // socket handshakes never pass through the axios 401→refresh
+      // interceptor — so re-mint the cookie explicitly and retry.
+      const isAuthError = /auth/i.test(error.message);
+      if (isAuthError) {
+        void this.refreshAuthAndReconnect();
+      }
+
       // Show toast only occasionally to avoid spam and not during auto-reconnect
       const now = Date.now();
       if (now - this.lastToastTime > this.toastCooldown) {
-        if (
-          !error.message.includes('Authentication') &&
-          this.reconnectAttempts > 2
-        ) {
+        if (!isAuthError && this.reconnectAttempts > 2) {
           // Only show toast after a few failed attempts
           // Emit event for localized toast (handled by useWebSocketToasts hook)
           webSocketEventEmitter.emit({ type: 'reconnecting' });
@@ -259,12 +313,6 @@ class WebSocketManager {
 
     this.socket.io.on('reconnect_error', (error: Error) => {
       logger.error('WebSocket reconnection error:', error.message);
-    });
-
-    this.socket.io.on('reconnect_failed', () => {
-      logger.error('WebSocket reconnection failed after all attempts');
-      // Emit event for localized toast (handled by useWebSocketToasts hook)
-      webSocketEventEmitter.emit({ type: 'reconnect_failed' });
     });
 
     // Data events
@@ -343,14 +391,13 @@ class WebSocketManager {
     });
   }
 
+  /**
+   * Manual reconnect for 'io server disconnect' — the one disconnect reason
+   * socket.io's own engine does not retry. Retries forever with capped
+   * exponential backoff; giving up would strand the tab (permanent
+   * "Connecting to server..." banner) until a manual reload.
+   */
   private handleReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      logger.error('Max reconnection attempts reached');
-      // Emit event for localized toast (handled by useWebSocketToasts hook)
-      webSocketEventEmitter.emit({ type: 'connection_lost' });
-      return;
-    }
-
     this.reconnectAttempts++;
     const delay = Math.min(
       this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1),
@@ -361,15 +408,38 @@ class WebSocketManager {
       `Attempting reconnect #${this.reconnectAttempts} in ${delay}ms`
     );
 
-    setTimeout(async () => {
-      if (this.currentUser && !this.socket?.connected) {
-        try {
-          await this.createConnection();
-        } catch (error) {
-          logger.error('Reconnection failed:', error);
-        }
+    setTimeout(() => {
+      if (this.currentUser && this.socket && !this.socket.connected) {
+        // Reconnecting the existing socket re-enters the automatic
+        // reconnection engine; creating a new socket here would orphan the
+        // old one and duplicate every event.
+        this.socket.connect();
       }
     }, delay);
+  }
+
+  /**
+   * Re-mint the expired access_token cookie so the next handshake can
+   * authenticate. Refresh failures are non-fatal: offline refreshes get
+   * retried on the next auth connect_error, and a dead refresh token gets
+   * handled by the HTTP layer (forced sign-out tears this connection down).
+   */
+  private async refreshAuthAndReconnect(): Promise<void> {
+    if (this.isRefreshingAuth) {
+      return;
+    }
+    this.isRefreshingAuth = true;
+    try {
+      await apiClient.refreshAccessToken();
+      if (this.currentUser && this.socket && !this.socket.connected) {
+        logger.info('Auth cookie refreshed - reconnecting WebSocket');
+        this.socket.connect();
+      }
+    } catch (error) {
+      logger.warn('WebSocket auth refresh failed:', error);
+    } finally {
+      this.isRefreshingAuth = false;
+    }
   }
 
   private emitToListeners(event: string, ...args: unknown[]): void {
@@ -511,7 +581,6 @@ class WebSocketManager {
     }
 
     this.currentUser = null;
-    this.isInitialized = false;
     this.isConnecting = false;
     this.messageQueue = [];
     this.reconnectAttempts = 0;
@@ -528,6 +597,7 @@ class WebSocketManager {
   static cleanup(): void {
     if (WebSocketManager.instance) {
       WebSocketManager.instance.disconnect();
+      WebSocketManager.instance.removeLifecycleListeners();
       WebSocketManager.instance = null;
     }
 

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1892,8 +1892,6 @@ export default {
   websocket: {
     reconnecting: 'Znovu se připojuji k serveru...',
     reconnected: 'Připojení k serveru obnoveno',
-    reconnectFailed: 'Nepodařilo se obnovit připojení k serveru',
-    connectionLost: 'Spojení se serverem ztraceno',
     connected: 'Připojeno k aktualizacím v reálném čase',
     disconnected: 'Odpojeno od aktualizací v reálném čase',
   },

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1893,8 +1893,6 @@ export default {
   websocket: {
     reconnecting: 'Verbinde erneut mit Server...',
     reconnected: 'Verbindung zum Server wiederhergestellt',
-    reconnectFailed: 'Wiederherstellung der Serververbindung fehlgeschlagen',
-    connectionLost: 'Verbindung zum Server verloren',
     connected: 'Mit Echtzeit-Updates verbunden',
     disconnected: 'Von Echtzeit-Updates getrennt',
   },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1929,8 +1929,6 @@ export default {
   websocket: {
     reconnecting: 'Reconnecting to server...',
     reconnected: 'Connection to server restored',
-    reconnectFailed: 'Failed to restore connection to server',
-    connectionLost: 'Connection to server lost',
     connected: 'Connected to real-time updates',
     disconnected: 'Disconnected from real-time updates',
   },

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1932,8 +1932,6 @@ export default {
   websocket: {
     reconnecting: 'Reconectando al servidor...',
     reconnected: 'Conexión al servidor restaurada',
-    reconnectFailed: 'Error al restaurar la conexión al servidor',
-    connectionLost: 'Conexión al servidor perdida',
     connected: 'Conectado a actualizaciones en tiempo real',
     disconnected: 'Desconectado de actualizaciones en tiempo real',
   },

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1881,8 +1881,6 @@ export default {
   websocket: {
     reconnecting: 'Reconnexion au serveur...',
     reconnected: 'Connexion au serveur rétablie',
-    reconnectFailed: 'Échec du rétablissement de la connexion au serveur',
-    connectionLost: 'Connexion au serveur perdue',
     connected: 'Connecté aux mises à jour en temps réel',
     disconnected: 'Déconnecté des mises à jour en temps réel',
   },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1762,8 +1762,6 @@ export default {
   websocket: {
     reconnecting: '正在重新连接服务器...',
     reconnected: '服务器连接已恢复',
-    reconnectFailed: '恢复服务器连接失败',
-    connectionLost: '与服务器的连接丢失',
     connected: '已连接到实时更新',
     disconnected: '已断开实时更新',
   },


### PR DESCRIPTION
## Problem

Users intermittently saw a persistent **"Connecting to server... Real-time updates will be available soon."** banner (`QueueStatsPanel`, shown whenever `isConnected === false`). It only cleared on a manual page reload — real-time queue/segmentation updates were dead until then.

## Root cause

Three compounding dead-ends in `webSocketManager.ts`:

1. **Finite reconnection budget.** `reconnectionAttempts: 10` with a ~1–5 s backoff gave socket.io only ~45 s of retries. Any outage longer than that (backend redeploy, network blip, laptop sleep) left the engine permanently stopped, with nothing ever calling `socket.connect()` again.
2. **Expired-cookie reconnect loop.** The handshake authenticates via the 15-min `access_token` httpOnly cookie. Socket handshakes never pass through the axios `401 → refresh` interceptor, so once the cookie expired every reconnect reused the stale cookie and failed forever with an auth error.
3. **No wake triggers.** Nothing kicked a reconnect when the network returned or a backgrounded/slept tab became visible again — the two cases where socket.io's own timers are most likely to be throttled or stopped.

## Fix

- **Never stop retrying** — `reconnectionAttempts: Infinity`, backoff capped at 15 s. The manual `'io server disconnect'` path retries forever too, and reconnects the *existing* socket (`socket.connect()`) instead of building a new one and orphaning the old.
- **Auth-aware reconnect** — an auth-flavored `connect_error` re-mints the cookie via `apiClient.refreshAccessToken()` then reconnects. Guarded by an `isRefreshingAuth` flag; refresh failures are non-fatal.
- **Lifecycle wake triggers** — `window 'online'` + `document 'visibilitychange'` force a reconnect when a session is active and the socket is down.
- **Socket teardown** — `createConnection()` now removes listeners + disconnects any previous socket before creating a new one, closing a latent duplicate-event / double-engine hazard.
- **Dead-code removal** — the terminal `reconnect_failed` / `connection_lost` events no longer exist (there is no give-up state), so their emitters, toast cases, event-union members, and translation keys in all 6 locales are removed.

## Verification

**Deployed the new frontend bundle to production** and drove the real app with Playwright (logged in as the test account):

- Live socket confirmed carrying the shipped change: `reconnectionAttempts === Infinity`, `reconnectionDelayMax === 15000`.
- **Transport drop** (`engine.close()`, a network-blip equivalent): banner appeared at t+0.3 s, auto-recovered by t+1.5 s — **no reload**.
- **Hard `disconnect()`** (disables socket.io's own retries, simulating a dead/stalled engine after sleep): stayed down as expected, then a dispatched `online` event reconnected it within 0.3 s — proving the new lifecycle path.
- Zero console errors/warnings across all disconnect/reconnect cycles.

**Tests:** 145 WebSocket-related unit tests pass (9 new regression tests covering Infinity retries, auth-refresh reconnect, online/visibility recovery, no-reconnect-while-connected, and socket teardown). Full local CI gate green (tsc + ESLint 0 + i18n complete ×6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connections now recover automatically when the app goes back online or becomes visible again.
  * Real-time status messaging was updated to better reflect connected and disconnected states.

* **Bug Fixes**
  * Improved reconnection behavior so temporary connection issues keep retrying instead of stopping early.
  * Authentication-related connection failures can now refresh access and reconnect automatically.

* **Documentation**
  * Updated WebSocket messages across supported languages to match the new connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->