### PR TITLE
feat(export): bundle ImageJ ROI files in microtubule exports

### DIFF
--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -1,0 +1,363 @@
+/**
+ * imagejRoiEncoder.test.ts
+ *
+ * Behavioral tests for src/services/export/imagejRoiEncoder.ts.
+ *
+ *  encodeImageJRoi (pure binary encoder)
+ *   - produces the ImageJ "Iout" magic + correct ROI type byte
+ *   - sets the SUB_PIXEL_RESOLUTION option flag
+ *   - round-trips sub-pixel float coordinates (absolute) exactly
+ *   - round-trips the ROI name via UTF-16BE (incl. non-ASCII)
+ *   - throws on < 2 points
+ *
+ *  exportImageJRois (per-frame writer, real temp-dir FS)
+ *   - skips video container rows + frames without polygons
+ *   - drops polylines with < 2 points / polygons with < 3 points
+ *   - names files by trackId and keeps the SAME name across frames
+ *   - suffixes colliding filenames within a frame (no overwrite)
+ *   - falls back to a generated name for untracked polygons
+ *   - returns a warning (not an error) when nothing was exported
+ *
+ * The inline decoder mirrors ImageJ's RoiDecoder layout so the test needs no
+ * external tool. It was cross-checked against Christoph Gohlke's reference
+ * `roifile` Python package during development.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  encodeImageJRoi,
+  exportImageJRois,
+  type RoiFrameInput,
+} from '../imagejRoiEncoder';
+
+// ---------------------------------------------------------------------------
+// Minimal ImageJ .roi decoder (subset: poly types with sub-pixel + name)
+// ---------------------------------------------------------------------------
+
+interface DecodedRoi {
+  magic: string;
+  type: number;
+  nCoords: number;
+  subPixel: boolean;
+  coords: Array<[number, number]>;
+  name: string;
+}
+
+function decodeRoi(buf: Buffer): DecodedRoi {
+  const magic = buf.toString('ascii', 0, 4);
+  const type = buf.readUInt8(6);
+  const n = buf.readUInt16BE(16);
+  const options = buf.readUInt16BE(50);
+  const subPixel = (options & 128) !== 0;
+
+  const coords: Array<[number, number]> = [];
+  if (subPixel) {
+    const fx = 64 + n * 4;
+    const fy = fx + n * 4;
+    for (let i = 0; i < n; i++) {
+      coords.push([buf.readFloatBE(fx + i * 4), buf.readFloatBE(fy + i * 4)]);
+    }
+  }
+
+  const header2Offset = buf.readInt32BE(60);
+  const nameOffset = buf.readInt32BE(header2Offset + 16);
+  const nameLength = buf.readInt32BE(header2Offset + 20);
+  let name = '';
+  if (nameOffset > 0 && nameLength > 0) {
+    for (let i = 0; i < nameLength; i++) {
+      name += String.fromCharCode(buf.readUInt16BE(nameOffset + i * 2));
+    }
+  }
+
+  return { magic, type, nCoords: n, subPixel, coords, name };
+}
+
+const ROI_TYPE_POLYGON = 0;
+const ROI_TYPE_POLYLINE = 5;
+
+// ---------------------------------------------------------------------------
+// encodeImageJRoi
+// ---------------------------------------------------------------------------
+
+describe('encodeImageJRoi', () => {
+  it('encodes a polyline with the correct magic, type and sub-pixel flag', () => {
+    const buf = encodeImageJRoi(
+      [
+        { x: 10.5, y: 20.25 },
+        { x: 30.75, y: 40 },
+        { x: 55.5, y: 12.5 },
+      ],
+      'polyline',
+      '42'
+    );
+    const d = decodeRoi(buf);
+    expect(d.magic).toBe('Iout');
+    expect(d.type).toBe(ROI_TYPE_POLYLINE);
+    expect(d.subPixel).toBe(true);
+    expect(d.nCoords).toBe(3);
+  });
+
+  it('round-trips sub-pixel coordinates exactly (float32 precision)', () => {
+    const pts = [
+      { x: 10.5, y: 20.25 },
+      { x: 30.75, y: 40 },
+      { x: 80.125, y: 90.875 },
+    ];
+    const d = decodeRoi(encodeImageJRoi(pts, 'polyline', 'x'));
+    expect(d.coords).toEqual(pts.map(p => [p.x, p.y]));
+  });
+
+  it('encodes a closed polygon as ROI type POLYGON', () => {
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 100, y: 100 },
+          { x: 200, y: 105.5 },
+          { x: 180.25, y: 220.75 },
+        ],
+        'polygon',
+        'poly1'
+      )
+    );
+    expect(d.type).toBe(ROI_TYPE_POLYGON);
+    expect(d.name).toBe('poly1');
+  });
+
+  it('round-trips a non-ASCII name via UTF-16BE', () => {
+    const name = 'µtub_αβ_7';
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 5, y: 5 },
+          { x: 512.9, y: 768.1 },
+        ],
+        'polyline',
+        name
+      )
+    );
+    expect(d.name).toBe(name);
+  });
+
+  it('omits the name block when no name is given', () => {
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline'
+      )
+    );
+    expect(d.name).toBe('');
+  });
+
+  it('throws when given fewer than 2 points', () => {
+    expect(() => encodeImageJRoi([{ x: 1, y: 1 }], 'polyline')).toThrow();
+    expect(() => encodeImageJRoi([], 'polygon')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportImageJRois (real temp-dir filesystem)
+// ---------------------------------------------------------------------------
+
+describe('exportImageJRois', () => {
+  const tmpDirs: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(
+      tmpDirs.map(d => fs.rm(d, { recursive: true, force: true }))
+    );
+  });
+
+  async function mkTmp(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'roi-test-'));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  function line(
+    trackId: string | null,
+    pts: Array<[number, number]>,
+    geometry: 'polyline' | 'polygon' = 'polyline'
+  ) {
+    return {
+      trackId,
+      geometry,
+      points: pts.map(([x, y]) => ({ x, y })),
+    };
+  }
+
+  it('writes loose per-frame files named by trackId, skipping containers and empty frames', async () => {
+    const out = await mkTmp();
+    // Real MT frame names look like "<original>.nd2 (frame N)" — path.parse
+    // would mangle them, so folders must key on (container, frameIndex).
+    const frames: RoiFrameInput[] = [
+      {
+        id: 'c1',
+        name: 'sample_60x.nd2',
+        isVideoContainer: true,
+        segmentation: null,
+      },
+      {
+        id: 'f0',
+        name: 'sample_60x.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('1', [
+              [10, 10],
+              [20, 25],
+            ]),
+            line('2', [
+              [50, 60],
+              [70, 80],
+            ]),
+            line('bad', [[5, 5]]), // < 2 points → dropped
+          ]),
+        },
+      },
+      {
+        id: 'f1',
+        name: 'sample_60x.nd2 (frame 2)',
+        parentVideoId: 'c1',
+        frameIndex: 1,
+        segmentation: { polygons: JSON.stringify([]) }, // no folder
+      },
+    ];
+
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result).toEqual({ frames: 1, rois: 2, warnings: [] });
+
+    const base = path.join(out, 'annotations', 'imagej');
+    // Grouped under the clean container name, then numeric frame index.
+    expect(await fs.readdir(base)).toEqual(['sample_60x']);
+    expect(await fs.readdir(path.join(base, 'sample_60x'))).toEqual([
+      'frame_0000',
+    ]); // empty frame 1 produced no folder
+    const frame0 = await fs.readdir(
+      path.join(base, 'sample_60x', 'frame_0000')
+    );
+    expect(frame0.sort()).toEqual(['1.roi', '2.roi']);
+  });
+
+  it('separates frames from different videos that share a frameIndex (multi-position ND2)', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'cA', name: 'D03_0000.nd2', isVideoContainer: true, segmentation: null },
+      { id: 'cB', name: 'D05_0000.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'a0',
+        name: 'D03_0000.nd2 (frame 1)',
+        parentVideoId: 'cA',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([line('1', [[1, 1], [2, 2]])]),
+        },
+      },
+      {
+        id: 'b0',
+        name: 'D05_0000.nd2 (frame 1)',
+        parentVideoId: 'cB',
+        frameIndex: 0, // SAME frameIndex as a0, different video
+        segmentation: {
+          polygons: JSON.stringify([line('1', [[3, 3], [4, 4]])]),
+        },
+      },
+    ];
+
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(2);
+
+    const base = path.join(out, 'annotations', 'imagej');
+    expect((await fs.readdir(base)).sort()).toEqual(['D03_0000', 'D05_0000']);
+    expect(await fs.readdir(path.join(base, 'D03_0000', 'frame_0000'))).toEqual([
+      '1.roi',
+    ]);
+    expect(await fs.readdir(path.join(base, 'D05_0000', 'frame_0000'))).toEqual([
+      '1.roi',
+    ]);
+  });
+
+  it('keeps the same trackId name across frames and suffixes collisions', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [10, 10],
+              [20, 25],
+            ]),
+          ]),
+        },
+      },
+      {
+        id: 'f1',
+        name: 'v.nd2 (frame 2)',
+        parentVideoId: 'c1',
+        frameIndex: 1,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [12, 12],
+              [22, 27],
+            ]),
+            line('7', [
+              [99, 99],
+              [88, 88],
+            ]), // duplicate trackId in the same frame
+            line(null, [
+              [1, 1],
+              [2, 2],
+              [3, 3],
+            ], 'polygon'), // untracked → generated fallback name
+          ]),
+        },
+      },
+    ];
+
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(4);
+
+    const base = path.join(out, 'annotations', 'imagej', 'v');
+    // trackId 7 present in both frames under the identical filename
+    const f0 = await fs.readdir(path.join(base, 'frame_0000'));
+    expect(f0).toEqual(['7.roi']);
+    const f1 = (await fs.readdir(path.join(base, 'frame_0001'))).sort();
+    expect(f1).toContain('7.roi');
+    expect(f1).toContain('7_2.roi'); // collision-suffixed, no overwrite
+    expect(f1.some(n => n.startsWith('roi_'))).toBe(true); // untracked fallback
+
+    // internal ROI name is stable across frames
+    const roiF0 = decodeRoi(
+      await fs.readFile(path.join(base, 'frame_0000', '7.roi'))
+    );
+    const roiF1 = decodeRoi(
+      await fs.readFile(path.join(base, 'frame_0001', '7.roi'))
+    );
+    expect(roiF0.name).toBe('7');
+    expect(roiF1.name).toBe('7');
+  });
+
+  it('returns a warning (not an error) when there is nothing to export', async () => {
+    const out = await mkTmp();
+    const result = await exportImageJRois(
+      [{ id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null }],
+      out,
+      'proj'
+    );
+    expect(result.rois).toBe(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/no microtubule polylines/i);
+  });
+});

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -7,15 +7,20 @@
  *   - produces the ImageJ "Iout" magic + correct ROI type byte
  *   - sets the SUB_PIXEL_RESOLUTION option flag
  *   - round-trips sub-pixel float coordinates (absolute) exactly
+ *   - writes the integer bbox + relative int16 block; float stays exact on wrap
  *   - round-trips the ROI name via UTF-16BE (incl. non-ASCII)
- *   - throws on < 2 points
+ *   - throws below the geometry minimum (polyline < 2 / polygon < 3)
  *
  *  exportImageJRois (per-frame writer, real temp-dir FS)
  *   - skips video container rows + frames without polygons
  *   - drops polylines with < 2 points / polygons with < 3 points
+ *   - separates videos that share a frameIndex (multi-position ND2)
  *   - names files by trackId and keeps the SAME name across frames
- *   - suffixes colliding filenames within a frame (no overwrite)
- *   - falls back to a generated name for untracked polygons
+ *   - suffixes colliding filenames within a frame (no overwrite), incl.
+ *     distinct labels that sanitize to the same name
+ *   - falls back to a generated name for untracked / empty-trackId polygons
+ *   - skips corrupt-JSON frames with a warning; drops non-finite polygons
+ *   - rejects when the job is cancelled
  *   - returns a warning (not an error) when nothing was exported
  *
  * The inline decoder mirrors ImageJ's RoiDecoder layout so the test needs no
@@ -42,16 +47,38 @@ interface DecodedRoi {
   type: number;
   nCoords: number;
   subPixel: boolean;
+  bbox: { top: number; left: number; bottom: number; right: number };
+  /** Integer coordinate block (int16, relative to left/top). */
+  intCoords: Array<[number, number]>;
+  /** Sub-pixel float coordinate block (absolute). */
   coords: Array<[number, number]>;
   name: string;
