### PR TITLE
test(essays): security-boundary unit tests

### DIFF
--- a/backend/src/api/controllers/__tests__/essaysController.test.ts
+++ b/backend/src/api/controllers/__tests__/essaysController.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../utils/config', () => ({
+  config: {
+    JWT_ACCESS_SECRET:
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    NODE_ENV: 'test',
+    ESSAYS_SERVICE_URL: 'http://essays:8000',
+    UPLOAD_DIR: '/app/uploads',
+  },
+}));
+vi.mock('../../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+// Stub the service so constructing the controller doesn't spin up axios/timers.
+const resolveDownload = vi.fn();
+vi.mock('../../../services/essaysService', () => ({
+  EssaysService: {
+    getInstance: () => ({
+      resolveDownload,
+      submitJob: vi.fn(),
+      listJobs: vi.fn(),
+      getJob: vi.fn(),
+      deleteJob: vi.fn(),
+    }),
+  },
+}));
+vi.mock('../../../utils/response', () => ({
+  ResponseHelper: {
+    unauthorized: vi.fn(),
+    notFound: vi.fn(),
+    badRequest: vi.fn(),
+    internalError: vi.fn(),
+  },
+}));
+
+import { EssaysController, parseOptions } from '../essaysController';
+import { ResponseHelper } from '../../../utils/response';
+// Real token service (config is mocked, so the secret is fixed) — the sentinel
+// tests must exercise the actual issue/verify crypto, not a stub.
+import { issueDownloadToken } from '../../../services/export/downloadTokenService';
+
+const JOB = '11111111-1111-1111-1111-111111111111';
+const USER = '33333333-3333-3333-3333-333333333333';
+const SENTINEL = 'essays';
+
+describe('parseOptions (evaluate.py option whitelist)', () => {
+  it('returns {} for non-string / empty / whitespace input', () => {
+    expect(parseOptions(undefined)).toEqual({});
+    expect(parseOptions(42)).toEqual({});
+    expect(parseOptions('')).toEqual({});
+    expect(parseOptions('   ')).toEqual({});
+  });
+
+  it('returns {} for invalid JSON', () => {
+    expect(parseOptions('{not json')).toEqual({});
+  });
+
+  it('drops unknown keys entirely', () => {
+    expect(parseOptions('{"evil":"rm -rf /","__proto__":{}}')).toEqual({});
+  });
+
+  it('drops ill-typed values (string number, non-boolean, non-finite)', () => {
+    expect(parseOptions('{"threshold":"5"}')).toEqual({});
+    expect(parseOptions('{"threshold":null}')).toEqual({});
+    expect(parseOptions('{"mtWidth":"3"}')).toEqual({});
+    expect(parseOptions('{"noOverlays":"true"}')).toEqual({});
+  });
+
+  it('keeps a falsy-zero numeric option (the !== undefined edge)', () => {
+    expect(parseOptions('{"threshold":0}')).toEqual({ threshold: 0 });
+  });
+
+  it('passes through exactly the whitelisted, well-typed keys', () => {
+    const out = parseOptions(
+      JSON.stringify({
+        threshold: 0.6,
+        mtWidth: 5,
+        bgGap: 1,
+        bgWidth: 5,
+        limitWells: 2,
+        tirfName: 'tirf',
+        solutionName: 'insol',
+        noOverlays: true,
+        noJson: false,
+        somethingElse: 'ignored',
+      })
+    );
+    expect(out).toEqual({
+      threshold: 0.6,
+      mtWidth: 5,
+      bgGap: 1,
+      bgWidth: 5,
+      limitWells: 2,
+      tirfName: 'tirf',
+      solutionName: 'insol',
+      noOverlays: true,
+      noJson: false,
+    });
+  });
+});
+
+describe('EssaysController.downloadJob (download-token sentinel)', () => {
+  const controller = new EssaysController();
+
+  const mockRes = () => {
+    const res: Record<string, unknown> = {
+      setHeader: vi.fn(),
+      sendFile: vi.fn((_p: string, cb?: (e?: Error) => void) => cb && cb()),
+      headersSent: false,
+    };
+    return res as never;
+  };
+  const reqWithToken = (token: string) =>
+    ({ params: { jobId: JOB }, query: { token } }) as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveDownload.mockResolvedValue({
+      filePath: '/exports/x.zip',
+      downloadName: 'x_results.zip',
+    });
+  });
+
+  it('streams the file for a valid essays token', async () => {
+    const { token } = issueDownloadToken(JOB, SENTINEL, USER);
+    const res = mockRes();
+    await controller.downloadJob(reqWithToken(token), res);
+    expect(resolveDownload).toHaveBeenCalledWith(USER, JOB);
+    expect((res as unknown as { sendFile: ReturnType<typeof vi.fn> }).sendFile)
+      .toHaveBeenCalled();
+    expect(ResponseHelper.unauthorized).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token minted for a different project (export ↔ essays isolation)', async () => {
+    const { token } = issueDownloadToken(
+      JOB,
+      '22222222-2222-2222-2222-222222222222',
+      USER
+    );
+    await controller.downloadJob(reqWithToken(token), mockRes());
+    expect(ResponseHelper.unauthorized).toHaveBeenCalled();
+    expect(resolveDownload).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token bound to a different jobId', async () => {
+    const { token } = issueDownloadToken('99999999-9999-9999-9999-999999999999', SENTINEL, USER);
+    await controller.downloadJob(reqWithToken(token), mockRes());
+    expect(ResponseHelper.unauthorized).toHaveBeenCalled();
+    expect(resolveDownload).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tampered/garbage token as unauthorized (not 500)', async () => {
+    await controller.downloadJob(reqWithToken('not.a.valid.token'), mockRes());
+    expect(ResponseHelper.unauthorized).toHaveBeenCalled();
+    expect(ResponseHelper.internalError).not.toHaveBeenCalled();
+    expect(resolveDownload).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when a valid token resolves no downloadable file', async () => {
+    resolveDownload.mockResolvedValue(null);
+    const { token } = issueDownloadToken(JOB, SENTINEL, USER);
+    await controller.downloadJob(reqWithToken(token), mockRes());
+    expect(ResponseHelper.notFound).toHaveBeenCalled();
+  });
+});

