### PR TITLE
feat(mt): propagation-aware MT tracking (motion model) + seed-prior warm-start + transformers pin

### DIFF
--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -267,9 +267,13 @@ def _align_endpoints(feat: _Filament, ref: _Filament) -> _Filament:
     *ref*'s endpoint labelling (minimises head-head + tail-tail distance).
 
     PySOAX centerline direction is arbitrary and can flip frame to frame;
-    without this the per-endpoint velocity would be garbage. The matching
-    cost itself is direction-invariant, so this only affects the velocity
-    bookkeeping, never the accepted/rejected decision.
+    without this the per-endpoint velocity would be garbage. A single
+    filament-vs-filament cost is direction-invariant (min-pairing endpoints,
+    ``|cos Δθ|``, order-independent mean embedding), so aligning a stored
+    observation never *retroactively* changes the cost of the link just
+    accepted. Its effect is confined to the per-endpoint velocity — which
+    does feed the next frame's predicted endpoints and therefore its costs;
+    that downstream influence is the whole point.
     """
     straight = float(np.linalg.norm(feat.end_a - ref.end_a)) + float(
         np.linalg.norm(feat.end_b - ref.end_b)
@@ -295,7 +299,16 @@ def _predict_filament(state: _TrackState, target_frame: int) -> _Filament:
     """
     last = state.last_feat
     emb = state.emb_template if state.emb_template is not None else last.mean_emb
-    if state.prev_feat is None or state.prev_frame is None:
+    # Fall back to a zero-velocity (identity) prediction with < 2 observations
+    # OR when either observation is degenerate (empty / single-point centerline
+    # → zero-vector endpoints, length 0): extrapolating from a [0, 0] endpoint
+    # would inject a spurious ~origin-directed velocity into the next frame.
+    if (
+        state.prev_feat is None
+        or state.prev_frame is None
+        or last.length <= 0.0
+        or state.prev_feat.length <= 0.0
+    ):
         return last._replace(mean_emb=emb)
     dt_prev = max(state.last_frame - state.prev_frame, 1)
     step = float(target_frame - state.last_frame)

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -106,11 +106,27 @@ class TrackRequest(BaseModel):
     spatial_weight: float = Field(0.3, ge=0.0, le=1.0)
     # Gap closing (second LAP): a filament may vanish for up to max_gap
     # frames and still be re-linked to its original track. 0 disables gap
-    # closing entirely.
-    max_gap: int = Field(2, ge=0)
+    # closing entirely. Default raised 2 -> 3: with gap_penalty=0.5 a 3-frame
+    # bridge costs base*2.0, so it is only accepted when base < ~0.3 (well
+    # inside the threshold), making the extra recall of short dropouts safe
+    # against spurious merges.
+    max_gap: int = Field(3, ge=0)
     # Multiplies the gap-close cost by (1 + gap_penalty * (gap - 1)) so that
     # longer gaps are progressively less attractive to bridge.
     gap_penalty: float = Field(0.5, ge=0.0)
+    # Constant-velocity motion compensation for the frame-to-frame LAP: each
+    # active track's endpoints are extrapolated to the next frame before the
+    # cost is measured, so legitimate MT motion no longer inflates the
+    # endpoint/orientation terms and pushes a true link past the threshold.
+    # A track needs >= 2 observations to have a velocity; its first step
+    # degrades to a zero-velocity (identity) prediction, i.e. the old
+    # behaviour. Disable to A/B against the memoryless tracker.
+    motion_model: bool = True
+    # EMA weight of the newest frame's mean embedding when maintaining the
+    # per-track embedding template used for re-identification. 0.5 = equal
+    # weight to the newest frame and the running history; 1.0 reproduces the
+    # old "match against the single previous frame" behaviour.
+    emb_template_alpha: float = Field(0.5, ge=0.0, le=1.0)
     # Weights of the four filament-cost terms (embedding, endpoint distance,
     # orientation, length). Each in [0, 1]; defaults sum to 1.
     w_emb: float = Field(0.5, ge=0.0, le=1.0)