+}
+
+/** Read an int16 the way ImageJ does — the encoder stores low 16 bits. */
+function readShort(buf: Buffer, off: number): number {
+  return buf.readInt16BE(off);
 }
 
 function decodeRoi(buf: Buffer): DecodedRoi {
   const magic = buf.toString('ascii', 0, 4);
   const type = buf.readUInt8(6);
+  const bbox = {
+    top: readShort(buf, 8),
+    left: readShort(buf, 10),
+    bottom: readShort(buf, 12),
+    right: readShort(buf, 14),
+  };
   const n = buf.readUInt16BE(16);
   const options = buf.readUInt16BE(50);
   const subPixel = (options & 128) !== 0;
+
+  const intCoords: Array<[number, number]> = [];
+  const ix = 64;
+  const iy = ix + n * 2;
+  for (let i = 0; i < n; i++) {
+    intCoords.push([readShort(buf, ix + i * 2), readShort(buf, iy + i * 2)]);
+  }
 
   const coords: Array<[number, number]> = [];
   if (subPixel) {
@@ -72,7 +99,7 @@ function decodeRoi(buf: Buffer): DecodedRoi {
     }
   }
 
-  return { magic, type, nCoords: n, subPixel, coords, name };
+  return { magic, type, nCoords: n, subPixel, bbox, intCoords, coords, name };
 }
 
 const ROI_TYPE_POLYGON = 0;
@@ -154,9 +181,50 @@ describe('encodeImageJRoi', () => {
     expect(d.name).toBe('');
   });
 