--- a/backend/src/api/controllers/essaysController.ts
+++ b/backend/src/api/controllers/essaysController.ts
@@ -20,7 +20,7 @@ const toErr = (e: unknown): Error =>
   e instanceof Error ? e : new Error(String(e));
 
 /** Parse and whitelist evaluate.py options sent as a JSON string form field. */
-function parseOptions(raw: unknown): EssayJobOptions {
+export function parseOptions(raw: unknown): EssayJobOptions {
   if (typeof raw !== 'string' || raw.trim() === '') return {};
   let parsed: Record<string, unknown>;
   try {

--- a/backend/src/services/__tests__/essaysService.test.ts
+++ b/backend/src/services/__tests__/essaysService.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'path';
+
+// vi.hoisted so the mock factories below can reference the prisma mock.
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    essayJob: {
+      findFirst: vi.fn() as any,
+    },
+  },
+}));
+
+const fsAccess = vi.fn();
+
+vi.mock('../../db', () => ({ prisma: prismaMock }));
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('../../utils/config', () => ({
+  config: {
+    ESSAYS_SERVICE_URL: 'http://essays:8000',
+    UPLOAD_DIR: '/app/uploads',
+  },
+}));
+// The service constructs an axios client + timers in its constructor; stub them
+// so getInstance() is side-effect-free under test.
+vi.mock('axios', () => ({
+  default: { create: vi.fn(() => ({ post: vi.fn() })) },
+}));
+vi.mock('fs', () => ({
+  promises: {
+    access: (...a: unknown[]) => fsAccess(...a),
+    mkdir: vi.fn(),
+    rm: vi.fn(),
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    readFile: vi.fn(),
+    rename: vi.fn(),
+    copyFile: vi.fn(),
+    unlink: vi.fn(),
+  },
+}));
+// Keep sanitizeFilename real-ish but avoid pulling in archiver et al.
+vi.mock('../export/exportFileOperations', () => ({
+  createZipArchive: vi.fn(),
+  sanitizeFilename: (s: string) => s.replace(/[^A-Za-z0-9_.-]/g, '_'),
+}));
+
+import { sanitizeNd2Name, EssaysService } from '../essaysService';
+
+const USER = 'user-1';
+const JOB = 'job-1';
+
+describe('sanitizeNd2Name (staged-filename sanitization)', () => {
+  it('strips a parent-traversal path to a bare basename', () => {
+    expect(sanitizeNd2Name('../evil.nd2')).toBe('evil.nd2');
+    expect(sanitizeNd2Name('../../../../tmp/x.nd2')).toBe('x.nd2');
+  });
+
+  it('strips an absolute path and appends a single .nd2', () => {
+    expect(sanitizeNd2Name('/etc/passwd')).toBe('passwd.nd2');
+  });
+
+  it('lowercases an uppercase extension without doubling it', () => {
+    expect(sanitizeNd2Name('WELL.ND2')).toBe('WELL.nd2');
+    expect(sanitizeNd2Name('D04_TIRF.Nd2')).toBe('D04_TIRF.nd2');
+  });
+
+  it('replaces unsafe characters with underscores', () => {
+    expect(sanitizeNd2Name('my well;rm -rf.nd2')).toBe('my_well_rm_-rf.nd2');
+  });
+
+  it('appends .nd2 when there is no extension', () => {
+    expect(sanitizeNd2Name('noext')).toBe('noext.nd2');
+  });
+});
+
+describe('EssaysService.resolveDownload (path-traversal + ownership guard)', () => {
+  const svc = EssaysService.getInstance();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.EXPORT_DIR = '/tmp/essays-exports-test';
+    fsAccess.mockResolvedValue(undefined);
+  });
+
+  it('returns null when the job is not found (ownership isolation)', async () => {
+    // findFirst is keyed on { id, userId }, so a mismatched owner yields null.
+    prismaMock.essayJob.findFirst.mockResolvedValue(null);
+    expect(await svc.resolveDownload(USER, JOB)).toBeNull();
+  });
+
+  it('returns null when the job is not completed', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'running',
+      resultZipKey: 'x.zip',
+      name: 'r',
+    });
+    expect(await svc.resolveDownload(USER, JOB)).toBeNull();
+  });
+
+  it('returns null when there is no resultZipKey', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      resultZipKey: null,
+      name: 'r',
+    });
+    expect(await svc.resolveDownload(USER, JOB)).toBeNull();
+  });
+
+  it('rejects a path-traversal resultZipKey before touching the filesystem', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      resultZipKey: '../../../etc/passwd',
+      name: 'r',
+    });
+    expect(await svc.resolveDownload(USER, JOB)).toBeNull();
+    expect(fsAccess).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the completed zip file is gone from disk', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      resultZipKey: 'good.zip',
+      name: 'r',
+    });
+    fsAccess.mockRejectedValue(new Error('ENOENT'));
+    expect(await svc.resolveDownload(USER, JOB)).toBeNull();
+  });
+
+  it('resolves a completed job to a path inside EXPORT_DIR with a sanitized name', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      resultZipKey: 'good.zip',
+      name: 'My Run/2026',
+    });
+    const dl = await svc.resolveDownload(USER, JOB);
+    expect(dl).not.toBeNull();
+    expect(dl!.filePath).toBe(
+      path.resolve('/tmp/essays-exports-test', 'good.zip')
+    );
+    // sanitized (no slash/space) and suffixed
+    expect(dl!.downloadName).toBe('My_Run_2026_results.zip');
+  });
+});

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -59,7 +59,7 @@ const clampProgress = (n: number): number =>
  * The extension is forced lowercase so the module's `*.nd2` glob never silently
  * skips an uppercase-extension well.
  */