@@ -221,6 +237,104 @@ def _filament_features(p: PolylineInput) -> _Filament:
     else:
         length = 0.0
     return _Filament(mean_emb, was_corrupt, end_a, end_b, theta, length)
+
+
+class _TrackState:
+    """Online per-track state accumulated during the frame-to-frame pass.
+
+    Holds the last two *endpoint-aligned* observations (so a constant-
+    velocity endpoint prediction can be computed despite arbitrary
+    centerline direction) plus an EMA embedding template. Matching a new
+    frame against the predicted endpoints + the running template — rather
+    than the raw previous frame — is what makes the LAP robust to the
+    per-frame geometry/embedding jitter of independently re-detected MTs.
+    """
+
+    __slots__ = ("last_frame", "last_feat", "prev_frame", "prev_feat", "emb_template")
+
+    def __init__(self, frame: int, feat: _Filament) -> None:
+        self.last_frame = frame
+        self.last_feat = feat
+        self.prev_frame: Optional[int] = None
+        self.prev_feat: Optional[_Filament] = None
+        self.emb_template: Optional[np.ndarray] = (
+            None if feat.mean_emb is None else feat.mean_emb.astype(np.float64).copy()
+        )
+
+
+def _align_endpoints(feat: _Filament, ref: _Filament) -> _Filament:
+    """Return *feat* with (end_a, end_b) swapped iff that better matches
+    *ref*'s endpoint labelling (minimises head-head + tail-tail distance).
+
+    PySOAX centerline direction is arbitrary and can flip frame to frame;
+    without this the per-endpoint velocity would be garbage. The matching
+    cost itself is direction-invariant, so this only affects the velocity
+    bookkeeping, never the accepted/rejected decision.
+    """
+    straight = float(np.linalg.norm(feat.end_a - ref.end_a)) + float(
+        np.linalg.norm(feat.end_b - ref.end_b)
+    )
+    swapped = float(np.linalg.norm(feat.end_b - ref.end_a)) + float(
+        np.linalg.norm(feat.end_a - ref.end_b)
+    )
+    if swapped < straight:
+        vec = feat.end_a - feat.end_b
+        theta = float(np.arctan2(float(vec[0]), float(vec[1])))
+        return feat._replace(end_a=feat.end_b, end_b=feat.end_a, theta=theta)
+    return feat
+
+
+def _predict_filament(state: _TrackState, target_frame: int) -> _Filament:
+    """Constant-velocity prediction of a track's filament at *target_frame*.
+
+    Endpoints are extrapolated from the last two observations; the mean
+    embedding is replaced by the track's EMA template. With < 2 observations
+    the velocity is unknown and this returns a zero-velocity (identity)
+    prediction — i.e. the old memoryless behaviour, so the first step of a
+    freshly-born track is never worse than before.
+    """
+    last = state.last_feat
+    emb = state.emb_template if state.emb_template is not None else last.mean_emb
+    if state.prev_feat is None or state.prev_frame is None:
+        return last._replace(mean_emb=emb)
+    dt_prev = max(state.last_frame - state.prev_frame, 1)
+    step = float(target_frame - state.last_frame)
+    # Cap per-endpoint extrapolation to the filament's own length (fallback
+    # 20 px): an MT does not translate more than its length between adjacent
+    # frames, so this bounds the damage from a single noisy velocity estimate.
+    cap = max(float(last.length), 20.0)
+
+    def _extrapolate(p_now: np.ndarray, p_then: np.ndarray) -> np.ndarray:
+        disp = (p_now - p_then) / dt_prev * step
+        n = float(np.linalg.norm(disp))
+        if n > cap:
+            disp = disp * (cap / n)
+        return p_now + disp
+
+    pred_a = _extrapolate(last.end_a, state.prev_feat.end_a)
+    pred_b = _extrapolate(last.end_b, state.prev_feat.end_b)
+    vec = pred_b - pred_a
+    theta = float(np.arctan2(float(vec[0]), float(vec[1])))
+    return last._replace(mean_emb=emb, end_a=pred_a, end_b=pred_b, theta=theta)
+
+
+def _update_track_state(
+    state: _TrackState, feat: _Filament, frame: int, alpha: float
+) -> None:
+    """Extend a track with a new observation: align its endpoints to the
+    previous frame, shift history, and blend the embedding into the EMA
+    template."""
+    aligned = _align_endpoints(feat, state.last_feat)
+    state.prev_feat = state.last_feat
+    state.prev_frame = state.last_frame
+    state.last_feat = aligned
+    state.last_frame = frame
+    if aligned.mean_emb is not None:
+        m = aligned.mean_emb.astype(np.float64)
+        if state.emb_template is None:
+            state.emb_template = m.copy()
+        else:
+            state.emb_template = alpha * m + (1.0 - alpha) * state.emb_template
 
 
 def _emb_distance(fa: _Filament, fb: _Filament) -> Optional[float]:
@@ -501,25 +615,46 @@ async def track(req: TrackRequest) -> TrackResponse:
         )
 
     # --- Step 1: frame-to-frame linking with birth/death -> tracklets ---
+    # An online per-track state (last two endpoint-aligned observations + EMA
+    # embedding template) lets each frame be matched against a constant-
+    # velocity *prediction* of where the track's filament should be, rather
+    # than the raw previous frame — the core of the propagation-aware upgrade.
     assignments: Dict[str, str] = {}
+    track_state: Dict[str, _TrackState] = {}
+
+    def _birth(pid: str, frame: int) -> str:
+        tid = _new_track_id()
+        assignments[pid] = tid
+        track_state[tid] = _TrackState(frame, feats[pid])
+        return tid
+
     for p in frames[0].polylines:
-        assignments[p.id] = _new_track_id()
+        _birth(p.id, frames[0].frame)
 
     for prev_f, next_f in zip(frames, frames[1:]):
         prev_pl, next_pl = prev_f.polylines, next_f.polylines
         # Defensive: any prev polyline without an id (e.g. after an empty
         # frame) is a fresh birth in its own frame.
         for p in prev_pl:
-            assignments.setdefault(p.id, _new_track_id())
+            if p.id not in assignments:
+                _birth(p.id, prev_f.frame)
         if not next_pl:
             continue
         if not prev_pl:
             for p in next_pl:
-                assignments[p.id] = _new_track_id()
+                _birth(p.id, next_f.frame)
             continue
 