-  it('throws when given fewer than 2 points', () => {
+  it('writes the integer bounding box + relative int16 coordinate block', () => {
+    // Rounded points → bbox {top:21,left:10,bottom:40,right:31}; int coords are
+    // stored relative to left/top. This locks the legacy int block that old
+    // ImageJ readers + Roi.getBounds() depend on (the float block is separate).
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 10.4, y: 20.6 },
+          { x: 30.5, y: 40.2 },
+        ],
+        'polyline',
+        'b'
+      )
+    );
+    expect(d.bbox).toEqual({ top: 21, left: 10, bottom: 40, right: 31 });
+    expect(d.intCoords).toEqual([
+      [0, 0],
+      [21, 19],
+    ]);
+  });
+
+  it('keeps float coords exact even when int coords wrap (huge values)', () => {
+    // int16 wraps by design (cosmetic); the float block stays authoritative.
+    const pts = [
+      { x: 70000.5, y: 40000.25 },
+      { x: 1.5, y: 2.5 },
+    ];
+    const d = decodeRoi(encodeImageJRoi(pts, 'polyline', 'big'));
+    expect(d.coords).toEqual(pts.map(p => [p.x, p.y]));
+  });
+
+  it('throws when given fewer than the geometry minimum points', () => {
     expect(() => encodeImageJRoi([{ x: 1, y: 1 }], 'polyline')).toThrow();
     expect(() => encodeImageJRoi([], 'polygon')).toThrow();
+    // a 2-point "polygon" is degenerate (needs >= 3)
+    expect(() =>
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polygon'
+      )
+    ).toThrow(/at least 3/);
   });
 });
 
@@ -359,5 +427,124 @@ describe('exportImageJRois', () => {
     expect(result.rois).toBe(0);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toMatch(/no microtubule polylines/i);
+  });
+
+  it('falls through empty-string trackId to a generated name (no identity collapse)', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('', [[10, 10], [20, 25]]), // empty trackId
+            line('', [[30, 30], [40, 45]]), // empty trackId again
+          ]),
+        },
+      },
+    ];
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(2);
+    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
+    const files = (await fs.readdir(dir)).sort();
+    // Distinct generated names, NOT a collapsed "export.roi"/"export_2.roi".
+    expect(files).toEqual(['roi_0001.roi', 'roi_0002.roi']);
+    const names = await Promise.all(
+      files.map(async f => decodeRoi(await fs.readFile(path.join(dir, f))).name)
+    );
+    expect(new Set(names).size).toBe(2); // distinct internal names
+  });
+
+  it('suffixes distinct labels that sanitize to the same filename (no overwrite)', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('a/b', [[10, 10], [20, 25]]), // sanitizes to a_b
+            line('a:b', [[30, 30], [40, 45]]), // also sanitizes to a_b
+          ]),
+        },
+      },
+    ];
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(2); // both written, neither overwritten
+    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
+    const files = (await fs.readdir(dir)).sort();
+    expect(files).toEqual(['a_b.roi', 'a_b_2.roi']);
+  });
+
+  it('skips a corrupt-JSON frame with a user-facing warning while exporting valid frames', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'good',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: { polygons: JSON.stringify([line('1', [[1, 1], [2, 2]])]) },
+      },
+      {
+        id: 'bad',
+        name: 'v.nd2 (frame 2)',
+        parentVideoId: 'c1',
+        frameIndex: 1,
+        segmentation: { polygons: '{not valid json' },
+      },
+    ];
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(1); // valid frame still exported
+    expect(result.warnings.some(w => /corrupt/i.test(w))).toBe(true);
+    const base = path.join(out, 'annotations', 'imagej', 'v');
+    expect(await fs.readdir(base)).toEqual(['frame_0000']); // no folder for bad
+  });
+
+  it('drops polygons with non-finite coordinates instead of emitting NaN ROIs', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('ok', [[1, 1], [2, 2]]),
+            line('nan', [[Number.NaN, 5], [1, 2]]), // dropped
+          ]),
+        },
+      },
+    ];
+    const result = await exportImageJRois(frames, out, 'proj');
+    expect(result.rois).toBe(1);
+    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
+    expect(await fs.readdir(dir)).toEqual(['ok.roi']);
+  });
+
+  it('rejects when the job is cancelled mid-export', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: { polygons: JSON.stringify([line('1', [[1, 1], [2, 2]])]) },
+      },
+    ];
+    await expect(
+      exportImageJRois(frames, out, 'proj', { shouldAbort: () => true })
+    ).rejects.toThrow(/cancel/i);
   });
 });

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -51,7 +51,7 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 * json/ - Custom JSON format
 ${
   project.type === 'microtubules'
-    ? '* imagej/ - ImageJ/Fiji .roi files (one file per microtubule, grouped as <video>/frame_NNNN/, named by cross-frame trackId)\n'
+    ? '* imagej/ - ImageJ/Fiji .roi files (one file per microtubule, grouped as <video>/frame_NNNN/, named by cross-frame trackId when tracking ran)\n'
     : ''
 }* metrics/ - Calculated metrics
 * documentation/ - This folder
@@ -239,13 +239,15 @@ Every microtubule export also bundles the polyline centerlines as native
 ImageJ \`.roi\` files, so you can re-open them in ImageJ / Fiji for manual
 re-measurement or line-based plugins. Files are loose (one \`.roi\` per
 microtubule), grouped as \`annotations/imagej/<video>/frame_NNNN/\`, and named
-by the cross-frame **trackId** — so the same microtubule keeps the same ROI
+by the cross-frame **trackId** when tracking ran (falling back to the
+polyline's name/id otherwise) — so a tracked microtubule keeps the same ROI
 name in every frame.
 
 - Geometry is stored with sub-pixel (float) precision, in image-pixel space.
-- To load a frame's ROIs: open the frame image in ImageJ, then
-  **Analyze ▸ Tools ▸ ROI Manager ▸ More ▸ Open…** and multi-select the
-  frame's \`.roi\` files (or drag the files onto the ImageJ window).
+- To load a frame's ROIs: open the frame image in ImageJ and **drag the
+  frame's \`.roi\` files onto the ImageJ window** — this accepts multiple files
+  at once and adds them to the ROI Manager. (ImageJ's *ROI Manager ▸ More ▸
+  Open…* loads only a single \`.roi\`, or a single RoiSet \`.zip\`, at a time.)
 
 ## Kymograph velocity metrics
 

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -49,7 +49,11 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 * coco/ - COCO format annotations
 * yolo/ - YOLO format annotations
 * json/ - Custom JSON format
-* metrics/ - Calculated metrics
+${
+  project.type === 'microtubules'
+    ? '* imagej/ - ImageJ/Fiji .roi files (one file per microtubule, grouped as <video>/frame_NNNN/, named by cross-frame trackId)\n'
+    : ''
+}* metrics/ - Calculated metrics
 * documentation/ - This folder
 
 ## Usage Instructions
@@ -78,7 +82,7 @@ function buildUnitContext(options?: ExportOptions): UnitContext {
   const areaUnit: UnitContext['areaUnit'] = isScaled ? 'um^2' : 'px^2';
   const lengthUnit: UnitContext['lengthUnit'] = isScaled ? 'um' : 'px';
   const scaleInfo = isScaled
-    ? `\n## Scale Conversion\n\n- **Scale**: ${options!.pixelToMicrometerScale} um/pixel\n- **Linear measurements**: Converted from pixels to micrometers (um)\n- **Area measurements**: Converted from pixels^2 to square micrometers (um^2)\n- **Dimensionless ratios**: Remain unchanged (scale-invariant)\n`
+    ? `\n## Scale Conversion\n\n- **Scale**: ${options?.pixelToMicrometerScale} um/pixel\n- **Linear measurements**: Converted from pixels to micrometers (um)\n- **Area measurements**: Converted from pixels^2 to square micrometers (um^2)\n- **Dimensionless ratios**: Remain unchanged (scale-invariant)\n`
     : '\n## Units\n\n- **All measurements are in pixel units**\n- **Linear measurements**: pixels (px)\n- **Area measurements**: square pixels (px^2)\n';
   return { areaUnit, lengthUnit, scaleInfo };
 }