-function sanitizeNd2Name(original: string): string {
+export function sanitizeNd2Name(original: string): string {
   const safe = path.basename(original).replace(/[^A-Za-z0-9._-]/g, '_');
   return safe.toLowerCase().endsWith('.nd2')
     ? `${safe.slice(0, -4)}.nd2`


### PR DESCRIPTION
## Summary

Follow-up to #269: unit tests that lock the security invariants the multi-agent review flagged, so a future refactor can't silently remove them. 22 tests, all passing (Vitest).

- **`resolveDownload`** (`essaysService`) — the download filesystem sandbox: rejects a `../`-traversal `resultZipKey` *before* touching the fs, and returns null for wrong owner / not-completed / missing-zip.
- **Download-token sentinel** (`essaysController.downloadJob`) — an essays token can't be forged from an export-project token or vice-versa (`projectId === 'essays'`), can't be replayed across `jobId`s, and a tampered token is `401` (not `500`).
- **`parseOptions`** (`essaysController`) — the `evaluate.py` option whitelist: unknown / ill-typed keys are dropped before they can become CLI args (keeps the falsy-`0` threshold edge).
- **`sanitizeNd2Name`** (`essaysService`) — strips path components and forces a single lowercase `.nd2` extension.

`sanitizeNd2Name` + `parseOptions` are exported so the pure functions are unit-testable (the only production change; both are internal helpers).

## Test
`cd backend && npx vitest run src/services/__tests__/essaysService.test.ts src/api/controllers/__tests__/essaysController.test.ts` → 2 files, 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)