### PR TITLE
fix(mt-export): match MT visualization badge to a metrics.xlsx label column

### DIFF
--- a/backend/src/services/__tests__/exportService.gaps2.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps2.test.ts
@@ -1036,6 +1036,39 @@ describe('ExportService — generateVisualizations skip paths', () => {
     expect(vizPath).toMatch(/_frame_0007_viz\.png$/);
   });
 
+  it('forwards labelPrefix into each generateVisualization options arg', async () => {
+    mockVizGenerate.mockResolvedValue('success');
+    // Call generateVisualizations directly with an explicit MT prefix (6th arg).
+    await (
+      service as unknown as {
+        generateVisualizations: (
+          images: unknown[],
+          exportDir: string,
+          options: unknown,
+          jobId: string | undefined,
+          onProgress: undefined,
+          labelPrefix: string
+        ) => Promise<void>;
+      }
+    ).generateVisualizations(
+      [makeMinimalImage()],
+      '/tmp/viz',
+      undefined,
+      undefined,
+      undefined,
+      'MT'
+    );
+    const optionsArg = mockVizGenerate.mock.calls[0][3] as { labelPrefix?: string };
+    expect(optionsArg.labelPrefix).toBe('MT');
+  });
+
+  it('defaults labelPrefix to the sperm prefix when not supplied', async () => {
+    mockVizGenerate.mockResolvedValue('success');
+    await callGenerateViz(service, [makeMinimalImage()]);
+    const optionsArg = mockVizGenerate.mock.calls[0][3] as { labelPrefix?: string };
+    expect(optionsArg.labelPrefix).toBe('S');
+  });
+
   it('throws "Export cancelled by user" when job is cancelled', async () => {
     getJobs(service).set('viz-cancel', {
       id: 'viz-cancel',

--- a/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
@@ -253,6 +253,46 @@ describe('computeMTGeometry', () => {
     expect(r2.trackId).toBeNull();
   });
 
+  it('labels instances MT1, MT2, … in first-appearance order', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ];
+    // Two distinct instances plus a polyline with no instanceId.
+    const seg = JSON.stringify([
+      { geometry: 'polyline', points: pts, instanceId: 'inst-a' },
+      { geometry: 'polyline', points: pts, instanceId: 'inst-b' },
+      { geometry: 'polyline', points: pts },
+    ]);
+    const rows = computeMTGeometry(
+      [makeFrame({ segmentation: { polygons: seg } })],
+      null
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows[0].label).toBe('MT1');
+    expect(rows[1].label).toBe('MT2');
+    // No instanceId → no badge on the image → empty label in metrics.
+    expect(rows[2].label).toBe('');
+  });
+
+  it('reuses the same MT label for repeated segments of one instance', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ];
+    // Instance "inst-a" appears in two rows (e.g. head + tail); both share MT1.
+    const seg = JSON.stringify([
+      { geometry: 'polyline', points: pts, instanceId: 'inst-a' },
+      { geometry: 'polyline', points: pts, instanceId: 'inst-b' },
+      { geometry: 'polyline', points: pts, instanceId: 'inst-a' },
+    ]);
+    const rows = computeMTGeometry(
+      [makeFrame({ segmentation: { polygons: seg } })],
+      null
+    );
+    expect(rows.map(r => r.label)).toEqual(['MT1', 'MT2', 'MT1']);
+  });
+
   it('emits one row per polyline across multiple frames', () => {
     const pts = [
       { x: 0, y: 0 },
@@ -520,6 +560,8 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
 
     expect(r.frameIndex).toBe(0);
     expect(r.imageId).toBe('frame-1');
+    // Label matches the "MT1" badge the visualization draws for this instance.
+    expect(r.label).toBe('MT1');
     expect(r.instanceId).toBe('inst-1');
     expect(r.trackId).toBe('track-7');
     expect(r.channel).toBe('DAPI');

--- a/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
@@ -53,6 +53,7 @@ import {
   type MTMetricsOptions,
   type MTMetricsRow,
 } from '../mtMetricsExporter';
+import { logger } from '../../../utils/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -575,6 +576,132 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
     expect(r.stdIntensity).toBe(5);
     expect(r.medianBackground).toBe(10);
     expect(r.signalMinusBackground).toBe(40);
+  });
+
+  // Faithfully mirrors the real ML contract: /mt-metrics echoes each polyline's
+  // image_id + instance_id back unchanged (mt_metrics.py:415).
+  const echoMlResponse = async (
+    _url: string,
+    body: { frames: Array<{ frame_index: number; polylines: Array<{ image_id: string; instance_id: string }> }> }
+  ) => ({
+    data: {
+      rows: body.frames.flatMap(f =>
+        f.polylines.map(pl => ({
+          ...mlResponse.data.rows[0],
+          frame_index: f.frame_index,
+          image_id: pl.image_id,
+          instance_id: pl.instance_id,
+        }))
+      ),
+      frames_processed: body.frames.length,
+      frame_height: 512,
+      frame_width: 512,
+    },
+  });
+
+  it('leaves the label empty for a polyline with no instanceId (intensity path)', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
+    // One polyline WITHOUT an instanceId → sent to ML with a synthetic id that
+    // is absent from the label map, so the row must come back with label ''.
+    const seg = JSON.stringify([
+      {
+        geometry: 'polyline',
+        points: [
+          { x: 10, y: 20 },
+          { x: 30, y: 40 },
+        ],
+      },
+    ]);
+    axiosPostMock.mockImplementationOnce(echoMlResponse);
+
+    const { rows } = await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: seg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: ['DAPI'] }
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].label).toBe('');
+    expect(rows[0].instanceId).toMatch(/^mt_/);
+    // A legitimate empty label must NOT be reported as join drift.
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('label join drift'),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('joins labels by instance_id regardless of ML row order', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
+    const seg = JSON.stringify([
+      {
+        geometry: 'polyline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ],
+        instanceId: 'inst-a',
+        trackId: 't-a',
+      },
+      {
+        geometry: 'polyline',
+        points: [
+          { x: 2, y: 2 },
+          { x: 3, y: 3 },
+        ],
+        instanceId: 'inst-b',
+        trackId: 't-b',
+      },
+    ]);
+    // ML returns the rows REVERSED — labels must still resolve by id, proving
+    // the join is id-based (not positional).
+    axiosPostMock.mockImplementationOnce(async (url: string, body) => {
+      const res = await echoMlResponse(url, body);
+      res.data.rows.reverse();
+      return res;
+    });
+
+    const { rows } = await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: seg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: ['DAPI'] }
+    );
+
+    const labelById = Object.fromEntries(rows.map(r => [r.instanceId, r.label]));
+    expect(labelById['inst-a']).toBe('MT1');
+    expect(labelById['inst-b']).toBe('MT2');
+  });
+
+  it('warns and blanks the label when ML returns an unsent instance_id', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
+    // ML returns an instance_id we never sent → genuine join drift.
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        rows: [
+          {
+            ...mlResponse.data.rows[0],
+            image_id: 'frame-1',
+            instance_id: 'ghost-id',
+          },
+        ],
+        frames_processed: 1,
+        frame_height: 512,
+        frame_width: 512,
+      },
+    });
+
+    const { rows } = await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: frameSeg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: ['DAPI'] }
+    );
+
+    expect(rows[0].label).toBe('');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('label join drift'),
+      'mtMetricsExporter',
+      expect.objectContaining({ instanceId: 'ghost-id' })
+    );
   });
 
   it('sets lengthUm and areaUm2 to null when scale is null', async () => {

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -25,6 +25,10 @@ import axios from 'axios';
 import { prisma } from '../../db/prismaClient';
 import { config } from '../../utils/config';
 import { logger } from '../../utils/logger';
+import {
+  buildInstanceLabelMap,
+  MICROTUBULE_LABEL_PREFIX,
+} from '../../utils/instanceLabels';
 
 // ----------------------------------------------------------------------------
 //  Types (mirror the Python Pydantic models — keep in sync if either changes)
@@ -46,6 +50,10 @@ export interface MTMetricsOptions {
 export interface MTMetricsRow {
   frameIndex: number;
   imageId: string;
+  /** Per-frame instance badge drawn on the visualization image ("MT1",
+   *  "MT2", …), matching {@link buildInstanceLabelMap}. Empty string when the
+   *  polyline has no `instanceId` (no badge is drawn for it either). */
+  label: string;
   instanceId: string;
   trackId: string | null;
   /** Channel machine name, or '' for geometry-only rows (no channel picked). */
@@ -322,9 +330,18 @@ export async function computeMTMetrics(
     }
 
     // Build the frames payload — only frames that actually have polylines.
+    // Also build a per-frame instance→label map ("MT1", …) from the full
+    // parsed polygon list so each emitted row carries the same badge the
+    // visualization draws on the image.
     const framesPayload: FramePayload[] = [];
+    const labelMapsByImage = new Map<string, Map<string, string>>();
     for (const fr of frames) {
-      const polylines = safeParsePolygons(fr.segmentation?.polygons)
+      const parsed = safeParsePolygons(fr.segmentation?.polygons);
+      labelMapsByImage.set(
+        fr.id,
+        buildInstanceLabelMap(parsed, MICROTUBULE_LABEL_PREFIX)
+      );
+      const polylines = parsed
         .filter(p => (p.geometry ?? 'polygon') === 'polyline')
         .filter(p => Array.isArray(p.points) && p.points.length >= 2)
         .map<PolylinePayload>(p => ({
@@ -403,6 +420,7 @@ export async function computeMTMetrics(
       allRows.push({
         frameIndex: row.frame_index,
         imageId: row.image_id,
+        label: labelMapsByImage.get(row.image_id)?.get(row.instance_id) ?? '',
         instanceId: row.instance_id,
         trackId: row.track_id,
         channel: row.channel,
@@ -457,7 +475,11 @@ export function computeMTGeometry(
     if (fr.isVideoContainer || !fr.parentVideoId || fr.frameIndex == null) {
       continue;
     }
-    const polylines = safeParsePolygons(fr.segmentation?.polygons)
+    const parsed = safeParsePolygons(fr.segmentation?.polygons);
+    // Same instance→label map the visualization uses, so geometry-only rows
+    // still carry the "MT1" badge shown on the image.
+    const labelMap = buildInstanceLabelMap(parsed, MICROTUBULE_LABEL_PREFIX);
+    const polylines = parsed
       .filter(p => (p.geometry ?? 'polygon') === 'polyline')
       .filter(p => Array.isArray(p.points) && p.points!.length >= 2);
     for (const p of polylines) {
@@ -465,6 +487,7 @@ export function computeMTGeometry(
       rows.push({
         frameIndex: fr.frameIndex,
         imageId: fr.id,
+        label: p.instanceId ? (labelMap.get(p.instanceId) ?? '') : '',
         instanceId:
           p.instanceId ?? `mt_${fr.id.slice(0, 8)}_${p.points!.length}`,
         trackId: p.trackId ?? null,
@@ -497,6 +520,7 @@ export function computeMTGeometry(
 const CSV_HEADERS: readonly (keyof MTMetricsRow)[] = [
   'frameIndex',
   'imageId',
+  'label',
   'instanceId',
   'trackId',
   'channel',

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -330,26 +330,41 @@ export async function computeMTMetrics(
     }
 
     // Build the frames payload — only frames that actually have polylines.
-    // Also build a per-frame instance→label map ("MT1", …) from the full
-    // parsed polygon list so each emitted row carries the same badge the
-    // visualization draws on the image.
+    // Alongside it, build a per-frame label map ("MT1", …) keyed by the EXACT
+    // `instance_id` sent to ML (real instanceId, or the synthesized fallback
+    // for polylines without one). Keying on the sent id means the response
+    // join below hits for every polyline we sent — including the empty-label
+    // no-instanceId case (stored as '') — so a genuine miss (an ML row we
+    // never sent) reads back as `undefined` and is flagged rather than
+    // silently blanking the label.
     const framesPayload: FramePayload[] = [];
-    const labelMapsByImage = new Map<string, Map<string, string>>();
+    const labelBySentId = new Map<string, Map<string, string>>();
     for (const fr of frames) {
       const parsed = safeParsePolygons(fr.segmentation?.polygons);
-      labelMapsByImage.set(
-        fr.id,
-        buildInstanceLabelMap(parsed, MICROTUBULE_LABEL_PREFIX)
+      const labelByInstanceId = buildInstanceLabelMap(
+        parsed,
+        MICROTUBULE_LABEL_PREFIX
       );
+      const sentIdToLabel = new Map<string, string>();
       const polylines = parsed
         .filter(p => (p.geometry ?? 'polygon') === 'polyline')
         .filter(p => Array.isArray(p.points) && p.points.length >= 2)
-        .map<PolylinePayload>(p => ({
-          image_id: fr.id,
-          instance_id: p.instanceId ?? `mt_${fr.id.slice(0, 8)}_${p.points!.length}`,
-          track_id: p.trackId ?? null,
-          points: p.points!.map(pt => [pt.x, pt.y]),
-        }));
+        .map<PolylinePayload>(p => {
+          const sentId =
+            p.instanceId ?? `mt_${fr.id.slice(0, 8)}_${p.points!.length}`;
+          // No instanceId → no badge on the image → empty label, matching viz.
+          sentIdToLabel.set(
+            sentId,
+            p.instanceId ? labelByInstanceId.get(p.instanceId) ?? '' : ''
+          );
+          return {
+            image_id: fr.id,
+            instance_id: sentId,
+            track_id: p.trackId ?? null,
+            points: p.points!.map(pt => [pt.x, pt.y]),
+          };
+        });
+      labelBySentId.set(fr.id, sentIdToLabel);
       if (!polylines.length) continue;
       framesPayload.push({
         image_id: fr.id,
@@ -417,10 +432,21 @@ export async function computeMTMetrics(
 
     const scale = options.pixelToMicrometerScale;
     for (const row of mlResponse.rows) {
+      // Every polyline we sent has an entry (badge or ''); `undefined` means
+      // ML returned an (image_id, instance_id) we never sent — a contract
+      // drift that would otherwise silently blank the label column.
+      const label = labelBySentId.get(row.image_id)?.get(row.instance_id);
+      if (label === undefined) {
+        logger.warn(
+          'MT metrics: ML returned an (image_id, instance_id) not present in the request — label join drift; label left blank',
+          'mtMetricsExporter',
+          { projectId, videoId, imageId: row.image_id, instanceId: row.instance_id }
+        );
+      }
       allRows.push({
         frameIndex: row.frame_index,
         imageId: row.image_id,
-        label: labelMapsByImage.get(row.image_id)?.get(row.instance_id) ?? '',
+        label: label ?? '',
         instanceId: row.instance_id,
         trackId: row.track_id,
         channel: row.channel,

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -31,6 +31,7 @@ import { coerceProjectType } from '../types/validation';
 import {
   MICROTUBULE_LABEL_PREFIX,
   SPERM_LABEL_PREFIX,
+  type InstanceLabelPrefix,
 } from '../utils/instanceLabels';
 import {
   sanitizeFilename,
@@ -844,7 +845,7 @@ export class ExportService {
     options?: VisualizationOptions,
     jobId?: string,
     onProgress?: (current: number, total: number) => void,
-    labelPrefix: string = SPERM_LABEL_PREFIX
+    labelPrefix: InstanceLabelPrefix = SPERM_LABEL_PREFIX
   ): Promise<void> {
     const vizDir = path.join(exportDir, 'visualizations');
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -29,6 +29,10 @@ import {
 } from './export/exportDocs';
 import { coerceProjectType } from '../types/validation';
 import {
+  MICROTUBULE_LABEL_PREFIX,
+  SPERM_LABEL_PREFIX,
+} from '../utils/instanceLabels';
+import {
   sanitizeFilename,
   getProgressMessage,
   createZipArchive,
@@ -501,6 +505,13 @@ export class ExportService {
       // Generate visualizations (can run in parallel)
       if (options.includeVisualizations && project.images) {
         const visualizationProgressBase = 5 + progressStep * progressIncrement;
+        // Microtubule polylines reuse the sperm labeller, so badge them "MT1"
+        // instead of the sperm "S1". The MT metrics table is labelled with the
+        // same prefix so rows can be matched to badges on the image.
+        const labelPrefix =
+          (project.type ?? '') === 'microtubules'
+            ? MICROTUBULE_LABEL_PREFIX
+            : SPERM_LABEL_PREFIX;
         exportTasks.push(
           this.generateVisualizations(
             project.images as ImageWithSegmentation[],
@@ -516,7 +527,8 @@ export class ExportService {
                 current,
                 total,
               });
-            }
+            },
+            labelPrefix
           ).then(() => {
             progressStep++;
             this.updateJobProgress(
@@ -831,7 +843,8 @@ export class ExportService {
     exportDir: string,
     options?: VisualizationOptions,
     jobId?: string,
-    onProgress?: (current: number, total: number) => void
+    onProgress?: (current: number, total: number) => void,
+    labelPrefix: string = SPERM_LABEL_PREFIX
   ): Promise<void> {
     const vizDir = path.join(exportDir, 'visualizations');
 
@@ -929,7 +942,7 @@ export class ExportService {
           fullImagePath,
           polygons,
           vizPath,
-          options
+          { ...options, labelPrefix }
         );
 
         if (result === 'success') {

--- a/backend/src/services/visualization/__tests__/visualizationGenerator.test.ts
+++ b/backend/src/services/visualization/__tests__/visualizationGenerator.test.ts
@@ -869,6 +869,23 @@ describe('VisualizationGenerator', () => {
       expect(labels).not.toContain('S2');
     });
 
+    it('uses the MT prefix when labelPrefix is set (microtubule export)', async () => {
+      const polys: Polygon[] = [
+        makePolyline({ instanceId: 'mt-a' }),
+        makePolyline({ instanceId: 'mt-b' }),
+      ];
+      await gen.generateVisualization('/img/test.png', polys, '/out/out.png', {
+        showNumbers: true,
+        labelPrefix: 'MT',
+      });
+
+      const fillTextCalls = ctxCalls.filter(c => c.method === 'fillText');
+      const labels = fillTextCalls.map(c => c.args[0]);
+      expect(labels).toContain('MT1');
+      expect(labels).toContain('MT2');
+      expect(labels.some(l => String(l).startsWith('S'))).toBe(false);
+    });
+
     it('does NOT draw sperm labels when showNumbers=false', async () => {
       const poly = makePolyline({ instanceId: 'sperm-a' });
       await gen.generateVisualization('/img/test.png', [poly], '/out/out.png', {

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -5,6 +5,10 @@ import path from 'path';
 import { logger } from '../../utils/logger';
 import type { PolygonPartClass } from '../../utils/polygonValidation';
 import type { BasePolygon } from '../../types/polygon';
+import {
+  buildInstanceLabelMap,
+  SPERM_LABEL_PREFIX,
+} from '../../utils/instanceLabels';
 
 export interface VisualizationOptions {
   showNumbers?: boolean;
@@ -15,6 +19,10 @@ export interface VisualizationOptions {
   strokeWidth?: number;
   fontSize?: number;
   transparency?: number;
+  /** Prefix for per-instance polyline badges ("S1", "MT1", …). Defaults to
+   *  the sperm prefix; the MT export passes `MICROTUBULE_LABEL_PREFIX`. The
+   *  metrics table is labelled with the same prefix so rows match the image. */
+  labelPrefix?: string;
 }
 
 /** Visualization polygon — `BasePolygon` plus the wider `PolygonPartClass`
@@ -174,15 +182,21 @@ export class VisualizationGenerator {
         }
       }
 
-      // Draw sperm instance labels (S1, S2, ...) at the centroid of each sperm's part midpoints
+      // Draw per-instance labels (S1/MT1, …) at the centroid of each
+      // instance's polyline midpoints. Labels come from the shared
+      // `buildInstanceLabelMap` so the exported metrics table can reproduce
+      // the exact same numbering (see mtMetricsExporter).
       if (mergedOptions.showNumbers) {
-        let spermIdx = 1;
-        for (const [, data] of spermInstances) {
-          if (data.midpoints.length > 0) {
-            // Average of midpoints = center of the sperm group
+        const instanceLabels = buildInstanceLabelMap(
+          polygons,
+          mergedOptions.labelPrefix ?? SPERM_LABEL_PREFIX
+        );
+        for (const [instanceId, data] of spermInstances) {
+          const label = instanceLabels.get(instanceId);
+          if (label && data.midpoints.length > 0) {
+            // Average of midpoints = center of the instance's polylines
             const cx = data.midpoints.reduce((s, p) => s + p.x, 0) / data.midpoints.length;
             const cy = data.midpoints.reduce((s, p) => s + p.y, 0) / data.midpoints.length;
-            const label = `S${spermIdx}`;
             const fontSize = Math.max(14, Math.min(24, Math.round(image.width / 60)));
             ctx.font = `bold ${fontSize}px Arial`;
             ctx.textAlign = 'center';
@@ -201,7 +215,6 @@ export class VisualizationGenerator {
             // Text
             ctx.fillStyle = '#FFFFFF';
             ctx.fillText(label, cx, cy);
-            spermIdx++;
           }
         }
       }

--- a/backend/src/services/visualization/visualizationGenerator.ts
+++ b/backend/src/services/visualization/visualizationGenerator.ts
@@ -8,6 +8,7 @@ import type { BasePolygon } from '../../types/polygon';
 import {
   buildInstanceLabelMap,
   SPERM_LABEL_PREFIX,
+  type InstanceLabelPrefix,
 } from '../../utils/instanceLabels';
 
 export interface VisualizationOptions {
@@ -22,7 +23,7 @@ export interface VisualizationOptions {
   /** Prefix for per-instance polyline badges ("S1", "MT1", …). Defaults to
    *  the sperm prefix; the MT export passes `MICROTUBULE_LABEL_PREFIX`. The
    *  metrics table is labelled with the same prefix so rows match the image. */
-  labelPrefix?: string;
+  labelPrefix?: InstanceLabelPrefix;
 }
 
 /** Visualization polygon — `BasePolygon` plus the wider `PolygonPartClass`

--- a/backend/src/utils/__tests__/instanceLabels.test.ts
+++ b/backend/src/utils/__tests__/instanceLabels.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for buildInstanceLabelMap — the single source of truth for the
+ * per-instance polyline badge numbering shared by the export visualization
+ * (draws "S1"/"MT1" on the image) and the MT metrics table (writes the same
+ * label into a column). The two must never drift, so this locks the rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildInstanceLabelMap,
+  SPERM_LABEL_PREFIX,
+  MICROTUBULE_LABEL_PREFIX,
+  type LabelablePolyline,
+} from '../instanceLabels';
+
+const pts = [
+  { x: 0, y: 0 },
+  { x: 1, y: 1 },
+];
+
+describe('buildInstanceLabelMap', () => {
+  it('returns an empty map when there are no polylines', () => {
+    expect(buildInstanceLabelMap([], MICROTUBULE_LABEL_PREFIX).size).toBe(0);
+  });
+
+  it('numbers unique instances in first-appearance order', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', instanceId: 'b', points: pts },
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    // 'b' appears first, so it is MT1 (order, not id sort).
+    expect(labels.get('b')).toBe('MT1');
+    expect(labels.get('a')).toBe('MT2');
+  });
+
+  it('reuses one label across repeated segments of the same instance', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+      { geometry: 'polyline', instanceId: 'b', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    expect(labels.get('a')).toBe('MT1');
+    expect(labels.get('b')).toBe('MT2');
+    expect(labels.size).toBe(2);
+  });
+
+  it('skips closed polygons entirely', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polygon', instanceId: 'poly', points: pts },
+      { geometry: 'polyline', instanceId: 'line', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    expect(labels.has('poly')).toBe(false);
+    expect(labels.get('line')).toBe('MT1');
+  });
+
+  it('does not label polylines without an instanceId', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', points: pts },
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    // Only the instance with an id earns a number, and it is the first number.
+    expect(labels.size).toBe(1);
+    expect(labels.get('a')).toBe('MT1');
+  });
+
+  it('does not consume a number for an instance with only <2-point polylines', () => {
+    const polygons: LabelablePolyline[] = [
+      // 'a' only ever has a single point — never drawable, gets no badge.
+      { geometry: 'polyline', instanceId: 'a', points: [{ x: 0, y: 0 }] },
+      { geometry: 'polyline', instanceId: 'b', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    expect(labels.has('a')).toBe(false);
+    // 'b' is the first *drawable* instance, so it is MT1 (not MT2).
+    expect(labels.get('b')).toBe('MT1');
+  });
+
+  it('labels a mixed instance as drawable if any of its polylines has >=2 points', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', instanceId: 'a', points: [{ x: 0, y: 0 }] },
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    expect(labels.get('a')).toBe('MT1');
+  });
+
+  it('honours the prefix argument', () => {
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+    ];
+    expect(buildInstanceLabelMap(polygons, SPERM_LABEL_PREFIX).get('a')).toBe(
+      'S1'
+    );
+  });
+});

--- a/backend/src/utils/__tests__/instanceLabels.test.ts
+++ b/backend/src/utils/__tests__/instanceLabels.test.ts
@@ -79,6 +79,21 @@ describe('buildInstanceLabelMap', () => {
     expect(labels.get('b')).toBe('MT1');
   });
 
+  it('numbers by FIRST-APPEARANCE, not first-drawable, order', () => {
+    // 'a' appears first (via a <2-point, non-drawable polyline), then 'b'
+    // becomes drawable first, then 'a' becomes drawable later. Numbering must
+    // follow first appearance ('a' before 'b'), matching the visualization's
+    // insertion order — NOT the order in which instances first became drawable.
+    const polygons: LabelablePolyline[] = [
+      { geometry: 'polyline', instanceId: 'a', points: [{ x: 0, y: 0 }] },
+      { geometry: 'polyline', instanceId: 'b', points: pts },
+      { geometry: 'polyline', instanceId: 'a', points: pts },
+    ];
+    const labels = buildInstanceLabelMap(polygons, MICROTUBULE_LABEL_PREFIX);
+    expect(labels.get('a')).toBe('MT1');
+    expect(labels.get('b')).toBe('MT2');
+  });
+
   it('labels a mixed instance as drawable if any of its polylines has >=2 points', () => {
     const polygons: LabelablePolyline[] = [
       { geometry: 'polyline', instanceId: 'a', points: [{ x: 0, y: 0 }] },

--- a/backend/src/utils/instanceLabels.ts
+++ b/backend/src/utils/instanceLabels.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-instance labelling for polyline projects (sperm, microtubule).
+ *
+ * The export visualization draws a per-instance badge ("S1", "MT1", …) on
+ * each image, and the microtubule metrics table carries the SAME label so a
+ * spreadsheet row can be matched back to the badge on the image. Both call
+ * sites feed this helper the *same* parsed polygon array for a given image
+ * (order preserved by `JSON.parse`), so the ordinal assignment is identical
+ * on both sides — the single source of truth for the numbering rule.
+ */
+
+/** Prefix drawn for sperm instances (S = sperm). */
+export const SPERM_LABEL_PREFIX = 'S';
+/** Prefix drawn for microtubule instances. */
+export const MICROTUBULE_LABEL_PREFIX = 'MT';
+
+/** Minimal polyline shape the labeller needs — a subset of both the
+ *  visualization `Polygon` and the exporter's `RawPolyline`. */
+export interface LabelablePolyline {
+  geometry?: string;
+  instanceId?: string | null;
+  points?: Array<{ x: number; y: number }> | null;
+}
+
+/**
+ * Assign sequential labels ("{prefix}1", "{prefix}2", …) to the unique
+ * `instanceId`s of the polyline polygons, in first-appearance order.
+ *
+ * Mirrors exactly what the visualization draws:
+ *  - Only polylines are considered; closed polygons never get a badge.
+ *  - Polylines without an `instanceId` are unlabelled (no badge on the image).
+ *  - An instance only earns a number if at least one of its polylines has
+ *    ≥ 2 points — a single-point polyline can't be drawn as a curve, so it
+ *    gets no midpoint badge and therefore consumes no number.
+ *
+ * @returns Map from `instanceId` to its label. Instances that earn no label
+ *          are absent from the map (callers should treat a miss as "no label").
+ */
+export function buildInstanceLabelMap(
+  polygons: readonly LabelablePolyline[],
+  prefix: string
+): Map<string, string> {
+  // First pass: remember first-appearance order and whether each instance has
+  // at least one drawable (≥ 2-point) polyline. Insertion order into the Map
+  // matches the visualization's `spermInstances` Map insertion order.
+  const drawableByInstance = new Map<string, boolean>();
+  for (const p of polygons) {
+    if (p.geometry !== 'polyline') continue;
+    const id = p.instanceId;
+    if (!id) continue;
+    if (!drawableByInstance.has(id)) {
+      drawableByInstance.set(id, false);
+    }
+    if (p.points && p.points.length >= 2) {
+      drawableByInstance.set(id, true);
+    }
+  }
+
+  // Second pass: number the drawable instances in first-appearance order.
+  const labels = new Map<string, string>();
+  let index = 1;
+  for (const [id, drawable] of drawableByInstance) {
+    if (drawable) {
+      labels.set(id, `${prefix}${index}`);
+      index++;
+    }
+  }
+  return labels;
+}

--- a/backend/src/utils/instanceLabels.ts
+++ b/backend/src/utils/instanceLabels.ts
@@ -4,15 +4,22 @@
  * The export visualization draws a per-instance badge ("S1", "MT1", …) on
  * each image, and the microtubule metrics table carries the SAME label so a
  * spreadsheet row can be matched back to the badge on the image. Both call
- * sites feed this helper the *same* parsed polygon array for a given image
- * (order preserved by `JSON.parse`), so the ordinal assignment is identical
- * on both sides — the single source of truth for the numbering rule.
+ * sites each parse the same stored `Segmentation.polygons` JSON for a given
+ * image (array order preserved by `JSON.parse`, both reads seeing one export
+ * job's DB snapshot), so the ordinal assignment is identical on both sides —
+ * the single source of truth for the numbering rule.
  */
 
 /** Prefix drawn for sperm instances (S = sperm). */
 export const SPERM_LABEL_PREFIX = 'S';
 /** Prefix drawn for microtubule instances. */
 export const MICROTUBULE_LABEL_PREFIX = 'MT';
+
+/** The two valid badge prefixes. Derived from the consts so the set can't
+ *  drift; a stray value (e.g. `'X'`) is rejected at compile time. */
+export type InstanceLabelPrefix =
+  | typeof SPERM_LABEL_PREFIX
+  | typeof MICROTUBULE_LABEL_PREFIX;
 
 /** Minimal polyline shape the labeller needs — a subset of both the
  *  visualization `Polygon` and the exporter's `RawPolyline`. */
@@ -38,11 +45,11 @@ export interface LabelablePolyline {
  */
 export function buildInstanceLabelMap(
   polygons: readonly LabelablePolyline[],
-  prefix: string
-): Map<string, string> {
+  prefix: InstanceLabelPrefix
+): ReadonlyMap<string, string> {
   // First pass: remember first-appearance order and whether each instance has
-  // at least one drawable (≥ 2-point) polyline. Insertion order into the Map
-  // matches the visualization's `spermInstances` Map insertion order.
+  // at least one drawable (≥ 2-point) polyline. First-appearance order is the
+  // same order the visualization uses when it groups polylines by `instanceId`.
   const drawableByInstance = new Map<string, boolean>();
   for (const p of polygons) {
     if (p.geometry !== 'polyline') continue;

--- a/src/lib/__tests__/downloadUtils.test.ts
+++ b/src/lib/__tests__/downloadUtils.test.ts
@@ -105,6 +105,10 @@ describe('downloadBlob', () => {
 
 describe('downloadFromResponse', () => {
   beforeEach(() => {
+    // Fake timers so downloadBlob's 100ms cleanup setTimeout is discarded on
+    // teardown instead of firing later with a stale mock link (which throws in
+    // jsdom's removeChild → an unhandled error that fails the whole CI run).
+    vi.useFakeTimers();
     URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost/mock');
     URL.revokeObjectURL = vi.fn();
     vi.spyOn(document.body, 'appendChild').mockImplementation(vi.fn());
@@ -116,7 +120,10 @@ describe('downloadFromResponse', () => {
     } as unknown as HTMLElement);
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it('uses response.data directly when it is already a Blob', async () => {
     const blob = new Blob(['content'], { type: 'application/octet-stream' });
@@ -133,6 +140,7 @@ describe('downloadFromResponse', () => {
 
 describe('downloadJSON', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost/mock');
     URL.revokeObjectURL = vi.fn();
     vi.spyOn(document.body, 'appendChild').mockImplementation(vi.fn());
@@ -144,7 +152,10 @@ describe('downloadJSON', () => {
     } as unknown as HTMLElement);
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it('appends .json extension when missing', () => {
     let capturedLink: any;
@@ -177,6 +188,7 @@ describe('downloadJSON', () => {
 
 describe('downloadExcel', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost/mock');
     URL.revokeObjectURL = vi.fn();
     vi.spyOn(document.body, 'appendChild').mockImplementation(vi.fn());
@@ -188,7 +200,10 @@ describe('downloadExcel', () => {
     } as unknown as HTMLElement);
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it('appends .xlsx extension when missing', () => {
     let capturedLink: any;
@@ -208,6 +223,7 @@ describe('downloadExcel', () => {
 
 describe('downloadCSV', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost/mock');
     URL.revokeObjectURL = vi.fn();
     vi.spyOn(document.body, 'appendChild').mockImplementation(vi.fn());
@@ -219,7 +235,10 @@ describe('downloadCSV', () => {
     } as unknown as HTMLElement);
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it('appends .csv extension when missing', () => {
     let capturedLink: any;


### PR DESCRIPTION
## Problem

In the microtubule export, polylines were badged **`S1`, `S2`, …** on the visualization images, but `metrics.xlsx` had **no matching identifier** — so a labelled microtubule on the image couldn't be traced back to its metrics row. The `S` prefix was also wrong: the visualization reused the **sperm** labeller (both sperm and MT are `geometry: 'polyline'`), so MTs inherited the sperm badge.

Root cause: the badge and the metrics rows were produced by two independent code paths. The visualization drew a per-image ordinal `S${spermIdx}` that was never persisted anywhere; the metrics exporter keyed rows only on raw `instanceId`/`trackId`.

## Fix

- **SSOT helper** `backend/src/utils/instanceLabels.ts` → `buildInstanceLabelMap(polygons, prefix)`. Both the visualization and the metrics exporter feed it the **same** parsed `segmentation.polygons` array (order preserved by `JSON.parse`), so the per-frame numbering is guaranteed identical on both sides.
- **Visualization**: badges are now project-type-driven — `MT1` for microtubule projects, `S1` for sperm (unchanged). Plumbed via a new `VisualizationOptions.labelPrefix`; `exportService` picks `MT`/`S` from `project.type`.
- **Metrics exporter**: adds a `label` column (right after `imageId`) to `metrics.xlsx`/`.csv`/`.json`, populated from the same helper. Empty string when a polyline has no `instanceId` (no badge is drawn for it either). Match a row to a badge via `frameIndex` + `label`.

## Notes

- The badge is a **per-frame** ordinal (not cross-frame stable) — same physical MT can be `MT1` on frame 0 and `MT2` on frame 3. Use `trackId` (already a column) for cross-frame identity.
- Confirmed the ML `/mt-metrics` endpoint echoes `image_id`/`instance_id` unchanged (`backend/segmentation/api/mt_metrics.py:414`), so the intensity-export label lookup resolves for real data.

## Verification

- Backend `tsc` passes against the worktree edits.
- 414 tests pass across the export + visualization suites, including new assertions: `MT1`/`MT2` render on the image and land in metrics rows; one label is reused across an instance's segments; no-`instanceId` polylines get an empty label; sperm `S1`/`S2` behavior is preserved.
- Unit test for the shared helper (`instanceLabels.test.ts`) locks the numbering rule (first-appearance order, ≥2-point drawable gate, prefix).

Not yet deployed — a real MT export run against production output files is the remaining end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)