+        if req.motion_model:
+            prev_feats = [
+                _predict_filament(track_state[assignments[p.id]], next_f.frame)
+                for p in prev_pl
+            ]
+        else:
+            prev_feats = [feats[p.id] for p in prev_pl]
+
         base = _build_link_cost(
-            [feats[p.id] for p in prev_pl],
+            prev_feats,
             [feats[p.id] for p in next_pl],
             img_diag,
             weights,
@@ -527,10 +662,15 @@ async def track(req: TrackRequest) -> TrackResponse:
         links = _solve_link_lap(base, req.cost_threshold)
         linked_cols = set(links.values())
         for pi, nj in links.items():
-            assignments[next_pl[nj].id] = assignments[prev_pl[pi].id]
+            tid = assignments[prev_pl[pi].id]
+            assignments[next_pl[nj].id] = tid
+            _update_track_state(
+                track_state[tid], feats[next_pl[nj].id], next_f.frame,
+                req.emb_template_alpha,
+            )
         for c, p in enumerate(next_pl):
             if c not in linked_cols:
-                assignments[p.id] = _new_track_id()
+                _birth(p.id, next_f.frame)
 
     # --- Step 2: gap closing over tracklet segments (second LAP) ---
     members: Dict[str, List[Tuple[int, str]]] = defaultdict(list)

--- a/backend/segmentation/models/microtubule/wrapper.py
+++ b/backend/segmentation/models/microtubule/wrapper.py
@@ -94,8 +94,29 @@ class MicrotubuleModel:
         logger.info(f"Microtubule v7 loaded from {ckpt_path} on {device_str}")
         return self
 
+    # Warm-start defaults. When a previous frame's centerlines are supplied,
+    # the seed threshold is lowered to ``PRIOR_SEED_THRESHOLD`` *only* along
+    # those centerlines (dilated by ``PRIOR_DILATE_PX``). A microtubule that
+    # was solid last frame but faded just under the 0.5 seed cut this frame is
+    # then still skeletonised, so a temporary detection dropout — the single
+    # biggest cause of a broken track — is recovered at the source instead of
+    # relying on the tracker to bridge a gap that may exceed max_gap.
+    PRIOR_SEED_THRESHOLD: float = 0.30
+    PRIOR_DILATE_PX: int = 2
+    # Recovered prior pixels within this many px of an already-detected MT are
+    # discarded. Warm start must ONLY fill genuine dropouts in empty regions:
+    # adding prior foreground next to a detected filament bridges the two in
+    # the skeleton graph, so the path tracer merges them and an instance is
+    # LOST. The guard confines recovery to regions the current frame detected
+    # nothing, making warm start strictly additive (never destructive).
+    PRIOR_MERGE_GUARD_PX: int = 3
+
     def predict(self, image_np, seed_threshold: Optional[float] = None,
-                pysoax_params: Optional[dict] = None) -> dict:
+                pysoax_params: Optional[dict] = None,
+                prev_centerlines: Optional[list] = None,
+                prior_seed_threshold: Optional[float] = None,
+                prior_dilate_px: Optional[int] = None,
+                prior_merge_guard_px: Optional[int] = None) -> dict:
         """Run v7 + PySOAX on a single 2D grayscale frame.
 
         Args:
@@ -106,6 +127,18 @@ class MicrotubuleModel:
                 PySOAX snakes are initialised. Defaults to 0.5.
             pysoax_params: Override of the production
                 ``PYSOAX_PARAMS_DEFAULT`` hyperparameters (Optuna-tuned).
+            prev_centerlines: Optional list of ``(M_i, 2)`` row,col centerlines
+                from the temporally-previous frame, in this frame's pixel
+                space (same H, W). When given, they seed a temporal prior:
+                the seed threshold is lowered to ``prior_seed_threshold`` along
+                the dilated previous centerlines so a faded continuation of a
+                known MT survives binarisation. ``None`` (the default, and
+                always the case for the first frame) reproduces the exact
+                stateless behaviour — so a cold start never regresses.
+            prior_seed_threshold: Lowered seed cut applied only under the
+                prior. Defaults to ``PRIOR_SEED_THRESHOLD`` (0.30).
+            prior_dilate_px: Half-width (px) of the rasterised prior band.
+                Defaults to ``PRIOR_DILATE_PX`` (2).
 
         Returns:
             ``{
@@ -148,7 +181,36 @@ class MicrotubuleModel:
             if seed_threshold is not None
             else self.DEFAULT_SEED_THRESHOLD
         )
-        binary = (seed_prob > thresh).astype(np.uint8) * 255
+        seed_fg = seed_prob > thresh
+        # Temporal seed prior: admit sub-threshold pixels that sit on last
+        # frame's filaments, so a briefly-faded MT is not dropped. Confined
+        # both spatially (only along the dilated previous centerlines) and to
+        # EMPTY regions (a merge guard drops recovery pixels adjacent to an
+        # already-detected MT), so warm start fills true dropouts without
+        # bridging two detected filaments at a crossing.
+        if prev_centerlines:
+            from scipy.ndimage import binary_dilation
+
+            H0, W0 = seed_prob.shape
+            prior = self._rasterize_centerlines(
+                prev_centerlines, H0, W0,
+                prior_dilate_px if prior_dilate_px is not None
+                else self.PRIOR_DILATE_PX,
+            )
+            low = (
+                prior_seed_threshold if prior_seed_threshold is not None
+                else self.PRIOR_SEED_THRESHOLD
+            )
+            guard = (
+                prior_merge_guard_px if prior_merge_guard_px is not None
+                else self.PRIOR_MERGE_GUARD_PX
+            )
+            recover = prior & (seed_prob > low) & ~seed_fg
+            if guard > 0 and recover.any():
+                near_existing = binary_dilation(seed_fg, iterations=int(guard))
+                recover = recover & ~near_existing
+            seed_fg = seed_fg | recover
+        binary = seed_fg.astype(np.uint8) * 255
 
         from pysoax import extract_soax_instances  # absolute import via sys.path
 
@@ -216,3 +278,67 @@ class MicrotubuleModel:
             "seed_prob": seed_prob,
             "embedding_samples": embedding_samples,
         }
+
+    @staticmethod
+    def _rasterize_centerlines(centerlines, H: int, W: int,
+                              dilate_px: int):
+        """Rasterise a list of (M, 2) row,col centerlines into a bool mask,
+        each drawn as a polyline of half-width ``dilate_px``.
+
+        Used to build the temporal seed prior. cv2 works in (x, y) = (col,
+        row), so the row/col columns are swapped before drawing.
+        """
+        import cv2
+        import numpy as np
+
+        mask = np.zeros((H, W), dtype=np.uint8)
+        thickness = max(1, 2 * int(dilate_px) + 1)
+        for cl in centerlines:
+            arr = np.asarray(cl, dtype=np.float64)
+            if arr.ndim != 2 or arr.shape[0] < 2 or arr.shape[1] != 2:
+                continue
+            # (row, col) -> (x=col, y=row) integer pixels for cv2.
+            pts = np.round(arr[:, ::-1]).astype(np.int32)
+            cv2.polylines(mask, [pts], isClosed=False, color=1,
+                          thickness=thickness)
+        return mask.astype(bool)
+
+    def predict_sequence(self, frames, seed_threshold: Optional[float] = None,
+                         pysoax_params: Optional[dict] = None,
+                         propagate: bool = True,
+                         prior_seed_threshold: Optional[float] = None,
+                         prior_dilate_px: Optional[int] = None,
+                         prior_merge_guard_px: Optional[int] = None) -> list:
+        """Segment an ordered list of frames, propagating each frame's
+        centerlines forward as the next frame's temporal seed prior.
+
+        This is the warm-start path: because the per-frame segmentation queue
+        processes frames independently (and out of order), a frame can only
+        see its predecessor's result when the whole video is walked in
+        sequence here. The first frame runs cold (``prev_centerlines=None``),
+        every subsequent frame is seed-primed by the one before it.
+
+        Args:
+            frames: ordered list of 2D grayscale ndarrays (all same H, W).
+            propagate: when False, every frame runs cold — identical to
+                looping :meth:`predict` — so callers can A/B the warm start.
+
+        Returns:
+            list of per-frame result dicts (same shape as :meth:`predict`),
+            in input order.
+        """
+        results: list = []
+        prev_cl = None
+        for img in frames:
+            res = self.predict(
+                img,
+                seed_threshold=seed_threshold,
+                pysoax_params=pysoax_params,
+                prev_centerlines=prev_cl if propagate else None,
+                prior_seed_threshold=prior_seed_threshold,
+                prior_dilate_px=prior_dilate_px,
+                prior_merge_guard_px=prior_merge_guard_px,
+            )
+            results.append(res)
+            prev_cl = res["centerlines_rc"] if propagate else None
+        return results

--- a/backend/segmentation/models/microtubule/wrapper.py
+++ b/backend/segmentation/models/microtubule/wrapper.py
@@ -108,7 +108,9 @@ class MicrotubuleModel:
     # adding prior foreground next to a detected filament bridges the two in
     # the skeleton graph, so the path tracer merges them and an instance is
     # LOST. The guard confines recovery to regions the current frame detected
-    # nothing, making warm start strictly additive (never destructive).
+    # nothing, so warm start is additive at the seed-mask level and, for
+    # guard > 0, non-bridging in the skeleton graph (recovered pixels stay
+    # >= guard px from any detection, forming their own components).
     PRIOR_MERGE_GUARD_PX: int = 3
 
     def predict(self, image_np, seed_threshold: Optional[float] = None,
@@ -139,6 +141,10 @@ class MicrotubuleModel:
                 prior. Defaults to ``PRIOR_SEED_THRESHOLD`` (0.30).
             prior_dilate_px: Half-width (px) of the rasterised prior band.
                 Defaults to ``PRIOR_DILATE_PX`` (2).
+            prior_merge_guard_px: Recovered prior pixels within this many px of
+                an already-detected MT are discarded, so warm start never
+                bridges two detected filaments. Defaults to
+                ``PRIOR_MERGE_GUARD_PX`` (3); 0 disables the guard.
 
         Returns:
             ``{
@@ -209,7 +215,25 @@ class MicrotubuleModel:
             if guard > 0 and recover.any():
                 near_existing = binary_dilation(seed_fg, iterations=int(guard))
                 recover = recover & ~near_existing
+            elif guard <= 0 and recover.any():
+                # Guard disabled: recovery may bridge two detected MTs and the
+                # tracer can then LOSE an instance. Left as an explicit escape
+                # hatch, but never silent.
+                logger.warning(
+                    "microtubule warm-start: merge guard disabled (guard=%d); "
+                    "recovered pixels may bridge detected filaments", guard,
+                )
+            n_recovered = int(recover.sum())
             seed_fg = seed_fg | recover
+            # Observability: a coordinate/size mismatch in prev_centerlines
+            # rasterises the prior off the real filaments and silently recovers
+            # nothing. Logging the count turns that into an explicit
+            # "recovered 0 px from N priors" instead of a no-op that looks like
+            # success.
+            logger.debug(
+                "microtubule warm-start: recovered %d seed px from %d prior "
+                "centerlines", n_recovered, len(prev_centerlines),
+            )
         binary = seed_fg.astype(np.uint8) * 255
 
         from pysoax import extract_soax_instances  # absolute import via sys.path
@@ -293,14 +317,28 @@ class MicrotubuleModel:
 
         mask = np.zeros((H, W), dtype=np.uint8)
         thickness = max(1, 2 * int(dilate_px) + 1)
+        drawn = 0
         for cl in centerlines:
             arr = np.asarray(cl, dtype=np.float64)
             if arr.ndim != 2 or arr.shape[0] < 2 or arr.shape[1] != 2:
+                continue
+            if not np.isfinite(arr).all():
+                # A NaN/Inf coord rounds to INT32_MIN and cv2 would paint a
+                # stray band across the frame → spurious recovery. Skip it.
                 continue
             # (row, col) -> (x=col, y=row) integer pixels for cv2.
             pts = np.round(arr[:, ::-1]).astype(np.int32)
             cv2.polylines(mask, [pts], isClosed=False, color=1,
                           thickness=thickness)
+            drawn += 1
+        if centerlines and drawn == 0:
+            # Nothing rasterised despite being given priors: usually a wrong
+            # shape/coordinate convention. Surface it rather than return an
+            # empty prior that silently recovers nothing.
+            logger.warning(
+                "microtubule warm-start: rasterised 0 of %d prior centerlines "
+                "(wrong shape/space?); prior is empty", len(centerlines),
+            )
         return mask.astype(bool)
 
     def predict_sequence(self, frames, seed_threshold: Optional[float] = None,
@@ -340,5 +378,11 @@ class MicrotubuleModel:
                 prior_merge_guard_px=prior_merge_guard_px,
             )
             results.append(res)
-            prev_cl = res["centerlines_rc"] if propagate else None
+            # Carry the last NON-EMPTY prior forward: a frame that detects
+            # nothing must not blank the prior, or a multi-frame dropout — the
+            # very case warm-start targets — would run cold on the next frame.
+            if propagate:
+                prev_cl = res["centerlines_rc"] or prev_cl
+            else:
+                prev_cl = None
         return results

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -44,16 +44,21 @@ segmentation-models-pytorch==0.5.0
 
 # Microtubule v7 dependencies (DINOv3 ViT-L/16 backbone via HuggingFace)
 # transformers 4.57+ is required to recognise the DINOv3 model config. Pinned to
-# 4.57.6 (not 4.57.0, which PyPI YANKED for a setup/install defect) — a bugfix
-# patch within the same 4.57 line that introduced DINOv3, so DINOv3 support is
-# preserved. Note: the arbitrary-code-exec advisory is only fixed in the 5.0
-# pre-release; staying on 4.57.x is a deliberate tradeoff (5.0 risks DINOv3
-# loading across SegFormer/Microtubule/Sperm — see the deferred ML-stack scope).
-# DINOv3 is gated — HF_TOKEN must be set before first load. tifffile is used
-# by both the model's percentile normalisation reference and the video
-# extractor (multi-page TIFF microscopy stacks). nd2 reads Nikon NIS-Elements
-# proprietary files (Apache-2.0, pure Python).
-transformers==4.57.6
+# 4.57.1 — the LAST version whose DINOv3-ViT-L forward output matches the v7
+# checkpoint. 4.57.2 silently changed the DINOv3 forward (no error, no failed
+# load): the ViT features degrade into low-frequency blobs, so the seed map
+# fills ~50% of the frame and PySOAX emits random microtubules. Verified by
+# bisection on a reference frame (4.57.0/.1 → 303 MTs tracing real filaments;
+# 4.57.2–4.57.6 → 76 scattered). 4.57.0 also worked but PyPI YANKED it for a
+# setup/install defect, so 4.57.1 is the safe floor. DO NOT bump into 4.57.2+
+# or 5.x without re-verifying MT output against a known-good frame — a green
+# build proves nothing here. The arbitrary-code-exec advisory is unfixed across
+# all of 4.57.x (only patched in the 5.0 pre-release), so this pin forfeits no
+# security fix that 4.57.6 had. DINOv3 is gated — HF_TOKEN must be set before
+# first load. tifffile is used by both the model's percentile normalisation
+# reference and the video extractor (multi-page TIFF microscopy stacks). nd2
+# reads Nikon NIS-Elements proprietary files (Apache-2.0, pure Python).
+transformers==4.57.1
 tifffile>=2024.1.30
 nd2>=0.10.0
 huggingface_hub>=0.20

--- a/backend/src/services/tracking/trackerService.ts
+++ b/backend/src/services/tracking/trackerService.ts
@@ -186,8 +186,9 @@ async function _runTrackingForContainerInner(
     // Max accepted filament-match cost for the two-step LAP tracker. The ML
     // side's filament-aware cost is a weighted sum of four [0,1] terms
     // (embedding + endpoint + orientation + length), so 0.6 accepts
-    // moderately-confident links. The remaining tracker params (max_gap=2,
-    // gap_penalty, term weights, image_hw fallback) use the ML defaults.
+    // moderately-confident links. The remaining tracker params (motion_model,
+    // emb_template_alpha, max_gap=3, gap_penalty, term weights, image_hw
+    // fallback) use the ML defaults.
     cost_threshold: 0.6,
   };
 


### PR DESCRIPTION
## Summary

Makes microtubule cross-frame tracking **propagation-aware** instead of memoryless detection-to-detection. Grew out of a question about using SAM 3 for mask-propagation tracking — the research verdict was that SAM 3 is concept-first (all instances of a category), SAM 2 is the instance-propagation tool, and thin filaments are SAM's documented worst case with a mask≠centerline output mismatch. The right idea ("propagate identity, don't re-detect each frame") applies to the *existing* centerline+embedding representation, which is what this PR does.

Three commits:

### 1. `feat(mt-tracker)` — propagation-aware LAP tracker (**deployed**)

The frame-to-frame LAP (`tracker_kymograph.py`) previously matched each new frame against the *raw previous frame*. It now matches against an online per-track state:

- **Constant-velocity endpoint prediction** — each track's endpoints are extrapolated to the next frame before the cost is measured, so legitimate MT motion no longer inflates the endpoint/orientation terms and pushes a true link past the threshold. Endpoints are aligned across frames (PySOAX centerline direction is arbitrary) so per-endpoint velocity is meaningful; extrapolation is capped to the filament length.
- **EMA embedding template** — re-identification matches against a running average of the track's embedding, not a single noisy frame.
- **`max_gap` 2 → 3** — safe: a 3-frame bridge costs `base × 2.0` given `gap_penalty=0.5`, so it is only accepted when the base cost is `< 0.3` (well inside the threshold).

New `TrackRequest` fields `motion_model` (default `true`) and `emb_template_alpha` (`0.5`); the API response shape is unchanged.

**Why it matters:** at an MT crossing the Hungarian assignment minimises *total* cost, so when detections jitter it picks the "swapped" pairing (`14+14 < 18+18`) and identities flip. Matching against the predicted position gives the correct pairing cost 0.

### 2. `feat(mt-seg)` — seed-prior warm-start (**opt-in, not deployed**)

`predict(prev_centerlines=…)` rasterises the previous frame's centerlines and lowers the seed cut (0.30) along them so a briefly-faded MT survives binarisation; `predict_sequence()` walks a video in order. A **merge guard (3 px)** discards recovered pixels adjacent to an already-detected MT — without it the prior bridges two MTs at a crossing in the skeleton graph and the tracer *loses* an instance. Frame 0 runs cold → byte-identical to the stateless path (no cold-start regression).

Kept opt-in and **not wired into the queue flow**: on real data MT detection is already stable (23–26 MT/frame, no dropouts), so guarded warm-start is a no-op there — the tracking win is the motion-model tracker above. It pays off only on videos with true full-dropout flicker.

### 3. `fix(ml)` — commit the durable `transformers==4.57.1` pin

**Critical.** The DINOv3 MT fix (4.57.2+ silently degrades the ViT forward → blobby MTs) was applied to the running prod image but the pin lived only as an *uncommitted* working-tree edit — `main` HEAD still ships the broken `4.57.6`, so a fresh ML build from HEAD silently regresses MT. This commits the pin so any rebuild is safe.

## Verification

- **Synthetic:** memoryless tracker swaps identities at a crossing; motion model keeps both.
- **Real persisted polylines** (baseline vs new): 61-frame flicker/singleton tracks 23→20, 121-frame 36→26 (−28%), 109-frame (already stable) unchanged, **no same-frame over-merge** on any.
- **Phase-2 logic** (deterministic, real PySOAX): recovers an isolated dropped MT (1→2 instances), merge guard blocks bridging (0 px recovered adjacent), cold-start byte-identical.
- **Phase-2 GPU** (real v7 network, 6 real frames): guarded warm-start leaves a well-segmented video unchanged (delta 0, no lost MTs).

## Deploy status

Phase 1 is **already deployed** to the prod `spheroseg-ml` image (built from the corrected requirements, `transformers==4.57.1` confirmed in the running image; Phase 2 wrapper is baseline in the image). Re-tracked a 61-frame video end-to-end (74→71 tracks) and verified in the production editor via Playwright: tracked polylines render coloured by trackId, a frame scrub 1→3 keeps 23/25 matched MTs' exact colour (stable trackId), 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional motion-aware tracking for more consistent object linking across frames.
  * Improved segmentation so later frames can be warm-started from earlier results for better sequence processing.

* **Bug Fixes**
  * Increased the default tracking gap tolerance, helping maintain track continuity through short interruptions.
  * Refined matching to reduce missed links and improve stability in challenging frame-to-frame updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->