@@ -228,6 +232,20 @@ The JSON format preserves the full microtubule structure:
 - \`instanceId\` — unique per polyline (one MT = one instance)
 - \`trackId\` — set when tracking ran successfully; equal across frames
   for sibling polylines representing the same MT over time
+
+## ImageJ / Fiji ROIs (\`annotations/imagej/\`)
+
+Every microtubule export also bundles the polyline centerlines as native
+ImageJ \`.roi\` files, so you can re-open them in ImageJ / Fiji for manual
+re-measurement or line-based plugins. Files are loose (one \`.roi\` per
+microtubule), grouped as \`annotations/imagej/<video>/frame_NNNN/\`, and named
+by the cross-frame **trackId** — so the same microtubule keeps the same ROI
+name in every frame.
+
+- Geometry is stored with sub-pixel (float) precision, in image-pixel space.
+- To load a frame's ROIs: open the frame image in ImageJ, then
+  **Analyze ▸ Tools ▸ ROI Manager ▸ More ▸ Open…** and multi-select the
+  frame's \`.roi\` files (or drag the files onto the ImageJ window).
 
 ## Kymograph velocity metrics
 

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -10,13 +10,13 @@
  * File layout produced here (offsets in bytes, all big-endian):
  *   0    "Iout" magic
  *   4    version (int16, 227)
- *   6    ROI type (uint8): 0 = polygon, 5 = polyline
+ *   6    ROI type (uint8): 0 = polygon, 5 = polyline  (on-disk codes)
  *   8    top / 10 left / 12 bottom / 14 right  (int16 integer bounding box)
  *   16   nCoordinates (int16)
  *   50   options (int16): SUB_PIXEL_RESOLUTION (128) is always set here
- *   56   position (int32, slice — 0 = not slice-associated)
+ *   56   position (int32): left 0 — loose per-frame files aren't slice-associated
  *   60   header2 offset (int32)
- *   64   integer x[n] (int16, relative to left), then integer y[n]
+ *   64   integer coords: x[n] then y[n] (int16; x relative to left, y to top)
  *   64+4n  float32 x[n] (absolute), then float32 y[n]  ← authoritative geometry
  *   +HEADER2  header2 block (name offset/length live here)
  *   +name   ROI name as UTF-16BE code units
@@ -28,6 +28,7 @@
 
 import * as path from 'path';
 import { promises as fs } from 'fs';
+import type { PolygonPoint } from '../../types/polygon';
 import { logger } from '../../utils/logger';
 import { mapWithConcurrency } from '../../utils/concurrency';
 import { sanitizeFilename } from './exportFileOperations';
@@ -38,17 +39,17 @@ import { sanitizeFilename } from './exportFileOperations';
 
 export type RoiGeometry = 'polyline' | 'polygon';
 
-export interface RoiPoint {
-  x: number;
-  y: number;
-}
+/** Alias of the canonical polygon point — kept for local readability. */
+export type RoiPoint = PolygonPoint;
 
 const MAGIC = 'Iout';
 const VERSION = 227; // supports sub-pixel floats + header2 name; universally read
 const HEADER_SIZE = 64;
 const HEADER2_SIZE = 64;
 
-// ROI type bytes (ij.gui.Roi constants)
+// On-disk ROI type codes from ij.io.RoiEncoder / RoiDecoder — NOT the
+// ij.gui.Roi runtime constants (whose POLYGON=2 / POLYLINE=6 differ). Changing
+// these to the gui values would silently corrupt every exported file.
 const ROI_TYPE_POLYGON = 0;
 const ROI_TYPE_POLYLINE = 5;
 
@@ -73,21 +74,23 @@ function putShort(buf: Buffer, offset: number, value: number): void {
  * Encode a single polyline/polygon into an ImageJ ``.roi`` byte buffer.
  *
  * @param points   Vertices in image-pixel space (sub-pixel floats preserved).
- * @param geometry ``'polyline'`` (open) or ``'polygon'`` (closed).
+ *                 Coordinates must be finite; callers filter beforehand.
+ * @param geometry ``'polyline'`` (open, ≥2 points) or ``'polygon'`` (closed,
+ *                 ≥3 points).
  * @param name     ROI name embedded in header2 (shown in RoiManager). Empty
  *                 string / undefined omits the name block.
- * @param position 1-based stack slice to associate the ROI with, or 0/undefined
- *                 for no association (ROI shows on any slice).
  */
 export function encodeImageJRoi(
   points: RoiPoint[],
   geometry: RoiGeometry,
-  name?: string,
-  position?: number
+  name?: string
 ): Buffer {
   const n = points.length;
-  if (n < 2) {
-    throw new Error(`ImageJ ROI requires at least 2 points, got ${n}`);
+  const minPoints = geometry === 'polygon' ? 3 : 2;
+  if (n < minPoints) {
+    throw new Error(
+      `ImageJ ${geometry} ROI requires at least ${minPoints} points, got ${n}`
+    );
   }
 
   // Integer bounding box from rounded coordinates (matches Roi.getBounds()).
@@ -112,7 +115,7 @@ export function encodeImageJRoi(
 
   const buf = Buffer.alloc(totalSize); // zero-filled: unset fields stay 0
 
-  // ---- Header (0..63) ----
+  // ---- Header (0..63) ----  (position @56 intentionally left 0)
   buf.write(MAGIC, 0, 'ascii');
   putShort(buf, 4, VERSION);
   buf.writeUInt8(roiType, 6);
@@ -122,7 +125,6 @@ export function encodeImageJRoi(
   putShort(buf, 14, right);
   putShort(buf, 16, n);
   putShort(buf, 50, SUB_PIXEL_RESOLUTION);
-  buf.writeInt32BE(position && position > 0 ? position : 0, 56);
   buf.writeInt32BE(header2Offset, 60);
 
   // ---- Coordinates (64..) ----
@@ -163,40 +165,90 @@ export interface RoiFrameInput {
   segmentation?: { polygons?: string | null } | null;
 }
 
+export interface ImageJRoiExportResult {
+  /** Frames that produced at least one .roi file. */
+  frames: number;
+  /** Total .roi files written. */
+  rois: number;
+  /** User-facing, non-fatal warnings (e.g. corrupt frames skipped). */
+  warnings: string[];
+}
+
 interface RawPolygon {
   id?: string;
   name?: string;
   geometry?: string;
-  points?: Array<{ x: number; y: number }>;
+  points?: PolygonPoint[];
   instanceId?: string;
   trackId?: string | null;
 }
 
 const FRAME_WRITE_CONCURRENCY = 8;
 
-function safeParsePolygons(json: string | null | undefined): RawPolygon[] {
+/**
+ * Parse a frame's polygons JSON, distinguishing "no polygons" from "corrupt".
+ * The `corrupt` flag lets the caller surface a warning instead of silently
+ * dropping a frame's microtubules (matching the COCO/JSON parse-failure path).
+ */
+function parseFramePolygons(json: string | null | undefined): {
+  polygons: RawPolygon[];
+  corrupt: boolean;
+} {
   if (!json) {
-    return [];
+    return { polygons: [], corrupt: false };
   }
   try {
-    const parsed = JSON.parse(json) as RawPolygon[];
-    return Array.isArray(parsed) ? parsed : [];
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed)
+      ? { polygons: parsed as RawPolygon[], corrupt: false }
+      : { polygons: [], corrupt: false };
   } catch {
+    return { polygons: [], corrupt: true };
+  }
+}
+
+function isFinitePoint(p: unknown): p is PolygonPoint {
+  return (
+    typeof p === 'object' &&
+    p !== null &&
+    Number.isFinite((p as PolygonPoint).x) &&
+    Number.isFinite((p as PolygonPoint).y)
+  );
+}
+
+/**
+ * Sanitised copy of a polygon's points, or `[]` if ANY point is missing/
+ * non-finite — a polyline with a hole is meaningless, so the whole polygon is
+ * dropped (and counted) rather than emitting a NaN-coordinate ROI ImageJ can't
+ * read.
+ */
+function validPoints(points: PolygonPoint[] | undefined): PolygonPoint[] {
+  if (!Array.isArray(points)) {
     return [];
   }
+  const out: PolygonPoint[] = [];
+  for (const p of points) {
+    if (!isFinitePoint(p)) {
+      return [];
+    }
+    out.push({ x: p.x, y: p.y });
+  }
+  return out;
 }
 
 /**
  * Cross-frame-stable ROI label. trackId keeps the same microtubule identically
- * named across every frame (the user-requested behaviour); the remaining
- * fallbacks only kick in for untracked polygons so a name is never empty.
+ * named across every frame (when cross-frame tracking ran); the remaining
+ * fallbacks kick in for untracked polygons so a name is never empty. Uses `||`
+ * (not `??`) so an empty-string trackId/name also falls through — an empty
+ * label would collapse distinct microtubules to the same file.
  */
 function roiLabel(p: RawPolygon, index: number): string {
   return (
-    p.trackId ??
-    p.name ??
-    p.instanceId ??
-    p.id ??
+    p.trackId ||
+    p.name ||
+    p.instanceId ||
+    p.id ||
     `roi_${String(index + 1).padStart(4, '0')}`
   );
 }
@@ -245,21 +297,25 @@ function frameFolderName(
  * Write ImageJ ``.roi`` files for every segmented frame of a microtubule
  * export. Output layout (loose files, grouped per frame):
  *
- *   annotations/imagej/<frameName>/<roiLabel>.roi
+ *   annotations/imagej/<video>/frame_NNNN/<roiLabel>.roi
  *
  * Both open polylines (→ ImageJ POLYLINE) and any closed polygons (→ POLYGON)
  * are emitted; MT projects are polyline-only in practice.
  *
- * @returns Counts for logging + a human-readable warning list (currently only
- *          "nothing to export", surfaced so a silently empty folder isn't
- *          mistaken for a bug).
+ * Degradation: corrupt-JSON frames are skipped and reported via the returned
+ * `warnings` (never silently dropped); polygons with too few / non-finite
+ * points are dropped and logged. This function must NOT reject on routine bad
+ * data — its caller treats a rejection as non-fatal, but keeping it total makes
+ * that contract obvious.
+ *
+ * @returns Counts + non-fatal warnings for the caller to fold into job.warnings.
  */
 export async function exportImageJRois(
   frameImages: RoiFrameInput[],
   exportDir: string,
   projectId: string,
   options: { shouldAbort?: () => boolean } = {}
-): Promise<{ frames: number; rois: number; warnings: string[] }> {
+): Promise<ImageJRoiExportResult> {
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
 
   // Container rows (carried in the same images array) supply a clean, human
@@ -277,51 +333,69 @@ export async function exportImageJRois(
     f => !f.isVideoContainer && !!f.segmentation?.polygons
   );
 
+  // Counters mutated by concurrent workers — safe because every increment is a
+  // synchronous statement with no interleaving await (single-threaded JS).
   let framesWritten = 0;
   let roisWritten = 0;
+  let corruptFrames = 0;
+  let droppedPolygons = 0;
 
   await mapWithConcurrency(
     frames,
     FRAME_WRITE_CONCURRENCY,
     async frame => {
-      // Normalise to concrete {geometry, points, label} items and drop
-      // degenerate geometry (polyline < 2 pts / polygon < 3 pts).
-      const items = safeParsePolygons(frame.segmentation?.polygons)
+      const parsed = parseFramePolygons(frame.segmentation?.polygons);
+      if (parsed.corrupt) {
+        corruptFrames++;
+        return;
+      }
+
+      // Normalise to concrete {geometry, points, label} items, dropping
+      // degenerate geometry (polyline < 2 / polygon < 3) and any polygon with
+      // non-finite coordinates. Default missing geometry to 'polyline' — this
+      // is the MT-only path and MT annotations are always open polylines.
+      const items = parsed.polygons
         .map((p, index) => {
-          const geometry = (p.geometry ?? 'polygon') as RoiGeometry;
-          const points = Array.isArray(p.points) ? p.points : [];
-          return { geometry, points, label: roiLabel(p, index) };
+          const geometry: RoiGeometry =
+            p.geometry === 'polygon' ? 'polygon' : 'polyline';
+          return { geometry, points: validPoints(p.points), label: roiLabel(p, index) };
         })
         .filter(
           it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3)
         );
 
+      droppedPolygons += parsed.polygons.length - items.length;
+
       if (items.length === 0) {
         return;
       }
 
-      const frameDir = path.join(baseDir, frameFolderName(frame, containerNames));
+      const frameDir = path.join(
+        baseDir,
+        frameFolderName(frame, containerNames)
+      );
       await fs.mkdir(frameDir, { recursive: true });
 
       const usedNames = new Set<string>();
       let frameRois = 0;
 
-      await Promise.all(
-        items.map(async ({ geometry, points, label }) => {
-          // Ensure a unique on-disk filename within the frame folder.
-          const fileBase = sanitizeFilename(label);
-          let candidate = fileBase;
-          let dupe = 2;
-          while (usedNames.has(candidate.toLowerCase())) {
-            candidate = `${fileBase}_${dupe++}`;
-          }
-          usedNames.add(candidate.toLowerCase());
+      // Sequential within a frame so the max concurrent open file handles stays
+      // at FRAME_WRITE_CONCURRENCY — a frame can hold 100+ microtubules, and a
+      // parallel write per ROI × 8 frames would risk EMFILE.
+      for (const { geometry, points, label } of items) {
+        // Ensure a unique on-disk filename within the frame folder.
+        const fileBase = sanitizeFilename(label);
+        let candidate = fileBase;
+        let dupe = 2;
+        while (usedNames.has(candidate.toLowerCase())) {
+          candidate = `${fileBase}_${dupe++}`;
+        }
+        usedNames.add(candidate.toLowerCase());
 
-          const buf = encodeImageJRoi(points, geometry, label);
-          await fs.writeFile(path.join(frameDir, `${candidate}.roi`), buf);
-          frameRois++;
-        })
-      );
+        const buf = encodeImageJRoi(points, geometry, label);
+        await fs.writeFile(path.join(frameDir, `${candidate}.roi`), buf);
+        frameRois++;
+      }
 
       if (frameRois > 0) {
         framesWritten++;
@@ -334,7 +408,20 @@ export async function exportImageJRois(
     }
   );
 
+  if (droppedPolygons > 0) {
+    logger.warn(
+      `ImageJ ROI export: dropped ${droppedPolygons} polygon(s) with too few or non-finite points`,
+      'imagejRoiEncoder',
+      { projectId }
+    );
+  }
+
   const warnings: string[] = [];
+  if (corruptFrames > 0) {
+    warnings.push(
+      `ImageJ ROI export: ${corruptFrames} frame(s) had corrupt polygon data and were skipped.`
+    );
+  }
   if (roisWritten === 0) {
     warnings.push(
       'ImageJ ROI export: no microtubule polylines were found to export.'
@@ -345,6 +432,8 @@ export async function exportImageJRois(
     projectId,
     frames: framesWritten,
     rois: roisWritten,
+    corruptFrames,
+    droppedPolygons,
   });
 
   return { frames: framesWritten, rois: roisWritten, warnings };

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -1,0 +1,351 @@
+/**
+ * ImageJ / Fiji ``.roi`` binary encoder + per-frame ROI exporter.
+ *
+ * Microtubule projects annotate open polylines that biologists want to
+ * re-open in ImageJ (RoiManager, kymograph plugins, manual re-measurement).
+ * ImageJ's native ROI format is a big-endian binary blob — NOT JSON — so this
+ * module hand-encodes it against the layout defined in ImageJ's
+ * ``ij/io/RoiEncoder.java`` / ``RoiDecoder.java``.
+ *
+ * File layout produced here (offsets in bytes, all big-endian):
+ *   0    "Iout" magic
+ *   4    version (int16, 227)
+ *   6    ROI type (uint8): 0 = polygon, 5 = polyline
+ *   8    top / 10 left / 12 bottom / 14 right  (int16 integer bounding box)
+ *   16   nCoordinates (int16)
+ *   50   options (int16): SUB_PIXEL_RESOLUTION (128) is always set here
+ *   56   position (int32, slice — 0 = not slice-associated)
+ *   60   header2 offset (int32)
+ *   64   integer x[n] (int16, relative to left), then integer y[n]
+ *   64+4n  float32 x[n] (absolute), then float32 y[n]  ← authoritative geometry
+ *   +HEADER2  header2 block (name offset/length live here)
+ *   +name   ROI name as UTF-16BE code units
+ *
+ * The sub-pixel float block preserves the true polyline geometry (tracking
+ * works in float space); the legacy integer block is required by the format
+ * but only used by very old readers.
+ */
+
+import * as path from 'path';
+import { promises as fs } from 'fs';
+import { logger } from '../../utils/logger';
+import { mapWithConcurrency } from '../../utils/concurrency';
+import { sanitizeFilename } from './exportFileOperations';
+
+// ---------------------------------------------------------------------------
+//  Low-level encoder
+// ---------------------------------------------------------------------------
+
+export type RoiGeometry = 'polyline' | 'polygon';
+
+export interface RoiPoint {
+  x: number;
+  y: number;
+}
+
+const MAGIC = 'Iout';
+const VERSION = 227; // supports sub-pixel floats + header2 name; universally read
+const HEADER_SIZE = 64;
+const HEADER2_SIZE = 64;
+
+// ROI type bytes (ij.gui.Roi constants)
+const ROI_TYPE_POLYGON = 0;
+const ROI_TYPE_POLYLINE = 5;
+
+// options flags (RoiDecoder)
+const SUB_PIXEL_RESOLUTION = 128;
+
+// header2 field offsets (relative to the header2 block start)
+const H2_NAME_OFFSET = 16;
+const H2_NAME_LENGTH = 20;
+
+/**
+ * Write the low 16 bits of ``value`` as a big-endian short. Mirrors ImageJ's
+ * ``putShort`` which casts to ``(short)`` — so out-of-int16-range coordinates
+ * wrap identically instead of throwing (the sub-pixel float block carries the
+ * real values, making the integer wrap cosmetic).
+ */
+function putShort(buf: Buffer, offset: number, value: number): void {
+  buf.writeUInt16BE(value & 0xffff, offset);
+}
+
+/**
+ * Encode a single polyline/polygon into an ImageJ ``.roi`` byte buffer.
+ *
+ * @param points   Vertices in image-pixel space (sub-pixel floats preserved).
+ * @param geometry ``'polyline'`` (open) or ``'polygon'`` (closed).
+ * @param name     ROI name embedded in header2 (shown in RoiManager). Empty
+ *                 string / undefined omits the name block.
+ * @param position 1-based stack slice to associate the ROI with, or 0/undefined
+ *                 for no association (ROI shows on any slice).
+ */
+export function encodeImageJRoi(
+  points: RoiPoint[],
+  geometry: RoiGeometry,
+  name?: string,
+  position?: number
+): Buffer {
+  const n = points.length;
+  if (n < 2) {
+    throw new Error(`ImageJ ROI requires at least 2 points, got ${n}`);
+  }
+
+  // Integer bounding box from rounded coordinates (matches Roi.getBounds()).
+  const xs = points.map(p => Math.round(p.x));
+  const ys = points.map(p => Math.round(p.y));
+  const left = Math.min(...xs);
+  const top = Math.min(...ys);
+  const right = Math.max(...xs);
+  const bottom = Math.max(...ys);
+
+  const roiType =
+    geometry === 'polyline' ? ROI_TYPE_POLYLINE : ROI_TYPE_POLYGON;
+
+  // Coordinate section = int16 x[n] + int16 y[n] + float32 x[n] + float32 y[n].
+  const coordBytes = n * 4 + n * 8;
+  const header2Offset = HEADER_SIZE + coordBytes;
+
+  const roiName = name ?? '';
+  const nameLength = roiName.length; // UTF-16 code units, not bytes
+  const nameOffset = header2Offset + HEADER2_SIZE;
+  const totalSize = nameOffset + nameLength * 2;
+
+  const buf = Buffer.alloc(totalSize); // zero-filled: unset fields stay 0
+
+  // ---- Header (0..63) ----
+  buf.write(MAGIC, 0, 'ascii');
+  putShort(buf, 4, VERSION);
+  buf.writeUInt8(roiType, 6);
+  putShort(buf, 8, top);
+  putShort(buf, 10, left);
+  putShort(buf, 12, bottom);
+  putShort(buf, 14, right);
+  putShort(buf, 16, n);
+  putShort(buf, 50, SUB_PIXEL_RESOLUTION);
+  buf.writeInt32BE(position && position > 0 ? position : 0, 56);
+  buf.writeInt32BE(header2Offset, 60);
+
+  // ---- Coordinates (64..) ----
+  const intXBase = HEADER_SIZE;
+  const intYBase = intXBase + n * 2;
+  const floatXBase = HEADER_SIZE + n * 4;
+  const floatYBase = floatXBase + n * 4;
+  for (let i = 0; i < n; i++) {
+    putShort(buf, intXBase + i * 2, xs[i] - left);
+    putShort(buf, intYBase + i * 2, ys[i] - top);
+    buf.writeFloatBE(points[i].x, floatXBase + i * 4);
+    buf.writeFloatBE(points[i].y, floatYBase + i * 4);
+  }
+
+  // ---- header2 + name ----
+  if (nameLength > 0) {
+    buf.writeInt32BE(nameOffset, header2Offset + H2_NAME_OFFSET);
+    buf.writeInt32BE(nameLength, header2Offset + H2_NAME_LENGTH);
+    for (let i = 0; i < nameLength; i++) {
+      buf.writeUInt16BE(roiName.charCodeAt(i), nameOffset + i * 2);
+    }
+  }
+
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+//  Per-frame exporter
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the Image rows the export pipeline passes in. */
+export interface RoiFrameInput {
+  id: string;
+  name: string;
+  parentVideoId?: string | null;
+  frameIndex?: number | null;
+  isVideoContainer?: boolean;
+  segmentation?: { polygons?: string | null } | null;
+}
+
+interface RawPolygon {
+  id?: string;
+  name?: string;
+  geometry?: string;
+  points?: Array<{ x: number; y: number }>;
+  instanceId?: string;
+  trackId?: string | null;
+}
+
+const FRAME_WRITE_CONCURRENCY = 8;
+
+function safeParsePolygons(json: string | null | undefined): RawPolygon[] {
+  if (!json) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(json) as RawPolygon[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Cross-frame-stable ROI label. trackId keeps the same microtubule identically
+ * named across every frame (the user-requested behaviour); the remaining
+ * fallbacks only kick in for untracked polygons so a name is never empty.
+ */
+function roiLabel(p: RawPolygon, index: number): string {
+  return (
+    p.trackId ??
+    p.name ??
+    p.instanceId ??
+    p.id ??
+    `roi_${String(index + 1).padStart(4, '0')}`
+  );
+}
+
+/**
+ * Per-frame output folder: ``<videoLabel>/frame_<NNNN>``.
+ *
+ * The frame's own display name is unusable as a key — real MT frames are named
+ * ``"<original>.nd2 (frame 1)"``, on which ``path.parse().name`` amputates the
+ * ``.nd2 (frame 1)`` "extension" and collapses every frame to one folder. So we
+ * key on the structured ``(parentVideoId, frameIndex)`` instead:
+ *  - videoLabel comes from the container row's name (a clean filename), which
+ *    also disambiguates multi-position ND2 splits (one container per position);
+ *  - frameIndex gives a guaranteed-unique numeric suffix within a video.
+ *
+ * @param containerNames  parentVideoId → container display name.
+ */
+function frameFolderName(
+  frame: RoiFrameInput,
+  containerNames: Map<string, string>
+): string {
+  const containerName = frame.parentVideoId
+    ? containerNames.get(frame.parentVideoId)
+    : undefined;
+
+  let videoLabel: string;
+  if (containerName) {
+    // Container names are real filenames (no "(frame N)" suffix), so stripping
+    // the extension here is safe and yields a readable video folder.
+    videoLabel = sanitizeFilename(path.parse(containerName).name);
+  } else if (frame.parentVideoId) {
+    videoLabel = `video_${frame.parentVideoId.slice(0, 8)}`;
+  } else {
+    videoLabel = 'video';
+  }
+
+  const frameLabel =
+    typeof frame.frameIndex === 'number'
+      ? `frame_${String(frame.frameIndex).padStart(4, '0')}`
+      : sanitizeFilename(frame.id);
+
+  return path.join(videoLabel, frameLabel);
+}
+
+/**
+ * Write ImageJ ``.roi`` files for every segmented frame of a microtubule
+ * export. Output layout (loose files, grouped per frame):
+ *
+ *   annotations/imagej/<frameName>/<roiLabel>.roi
+ *
+ * Both open polylines (→ ImageJ POLYLINE) and any closed polygons (→ POLYGON)
+ * are emitted; MT projects are polyline-only in practice.
+ *
+ * @returns Counts for logging + a human-readable warning list (currently only
+ *          "nothing to export", surfaced so a silently empty folder isn't
+ *          mistaken for a bug).
+ */
+export async function exportImageJRois(
+  frameImages: RoiFrameInput[],
+  exportDir: string,
+  projectId: string,
+  options: { shouldAbort?: () => boolean } = {}
+): Promise<{ frames: number; rois: number; warnings: string[] }> {
+  const baseDir = path.join(exportDir, 'annotations', 'imagej');
+
+  // Container rows (carried in the same images array) supply a clean, human
+  // readable video-folder label — build the lookup before filtering them out.
+  const containerNames = new Map<string, string>();
+  for (const f of frameImages) {
+    if (f.isVideoContainer && f.name) {
+      containerNames.set(f.id, f.name);
+    }
+  }
+
+  // Frames that actually carry segmentation geometry. Video container rows
+  // never hold polygons, so skip them.
+  const frames = frameImages.filter(
+    f => !f.isVideoContainer && !!f.segmentation?.polygons
+  );
+
+  let framesWritten = 0;
+  let roisWritten = 0;
+
+  await mapWithConcurrency(
+    frames,
+    FRAME_WRITE_CONCURRENCY,
+    async frame => {
+      // Normalise to concrete {geometry, points, label} items and drop
+      // degenerate geometry (polyline < 2 pts / polygon < 3 pts).
+      const items = safeParsePolygons(frame.segmentation?.polygons)
+        .map((p, index) => {
+          const geometry = (p.geometry ?? 'polygon') as RoiGeometry;
+          const points = Array.isArray(p.points) ? p.points : [];
+          return { geometry, points, label: roiLabel(p, index) };
+        })
+        .filter(
+          it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3)
+        );
+
+      if (items.length === 0) {
+        return;
+      }
+
+      const frameDir = path.join(baseDir, frameFolderName(frame, containerNames));
+      await fs.mkdir(frameDir, { recursive: true });
+
+      const usedNames = new Set<string>();
+      let frameRois = 0;
+
+      await Promise.all(
+        items.map(async ({ geometry, points, label }) => {
+          // Ensure a unique on-disk filename within the frame folder.
+          const fileBase = sanitizeFilename(label);
+          let candidate = fileBase;
+          let dupe = 2;
+          while (usedNames.has(candidate.toLowerCase())) {
+            candidate = `${fileBase}_${dupe++}`;
+          }
+          usedNames.add(candidate.toLowerCase());
+
+          const buf = encodeImageJRoi(points, geometry, label);
+          await fs.writeFile(path.join(frameDir, `${candidate}.roi`), buf);
+          frameRois++;
+        })
+      );
+
+      if (frameRois > 0) {
+        framesWritten++;
+        roisWritten += frameRois;
+      }
+    },
+    {
+      shouldAbort: options.shouldAbort,
+      abortMessage: 'Export cancelled by user',
+    }
+  );
+
+  const warnings: string[] = [];
+  if (roisWritten === 0) {
+    warnings.push(
+      'ImageJ ROI export: no microtubule polylines were found to export.'
+    );
+  }
+
+  logger.info('ImageJ ROI export complete', 'imagejRoiEncoder', {
+    projectId,
+    frames: framesWritten,
+    rois: roisWritten,
+  });
+
+  return { frames: framesWritten, rois: roisWritten, warnings };
+}

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -617,9 +617,11 @@ export class ExportService {
       // ImageJ ROI files — ALWAYS bundled for MT projects (no toggle) so
       // biologists can re-open microtubule polylines in ImageJ / Fiji
       // (RoiManager, kymograph plugins). Written as loose `.roi` files grouped
-      // per frame under `annotations/imagej/<frame>/`, each named by its
-      // cross-frame trackId so the same microtubule keeps one name across
-      // frames. Independent of the selected annotation formats.
+      // per frame under `annotations/imagej/<video>/frame_NNNN/`, named by
+      // cross-frame trackId when tracking ran. Independent of the selected
+      // annotation formats. Because this is always-on (the user did not opt in),
+      // a failure must NOT sink the whole export they did request: it degrades
+      // to a warning. Only a genuine cancellation stays fatal.
       if ((project.type ?? '') === 'microtubules' && project.images?.length) {
         exportTasks.push(
           exportImageJRois(
@@ -627,14 +629,34 @@ export class ExportService {
             exportDir,
             project.id,
             { shouldAbort: () => this.isJobCancelled(jobId) }
-          ).then(result => {
-            if (result.warnings.length) {
+          )
+            .then(result => {
+              if (result.warnings.length) {
+                const job = this.exportJobs.get(jobId);
+                if (job) {
+                  job.warnings = [...(job.warnings ?? []), ...result.warnings];
+                }
+              }
+            })
+            .catch(error => {
+              // A real user cancellation should still fail the job.
+              if (this.isJobCancelled(jobId)) {
+                throw error;
+              }
+              logger.error(
+                'ImageJ ROI export failed (non-fatal; rest of export continues)',
+                error instanceof Error ? error : new Error(String(error)),
+                'ExportService',
+                { jobId, projectId: project.id }
+              );
               const job = this.exportJobs.get(jobId);
               if (job) {
-                job.warnings = [...(job.warnings ?? []), ...result.warnings];
+                job.warnings = [
+                  ...(job.warnings ?? []),
+                  'ImageJ ROI export could not be completed; the rest of the export is unaffected.',
+                ];
               }
-            }
-          })
+            })
         );
       }
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -43,6 +43,7 @@ import {
   exportMicrotubuleKymographs,
   type MTKymographOptions,
 } from './export/mtKymographExporter';
+import { exportImageJRois } from './export/imagejRoiEncoder';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -610,6 +611,30 @@ export class ExportService {
             exportDir,
             options.mtKymographs
           )
+        );
+      }
+
+      // ImageJ ROI files — ALWAYS bundled for MT projects (no toggle) so
+      // biologists can re-open microtubule polylines in ImageJ / Fiji
+      // (RoiManager, kymograph plugins). Written as loose `.roi` files grouped
+      // per frame under `annotations/imagej/<frame>/`, each named by its
+      // cross-frame trackId so the same microtubule keeps one name across
+      // frames. Independent of the selected annotation formats.
+      if ((project.type ?? '') === 'microtubules' && project.images?.length) {
+        exportTasks.push(
+          exportImageJRois(
+            project.images as ImageWithSegmentation[],
+            exportDir,
+            project.id,
+            { shouldAbort: () => this.isJobCancelled(jobId) }
+          ).then(result => {
+            if (result.warnings.length) {
+              const job = this.exportJobs.get(jobId);
+              if (job) {
+                job.warnings = [...(job.warnings ?? []), ...result.warnings];
+              }
+            }
+          })
         );
       }
 


### PR DESCRIPTION
## Summary
Microtubule project exports now always bundle native ImageJ/Fiji `.roi` files alongside the existing COCO/YOLO/JSON annotations, so users can re-open microtubule polylines in ImageJ (ROI Manager, kymograph plugins).

Layout: `annotations/imagej/<video>/frame_NNNN/<trackId>.roi` — loose files per frame, each named by cross-frame `trackId` (same microtubule → same name across frames). Always-on for `microtubules` projects (no toggle), so there is **no frontend or i18n change**.

## Implementation
- **`imagejRoiEncoder.ts`** (new): pure `encodeImageJRoi()` big-endian `.roi` encoder (ROI type POLYLINE=5 / POLYGON=0, sub-pixel float coordinate block flagged via `OPTIONS |= 128`, UTF-16BE ROI name in header2) + `exportImageJRois()` per-frame writer.
- **`exportService.ts`**: one always-on task in `processExportJob`, gated on `project.type === 'microtubules'`.
- **`exportDocs.ts`**: README folder listing (MT only) + an "ImageJ / Fiji ROIs" section in the microtubule guide.

## Verification
- **Round-trip**: encoded with the new code, decoded with Christoph Gohlke's reference `roifile` — POLYLINE/POLYGON type, sub-pixel coordinates, and UTF-16 names all round-trip exactly.
- **Real production data**: ran the real writer against MT projects — cross-frame naming stable (140/140 shared `trackId` filenames across frames); a degenerate all-same-`trackId` project is handled safely via collision suffixing.
- **Real-data bug caught + fixed**: `path.parse()` mangles frame names like `"<orig>.nd2 (frame 1)"` (amputates `.nd2 (frame 1)` as the "extension"), which collapsed all frames into one folder — folders now key on `(container name, frameIndex)`.
- Backend type-check clean, backend ESLint clean on new source, export test suite **193/193** green (10 new tests).

## Not included
- **Not yet deployed** — backend rebuild + recreate needed for it to take effect in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microtubule exports now generate ImageJ/Fiji `.roi` files alongside existing outputs.
  * ROI exports are organized by video and frame, with consistent cross-frame naming when `trackId` is available.

* **Documentation**
  * Updated export documentation with an ImageJ/Fiji folder structure and load instructions.

* **Bug Fixes**
  * Invalid/corrupt ROI inputs are skipped with warnings; finite-coordinate validation prevents NaN ROI files.
  * Export behavior improves around empty outputs and job cancellation.

* **Tests**
  * Added comprehensive coverage for ImageJ/Fiji ROI encoding/decoding and export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->