### PR TITLE
feat(essays): persist result zip until dismiss (survive restart/logout)

### DIFF
--- a/backend/src/services/__tests__/essaysService.test.ts
+++ b/backend/src/services/__tests__/essaysService.test.ts
@@ -136,18 +136,20 @@ describe('EssaysService.resolveDownload (path-traversal + ownership guard)', () 
     expect(await svc.resolveDownload(USER, JOB)).toBeNull();
   });
 
-  it('resolves a completed job to a path inside EXPORT_DIR with a sanitized name', async () => {
+  it('resolves a completed job to a path inside the uploads volume with a sanitized name', async () => {
     prismaMock.essayJob.findFirst.mockResolvedValue({
       id: JOB,
       userId: USER,
       status: 'completed',
-      resultZipKey: 'good.zip',
+      // resultZipKey is relative to the (persistent) uploads volume.
+      resultZipKey: 'essays-results/job-1.zip',
       name: 'My Run/2026',
     });
     const dl = await svc.resolveDownload(USER, JOB);
     expect(dl).not.toBeNull();
+    // config mock sets UPLOAD_DIR = '/app/uploads'
     expect(dl!.filePath).toBe(
-      path.resolve('/tmp/essays-exports-test', 'good.zip')
+      path.resolve('/app/uploads', 'essays-results/job-1.zip')
     );
     // sanitized (no slash/space) and suffixed
     expect(dl!.downloadName).toBe('My_Run_2026_results.zip');

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -232,12 +232,16 @@ export class EssaysService {
   async deleteJob(userId: string, jobId: string): Promise<boolean> {
     const job = await prisma.essayJob.findFirst({ where: { id: jobId, userId } });
     if (!job) return false;
+    // Raw job dir is usually already gone (freed on completion); remove it if a
+    // failed/in-progress job still has it.
     await fs
       .rm(this.jobDir(userId, jobId), { recursive: true, force: true })
       .catch(() => {});
+    // Remove the persisted result zip (dismiss = delete the deliverable too).
     if (job.resultZipKey) {
-      const zp = path.resolve(exportDir(), job.resultZipKey);
-      if (zp.startsWith(exportDir() + path.sep)) {
+      const base = path.resolve(this.uploadDir);
+      const zp = path.resolve(base, job.resultZipKey);
+      if (zp.startsWith(base + path.sep)) {
         await fs.rm(zp, { force: true }).catch(() => {});
       }
     }
@@ -252,8 +256,12 @@ export class EssaysService {
   ): Promise<{ filePath: string; downloadName: string } | null> {
     const job = await prisma.essayJob.findFirst({ where: { id: jobId, userId } });
     if (!job || job.status !== 'completed' || !job.resultZipKey) return null;
-    const filePath = path.resolve(exportDir(), job.resultZipKey);
-    if (!filePath.startsWith(exportDir() + path.sep)) return null;
+    // resultZipKey is relative to the persistent uploads volume (essays-results/
+    // <jobId>.zip) so the download survives a backend restart and is available
+    // until the user dismisses the job.
+    const base = path.resolve(this.uploadDir);
+    const filePath = path.resolve(base, job.resultZipKey);
+    if (!filePath.startsWith(base + path.sep)) return null;
     try {
       await fs.access(filePath);
     } catch {
@@ -372,10 +380,26 @@ export class EssaysService {
 
       const outputDir = path.join(this.jobDir(job.userId, job.id), 'output');
       const zipBase = `${sanitizeFilename(job.name)}_${job.id.slice(0, 8)}`;
-      // createZipArchive opens the zip without creating EXPORT_DIR — ensure it
-      // exists (a fresh container has no ./exports).
+      // Zip the raw output. createZipArchive writes into EXPORT_DIR (the
+      // container-ephemeral ./exports) — ensure it exists, then MOVE the archive
+      // onto the persistent uploads volume so it survives a backend restart and
+      // stays downloadable until the user dismisses the job.
       await fs.mkdir(exportDir(), { recursive: true });
-      const zipPath = await createZipArchive(outputDir, zipBase);
+      const stagedZip = await createZipArchive(outputDir, zipBase);
+
+      const resultsDir = path.join(this.uploadDir, 'essays-results');
+      await fs.mkdir(resultsDir, { recursive: true });
+      const persistentZip = path.join(resultsDir, `${job.id}.zip`);
+      try {
+        await fs.rename(stagedZip, persistentZip);
+      } catch {
+        // EXPORT_DIR and the uploads volume are usually different devices —
+        // fall back to copy + unlink on EXDEV.
+        await fs.copyFile(stagedZip, persistentZip);
+        await fs.rm(stagedZip, { force: true }).catch(() => {});
+      }
+      const resultZipKey = path.posix.join('essays-results', `${job.id}.zip`);
+
       await prisma.essayJob.update({
         where: { id: job.id },
         data: {
@@ -383,17 +407,16 @@ export class EssaysService {
           progress: 100,
           mtCount: ws.mtCount ?? job.mtCount,
           device: ws.device ?? job.device,
-          resultZipKey: path.basename(zipPath),
+          resultZipKey,
           completedAt: new Date(),
         },
       });
-      logger.info(
-        `essays job ${job.id} completed -> ${path.basename(zipPath)}`,
-        CTX
-      );
+      logger.info(`essays job ${job.id} completed -> ${resultZipKey}`, CTX);
+
       // Free the (potentially tens-of-GB) input .nd2 files + raw output now that
-      // the zip in EXPORT_DIR is the sole download artifact — the job dir is no
-      // longer needed. Best-effort; a leftover is swept later regardless.
+      // the persisted zip is the sole download artifact — the raw job dir is no
+      // longer needed. The result zip lives outside it (essays-results/) and
+      // stays until the user dismisses the job.
       await fs
         .rm(this.jobDir(job.userId, job.id), { recursive: true, force: true })
         .catch((e) =>


### PR DESCRIPTION
## Summary

Follow-up to #269/#271: essays result zips are now durable. Previously `finalize()` wrote the zip to `EXPORT_DIR` (container-ephemeral `./exports`), lost on a backend restart/crash — and since the raw input `.nd2` folder is freed on completion, the result became unrecoverable (real risk after a 78-min 180-well run).

Now the zip is moved onto the **persistent uploads volume** (`essays-results/<jobId>.zip`), so a completed run is downloadable **any time — across logout and restarts — until the user dismisses (deletes) the job**, matching the classic export UX. Raw input+output are still freed for disk.

- `finalize()`: zip → move onto the uploads volume; `resultZipKey` is now a uploads-relative key.
- `resolveDownload()` / `deleteJob()`: resolve against `UPLOAD_DIR` (same traversal guard); dismiss removes the persisted zip.
- Security unit test updated (22 tests pass).

## Verified on prod
Real completed 180-well job (44 655 MT): downloads HTTP 200, full 1.48 GB, **after a backend recreate** — new container's ephemeral `/app/exports` is empty, zip survives on the volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded essay results now use a shared uploads location, making completed job files available even after backend restarts.
  * Job deletions and download links now resolve files more reliably and with stronger path safety.
  * Completion details are updated consistently when results are packaged, including progress and device counts.

* **Tests**
  * Updated coverage to reflect the new file storage and download path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->