### PR TITLE
test: fix four CI flakes (queueWorker mock race, unhandled-window micro/real-timer, LanguageContext)

### DIFF
--- a/backend/src/workers/__tests__/queueWorker.gaps5.test.ts
+++ b/backend/src/workers/__tests__/queueWorker.gaps5.test.ts
@@ -28,7 +28,12 @@ vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-vi.mock('../../services/queueService');
+// NOTE: queueService is mocked with an explicit factory further down (its
+// getInstance() must return a stub exposing setQueueWorker, which the
+// QueueWorker constructor calls). A *second* bare `vi.mock('...queueService')`
+// used to sit here — two registrations for the same module race, and when the
+// bare auto-mock won, getInstance() returned undefined and the constructor
+// crashed on `queueService.setQueueWorker` (flaky in CI). Keep only the factory.
 vi.mock('../../services/segmentationService');
 vi.mock('../../services/imageService');
 vi.mock('@prisma/client', () => {

--- a/src/components/__tests__/ImageUploader.cancel.test.tsx
+++ b/src/components/__tests__/ImageUploader.cancel.test.tsx
@@ -116,6 +116,20 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
   >(new Map());
   const [isUploading, setIsUploading] = React.useState(false);
 
+  // simulateChunkedUpload below is a fire-and-forget async loop driven by a
+  // real setTimeout. If the component unmounts (test teardown) mid-upload, its
+  // next tick calls setUploadStates after jsdom is gone and throws
+  // "window is not defined" — a flaky unhandled CI error. Track mount status
+  // and bail before any post-unmount state write (a ref read is safe after
+  // teardown; setUploadStates is not).
+  const mountedRef = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     // Support both standard FileList (files) and test-injected _files array
     const selectedFiles = Array.from(
@@ -169,6 +183,10 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
 
     try {
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        // Stop touching state once the component has unmounted (test teardown).
+        if (!mountedRef.current) {
+          return;
+        }
         if (abortController.signal.aborted) {
           throw new DOMException('Upload cancelled', 'AbortError');
         }
@@ -190,6 +208,9 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
 
         // Simulate chunk upload delay; check abort after the wait too
         await new Promise(resolve => setTimeout(resolve, 50));
+        if (!mountedRef.current) {
+          return;
+        }
         if (abortController.signal.aborted) {
           throw new DOMException('Upload cancelled', 'AbortError');
         }

--- a/src/components/project/__tests__/QueueStatsPanel.cancel.test.tsx
+++ b/src/components/project/__tests__/QueueStatsPanel.cancel.test.tsx
@@ -109,6 +109,20 @@ const QueueStatsPanel: React.FC<QueueStatsProps> = ({
     jobIds: [],
   });
 
+  // simulateBatchProcessing below is a fire-and-forget async loop driven by a
+  // real setTimeout. If the component unmounts (test teardown) while it is
+  // mid-flight, its next tick calls setBatchState after jsdom is gone and
+  // throws "window is not defined" — a flaky unhandled error that fails CI.
+  // Track mount status and bail before any post-unmount state write (a ref read
+  // is safe even after teardown; setBatchState is not).
+  const mountedRef = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   const startBatchSegmentation = async () => {
     const batchId = `batch-seg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const jobIds = Array.from(
@@ -142,6 +156,11 @@ const QueueStatsPanel: React.FC<QueueStatsProps> = ({
     const totalJobs = jobIds.length;
 
     for (let i = 0; i < totalJobs; i++) {
+      // Stop if the component unmounted while we were awaiting the timer.
+      if (!mountedRef.current) {
+        return;
+      }
+
       // Check if cancelled
       const operation = mockOperationManager.getOperation(batchId);
       if (operation?.status === 'cancelled') {
@@ -160,6 +179,11 @@ const QueueStatsPanel: React.FC<QueueStatsProps> = ({
 
       // Simulate processing time
       await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    // Stop if the component unmounted during the final await.
+    if (!mountedRef.current) {
+      return;
     }
 
     // Complete if not cancelled

--- a/src/contexts/__tests__/LanguageContext.test.tsx
+++ b/src/contexts/__tests__/LanguageContext.test.tsx
@@ -296,14 +296,22 @@ describe('LanguageContext', () => {
       // setUser → LanguageContext userId-effect → getUserProfile →
       // setLanguage('de'). Under full-suite CPU contention this can exceed
       // waitFor's default 1000ms, so give it a load-tolerant deadline.
+      //
+      // Persistence (localStorage.setItem) happens in a SEPARATE effect keyed on
+      // `language`, one commit AFTER `result.current.language` flips to 'de'.
+      // Asserting setItem synchronously right after the language waitFor raced
+      // that effect (flaky "Number of calls: 0" under load), so wait for the
+      // side-effect itself inside the same polling window.
       await waitFor(
         () => {
           expect(result.current.language).toBe('de');
+          expect(localStorageMock.setItem).toHaveBeenCalledWith(
+            'language',
+            'de'
+          );
         },
         { timeout: 5000 }
       );
-
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('language', 'de');
     });
   });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -322,11 +322,25 @@ afterAll(() => {
 });
 
 // Global cleanup to prevent memory leaks
-afterEach(() => {
+afterEach(async () => {
+  // Drain the microtask queue so any fire-and-forget async work still pending
+  // when a test ends runs its `.catch`/`.then` tail NOW, while jsdom's `window`
+  // still exists. Example: ThemeSwitcher's onClick calls an async
+  // handleThemeChange that awaits a rejected setTheme and logs in `catch`; a
+  // thumbnail fetch that rejects behaves the same. If that continuation instead
+  // runs after the file's jsdom environment is torn down, it throws
+  // "ReferenceError: window is not defined", which Vitest reports as an
+  // unhandled error and fails the whole run (the "Errors N" merge gate) even
+  // though every test passed. Microtask-based (not setTimeout) so it stays safe
+  // if a test left fake timers installed.
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+
   // Clear all timers to prevent accumulation
   vi.clearAllTimers();
 
-  // Clean up any pending promises
+  // Reset mock call history between tests
   vi.clearAllMocks();
 
   // Force garbage collection hint by clearing large objects


### PR DESCRIPTION
Fixes the CI test flakes (all test-infra only, no production code). The two requested flakes plus two more that surfaced while validating.

## 1. Backend — `queueWorker.gaps5.test.ts` mock race
`TypeError: Cannot read properties of undefined (reading 'setQueueWorker')`.
**Root cause (reproduced deterministically):** two `vi.mock('...queueService')` — a bare auto-mock (→ `getInstance()` returns `undefined`) *and* an explicit factory. They race; when the auto-mock won, the constructor crashed. Removed the redundant bare mock.

## 2. Frontend — `ReferenceError: window is not defined` (microtask class)
A fire-and-forget async **error handler** leaves a pending microtask; if it runs after jsdom teardown its `.catch` tail hits a gone `window`. Fixed the mechanism in the shared `afterEach` (`src/test/setup.ts`): drain the microtask queue so those tails run while `window` still exists (microtask-based → safe under fake timers).

## 3. Frontend — `window is not defined` (real-timer class)
`QueueStatsPanel.cancel` / `ImageUploader.cancel` run fire-and-forget loops driven by real `setTimeout` (`simulateBatchProcessing` / `simulateChunkedUpload`); on unmount mid-loop the next tick calls `setState` post-teardown. Added a `mountedRef` (cleared in an unmount effect) and bail before any post-unmount state write.

## 4. Frontend — flaky `LanguageContext` localStorage assertion
Waited for `language === 'de'` then *synchronously* asserted the `setItem` side-effect, which fires one commit later. Folded it into the same `waitFor`.

## Verification
- Backend #1: reproduced-then-fixed; 5/5 stable.
- Full frontend suite green with 0 unhandled errors (multiple local runs, 5611 tests).
- **CI: 3 consecutive green runs** on the final commit (the flakes previously recurred roughly every other run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)