### PR TITLE
feat(mt): ImageJ RoiSet.zip export + right-click propagate/delete-track

### DIFF
--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -220,6 +220,101 @@ class SegmentationController {
   };
 
   /**
+   * Map a track-operation error to the right HTTP status: ownership failures are
+   * 404 and geometry-shape failures are validation errors, so they don't leak as
+   * generic 500s.
+   */
+  private handleTrackOpError(
+    error: unknown,
+    res: Response,
+    fallbackMessage: string
+  ): void {
+    const message = error instanceof Error ? error.message : '';
+    if (/no access|not found/i.test(message)) {
+      ResponseHelper.notFound(res, 'Video nenalezeno nebo bez přístupu');
+      return;
+    }
+    if (/at least 2 points/i.test(message)) {
+      ResponseHelper.validationError(res, message);
+      return;
+    }
+    ResponseHelper.internalError(res, error as Error, fallbackMessage);
+  }
+
+  /**
+   * Propagate a microtubule polyline into all following frames of a video.
+   */
+  propagateTrack = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { videoId } = req.params;
+      const { fromFrameIndex, polyline } = req.body;
+
+      const userId = this.validateUser(req, res);
+      if (!userId) {
+        return;
+      }
+      if (!this.validateParams(req.params, ['videoId'], res)) {
+        return;
+      }
+
+      const result =
+        await this.segmentationService.propagateTrackGeometryForward(
+          videoId as string,
+          Number(fromFrameIndex),
+          polyline,
+          userId
+        );
+
+      ResponseHelper.success(
+        res,
+        result,
+        'Mikrotubulus propagován do dalších snímků'
+      );
+    } catch (error) {
+      logger.error(
+        'Failed to propagate microtubule track',
+        error instanceof Error ? error : undefined,
+        'SegmentationController',
+        { videoId: req.params.videoId, userId: req.user?.id }
+      );
+      this.handleTrackOpError(error, res, 'Chyba při propagaci mikrotubulu');
+    }
+  };
+
+  /**
+   * Delete a whole microtubule track (every frame of the video).
+   */
+  deleteTrack = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { videoId, trackId } = req.params;
+
+      const userId = this.validateUser(req, res);
+      if (!userId) {
+        return;
+      }
+      if (!this.validateParams(req.params, ['videoId', 'trackId'], res)) {
+        return;
+      }
+
+      const result = await this.segmentationService.deleteTrackAcrossVideo(
+        videoId as string,
+        trackId as string,
+        userId
+      );
+
+      ResponseHelper.success(res, result, 'Track mikrotubulu smazán');
+    } catch (error) {
+      logger.error(
+        'Failed to delete microtubule track',
+        error instanceof Error ? error : undefined,
+        'SegmentationController',
+        { videoId: req.params.videoId, userId: req.user?.id }
+      );
+      this.handleTrackOpError(error, res, 'Chyba při mazání tracku');
+    }
+  };
+
+  /**
    * Batch process multiple images
    */
   batchSegment = async (req: Request, res: Response): Promise<void> => {

--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -1,5 +1,8 @@
 import { Request, Response } from 'express';
-import { SegmentationService } from '../../services/segmentationService';
+import {
+  SegmentationService,
+  VideoAccessError,
+} from '../../services/segmentationService';
 import { ImageService } from '../../services/imageService';
 import { logger } from '../../utils/logger';
 import { ResponseHelper } from '../../utils/response';
@@ -229,13 +232,15 @@ class SegmentationController {
     res: Response,
     fallbackMessage: string
   ): void {
-    const message = error instanceof Error ? error.message : '';
-    if (/no access|not found/i.test(message)) {
+    // Ownership failures are a typed error (not a substring match, which would
+    // silently drift-break if the message is reworded).
+    if (error instanceof VideoAccessError) {
       ResponseHelper.notFound(res, 'Video nenalezeno nebo bez přístupu');
       return;
     }
-    if (/at least 2 points/i.test(message)) {
-      ResponseHelper.validationError(res, message);
+    // Geometry-shape failure (also gated at the route, so this is defensive).
+    if (error instanceof Error && /at least 2( finite)? points/i.test(error.message)) {
+      ResponseHelper.validationError(res, error.message);
       return;
     }
     ResponseHelper.internalError(res, error as Error, fallbackMessage);

--- a/backend/src/api/controllers/segmentationController.ts
+++ b/backend/src/api/controllers/segmentationController.ts
@@ -223,6 +223,46 @@ class SegmentationController {
   };
 
   /**
+   * Delete segmentation annotations for many images at once (bulk action from
+   * the project page; the images themselves are kept).
+   */
+  deleteSegmentationBatch = async (
+    req: Request,
+    res: Response
+  ): Promise<void> => {
+    try {
+      const { imageIds } = req.body;
+      const userId = this.validateUser(req, res);
+      if (!userId) {
+        return;
+      }
+      if (!Array.isArray(imageIds) || imageIds.length === 0) {
+        ResponseHelper.validationError(res, 'imageIds musí být neprázdné pole');
+        return;
+      }
+
+      const result = await this.segmentationService.deleteSegmentationBatch(
+        imageIds,
+        userId
+      );
+
+      ResponseHelper.success(res, result, 'Anotace smazány');
+    } catch (error) {
+      logger.error(
+        'Failed to batch-delete segmentation annotations',
+        error instanceof Error ? error : undefined,
+        'SegmentationController',
+        { userId: req.user?.id }
+      );
+      ResponseHelper.internalError(
+        res,
+        error as Error,
+        'Chyba při mazání anotací'
+      );
+    }
+  };
+
+  /**
    * Map a track-operation error to the right HTTP status: ownership failures are
    * 404 and geometry-shape failures are validation errors, so they don't leak as
    * generic 500s.

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -108,6 +108,65 @@ router.delete(
 );
 
 /**
+ * @route POST /api/segmentation/videos/:videoId/tracks/propagate
+ * @description Propagate a microtubule polyline into all following frames
+ * @access Private
+ */
+router.post(
+  '/videos/:videoId/tracks/propagate',
+  [
+    param('videoId').isUUID().withMessage('ID videa musí být platné UUID'),
+    body('fromFrameIndex')
+      .isInt({ min: 0 })
+      .withMessage('fromFrameIndex musí být nezáporné číslo'),
+    body('polyline').isObject().withMessage('polyline musí být objekt'),
+    body('polyline.points')
+      .isArray({ min: 2 })
+      .withMessage('polyline musí mít alespoň 2 body'),
+    body('polyline.points.*.x')
+      .isNumeric()
+      .withMessage('Souřadnice x musí být číslo'),
+    body('polyline.points.*.y')
+      .isNumeric()
+      .withMessage('Souřadnice y musí být číslo'),
+    body('polyline.trackId')
+      .optional({ nullable: true })
+      .isString()
+      .withMessage('trackId musí být řetězec'),
+    body('polyline.name')
+      .optional({ nullable: true })
+      .isString()
+      .withMessage('name musí být řetězec'),
+    body('polyline.geometry')
+      .optional()
+      .isIn(['polygon', 'polyline'])
+      .withMessage('geometry musí být polygon nebo polyline'),
+  ],
+  handleValidation,
+  segmentationController.propagateTrack
+);
+
+/**
+ * @route DELETE /api/segmentation/videos/:videoId/tracks/:trackId
+ * @description Delete a whole microtubule track across every frame of the video
+ * @access Private
+ */
+router.delete(
+  '/videos/:videoId/tracks/:trackId',
+  [
+    param('videoId').isUUID().withMessage('ID videa musí být platné UUID'),
+    param('trackId')
+      .isString()
+      .trim()
+      .notEmpty()
+      .isLength({ max: 200 })
+      .withMessage('trackId musí být neprázdný řetězec'),
+  ],
+  handleValidation,
+  segmentationController.deleteTrack
+);
+
+/**
  * @route POST /api/segmentation/batch
  * @description Process multiple images in batch
  * @access Private

--- a/backend/src/api/routes/segmentationRoutes.ts
+++ b/backend/src/api/routes/segmentationRoutes.ts
@@ -167,6 +167,25 @@ router.delete(
 );
 
 /**
+ * @route POST /api/segmentation/batch/delete
+ * @description Delete segmentation annotations for many images at once
+ * @access Private
+ */
+router.post(
+  '/batch/delete',
+  [
+    body('imageIds')
+      .isArray({ min: 1, max: 10000 })
+      .withMessage('Musíte zadat 1-10000 obrázků'),
+    body('imageIds.*')
+      .isUUID()
+      .withMessage('ID obrázku musí být platné UUID'),
+  ],
+  handleValidation,
+  segmentationController.deleteSegmentationBatch
+);
+
+/**
  * @route POST /api/segmentation/batch
  * @description Process multiple images in batch
  * @access Private

--- a/backend/src/services/__tests__/segmentationService.trackOps.test.ts
+++ b/backend/src/services/__tests__/segmentationService.trackOps.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../../utils/config', () => ({
+  config: {
+    SEGMENTATION_SERVICE_URL: 'http://localhost:8000',
+    UPLOAD_DIR: './test-uploads',
+    STORAGE_TYPE: 'local',
+    NODE_ENV: 'test',
+  },
+}));
+
+import {
+  removePolygonsWithTrackId,
+  upsertTrackPolyline,
+  type PropagatedPolyline,
+} from '../segmentationService';
+
+const poly = (trackId: string | undefined, extra: Record<string, unknown> = {}) => ({
+  id: `poly_${Math.random().toString(36).slice(2, 8)}`,
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 10 },
+  ],
+  type: 'external',
+  geometry: 'polyline',
+  ...(trackId !== undefined ? { trackId } : {}),
+  ...extra,
+});
+
+describe('removePolygonsWithTrackId', () => {
+  it('removes every polygon carrying the trackId and counts them', () => {
+    const polys = [poly('t1'), poly('t2'), poly('t1'), poly(undefined)];
+    const { polygons, removed } = removePolygonsWithTrackId(polys, 't1');
+    expect(removed).toBe(2);
+    expect(polygons).toHaveLength(2);
+    expect(
+      polygons.every(p => (p as { trackId?: string }).trackId !== 't1')
+    ).toBe(true);
+  });
+
+  it('leaves the list untouched when the trackId is absent', () => {
+    const polys = [poly('t2'), poly(undefined)];
+    const { polygons, removed } = removePolygonsWithTrackId(polys, 't1');
+    expect(removed).toBe(0);
+    expect(polygons).toHaveLength(2);
+  });
+
+  it('never matches an empty-string trackId against a real one', () => {
+    const polys = [poly('t1'), poly('')];
+    const { removed } = removePolygonsWithTrackId(polys, 't1');
+    expect(removed).toBe(1);
+  });
+});
+
+describe('upsertTrackPolyline', () => {
+  const source: PropagatedPolyline = {
+    trackId: 't1',
+    name: 'MT-A',
+    geometry: 'polyline',
+    points: [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+      { x: 5, y: 6 },
+    ],
+  };
+
+  it('overwrites an existing polyline with the same trackId (no duplicate)', () => {
+    const existing = [poly('t1', { name: 'stale' }), poly('t2')];
+    let n = 0;
+    const out = upsertTrackPolyline(existing, 't1', source, () => `new_${n++}`);
+    const t1s = out.filter(p => (p as { trackId?: string }).trackId === 't1');
+    expect(t1s).toHaveLength(1); // overwritten, not duplicated
+    expect(out).toHaveLength(2); // t1 (replaced) + t2 (untouched)
+    const added = t1s[0] as Record<string, unknown>;
+    expect(added.id).toBe('new_0'); // fresh id, not the stale one
+    expect(added.points).toEqual(source.points);
+    expect(added.name).toBe('MT-A');
+    expect(added.geometry).toBe('polyline');
+    expect(added.type).toBe('external');
+  });
+
+  it('adds the polyline when the frame does not have that track yet', () => {
+    const existing = [poly('t2')];
+    const out = upsertTrackPolyline(existing, 't1', source, () => 'fresh');
+    expect(out).toHaveLength(2);
+    expect(
+      out.some(p => (p as { trackId?: string }).trackId === 't1')
+    ).toBe(true);
+  });
+
+  it('deep-copies points so later edits do not alias the source', () => {
+    const out = upsertTrackPolyline([], 't1', source, () => 'id');
+    const added = out[0] as { points: Array<{ x: number; y: number }> };
+    added.points[0].x = 999;
+    expect(source.points[0].x).toBe(1); // source untouched
+  });
+
+  it('omits the name field when the source has none', () => {
+    const noName: PropagatedPolyline = {
+      trackId: 't9',
+      geometry: 'polyline',
+      points: [
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+      ],
+    };
+    const out = upsertTrackPolyline([], 't9', noName, () => 'id');
+    expect('name' in (out[0] as object)).toBe(false);
+  });
+});

--- a/backend/src/services/__tests__/segmentationService.trackOpsService.test.ts
+++ b/backend/src/services/__tests__/segmentationService.trackOpsService.test.ts
@@ -1,0 +1,225 @@
+/**
+ * segmentationService.trackOpsService.test.ts
+ *
+ * Orchestration tests (mocked Prisma) for the cross-frame track endpoints —
+ * complements the pure-helper unit tests in segmentationService.trackOps.test.ts.
+ *
+ *  propagateTrackGeometryForward
+ *   - generates one mt_<hex> trackId when the source is untracked and writes
+ *     that SAME id into every following frame (the feature's core identity
+ *     promise — a regression here silently gives each frame a different colour)
+ *   - reuses the source trackId when present
+ *   - SKIPS a corrupt-JSON frame instead of overwriting it with just the
+ *     propagated polyline (data-loss guard)
+ *   - skips frames with no segmentation row; empty set → no transaction
+ *   - throws VideoAccessError when the video is not owned
+ *
+ *  deleteTrackAcrossVideo
+ *   - removes the track from exactly the frames that carry it
+ *   - throws VideoAccessError when the video is not owned
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import {
+  SegmentationService,
+  VideoAccessError,
+} from '../segmentationService';
+import { ImageService } from '../imageService';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../utils/config', () => ({
+  config: {
+    SEGMENTATION_SERVICE_URL: 'http://localhost:8000',
+    STORAGE_TYPE: 'local',
+    UPLOAD_DIR: '/tmp/uploads',
+    NODE_ENV: 'test',
+  },
+}));
+vi.mock('../../storage');
+vi.mock('../segmentationThumbnailService');
+vi.mock('../thumbnailManager', () => ({
+  ThumbnailManager: function MockThumbnailManager(this: any) {
+    this.generateAllThumbnails = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+vi.mock('../imageService');
+
+const seg = (id: string, polygons: unknown[]) => ({
+  id: `seg-${id}`,
+  polygons: JSON.stringify(polygons),
+});
+const line = (trackId?: string) => ({
+  id: `p-${Math.random().toString(36).slice(2, 7)}`,
+  type: 'external',
+  geometry: 'polyline',
+  points: [
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+  ],
+  ...(trackId ? { trackId } : {}),
+});
+
+/** Parse the polygons JSON written by a given segmentation.update mock call. */
+const writtenPolys = (call: any): any[] =>
+  JSON.parse(call[0].data.polygons);
+
+describe('SegmentationService track ops (orchestration)', () => {
+  let service: SegmentationService;
+  let prismaMock: any;
+  let imageServiceMock: any;
+
+  beforeEach(() => {
+    prismaMock = {
+      segmentation: { update: vi.fn(x => x) },
+      image: { findMany: vi.fn() },
+      $transaction: vi.fn().mockResolvedValue([]),
+    };
+    imageServiceMock = { getImageById: vi.fn() };
+    service = new SegmentationService(
+      prismaMock as PrismaClient,
+      imageServiceMock as ImageService
+    );
+    // getImageById returns a truthy container by default (owned).
+    imageServiceMock.getImageById.mockResolvedValue({ id: 'vid', isVideoContainer: true });
+  });
+
+  describe('propagateTrackGeometryForward', () => {
+    const srcPolyline = {
+      geometry: 'polyline' as const,
+      points: [
+        { x: 5, y: 5 },
+        { x: 6, y: 7 },
+        { x: 8, y: 9 },
+      ],
+    };
+
+    it('generates one mt_<hex> trackId and writes it identically into every following frame', async () => {
+      prismaMock.image.findMany.mockResolvedValue([
+        { id: 'f1', segmentation: seg('1', [line('other')]) },
+        { id: 'f2', segmentation: seg('2', []) },
+      ]);
+
+      const res = await service.propagateTrackGeometryForward(
+        'vid',
+        0,
+        { ...srcPolyline, trackId: undefined },
+        'user'
+      );
+
+      expect(res.trackId).toMatch(/^mt_[0-9a-f]{8}$/);
+      expect(res.framesUpdated).toBe(2);
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+
+      // Every written frame carries the SAME generated trackId on the new line.
+      const calls = prismaMock.segmentation.update.mock.calls;
+      expect(calls).toHaveLength(2);
+      for (const call of calls) {
+        const added = writtenPolys(call).filter(p => p.trackId === res.trackId);
+        expect(added).toHaveLength(1);
+        expect(added[0].points).toEqual(srcPolyline.points);
+      }
+      // Frame f1's unrelated 'other' track is preserved (not clobbered).
+      expect(
+        writtenPolys(calls[0]).some(p => p.trackId === 'other')
+      ).toBe(true);
+    });
+
+    it('reuses the source trackId when it already has one', async () => {
+      prismaMock.image.findMany.mockResolvedValue([
+        { id: 'f1', segmentation: seg('1', [line('t7')]) },
+      ]);
+      const res = await service.propagateTrackGeometryForward(
+        'vid',
+        0,
+        { ...srcPolyline, trackId: 't7' },
+        'user'
+      );
+      expect(res.trackId).toBe('t7');
+      // Overwrite: the frame ends with exactly one 't7' line (no duplicate).
+      expect(
+        writtenPolys(prismaMock.segmentation.update.mock.calls[0]).filter(
+          p => p.trackId === 't7'
+        )
+      ).toHaveLength(1);
+    });
+
+    it('skips a corrupt-JSON frame instead of clobbering it', async () => {
+      prismaMock.image.findMany.mockResolvedValue([
+        { id: 'good', segmentation: seg('good', [line('a'), line('b')]) },
+        { id: 'bad', segmentation: { id: 'seg-bad', polygons: '{not json' } },
+      ]);
+      const res = await service.propagateTrackGeometryForward(
+        'vid',
+        0,
+        { ...srcPolyline, trackId: 'x' },
+        'user'
+      );
+      // Only the good frame is written; the corrupt frame is left untouched.
+      expect(res.framesUpdated).toBe(1);
+      expect(prismaMock.segmentation.update).toHaveBeenCalledTimes(1);
+      expect(prismaMock.segmentation.update.mock.calls[0][0].where.id).toBe(
+        'seg-good'
+      );
+    });
+
+    it('skips frames with no segmentation row and does not open a transaction when nothing is written', async () => {
+      prismaMock.image.findMany.mockResolvedValue([
+        { id: 'f1', segmentation: null },
+      ]);
+      const res = await service.propagateTrackGeometryForward(
+        'vid',
+        0,
+        { ...srcPolyline, trackId: 't' },
+        'user'
+      );
+      expect(res.framesUpdated).toBe(0);
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws VideoAccessError when the video is not owned', async () => {
+      imageServiceMock.getImageById.mockResolvedValue(null);
+      await expect(
+        service.propagateTrackGeometryForward('vid', 0, srcPolyline, 'user')
+      ).rejects.toBeInstanceOf(VideoAccessError);
+    });
+
+    it('throws on a degenerate (<2 point) polyline', async () => {
+      await expect(
+        service.propagateTrackGeometryForward(
+          'vid',
+          0,
+          { geometry: 'polyline', points: [{ x: 1, y: 1 }] },
+          'user'
+        )
+      ).rejects.toThrow(/at least 2/);
+    });
+  });
+
+  describe('deleteTrackAcrossVideo', () => {
+    it('removes the track from exactly the frames that carry it', async () => {
+      prismaMock.image.findMany.mockResolvedValue([
+        { id: 'f1', segmentation: seg('1', [line('t1'), line('t2')]) },
+        { id: 'f2', segmentation: seg('2', [line('t2')]) }, // no t1 → untouched
+        { id: 'f3', segmentation: seg('3', [line('t1')]) },
+        { id: 'f4', segmentation: null },
+      ]);
+      const res = await service.deleteTrackAcrossVideo('vid', 't1', 'user');
+      expect(res.framesAffected).toBe(2); // f1 + f3
+      expect(prismaMock.segmentation.update).toHaveBeenCalledTimes(2);
+      // t1 is gone from every written frame; t2 survives.
+      for (const call of prismaMock.segmentation.update.mock.calls) {
+        const polys = writtenPolys(call);
+        expect(polys.some(p => p.trackId === 't1')).toBe(false);
+      }
+    });
+
+    it('throws VideoAccessError when the video is not owned', async () => {
+      imageServiceMock.getImageById.mockResolvedValue(null);
+      await expect(
+        service.deleteTrackAcrossVideo('vid', 't1', 'user')
+      ).rejects.toBeInstanceOf(VideoAccessError);
+    });
+  });
+});

--- a/backend/src/services/export/__tests__/imagejColor.test.ts
+++ b/backend/src/services/export/__tests__/imagejColor.test.ts
@@ -1,0 +1,103 @@
+/**
+ * imagejColor.test.ts — parity with the frontend colour math.
+ *
+ * The exported ROI stroke colour MUST match what the editor renders, otherwise
+ * the same microtubule reads as one colour in the app and another in ImageJ.
+ * `referenceHue` below re-implements the FE loop from
+ * `src/pages/segmentation/utils/instanceColors.ts` INDEPENDENTLY (not imported),
+ * so these tests fail if either side drifts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  colorKeyForRoi,
+  hueFromColorKey,
+  imageJStrokeColor,
+} from '../imagejColor';
+
+/** Independent re-implementation of the FE hue hash for cross-checking. */
+function referenceHue(key: string): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % 360;
+}
+
+describe('colorKeyForRoi', () => {
+  it('prefers trackId over instanceId and id', () => {
+    expect(
+      colorKeyForRoi({ trackId: 'mt_7', instanceId: 'mt_9', id: 'abc' })
+    ).toBe('mt_7');
+  });
+
+  it('falls back to an mt_-prefixed instanceId when trackId is absent', () => {
+    expect(colorKeyForRoi({ instanceId: 'mt_9', id: 'abc' })).toBe('mt_9');
+  });
+
+  it('ignores a non-mt instanceId and uses the id', () => {
+    expect(colorKeyForRoi({ instanceId: 'sperm_3', id: 'abc' })).toBe('abc');
+  });
+
+  it('returns empty string when no identity is present', () => {
+    expect(colorKeyForRoi({})).toBe('');
+  });
+});
+
+describe('hueFromColorKey', () => {
+  it('matches the frontend hash for representative keys', () => {
+    for (const key of ['mt_42', 'mt_0d08f27f', 'track_99', 'a', '']) {
+      expect(hueFromColorKey(key)).toBe(referenceHue(key));
+    }
+  });
+
+  it('pins the known FE hue for mt_42 (regression anchor)', () => {
+    // Hand-computed from the djb2 loop; locks the algorithm so a refactor that
+    // changes the hash is caught even if the FE reference above also drifts.
+    expect(hueFromColorKey('mt_42')).toBe(62);
+  });
+
+  it('is stable and bounded to [0, 359]', () => {
+    for (const key of ['mt_1', 'mt_2', 'x'.repeat(50), 'µ_αβ']) {
+      const h = hueFromColorKey(key);
+      expect(h).toBeGreaterThanOrEqual(0);
+      expect(h).toBeLessThan(360);
+      expect(hueFromColorKey(key)).toBe(h);
+    }
+  });
+});
+
+describe('imageJStrokeColor', () => {
+  it('always sets an opaque alpha (0xFF) so ImageJ treats the colour as set', () => {
+    const argb = imageJStrokeColor('mt_42');
+    expect((argb >>> 24) & 0xff).toBe(0xff);
+  });
+
+  it('is a stable, unsigned 32-bit value per key', () => {
+    const a = imageJStrokeColor('mt_42');
+    expect(a).toBe(imageJStrokeColor('mt_42'));
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(a).toBeLessThanOrEqual(0xffffffff);
+  });
+
+  it('produces different colours for different tracks', () => {
+    expect(imageJStrokeColor('mt_aaa')).not.toBe(imageJStrokeColor('mt_bbb'));
+  });
+
+  it('encodes hsl(62, 70%, 55%) for mt_42 as RGB (215, 221, 60)', () => {
+    // hue 62 → C=0.63, X≈0.609, m=0.235 → R≈0.844 G≈0.865 B≈0.235 → ×255.
+    const argb = imageJStrokeColor('mt_42');
+    const r = (argb >>> 16) & 0xff;
+    const g = (argb >>> 8) & 0xff;
+    const b = argb & 0xff;
+    expect([r, g, b]).toEqual([215, 221, 60]);
+  });
+
+  it('returns opaque neutral gray (153,153,153) for an empty key', () => {
+    const argb = imageJStrokeColor('');
+    expect((argb >>> 24) & 0xff).toBe(0xff);
+    expect((argb >>> 16) & 0xff).toBe(153);
+    expect((argb >>> 8) & 0xff).toBe(153);
+    expect(argb & 0xff).toBe(153);
+  });
+});

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -9,19 +9,23 @@
  *   - round-trips sub-pixel float coordinates (absolute) exactly
  *   - writes the integer bbox + relative int16 block; float stays exact on wrap
  *   - round-trips the ROI name via UTF-16BE (incl. non-ASCII)
+ *   - writes the optional slice position (@56) and ARGB stroke colour (@40)
+ *   - leaves position/stroke at 0 when options are omitted (byte back-compat)
  *   - throws below the geometry minimum (polyline < 2 / polygon < 3)
  *
- *  exportImageJRois (per-frame writer, real temp-dir FS)
- *   - skips video container rows + frames without polygons
- *   - drops polylines with < 2 points / polygons with < 3 points
+ *  buildVideoRoiEntries (pure zip-entry builder)
+ *   - places each ROI on its 1-based slice position + per-track stroke colour
+ *   - names entries <label>__frame_NNNN, MT-first + globally unique
+ *   - keeps the same trackId's colour identical across frames
+ *   - dedups colliding labels within a frame; drops degenerate / non-finite
+ *   - counts corrupt-JSON frames + dropped polygons
+ *
+ *  exportImageJRoiSets (real temp-dir FS)
+ *   - writes one <video>_RoiSet.zip per video container (valid PK zip)
  *   - separates videos that share a frameIndex (multi-position ND2)
- *   - names files by trackId and keeps the SAME name across frames
- *   - suffixes colliding filenames within a frame (no overwrite), incl.
- *     distinct labels that sanitize to the same name
- *   - falls back to a generated name for untracked / empty-trackId polygons
- *   - skips corrupt-JSON frames with a warning; drops non-finite polygons
+ *   - the zip round-trips real ROI bytes (position + stroke survive deflate)
+ *   - skips corrupt frames with a warning; warns when nothing was exported
  *   - rejects when the job is cancelled
- *   - returns a warning (not an error) when nothing was exported
  *
  * The inline decoder mirrors ImageJ's RoiDecoder layout so the test needs no
  * external tool. It was cross-checked against Christoph Gohlke's reference
@@ -32,10 +36,13 @@ import { describe, it, expect, afterAll } from 'vitest';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as zlib from 'zlib';
 import {
   encodeImageJRoi,
-  exportImageJRois,
+  buildVideoRoiEntries,
+  exportImageJRoiSets,
   type RoiFrameInput,
+  type RoiZipEntry,
 } from '../imagejRoiEncoder';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +59,10 @@ interface DecodedRoi {
   intCoords: Array<[number, number]>;
   /** Sub-pixel float coordinate block (absolute). */
   coords: Array<[number, number]>;
+  /** 1-based stack slice (@56); 0 when unset. */
+  position: number;
+  /** ARGB stroke colour (@40, unsigned); 0 when unset. */
+  strokeColor: number;
   name: string;
 }
 
@@ -70,8 +81,10 @@ function decodeRoi(buf: Buffer): DecodedRoi {
     right: readShort(buf, 14),
   };
   const n = buf.readUInt16BE(16);
+  const strokeColor = buf.readUInt32BE(40);
   const options = buf.readUInt16BE(50);
   const subPixel = (options & 128) !== 0;
+  const position = buf.readInt32BE(56);
 
   const intCoords: Array<[number, number]> = [];
   const ix = 64;
@@ -99,11 +112,81 @@ function decodeRoi(buf: Buffer): DecodedRoi {
     }
   }
 
-  return { magic, type, nCoords: n, subPixel, bbox, intCoords, coords, name };
+  return {
+    magic,
+    type,
+    nCoords: n,
+    subPixel,
+    bbox,
+    intCoords,
+    coords,
+    position,
+    strokeColor,
+    name,
+  };
 }
 
 const ROI_TYPE_POLYGON = 0;
 const ROI_TYPE_POLYLINE = 5;
+
+// ---------------------------------------------------------------------------
+// Minimal ZIP reader (central directory + local headers; deflate/stored)
+// ---------------------------------------------------------------------------
+
+/** Total entry count from the End Of Central Directory record. */
+function zipEntryCount(buf: Buffer): number {
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      return buf.readUInt16LE(i + 10);
+    }
+  }
+  throw new Error('EOCD not found');
+}
+
+/** All entry names, read from the central directory (no inflation needed). */
+function zipEntryNames(buf: Buffer): string[] {
+  const names: string[] = [];
+  let i = 0;
+  while (i <= buf.length - 4) {
+    if (buf.readUInt32LE(i) === 0x02014b50) {
+      const nameLen = buf.readUInt16LE(i + 28);
+      const extraLen = buf.readUInt16LE(i + 30);
+      const commentLen = buf.readUInt16LE(i + 32);
+      names.push(buf.toString('utf8', i + 46, i + 46 + nameLen));
+      i += 46 + nameLen + extraLen + commentLen;
+    } else {
+      i++;
+    }
+  }
+  return names;
+}
+
+/** Extract one entry's bytes by name (handles stored + deflate). */
+function zipExtract(buf: Buffer, name: string): Buffer {
+  let i = 0;
+  while (i <= buf.length - 4) {
+    if (buf.readUInt32LE(i) === 0x02014b50) {
+      const nameLen = buf.readUInt16LE(i + 28);
+      const extraLen = buf.readUInt16LE(i + 30);
+      const commentLen = buf.readUInt16LE(i + 32);
+      const entryName = buf.toString('utf8', i + 46, i + 46 + nameLen);
+      if (entryName === name) {
+        const method = buf.readUInt16LE(i + 10);
+        const compSize = buf.readUInt32LE(i + 20);
+        const localOff = buf.readUInt32LE(i + 42);
+        const lNameLen = buf.readUInt16LE(localOff + 26);
+        const lExtraLen = buf.readUInt16LE(localOff + 28);
+        const dataStart = localOff + 30 + lNameLen + lExtraLen;
+        const data = buf.subarray(dataStart, dataStart + compSize);
+        return method === 0 ? Buffer.from(data) : zlib.inflateRawSync(data);
+      }
+      i += 46 + nameLen + extraLen + commentLen;
+    } else {
+      i++;
+    }
+  }
+  throw new Error(`entry not found: ${name}`);
+}
 
 // ---------------------------------------------------------------------------
 // encodeImageJRoi
@@ -212,6 +295,53 @@ describe('encodeImageJRoi', () => {
     expect(d.coords).toEqual(pts.map(p => [p.x, p.y]));
   });
 
+  it('writes the optional slice position and ARGB stroke colour', () => {
+    const argb = 0xff00ff00; // opaque green
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt',
+        { position: 7, strokeColor: argb }
+      )
+    );
+    expect(d.position).toBe(7);
+    expect(d.strokeColor).toBe(argb);
+  });
+
+  it('leaves position + stroke at 0 when options are omitted (byte back-compat)', () => {
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt'
+      )
+    );
+    expect(d.position).toBe(0);
+    expect(d.strokeColor).toBe(0);
+  });
+
+  it('ignores a zero / non-positive position (stays unset)', () => {
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt',
+        { position: 0 }
+      )
+    );
+    expect(d.position).toBe(0);
+  });
+
   it('throws when given fewer than the geometry minimum points', () => {
     expect(() => encodeImageJRoi([{ x: 1, y: 1 }], 'polyline')).toThrow();
     expect(() => encodeImageJRoi([], 'polygon')).toThrow();
@@ -236,6 +366,8 @@ describe('encodeImageJRoi', () => {
 // so a *shared* wrong offset would round-trip cleanly and pass. This test pins
 // the on-disk bytes to a reference `.roi` produced by an INDEPENDENT
 // implementation — Christoph Gohlke's `roifile` (Python) — closing that gap.
+// It passes NO options, so position/stroke stay 0 and the layout is unchanged
+// from before this feature (guarding the back-compat path).
 //
 // fixtures/golden_polyline.roi was generated once with roifile 2026.2.10:
 //
@@ -306,10 +438,234 @@ describe('encodeImageJRoi — golden file (roifile reference)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// exportImageJRois (real temp-dir filesystem)
+// buildVideoRoiEntries (pure zip-entry builder)
 // ---------------------------------------------------------------------------
 
-describe('exportImageJRois', () => {
+function line(
+  trackId: string | null,
+  pts: Array<[number, number]>,
+  geometry: 'polyline' | 'polygon' = 'polyline'
+) {
+  return {
+    trackId,
+    geometry,
+    points: pts.map(([x, y]) => ({ x, y })),
+  };
+}
+
+/** Index built entries by name for convenient assertions. */
+function byName(entries: RoiZipEntry[]): Map<string, RoiZipEntry> {
+  return new Map(entries.map(e => [e.name, e]));
+}
+
+describe('buildVideoRoiEntries', () => {
+  it('places each ROI on its 1-based slice with a per-track stroke colour', () => {
+    const frames: RoiFrameInput[] = [
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [10, 10],
+              [20, 25],
+            ]),
+          ]),
+        },
+      },
+      {
+        id: 'f2',
+        name: 'v.nd2 (frame 3)',
+        parentVideoId: 'c1',
+        frameIndex: 2,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [12, 12],
+              [22, 27],
+            ]),
+          ]),
+        },
+      },
+    ];
+
+    const build = buildVideoRoiEntries(frames);
+    expect(build.entries.map(e => e.name)).toEqual([
+      '7__frame_0000.roi',
+      '7__frame_0002.roi',
+    ]);
+
+    const map = byName(build.entries);
+    const f0 = decodeRoi(map.get('7__frame_0000.roi')!.buffer);
+    const f2 = decodeRoi(map.get('7__frame_0002.roi')!.buffer);
+    expect(f0.position).toBe(1); // frameIndex 0 → slice 1
+    expect(f2.position).toBe(3); // frameIndex 2 → slice 3
+    // Same track ⇒ identical colour across frames, and it must be a real
+    // opaque colour (alpha 0xFF), not the unset 0.
+    expect(f0.strokeColor).toBe(f2.strokeColor);
+    expect((f0.strokeColor >>> 24) & 0xff).toBe(0xff);
+  });
+
+  it('gives distinct tracks distinct colours', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'f0',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('a', [
+              [1, 1],
+              [2, 2],
+            ]),
+            line('b', [
+              [3, 3],
+              [4, 4],
+            ]),
+          ]),
+        },
+      },
+    ]);
+    const [a, b] = build.entries.map(e => decodeRoi(e.buffer));
+    expect(a.strokeColor).not.toBe(b.strokeColor);
+  });
+
+  it('processes frames in frameIndex order regardless of input order', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'f2',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 2,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [1, 1],
+              [2, 2],
+            ]),
+          ]),
+        },
+      },
+      {
+        id: 'f0',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [1, 1],
+              [2, 2],
+            ]),
+          ]),
+        },
+      },
+    ]);
+    expect(build.entries.map(e => e.name)).toEqual([
+      '7__frame_0000.roi',
+      '7__frame_0002.roi',
+    ]);
+  });
+
+  it('dedups colliding labels within a frame and drops degenerate geometry', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'f0',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('7', [
+              [1, 1],
+              [2, 2],
+            ]),
+            line('7', [
+              [9, 9],
+              [8, 8],
+            ]), // duplicate trackId same frame → suffixed
+            line('bad', [[5, 5]]), // < 2 points → dropped
+          ]),
+        },
+      },
+    ]);
+    const names = build.entries.map(e => e.name).sort();
+    // Sorted: '2' (0x32) < '_' (0x5F), so '7_2__' precedes '7__'.
+    expect(names).toEqual(['7_2__frame_0000.roi', '7__frame_0000.roi']);
+    expect(build.droppedPolygons).toBe(1);
+    expect(build.framesWithRois).toBe(1);
+  });
+
+  it('counts corrupt-JSON frames and drops non-finite polygons', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'bad',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: { polygons: '{not json' },
+      },
+      {
+        id: 'f1',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 1,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('ok', [
+              [1, 1],
+              [2, 2],
+            ]),
+            line('nan', [
+              [Number.NaN, 5],
+              [1, 2],
+            ]),
+          ]),
+        },
+      },
+    ]);
+    expect(build.corruptFrames).toBe(1);
+    expect(build.droppedPolygons).toBe(1);
+    expect(build.entries.map(e => e.name)).toEqual(['ok__frame_0001.roi']);
+  });
+
+  it('falls back to a generated label for untracked / empty-trackId polylines', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'f0',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('', [
+              [1, 1],
+              [2, 2],
+            ]),
+            line('', [
+              [3, 3],
+              [4, 4],
+            ]),
+          ]),
+        },
+      },
+    ]);
+    const names = build.entries.map(e => e.name).sort();
+    expect(names).toEqual([
+      'roi_0001__frame_0000.roi',
+      'roi_0002__frame_0000.roi',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportImageJRoiSets (real temp-dir filesystem)
+// ---------------------------------------------------------------------------
+
+describe('exportImageJRoiSets', () => {
   const tmpDirs: string[] = [];
 
   afterAll(async () => {
@@ -319,27 +675,13 @@ describe('exportImageJRois', () => {
   });
 
   async function mkTmp(): Promise<string> {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'roi-test-'));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'roizip-test-'));
     tmpDirs.push(dir);
     return dir;
   }
 
-  function line(
-    trackId: string | null,
-    pts: Array<[number, number]>,
-    geometry: 'polyline' | 'polygon' = 'polyline'
-  ) {
-    return {
-      trackId,
-      geometry,
-      points: pts.map(([x, y]) => ({ x, y })),
-    };
-  }
-
-  it('writes loose per-frame files named by trackId, skipping containers and empty frames', async () => {
+  it('writes one <video>_RoiSet.zip per container, skipping empty frames', async () => {
     const out = await mkTmp();
-    // Real MT frame names look like "<original>.nd2 (frame N)" — path.parse
-    // would mangle them, so folders must key on (container, frameIndex).
     const frames: RoiFrameInput[] = [
       {
         id: 'c1',
@@ -362,7 +704,6 @@ describe('exportImageJRois', () => {
               [50, 60],
               [70, 80],
             ]),
-            line('bad', [[5, 5]]), // < 2 points → dropped
           ]),
         },
       },
@@ -371,26 +712,26 @@ describe('exportImageJRois', () => {
         name: 'sample_60x.nd2 (frame 2)',
         parentVideoId: 'c1',
         frameIndex: 1,
-        segmentation: { polygons: JSON.stringify([]) }, // no folder
+        segmentation: { polygons: JSON.stringify([]) }, // no ROIs
       },
     ];
 
-    const result = await exportImageJRois(frames, out, 'proj');
+    const result = await exportImageJRoiSets(frames, out, 'proj');
     expect(result).toEqual({ frames: 1, rois: 2, warnings: [] });
 
     const base = path.join(out, 'annotations', 'imagej');
-    // Grouped under the clean container name, then numeric frame index.
-    expect(await fs.readdir(base)).toEqual(['sample_60x']);
-    expect(await fs.readdir(path.join(base, 'sample_60x'))).toEqual([
-      'frame_0000',
-    ]); // empty frame 1 produced no folder
-    const frame0 = await fs.readdir(
-      path.join(base, 'sample_60x', 'frame_0000')
-    );
-    expect(frame0.sort()).toEqual(['1.roi', '2.roi']);
+    expect(await fs.readdir(base)).toEqual(['sample_60x_RoiSet.zip']);
+
+    const zip = await fs.readFile(path.join(base, 'sample_60x_RoiSet.zip'));
+    expect(zip.subarray(0, 2).toString('ascii')).toBe('PK'); // local file header
+    expect(zipEntryCount(zip)).toBe(2);
+    expect(zipEntryNames(zip).sort()).toEqual([
+      '1__frame_0000.roi',
+      '2__frame_0000.roi',
+    ]);
   });
 
-  it('separates frames from different videos that share a frameIndex (multi-position ND2)', async () => {
+  it('separates videos that share a frameIndex (multi-position ND2)', async () => {
     const out = await mkTmp();
     const frames: RoiFrameInput[] = [
       {
@@ -435,167 +776,55 @@ describe('exportImageJRois', () => {
       },
     ];
 
-    const result = await exportImageJRois(frames, out, 'proj');
+    const result = await exportImageJRoiSets(frames, out, 'proj');
     expect(result.rois).toBe(2);
-
     const base = path.join(out, 'annotations', 'imagej');
-    expect((await fs.readdir(base)).sort()).toEqual(['D03_0000', 'D05_0000']);
-    expect(await fs.readdir(path.join(base, 'D03_0000', 'frame_0000'))).toEqual(
-      ['1.roi']
-    );
-    expect(await fs.readdir(path.join(base, 'D05_0000', 'frame_0000'))).toEqual(
-      ['1.roi']
-    );
+    expect((await fs.readdir(base)).sort()).toEqual([
+      'D03_0000_RoiSet.zip',
+      'D05_0000_RoiSet.zip',
+    ]);
   });
 
-  it('keeps the same trackId name across frames and suffixes collisions', async () => {
+  it('the zip round-trips real ROI bytes (position + colour survive deflate)', async () => {
     const out = await mkTmp();
     const frames: RoiFrameInput[] = [
       { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
       {
-        id: 'f0',
-        name: 'v.nd2 (frame 1)',
+        id: 'f4',
+        name: 'v.nd2 (frame 5)',
         parentVideoId: 'c1',
-        frameIndex: 0,
+        frameIndex: 4,
         segmentation: {
           polygons: JSON.stringify([
-            line('7', [
-              [10, 10],
-              [20, 25],
+            line('mt_42', [
+              [10.5, 20.25],
+              [30.75, 40],
+              [55.5, 12.5],
             ]),
           ]),
         },
       },
-      {
-        id: 'f1',
-        name: 'v.nd2 (frame 2)',
-        parentVideoId: 'c1',
-        frameIndex: 1,
-        segmentation: {
-          polygons: JSON.stringify([
-            line('7', [
-              [12, 12],
-              [22, 27],
-            ]),
-            line('7', [
-              [99, 99],
-              [88, 88],
-            ]), // duplicate trackId in the same frame
-            line(
-              null,
-              [
-                [1, 1],
-                [2, 2],
-                [3, 3],
-              ],
-              'polygon'
-            ), // untracked → generated fallback name
-          ]),
-        },
-      },
     ];
-
-    const result = await exportImageJRois(frames, out, 'proj');
-    expect(result.rois).toBe(4);
-
-    const base = path.join(out, 'annotations', 'imagej', 'v');
-    // trackId 7 present in both frames under the identical filename
-    const f0 = await fs.readdir(path.join(base, 'frame_0000'));
-    expect(f0).toEqual(['7.roi']);
-    const f1 = (await fs.readdir(path.join(base, 'frame_0001'))).sort();
-    expect(f1).toContain('7.roi');
-    expect(f1).toContain('7_2.roi'); // collision-suffixed, no overwrite
-    expect(f1.some(n => n.startsWith('roi_'))).toBe(true); // untracked fallback
-
-    // internal ROI name is stable across frames
-    const roiF0 = decodeRoi(
-      await fs.readFile(path.join(base, 'frame_0000', '7.roi'))
+    await exportImageJRoiSets(frames, out, 'proj');
+    const zip = await fs.readFile(
+      path.join(out, 'annotations', 'imagej', 'v_RoiSet.zip')
     );
-    const roiF1 = decodeRoi(
-      await fs.readFile(path.join(base, 'frame_0001', '7.roi'))
+    const roi = decodeRoi(zipExtract(zip, 'mt_42__frame_0004.roi'));
+    expect(roi.type).toBe(ROI_TYPE_POLYLINE);
+    expect(roi.position).toBe(5); // frameIndex 4 → slice 5
+    expect(roi.coords).toEqual([
+      [10.5, 20.25],
+      [30.75, 40],
+      [55.5, 12.5],
+    ]);
+    // mt_42 → hsl(62,70%,55%) → rgb(215,221,60), opaque.
+    expect(roi.strokeColor).toBe(
+      ((0xff << 24) | (215 << 16) | (221 << 8) | 60) >>> 0
     );
-    expect(roiF0.name).toBe('7');
-    expect(roiF1.name).toBe('7');
+    expect(roi.name).toBe('mt_42');
   });
 
-  it('returns a warning (not an error) when there is nothing to export', async () => {
-    const out = await mkTmp();
-    const result = await exportImageJRois(
-      [{ id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null }],
-      out,
-      'proj'
-    );
-    expect(result.rois).toBe(0);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toMatch(/no microtubule polylines/i);
-  });
-
-  it('falls through empty-string trackId to a generated name (no identity collapse)', async () => {
-    const out = await mkTmp();
-    const frames: RoiFrameInput[] = [
-      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
-      {
-        id: 'f0',
-        name: 'v.nd2 (frame 1)',
-        parentVideoId: 'c1',
-        frameIndex: 0,
-        segmentation: {
-          polygons: JSON.stringify([
-            line('', [
-              [10, 10],
-              [20, 25],
-            ]), // empty trackId
-            line('', [
-              [30, 30],
-              [40, 45],
-            ]), // empty trackId again
-          ]),
-        },
-      },
-    ];
-    const result = await exportImageJRois(frames, out, 'proj');
-    expect(result.rois).toBe(2);
-    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
-    const files = (await fs.readdir(dir)).sort();
-    // Distinct generated names, NOT a collapsed "export.roi"/"export_2.roi".
-    expect(files).toEqual(['roi_0001.roi', 'roi_0002.roi']);
-    const names = await Promise.all(
-      files.map(async f => decodeRoi(await fs.readFile(path.join(dir, f))).name)
-    );
-    expect(new Set(names).size).toBe(2); // distinct internal names
-  });
-
-  it('suffixes distinct labels that sanitize to the same filename (no overwrite)', async () => {
-    const out = await mkTmp();
-    const frames: RoiFrameInput[] = [
-      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
-      {
-        id: 'f0',
-        name: 'v.nd2 (frame 1)',
-        parentVideoId: 'c1',
-        frameIndex: 0,
-        segmentation: {
-          polygons: JSON.stringify([
-            line('a/b', [
-              [10, 10],
-              [20, 25],
-            ]), // sanitizes to a_b
-            line('a:b', [
-              [30, 30],
-              [40, 45],
-            ]), // also sanitizes to a_b
-          ]),
-        },
-      },
-    ];
-    const result = await exportImageJRois(frames, out, 'proj');
-    expect(result.rois).toBe(2); // both written, neither overwritten
-    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
-    const files = (await fs.readdir(dir)).sort();
-    expect(files).toEqual(['a_b.roi', 'a_b_2.roi']);
-  });
-
-  it('skips a corrupt-JSON frame with a user-facing warning while exporting valid frames', async () => {
+  it('skips a corrupt-JSON frame with a warning while exporting valid frames', async () => {
     const out = await mkTmp();
     const frames: RoiFrameInput[] = [
       { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
@@ -621,40 +850,25 @@ describe('exportImageJRois', () => {
         segmentation: { polygons: '{not valid json' },
       },
     ];
-    const result = await exportImageJRois(frames, out, 'proj');
-    expect(result.rois).toBe(1); // valid frame still exported
+    const result = await exportImageJRoiSets(frames, out, 'proj');
+    expect(result.rois).toBe(1);
     expect(result.warnings.some(w => /corrupt/i.test(w))).toBe(true);
-    const base = path.join(out, 'annotations', 'imagej', 'v');
-    expect(await fs.readdir(base)).toEqual(['frame_0000']); // no folder for bad
   });
 
-  it('drops polygons with non-finite coordinates instead of emitting NaN ROIs', async () => {
+  it('returns a warning (not an error) when there is nothing to export', async () => {
     const out = await mkTmp();
-    const frames: RoiFrameInput[] = [
-      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
-      {
-        id: 'f0',
-        name: 'v.nd2 (frame 1)',
-        parentVideoId: 'c1',
-        frameIndex: 0,
-        segmentation: {
-          polygons: JSON.stringify([
-            line('ok', [
-              [1, 1],
-              [2, 2],
-            ]),
-            line('nan', [
-              [Number.NaN, 5],
-              [1, 2],
-            ]), // dropped
-          ]),
-        },
-      },
-    ];
-    const result = await exportImageJRois(frames, out, 'proj');
-    expect(result.rois).toBe(1);
-    const dir = path.join(out, 'annotations', 'imagej', 'v', 'frame_0000');
-    expect(await fs.readdir(dir)).toEqual(['ok.roi']);
+    const result = await exportImageJRoiSets(
+      [{ id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null }],
+      out,
+      'proj'
+    );
+    expect(result.rois).toBe(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/no microtubule polylines/i);
+    // No zip written for an empty export.
+    await expect(
+      fs.readdir(path.join(out, 'annotations', 'imagej'))
+    ).rejects.toThrow();
   });
 
   it('rejects when the job is cancelled mid-export', async () => {
@@ -677,7 +891,7 @@ describe('exportImageJRois', () => {
       },
     ];
     await expect(
-      exportImageJRois(frames, out, 'proj', { shouldAbort: () => true })
+      exportImageJRoiSets(frames, out, 'proj', { shouldAbort: () => true })
     ).rejects.toThrow(/cancel/i);
   });
 });

--- a/backend/src/services/export/imagejColor.ts
+++ b/backend/src/services/export/imagejColor.ts
@@ -1,0 +1,97 @@
+/**
+ * ImageJ ROI stroke-colour derivation.
+ *
+ * Mirrors the frontend `src/pages/segmentation/utils/instanceColors.ts` so a
+ * microtubule exported to a `.roi` gets the SAME colour it shows in the editor.
+ * The FE renders `hsl(hue, 70%, 55%)` from a djb2-style hash of the polyline's
+ * colour key (cross-frame trackId first). ImageJ stores a stroke colour as a
+ * single ARGB int, so here we reproduce that exact hue hash, convert HSL→RGB,
+ * and pack it with an opaque alpha.
+ *
+ * Parity is enforced by `__tests__/imagejColor.test.ts`: the integer hue math
+ * is byte-identical to the FE loop, so a drift fails loudly rather than shipping
+ * mismatched export colours.
+ */
+
+/** Minimal shape needed to pick a colour key — a subset of the polygon row. */
+export interface RoiColorInput {
+  trackId?: string | null;
+  instanceId?: string | null;
+  id?: string | null;
+}
+
+// Fixed saturation / lightness for the unselected editor state. The export
+// never renders a "selected" ROI, so the +selection shift is not reproduced.
+const SAT = 0.7;
+const LIGHT = 0.55;
+
+// Neutral gray for empty keys — matches the FE NEUTRAL_COLOR `hsl(0, 0%, 60%)`
+// so a malformed / identity-less polyline doesn't masquerade as a real colour.
+const NEUTRAL_GRAY = Math.round(0.6 * 255); // 153
+
+/**
+ * Colour-key precedence identical to `CanvasPolygon.tsx`: cross-frame trackId,
+ * then an `mt_`-prefixed instanceId, then the per-polygon id. Guarantees a
+ * distinct-but-stable colour per microtubule across every frame.
+ */
+export function colorKeyForRoi(p: RoiColorInput): string {
+  if (p.trackId) return p.trackId;
+  if (typeof p.instanceId === 'string' && p.instanceId.startsWith('mt_')) {
+    return p.instanceId;
+  }
+  return p.id ?? '';
+}
+
+/**
+ * djb2-style hash → hue in [0, 359]. Byte-identical to the FE hash loop
+ * (`hash = ((hash << 5) - hash + charCode) | 0`) so exported hues match.
+ */
+export function hueFromColorKey(key: string): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % 360;
+}
+
+/** Standard HSL→RGB. h in [0, 360), s/l in [0, 1] → [r, g, b] as 0–255 ints. */
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+}
+
+/**
+ * ImageJ stroke colour as an ARGB int (alpha in the high byte) for a polyline's
+ * colour key. Alpha is forced opaque (`0xFF`) because ImageJ's RoiDecoder reads
+ * a value whose bytes are all zero as "no stroke colour set". The returned int
+ * is unsigned; write it with `Buffer.writeUInt32BE` at the STROKE_COLOR offset.
+ */
+export function imageJStrokeColor(colorKey: string): number {
+  if (!colorKey) {
+    return (
+      ((0xff << 24) |
+        (NEUTRAL_GRAY << 16) |
+        (NEUTRAL_GRAY << 8) |
+        NEUTRAL_GRAY) >>>
+      0
+    );
+  }
+  const hue = hueFromColorKey(colorKey);
+  const [r, g, b] = hslToRgb(hue, SAT, LIGHT);
+  return ((0xff << 24) | (r << 16) | (g << 8) | b) >>> 0;
+}

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -158,7 +158,9 @@ export function encodeImageJRoi(
     buf.writeUInt32BE(options.strokeColor >>> 0, STROKE_COLOR_OFFSET);
   }
   if (options?.position && options.position > 0) {
-    buf.writeInt32BE(options.position, POSITION_OFFSET);
+    // POSITION is an int32 slice index; truncate defensively so a fractional
+    // value never reaches writeInt32BE (which would throw).
+    buf.writeInt32BE(Math.trunc(options.position), POSITION_OFFSET);
   }
 
   // ---- Coordinates (64..) ----
@@ -508,6 +510,7 @@ export async function exportImageJRoiSets(
   let roisWritten = 0;
   let corruptFrames = 0;
   let droppedPolygons = 0;
+  let failedVideos = 0;
   const usedZipNames = new Set<string>();
 
   // One zip per video, written sequentially to cap concurrent write streams.
@@ -529,11 +532,25 @@ export async function exportImageJRoiSets(
     }
     usedZipNames.add(zipName.toLowerCase());
 
-    await fs.mkdir(baseDir, { recursive: true });
-    await writeRoiSetZip(path.join(baseDir, zipName), build.entries);
-
-    framesWritten += build.framesWithRois;
-    roisWritten += build.entries.length;
+    const zipPath = path.join(baseDir, zipName);
+    try {
+      await fs.mkdir(baseDir, { recursive: true });
+      await writeRoiSetZip(zipPath, build.entries);
+      framesWritten += build.framesWithRois;
+      roisWritten += build.entries.length;
+    } catch (error) {
+      // One video's zip failing must not drop the rest. Remove the partial
+      // (possibly truncated) file so a corrupt zip is never shipped, record a
+      // per-video warning, and continue with the remaining videos.
+      failedVideos++;
+      await fs.rm(zipPath, { force: true }).catch(() => {});
+      logger.error(
+        `ImageJ RoiSet export failed for video "${label}"`,
+        error instanceof Error ? error : new Error(String(error)),
+        'imagejRoiEncoder',
+        { projectId, videoKey }
+      );
+    }
   }
 
   if (droppedPolygons > 0) {
@@ -545,6 +562,11 @@ export async function exportImageJRoiSets(
   }
 
   const warnings: string[] = [];
+  if (failedVideos > 0) {
+    warnings.push(
+      `ImageJ ROI export: ${failedVideos} video(s) could not be packaged into a RoiSet.zip and were skipped.`
+    );
+  }
   if (corruptFrames > 0) {
     warnings.push(
       `ImageJ ROI export: ${corruptFrames} frame(s) had corrupt polygon data and were skipped.`

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -13,8 +13,10 @@
  *   6    ROI type (uint8): 0 = polygon, 5 = polyline  (on-disk codes)
  *   8    top / 10 left / 12 bottom / 14 right  (int16 integer bounding box)
  *   16   nCoordinates (int16)
+ *   40   stroke colour (uint32 ARGB): 0 = unset; set for per-track colouring
  *   50   options (int16): SUB_PIXEL_RESOLUTION (128) is always set here
- *   56   position (int32): left 0 — loose per-frame files aren't slice-associated
+ *   56   position (int32): 0 = unset; the 1-based stack slice for RoiSet.zip
+ *        exports so each ROI lands on its own video frame
  *   60   header2 offset (int32)
  *   64   integer coords: x[n] then y[n] (int16; x relative to left, y to top)
  *   64+4n  float32 x[n] (absolute), then float32 y[n]  ← authoritative geometry
@@ -27,11 +29,12 @@
  */
 
 import * as path from 'path';
-import { promises as fs } from 'fs';
+import { promises as fs, createWriteStream } from 'fs';
+import archiver from 'archiver';
 import type { PolygonPoint } from '../../types/polygon';
 import { logger } from '../../utils/logger';
-import { mapWithConcurrency } from '../../utils/concurrency';
 import { sanitizeFilename } from './exportFileOperations';
+import { colorKeyForRoi, imageJStrokeColor } from './imagejColor';
 
 // ---------------------------------------------------------------------------
 //  Low-level encoder
@@ -53,6 +56,10 @@ const HEADER2_SIZE = 64;
 const ROI_TYPE_POLYGON = 0;
 const ROI_TYPE_POLYLINE = 5;
 
+// header field offsets used for the optional stroke colour + slice position.
+const STROKE_COLOR_OFFSET = 40;
+const POSITION_OFFSET = 56;
+
 // options flags (RoiDecoder)
 const SUB_PIXEL_RESOLUTION = 128;
 
@@ -70,6 +77,21 @@ function putShort(buf: Buffer, offset: number, value: number): void {
   buf.writeUInt16BE(value & 0xffff, offset);
 }
 
+/** Optional ImageJ header fields for slice-aware, colour-coded ROIs. */
+export interface RoiEncodeOptions {
+  /**
+   * 1-based stack slice this ROI belongs to (ImageJ POSITION @56). Lets a
+   * RoiSet.zip place each ROI on its own video frame. Omit / 0 leaves it unset.
+   */
+  position?: number;
+  /**
+   * ARGB stroke colour (alpha in the high byte, `0xFF` = opaque). ImageJ reads
+   * an all-zero value as "no colour set", so pass a value with alpha. Omit to
+   * leave the ROI at ImageJ's default colour.
+   */
+  strokeColor?: number;
+}
+
 /**
  * Encode a single polyline/polygon into an ImageJ ``.roi`` byte buffer.
  *
@@ -79,11 +101,13 @@ function putShort(buf: Buffer, offset: number, value: number): void {
  *                 ≥3 points).
  * @param name     ROI name embedded in header2 (shown in RoiManager). Empty
  *                 string / undefined omits the name block.
+ * @param options  Optional slice position + stroke colour (see RoiEncodeOptions).
  */
 export function encodeImageJRoi(
   points: RoiPoint[],
   geometry: RoiGeometry,
-  name?: string
+  name?: string,
+  options?: RoiEncodeOptions
 ): Buffer {
   const n = points.length;
   const minPoints = geometry === 'polygon' ? 3 : 2;
@@ -115,7 +139,7 @@ export function encodeImageJRoi(
 
   const buf = Buffer.alloc(totalSize); // zero-filled: unset fields stay 0
 
-  // ---- Header (0..63) ----  (position @56 intentionally left 0)
+  // ---- Header (0..63) ----
   buf.write(MAGIC, 0, 'ascii');
   putShort(buf, 4, VERSION);
   buf.writeUInt8(roiType, 6);
@@ -126,6 +150,16 @@ export function encodeImageJRoi(
   putShort(buf, 16, n);
   putShort(buf, 50, SUB_PIXEL_RESOLUTION);
   buf.writeInt32BE(header2Offset, 60);
+
+  // Optional stroke colour (ARGB, unsigned) + 1-based slice position. Left 0
+  // (already zero-filled) when the caller omits them, preserving the exact
+  // byte layout the golden-file test pins for the no-options path.
+  if (options?.strokeColor) {
+    buf.writeUInt32BE(options.strokeColor >>> 0, STROKE_COLOR_OFFSET);
+  }
+  if (options?.position && options.position > 0) {
+    buf.writeInt32BE(options.position, POSITION_OFFSET);
+  }
 
   // ---- Coordinates (64..) ----
   const intXBase = HEADER_SIZE;
@@ -166,9 +200,9 @@ export interface RoiFrameInput {
 }
 
 export interface ImageJRoiExportResult {
-  /** Frames that produced at least one .roi file. */
+  /** Frames that contributed at least one ROI to a zip. */
   frames: number;
-  /** Total .roi files written. */
+  /** Total ROI entries written across all RoiSet.zip files. */
   rois: number;
   /** User-facing, non-fatal warnings (e.g. corrupt frames skipped). */
   warnings: string[];
@@ -182,8 +216,6 @@ interface RawPolygon {
   instanceId?: string;
   trackId?: string | null;
 }
-
-const FRAME_WRITE_CONCURRENCY = 8;
 
 /**
  * Parse a frame's polygons JSON, distinguishing "no polygons" from "corrupt".
@@ -254,63 +286,197 @@ function roiLabel(p: RawPolygon, index: number): string {
 }
 
 /**
- * Per-frame output folder: ``<videoLabel>/frame_<NNNN>``.
- *
- * The frame's own display name is unusable as a key — real MT frames are named
- * ``"<original>.nd2 (frame 1)"``, on which ``path.parse().name`` amputates the
- * ``.nd2 (frame 1)`` "extension" and collapses every frame to one folder. So we
- * key on the structured ``(parentVideoId, frameIndex)`` instead:
- *  - videoLabel comes from the container row's name (a clean filename), which
- *    also disambiguates multi-position ND2 splits (one container per position);
- *  - frameIndex gives a guaranteed-unique numeric suffix within a video.
- *
- * @param containerNames  parentVideoId → container display name.
+ * Frame slice label ``frame_NNNN`` from the structured frameIndex — NOT the
+ * display name, which for real MT frames is ``"<original>.nd2 (frame 1)"`` and
+ * would collapse under ``path.parse``. Falls back to the sanitised id.
  */
-function frameFolderName(
-  frame: RoiFrameInput,
-  containerNames: Map<string, string>
-): string {
-  const containerName = frame.parentVideoId
-    ? containerNames.get(frame.parentVideoId)
-    : undefined;
-
-  let videoLabel: string;
-  if (containerName) {
-    // Container names are real filenames (no "(frame N)" suffix), so stripping
-    // the extension here is safe and yields a readable video folder.
-    videoLabel = sanitizeFilename(path.parse(containerName).name);
-  } else if (frame.parentVideoId) {
-    videoLabel = `video_${frame.parentVideoId.slice(0, 8)}`;
-  } else {
-    videoLabel = 'video';
-  }
-
-  const frameLabel =
-    typeof frame.frameIndex === 'number'
-      ? `frame_${String(frame.frameIndex).padStart(4, '0')}`
-      : sanitizeFilename(frame.id);
-
-  return path.join(videoLabel, frameLabel);
+function frameLabelFor(frame: RoiFrameInput): string {
+  return typeof frame.frameIndex === 'number'
+    ? `frame_${String(frame.frameIndex).padStart(4, '0')}`
+    : sanitizeFilename(frame.id);
 }
 
 /**
- * Write ImageJ ``.roi`` files for every segmented frame of a microtubule
- * export. Output layout (loose files, grouped per frame):
+ * Clean, human-readable label for a video's RoiSet.zip. The container row's
+ * name is a real filename (no "(frame N)" suffix), so stripping the extension
+ * is safe; multi-position ND2 splits already yield one container per position,
+ * so the label also disambiguates them.
+ */
+function videoZipLabel(
+  videoKey: string,
+  containerNames: Map<string, string>
+): string {
+  if (videoKey === NO_VIDEO_KEY) return 'video';
+  const name = containerNames.get(videoKey);
+  if (name) return sanitizeFilename(path.parse(name).name);
+  return `video_${videoKey.slice(0, 8)}`;
+}
+
+/** Sentinel bucket for the rare MT frame with no parentVideoId. */
+const NO_VIDEO_KEY = '__novideo__';
+
+/** A single entry in a RoiSet.zip: the on-disk name + the encoded ROI bytes. */
+export interface RoiZipEntry {
+  /** Entry name including the ``.roi`` extension (becomes the ROI-Manager name). */
+  name: string;
+  buffer: Buffer;
+}
+
+export interface VideoRoiBuild {
+  entries: RoiZipEntry[];
+  framesWithRois: number;
+  corruptFrames: number;
+  droppedPolygons: number;
+}
+
+/**
+ * Build the ImageJ ``.roi`` zip entries for ONE video's frames. Pure (no IO)
+ * so the exact bytes — slice position, per-track stroke colour, geometry, and
+ * entry names — are unit-testable with the inline decoder.
  *
- *   annotations/imagej/<video>/frame_NNNN/<roiLabel>.roi
+ * Frames are processed in frameIndex order. Each ROI carries ``position =
+ * frameIndex + 1`` (1-based ImageJ slice) and a stroke colour derived from its
+ * track (identical hue to the editor). Entry names are ``<label>__frame_NNNN``
+ * (MT-first) so the same microtubule's ROIs sort together in the ROI Manager
+ * and every name is unique within the zip.
  *
- * Both open polylines (→ ImageJ POLYLINE) and any closed polygons (→ POLYGON)
- * are emitted; MT projects are polyline-only in practice.
+ * Degradation matches the rest of the export: corrupt-JSON frames are counted
+ * (surfaced as a warning by the caller), and polygons with too few / non-finite
+ * points are dropped and counted.
+ */
+export function buildVideoRoiEntries(frames: RoiFrameInput[]): VideoRoiBuild {
+  const ordered = [...frames].sort(
+    (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
+  );
+
+  const entries: RoiZipEntry[] = [];
+  let framesWithRois = 0;
+  let corruptFrames = 0;
+  let droppedPolygons = 0;
+  const usedEntryNames = new Set<string>();
+
+  for (const frame of ordered) {
+    const parsed = parseFramePolygons(frame.segmentation?.polygons);
+    if (parsed.corrupt) {
+      corruptFrames++;
+      continue;
+    }
+
+    const frameLabel = frameLabelFor(frame);
+    const position =
+      typeof frame.frameIndex === 'number' ? frame.frameIndex + 1 : undefined;
+
+    // Normalise to concrete items, dropping degenerate geometry (polyline < 2 /
+    // polygon < 3) and any polygon with non-finite coordinates. Missing geometry
+    // defaults to 'polyline' — MT annotations are always open polylines.
+    const items = parsed.polygons
+      .map((p, index) => {
+        const geometry: RoiGeometry =
+          p.geometry === 'polygon' ? 'polygon' : 'polyline';
+        return {
+          geometry,
+          points: validPoints(p.points),
+          label: roiLabel(p, index),
+          strokeColor: imageJStrokeColor(colorKeyForRoi(p)),
+        };
+      })
+      .filter(it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3));
+
+    droppedPolygons += parsed.polygons.length - items.length;
+    if (items.length === 0) continue;
+
+    // Dedup labels within the frame first (distinct MTs that sanitise to the
+    // same base must not collide), then suffix the unique frame label.
+    const usedInFrame = new Set<string>();
+    let frameRois = 0;
+    for (const { geometry, points, label, strokeColor } of items) {
+      const base = sanitizeFilename(label);
+      let labelCandidate = base;
+      let dupe = 2;
+      while (usedInFrame.has(labelCandidate.toLowerCase())) {
+        labelCandidate = `${base}_${dupe++}`;
+      }
+      usedInFrame.add(labelCandidate.toLowerCase());
+
+      // frameLabel is unique per frame, so cross-frame collisions cannot occur;
+      // this guard only defends against a pathological repeat.
+      let entryStem = `${labelCandidate}__${frameLabel}`;
+      let extra = 2;
+      while (usedEntryNames.has(entryStem.toLowerCase())) {
+        entryStem = `${labelCandidate}__${frameLabel}_${extra++}`;
+      }
+      usedEntryNames.add(entryStem.toLowerCase());
+
+      const buffer = encodeImageJRoi(points, geometry, label, {
+        position,
+        strokeColor,
+      });
+      entries.push({ name: `${entryStem}.roi`, buffer });
+      frameRois++;
+    }
+    if (frameRois > 0) framesWithRois++;
+  }
+
+  return { entries, framesWithRois, corruptFrames, droppedPolygons };
+}
+
+/**
+ * Stream a video's ROI entries into a single deflated RoiSet.zip. Kept separate
+ * from `buildVideoRoiEntries` so the byte generation stays pure/testable and
+ * only this thin wrapper touches the filesystem.
+ */
+async function writeRoiSetZip(
+  zipPath: string,
+  entries: RoiZipEntry[]
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const output = createWriteStream(zipPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    let settled = false;
+    const fail = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    output.on('close', () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+    output.on('error', fail);
+    // A zip 'warning' (e.g. a stat failure) would silently truncate the archive,
+    // so treat it as fatal for correctness.
+    archive.on('warning', fail);
+    archive.on('error', fail);
+    archive.pipe(output);
+    for (const entry of entries) {
+      archive.append(entry.buffer, { name: entry.name });
+    }
+    archive.finalize().catch(fail);
+  });
+}
+
+/**
+ * Export one ImageJ **RoiSet.zip per video** for a microtubule project:
+ *
+ *   annotations/imagej/<video>_RoiSet.zip
+ *
+ * Biologists drag the single zip into ImageJ / Fiji; the ROI Manager loads
+ * every microtubule polyline, each placed on its own stack slice (via the ROI
+ * position) and coloured per track (matching the editor). Both open polylines
+ * (→ ImageJ POLYLINE) and any closed polygons (→ POLYGON) are emitted; MT
+ * projects are polyline-only in practice.
  *
  * Degradation: corrupt-JSON frames are skipped and reported via the returned
  * `warnings` (never silently dropped); polygons with too few / non-finite
  * points are dropped and logged. This function must NOT reject on routine bad
- * data — its caller treats a rejection as non-fatal, but keeping it total makes
- * that contract obvious.
+ * data — its caller treats a rejection as non-fatal — but a genuine
+ * cancellation stays fatal.
  *
  * @returns Counts + non-fatal warnings for the caller to fold into job.warnings.
  */
-export async function exportImageJRois(
+export async function exportImageJRoiSets(
   frameImages: RoiFrameInput[],
   exportDir: string,
   projectId: string,
@@ -319,7 +485,7 @@ export async function exportImageJRois(
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
 
   // Container rows (carried in the same images array) supply a clean, human
-  // readable video-folder label — build the lookup before filtering them out.
+  // readable video label — build the lookup before filtering them out.
   const containerNames = new Map<string, string>();
   for (const f of frameImages) {
     if (f.isVideoContainer && f.name) {
@@ -327,86 +493,48 @@ export async function exportImageJRois(
     }
   }
 
-  // Frames that actually carry segmentation geometry. Video container rows
-  // never hold polygons, so skip them.
-  const frames = frameImages.filter(
-    f => !f.isVideoContainer && !!f.segmentation?.polygons
-  );
+  // Segmented frames grouped by their video container (one zip each). Container
+  // rows never hold polygons, so skip them.
+  const byVideo = new Map<string, RoiFrameInput[]>();
+  for (const f of frameImages) {
+    if (f.isVideoContainer || !f.segmentation?.polygons) continue;
+    const key = f.parentVideoId ?? NO_VIDEO_KEY;
+    const arr = byVideo.get(key);
+    if (arr) arr.push(f);
+    else byVideo.set(key, [f]);
+  }
 
-  // Counters mutated by concurrent workers — safe because every increment is a
-  // synchronous statement with no interleaving await (single-threaded JS).
   let framesWritten = 0;
   let roisWritten = 0;
   let corruptFrames = 0;
   let droppedPolygons = 0;
+  const usedZipNames = new Set<string>();
 
-  await mapWithConcurrency(
-    frames,
-    FRAME_WRITE_CONCURRENCY,
-    async frame => {
-      const parsed = parseFramePolygons(frame.segmentation?.polygons);
-      if (parsed.corrupt) {
-        corruptFrames++;
-        return;
-      }
-
-      // Normalise to concrete {geometry, points, label} items, dropping
-      // degenerate geometry (polyline < 2 / polygon < 3) and any polygon with
-      // non-finite coordinates. Default missing geometry to 'polyline' — this
-      // is the MT-only path and MT annotations are always open polylines.
-      const items = parsed.polygons
-        .map((p, index) => {
-          const geometry: RoiGeometry =
-            p.geometry === 'polygon' ? 'polygon' : 'polyline';
-          return { geometry, points: validPoints(p.points), label: roiLabel(p, index) };
-        })
-        .filter(
-          it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3)
-        );
-
-      droppedPolygons += parsed.polygons.length - items.length;
-
-      if (items.length === 0) {
-        return;
-      }
-
-      const frameDir = path.join(
-        baseDir,
-        frameFolderName(frame, containerNames)
-      );
-      await fs.mkdir(frameDir, { recursive: true });
-
-      const usedNames = new Set<string>();
-      let frameRois = 0;
-
-      // Sequential within a frame so the max concurrent open file handles stays
-      // at FRAME_WRITE_CONCURRENCY — a frame can hold 100+ microtubules, and a
-      // parallel write per ROI × 8 frames would risk EMFILE.
-      for (const { geometry, points, label } of items) {
-        // Ensure a unique on-disk filename within the frame folder.
-        const fileBase = sanitizeFilename(label);
-        let candidate = fileBase;
-        let dupe = 2;
-        while (usedNames.has(candidate.toLowerCase())) {
-          candidate = `${fileBase}_${dupe++}`;
-        }
-        usedNames.add(candidate.toLowerCase());
-
-        const buf = encodeImageJRoi(points, geometry, label);
-        await fs.writeFile(path.join(frameDir, `${candidate}.roi`), buf);
-        frameRois++;
-      }
-
-      if (frameRois > 0) {
-        framesWritten++;
-        roisWritten += frameRois;
-      }
-    },
-    {
-      shouldAbort: options.shouldAbort,
-      abortMessage: 'Export cancelled by user',
+  // One zip per video, written sequentially to cap concurrent write streams.
+  for (const [videoKey, videoFrames] of byVideo) {
+    if (options.shouldAbort?.()) {
+      throw new Error('Export cancelled by user');
     }
-  );
+
+    const build = buildVideoRoiEntries(videoFrames);
+    corruptFrames += build.corruptFrames;
+    droppedPolygons += build.droppedPolygons;
+    if (build.entries.length === 0) continue;
+
+    const label = videoZipLabel(videoKey, containerNames);
+    let zipName = `${label}_RoiSet.zip`;
+    let dupe = 2;
+    while (usedZipNames.has(zipName.toLowerCase())) {
+      zipName = `${label}_RoiSet_${dupe++}.zip`;
+    }
+    usedZipNames.add(zipName.toLowerCase());
+
+    await fs.mkdir(baseDir, { recursive: true });
+    await writeRoiSetZip(path.join(baseDir, zipName), build.entries);
+
+    framesWritten += build.framesWithRois;
+    roisWritten += build.entries.length;
+  }
 
   if (droppedPolygons > 0) {
     logger.warn(
@@ -428,8 +556,9 @@ export async function exportImageJRois(
     );
   }
 
-  logger.info('ImageJ ROI export complete', 'imagejRoiEncoder', {
+  logger.info('ImageJ RoiSet.zip export complete', 'imagejRoiEncoder', {
     projectId,
+    videos: usedZipNames.size,
     frames: framesWritten,
     rois: roisWritten,
     corruptFrames,

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -48,7 +48,7 @@ import {
   exportMicrotubuleKymographs,
   type MTKymographOptions,
 } from './export/mtKymographExporter';
-import { exportImageJRois } from './export/imagejRoiEncoder';
+import { exportImageJRoiSets } from './export/imagejRoiEncoder';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
@@ -627,17 +627,18 @@ export class ExportService {
         );
       }
 
-      // ImageJ ROI files — ALWAYS bundled for MT projects (no toggle) so
+      // ImageJ ROI export — ALWAYS bundled for MT projects (no toggle) so
       // biologists can re-open microtubule polylines in ImageJ / Fiji
-      // (RoiManager, kymograph plugins). Written as loose `.roi` files grouped
-      // per frame under `annotations/imagej/<video>/frame_NNNN/`, named by
-      // cross-frame trackId when tracking ran. Independent of the selected
-      // annotation formats. Because this is always-on (the user did not opt in),
-      // a failure must NOT sink the whole export they did request: it degrades
-      // to a warning. Only a genuine cancellation stays fatal.
+      // (RoiManager, kymograph plugins). Written as one `RoiSet.zip` per video
+      // under `annotations/imagej/<video>_RoiSet.zip`; each ROI is placed on its
+      // own stack slice and coloured per cross-frame trackId (matching the
+      // editor). Independent of the selected annotation formats. Because this is
+      // always-on (the user did not opt in), a failure must NOT sink the whole
+      // export they did request: it degrades to a warning. Only a genuine
+      // cancellation stays fatal.
       if ((project.type ?? '') === 'microtubules' && project.images?.length) {
         exportTasks.push(
-          exportImageJRois(
+          exportImageJRoiSets(
             project.images as ImageWithSegmentation[],
             exportDir,
             project.id,

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -196,6 +196,62 @@ export function parsePolygonsJsonForDiff(
   }
 }
 
+/** Geometry the editor sends when propagating a microtubule forward. */
+export interface PropagatedPolyline {
+  trackId?: string | null;
+  name?: string | null;
+  geometry?: 'polygon' | 'polyline';
+  points: Array<{ x: number; y: number }>;
+}
+
+/**
+ * Remove every polygon carrying `trackId`. Returns the survivors plus the count
+ * removed. Shared by the explicit "delete whole track" endpoint and kept in
+ * lockstep with the save-time delete propagation so both paths agree on what
+ * "a track" is (all polylines with that trackId).
+ */
+export function removePolygonsWithTrackId(
+  polys: unknown[],
+  trackId: string
+): { polygons: unknown[]; removed: number } {
+  let removed = 0;
+  const polygons = polys.filter(p => {
+    if ((p as Record<string, unknown>).trackId === trackId) {
+      removed++;
+      return false;
+    }
+    return true;
+  });
+  return { polygons, removed };
+}
+
+/**
+ * Overwrite-or-insert a propagated polyline into one frame's polygon list: drop
+ * any existing polyline already carrying `trackId` (overwrite), then append a
+ * fresh copy that shares the trackId (add where missing). `makeId` supplies a
+ * unique per-polygon id so the frame's ids stay distinct.
+ */
+export function upsertTrackPolyline(
+  polys: unknown[],
+  trackId: string,
+  polyline: PropagatedPolyline,
+  makeId: () => string
+): unknown[] {
+  const { polygons } = removePolygonsWithTrackId(polys, trackId);
+  const copy: Record<string, unknown> = {
+    id: makeId(),
+    trackId,
+    type: 'external',
+    geometry: polyline.geometry === 'polygon' ? 'polygon' : 'polyline',
+    points: polyline.points.map(pt => ({ x: pt.x, y: pt.y })),
+    area: 0,
+    confidence: 1,
+  };
+  if (polyline.name) copy.name = polyline.name;
+  polygons.push(copy);
+  return polygons;
+}
+
 export interface SegmentationRequest {
   imageId: string;
   model?: KnownModelId;
@@ -2061,6 +2117,139 @@ export class SegmentationService {
       }
     }
     return ops;
+  }
+
+  /**
+   * Delete a whole microtubule track: remove every polyline carrying `trackId`
+   * from ALL frames of the video in a single transaction. This is the explicit,
+   * immediate counterpart to the save-time delete propagation
+   * (`computeCrossFrameTrackPropagation`) and shares `removePolygonsWithTrackId`
+   * so both paths agree on what a track is.
+   *
+   * @throws if the video is not found / not owned by the user.
+   */
+  async deleteTrackAcrossVideo(
+    videoId: string,
+    trackId: string,
+    userId: string
+  ): Promise<{ framesAffected: number }> {
+    // Ownership: the video container is an Image row the user must be able to access.
+    const container = await this.imageService.getImageById(videoId, userId);
+    if (!container) {
+      throw new Error('Video not found or no access');
+    }
+
+    const frames = await this.prisma.image.findMany({
+      where: { parentVideoId: videoId },
+      select: {
+        id: true,
+        segmentation: { select: { id: true, polygons: true } },
+      },
+    });
+
+    const ops: Prisma.PrismaPromise<unknown>[] = [];
+    let framesAffected = 0;
+    for (const frame of frames) {
+      if (!frame.segmentation) continue;
+      const parsed = parsePolygonsJsonForDiff(frame.segmentation.polygons, {
+        currentImageId: frame.id,
+        parentVideoId: videoId,
+      });
+      const { polygons, removed } = removePolygonsWithTrackId(parsed, trackId);
+      if (removed > 0) {
+        framesAffected++;
+        ops.push(
+          this.prisma.segmentation.update({
+            where: { id: frame.segmentation.id },
+            data: { polygons: JSON.stringify(polygons), updatedAt: new Date() },
+          })
+        );
+      }
+    }
+
+    if (ops.length > 0) {
+      await this.prisma.$transaction(ops);
+    }
+
+    logger.info('Deleted microtubule track across video', 'SegmentationService', {
+      videoId,
+      trackId,
+      framesAffected,
+    });
+    return { framesAffected };
+  }
+
+  /**
+   * Propagate a microtubule polyline forward: stamp `polyline`'s geometry into
+   * every frame of the video with `frameIndex > fromFrameIndex`, overwriting any
+   * existing polyline that already carries the track's id and adding it where
+   * missing. Runs in a single transaction so the video stays consistent.
+   *
+   * A trackId is generated (`mt_<hex>`) when the source polyline has none, so
+   * the propagated set forms one coherent, stably-coloured track; the generated
+   * id is returned for the editor to patch onto the source polyline. Frames with
+   * no segmentation row yet are skipped (there is nothing to attach to).
+   *
+   * @throws if the video is not owned or the polyline has fewer than 2 points.
+   */
+  async propagateTrackGeometryForward(
+    videoId: string,
+    fromFrameIndex: number,
+    polyline: PropagatedPolyline,
+    userId: string
+  ): Promise<{ trackId: string; framesUpdated: number }> {
+    const container = await this.imageService.getImageById(videoId, userId);
+    if (!container) {
+      throw new Error('Video not found or no access');
+    }
+    if (!Array.isArray(polyline.points) || polyline.points.length < 2) {
+      throw new Error('Propagated polyline needs at least 2 points');
+    }
+
+    const trackId =
+      typeof polyline.trackId === 'string' && polyline.trackId.length > 0
+        ? polyline.trackId
+        : `mt_${uuidv4().replace(/-/g, '').slice(0, 8)}`;
+
+    const frames = await this.prisma.image.findMany({
+      where: { parentVideoId: videoId, frameIndex: { gt: fromFrameIndex } },
+      select: {
+        id: true,
+        segmentation: { select: { id: true, polygons: true } },
+      },
+    });
+
+    const ops: Prisma.PrismaPromise<unknown>[] = [];
+    let framesUpdated = 0;
+    for (const frame of frames) {
+      // A frame that never segmented has no row to attach the polyline to; skip
+      // it rather than fabricate a partial segmentation record.
+      if (!frame.segmentation) continue;
+      const parsed = parsePolygonsJsonForDiff(frame.segmentation.polygons, {
+        currentImageId: frame.id,
+        parentVideoId: videoId,
+      });
+      const updated = upsertTrackPolyline(parsed, trackId, polyline, uuidv4);
+      ops.push(
+        this.prisma.segmentation.update({
+          where: { id: frame.segmentation.id },
+          data: { polygons: JSON.stringify(updated), updatedAt: new Date() },
+        })
+      );
+      framesUpdated++;
+    }
+
+    if (ops.length > 0) {
+      await this.prisma.$transaction(ops);
+    }
+
+    logger.info('Propagated microtubule track forward', 'SegmentationService', {
+      videoId,
+      trackId,
+      fromFrameIndex,
+      framesUpdated,
+    });
+    return { trackId, framesUpdated };
   }
 }
 

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -17,6 +17,7 @@ import { SegmentationThumbnailService } from './segmentationThumbnailService';
 import { ThumbnailManager } from './thumbnailManager';
 import { getStorageProvider } from '../storage/index';
 import { safeMlFilename } from '../utils/mlFilename';
+import { mapWithConcurrency } from '../utils/concurrency';
 
 export interface SegmentationPoint {
   x: number;
@@ -1796,6 +1797,47 @@ export class SegmentationService {
       imageId,
       userId,
     });
+  }
+
+  /**
+   * Delete segmentation annotations for many images at once (the images
+   * themselves are kept). Reuses the single-image path per image (ownership
+   * check + deleteMany + status reset back to 'no_segmentation') with bounded
+   * concurrency. Failures are collected, not thrown, so one inaccessible /
+   * absent image doesn't sink the whole batch.
+   */
+  async deleteSegmentationBatch(
+    imageIds: string[],
+    userId: string
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
+    const failedIds: string[] = [];
+    let deletedCount = 0;
+    // Increments run synchronously with no interleaving await, so they're safe
+    // under mapWithConcurrency (single-threaded JS).
+    await mapWithConcurrency(imageIds, 8, async imageId => {
+      try {
+        await this.deleteSegmentationResults(imageId, userId);
+        deletedCount++;
+      } catch (error) {
+        failedIds.push(imageId);
+        logger.warn(
+          'Batch annotation delete: skipped an image',
+          'SegmentationService',
+          {
+            imageId,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      }
+    });
+
+    logger.info('Batch annotation delete complete', 'SegmentationService', {
+      userId,
+      requested: imageIds.length,
+      deletedCount,
+      failed: failedIds.length,
+    });
+    return { deletedCount, failedIds };
   }
 
   /**

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -205,10 +205,44 @@ export interface PropagatedPolyline {
 }
 
 /**
+ * Thrown when a track operation targets a video the user does not own / that
+ * does not exist. The controller maps this to a 404 by `instanceof` rather than
+ * matching a free-text message (which drift-breaks silently).
+ */
+export class VideoAccessError extends Error {
+  constructor(message = 'Video not found or no access') {
+    super(message);
+    this.name = 'VideoAccessError';
+  }
+}
+
+/**
+ * Parse a frame's polygons for a WRITE path. Unlike `parsePolygonsJsonForDiff`
+ * (lenient — returns `[]` on corrupt/non-array, which is safe only for a
+ * read-only diff), this reports `corrupt` so a writer can SKIP a frame it cannot
+ * read instead of overwriting the frame's real polygons with new geometry
+ * (silent data loss).
+ */
+export function parsePolygonsForWrite(json: string): {
+  polygons: unknown[];
+  corrupt: boolean;
+} {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed)
+      ? { polygons: parsed, corrupt: false }
+      : { polygons: [], corrupt: true };
+  } catch {
+    return { polygons: [], corrupt: true };
+  }
+}
+
+/**
  * Remove every polygon carrying `trackId`. Returns the survivors plus the count
- * removed. Shared by the explicit "delete whole track" endpoint and kept in
- * lockstep with the save-time delete propagation so both paths agree on what
- * "a track" is (all polylines with that trackId).
+ * removed. Used by `deleteTrackAcrossVideo` and `upsertTrackPolyline`. The
+ * save-time delete propagation (`computeCrossFrameTrackPropagation`) defines a
+ * track by the same `trackId`-equality rule but via its own inline filter, so
+ * the three agree conceptually on what "a track" is without sharing this code.
  */
 export function removePolygonsWithTrackId(
   polys: unknown[],
@@ -237,6 +271,17 @@ export function upsertTrackPolyline(
   polyline: PropagatedPolyline,
   makeId: () => string
 ): unknown[] {
+  // Enforce the "valid polyline" invariant here so it travels with the value —
+  // the helper is exported and a direct caller must not be able to persist a
+  // degenerate (< 2 points) or NaN-coordinate polyline.
+  const pts = polyline.points;
+  if (
+    !Array.isArray(pts) ||
+    pts.length < 2 ||
+    !pts.every(p => Number.isFinite(p?.x) && Number.isFinite(p?.y))
+  ) {
+    throw new Error('Propagated polyline needs at least 2 finite points');
+  }
   const { polygons } = removePolygonsWithTrackId(polys, trackId);
   const copy: Record<string, unknown> = {
     id: makeId(),
@@ -2123,10 +2168,11 @@ export class SegmentationService {
    * Delete a whole microtubule track: remove every polyline carrying `trackId`
    * from ALL frames of the video in a single transaction. This is the explicit,
    * immediate counterpart to the save-time delete propagation
-   * (`computeCrossFrameTrackPropagation`) and shares `removePolygonsWithTrackId`
-   * so both paths agree on what a track is.
+   * (`computeCrossFrameTrackPropagation`); both define a track by the same
+   * `trackId`-equality rule (this one via `removePolygonsWithTrackId`, the other
+   * via its own inline filter), so they stay consistent conceptually.
    *
-   * @throws if the video is not found / not owned by the user.
+   * @throws {VideoAccessError} if the video is not found / not owned by the user.
    */
   async deleteTrackAcrossVideo(
     videoId: string,
@@ -2136,7 +2182,7 @@ export class SegmentationService {
     // Ownership: the video container is an Image row the user must be able to access.
     const container = await this.imageService.getImageById(videoId, userId);
     if (!container) {
-      throw new Error('Video not found or no access');
+      throw new VideoAccessError();
     }
 
     const frames = await this.prisma.image.findMany({
@@ -2188,9 +2234,11 @@ export class SegmentationService {
    * A trackId is generated (`mt_<hex>`) when the source polyline has none, so
    * the propagated set forms one coherent, stably-coloured track; the generated
    * id is returned for the editor to patch onto the source polyline. Frames with
-   * no segmentation row yet are skipped (there is nothing to attach to).
+   * no segmentation row yet — or whose polygons JSON is unreadable — are skipped
+   * (a corrupt frame must never be overwritten with just the propagated line).
    *
-   * @throws if the video is not owned or the polyline has fewer than 2 points.
+   * @throws {VideoAccessError} if the video is not owned.
+   * @throws if the polyline has fewer than 2 points.
    */
   async propagateTrackGeometryForward(
     videoId: string,
@@ -2200,7 +2248,7 @@ export class SegmentationService {
   ): Promise<{ trackId: string; framesUpdated: number }> {
     const container = await this.imageService.getImageById(videoId, userId);
     if (!container) {
-      throw new Error('Video not found or no access');
+      throw new VideoAccessError();
     }
     if (!Array.isArray(polyline.points) || polyline.points.length < 2) {
       throw new Error('Propagated polyline needs at least 2 points');
@@ -2221,14 +2269,25 @@ export class SegmentationService {
 
     const ops: Prisma.PrismaPromise<unknown>[] = [];
     let framesUpdated = 0;
+    let corruptFrames = 0;
     for (const frame of frames) {
       // A frame that never segmented has no row to attach the polyline to; skip
       // it rather than fabricate a partial segmentation record.
       if (!frame.segmentation) continue;
-      const parsed = parsePolygonsJsonForDiff(frame.segmentation.polygons, {
-        currentImageId: frame.id,
-        parentVideoId: videoId,
-      });
+      // Use the corrupt-aware parse: overwriting an unreadable frame with only
+      // the propagated polyline would silently destroy its other microtubules.
+      const { polygons: parsed, corrupt } = parsePolygonsForWrite(
+        frame.segmentation.polygons
+      );
+      if (corrupt) {
+        corruptFrames++;
+        logger.warn(
+          'Skipping frame with unreadable polygons during propagate',
+          'SegmentationService',
+          { imageId: frame.id, parentVideoId: videoId }
+        );
+        continue;
+      }
       const updated = upsertTrackPolyline(parsed, trackId, polyline, uuidv4);
       ops.push(
         this.prisma.segmentation.update({
@@ -2248,6 +2307,7 @@ export class SegmentationService {
       trackId,
       fromFrameIndex,
       framesUpdated,
+      corruptFramesSkipped: corruptFrames,
     });
     return { trackId, framesUpdated };
   }

--- a/docs/superpowers/specs/2026-07-06-mt-imagej-roiset-and-track-ops-design.md
+++ b/docs/superpowers/specs/2026-07-06-mt-imagej-roiset-and-track-ops-design.md
@@ -1,0 +1,156 @@
+# MT ImageJ RoiSet export + cross-frame track operations
+
+Date: 2026-07-06
+Status: Approved (design), pending implementation
+Project type scope: **microtubules only**
+
+## Problem
+
+Two pain points reported for microtubule (MT) projects:
+
+1. **ImageJ export is unwieldy.** The MT export writes thousands of loose
+   `.roi` files (`annotations/imagej/<video>/frame_NNNN/<trackId>.roi`).
+   Biologists want **one file per video** they can drag-and-drop into
+   ImageJ / Fiji. ImageJ cannot read `.nd2`, so the native single-file
+   equivalent is a **RoiSet.zip** (loads into the ROI Manager).
+
+2. **No cross-frame track editing from the canvas.** Users want, from the
+   right-click menu on an MT polyline:
+   - **Propagate** the polyline forward into all following frames.
+   - **Delete** an MT to remove the **entire track** (all frames), not
+     just the current frame.
+
+## Decisions (locked with the user)
+
+| Topic                      | Decision                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| Export format              | One `annotations/imagej/<video>_RoiSet.zip` per video container                   |
+| Loose `.roi` files         | **Removed** — replaced by the zip (no dead output)                                |
+| ROI colour                 | Per-`trackId` stroke colour, identical hue math to the editor                     |
+| Propagate overwrite policy | **Overwrite** same-`trackId` polyline in every following frame; add where missing |
+| Propagate range            | Forward only: `frameIndex > current`                                              |
+| Delete scope               | **Whole track** — all frames of the video (past + future)                         |
+| Delete confirmation        | Yes — dialog states the frame count                                               |
+| Gating                     | Both editor features are microtubules-only                                        |
+
+## Feature A — RoiSet.zip export
+
+### ImageJ `.roi` format additions
+
+The existing pure encoder `encodeImageJRoi(points, geometry, name)` writes a
+zero-filled header and leaves two fields at 0. We extend it with an optional
+`options` argument:
+
+- **`position`** (int32 @ offset 56): 1-based stack slice = `frameIndex + 1`.
+  Lets ImageJ place each ROI on its own frame of the opened stack.
+- **`strokeColor`** (int32 @ offset 40): ARGB, alpha `0xFF` (opaque required or
+  ImageJ treats the colour as unset). Value derived from the MT's colour key.
+
+Back-compat: when `options` is omitted the bytes stay 0 (identical to today's
+golden fixture).
+
+### Colour parity (`backend/src/services/export/imagejColor.ts`, new)
+
+Ports the frontend `instanceColors.ts` hue math so exported colours match the
+editor exactly:
+
+- `colorKeyForRoi(p)` — precedence `trackId || (mt_-prefixed instanceId) || id`
+  (mirrors `CanvasPolygon.tsx`).
+- djb2-style hash → `hue = |hash| % 360`; fixed `S=70%`, `L=55%` (unselected).
+- HSL→RGB → `0xFF000000 | (r<<16)|(g<<8)|b`.
+
+A parity unit test asserts a handful of keys produce the same hue as the FE
+values in `instanceColors.test.ts`.
+
+### Per-video zip exporter (`imagejRoiEncoder.ts`)
+
+Replace `exportImageJRois` with **`exportImageJRoiSets`**:
+
+- Group frames by `parentVideoId` (container row supplies the clean video
+  label; multi-position ND2 splits already yield one container per position).
+- For each video: open an `archiver('zip')` stream to
+  `annotations/imagej/<videoLabel>_RoiSet.zip`. Process videos sequentially to
+  cap open streams; append frames in `frameIndex` order.
+- For each valid polyline/polygon: `position = frameIndex + 1`,
+  `strokeColor = imageJStrokeColor(colorKeyForRoi(p))`, encode, append as
+  entry `<safeLabel>__frame_<NNNN>.roi` (MT-first so the same track's ROIs are
+  adjacent in the ROI Manager and globally unique).
+- Preserve the return contract `{ frames, rois, warnings }`, corrupt-frame →
+  warning, dropped-polygon → log, `shouldAbort()` between frames → `archive.abort()`
+  - rethrow (cancellation stays fatal).
+- Delete the now-dead loose-file path (`frameFolderName` etc.).
+
+`exportService.ts`: swap the call, update the comment block.
+
+## Feature B — Propagate track forward
+
+### Backend
+
+- Route: `POST /api/segmentation/videos/:videoId/tracks/propagate`
+  body `{ fromFrameIndex, polyline: { trackId?, name?, points, geometry } }`.
+- Controller `trackOpsController.ts` → service
+  `segmentationService.propagateTrackGeometryForward(videoId, fromFrameIndex, polyline, userId)`:
+  - Verify the user owns the video/project.
+  - `trackId = polyline.trackId || generated 'mt_<uuid>'`.
+  - In one Prisma transaction: for every child frame with `frameIndex > fromFrameIndex`,
+    parse its polygons, drop any polyline with `trackId`, append a copy
+    (fresh per-frame polygon `id`, shared `trackId`, `name`, `points`, `geometry`),
+    write back.
+  - Return `{ trackId, framesUpdated }`.
+
+### Frontend
+
+- `PolygonContextMenu.tsx`: new item "Propagate to following frames"
+  (`ChevronsRight`), rendered only for `isMicrotubules && isPolyline`.
+- `usePolygonHandlers.ts` + `SegmentationEditor.tsx`: handler reads the source
+  polyline from the editor, calls `apiClient.propagateTrackForward(...)`, then on
+  success patches the source polyline's `trackId` in editor state (so colour /
+  next save stay consistent), refreshes via the reload-nonce, and toasts
+  `framesUpdated`.
+- `src/lib/api.ts`: `propagateTrackForward(videoId, fromFrameIndex, polyline)`.
+
+## Feature C — Delete whole track
+
+### Backend
+
+- Route: `DELETE /api/segmentation/videos/:videoId/tracks/:trackId`.
+- Service `deleteTrackAcrossVideo(videoId, trackId, userId)`: one transaction,
+  remove every polyline with `trackId` from all child frames; return
+  `{ framesAffected }`. Shared helper factored so the existing save-time delete
+  propagation can reuse it (no duplicate delete logic).
+
+### Frontend
+
+- `PolygonContextMenu.tsx`: the delete `AlertDialog` becomes track-aware — when
+  the polyline is an MT with a `trackId`, title/description say "delete the
+  whole track across N frames" (`N` = the video's frame count, known to the
+  editor); otherwise the current single-polygon copy.
+- Delete handler: MT with `trackId` → `apiClient.deleteTrack(videoId, trackId)`
+  - refresh + toast; otherwise the existing local `handleDeletePolygon`.
+
+## i18n
+
+New strings in all six files (`en, cs, es, de, fr, zh`); validate with
+`node scripts/check-i18n.cjs`.
+
+## Testing & verification
+
+- **Unit:** `imagejColor.test.ts` (FE parity); extend `imagejRoiEncoder.test.ts`
+  (position @56, stroke @40, golden unchanged when `options` omitted); service
+  unit tests for `propagateTrackGeometryForward` / `deleteTrackAcrossVideo`
+  (pure diff over fixture polygon arrays).
+- **Feature A wire-level:** run `exportImageJRoiSets` on fixture frames, unzip,
+  decode with Python `roifile`; assert ROI count, `position`, `stroke_color`,
+  coordinates.
+- **Features B/C cross-stack (gate F):** build FE + BE, exercise on the running
+  stack with real MT data via Playwright — right-click → Propagate → scrub to a
+  later frame → MT present with the same colour; delete track → confirm dialog
+  with count → MT gone across frames; confirm via `docker logs spheroseg-backend`
+  and a DB query; zero console errors.
+- **Gate G:** `make build-service SERVICE=frontend` + backend build before done.
+
+## Out of scope
+
+- Backward propagation and "fill only missing frames" (explicitly deferred).
+- Embedding the image + overlay into a single TIFF (RoiSet.zip chosen instead).
+- Time-aware geometry interpolation between frames (propagation is a frozen copy).

--- a/src/components/project/ProjectToolbar.tsx
+++ b/src/components/project/ProjectToolbar.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   FolderPlus,
   Plus,
+  Eraser,
 } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -50,6 +51,8 @@ interface ProjectToolbarProps {
   isPartiallySelected?: boolean;
   onSelectAllToggle?: () => void;
   onBatchDelete?: () => void;
+  /** Delete segmentation annotations for the selected images (keeps images). */
+  onDeleteAnnotations?: () => void;
   showSelectAll?: boolean;
   // Export state callbacks
   onExportingChange?: (isExporting: boolean) => void;
@@ -85,6 +88,7 @@ const ProjectToolbar = ({
   isPartiallySelected = false,
   onSelectAllToggle,
   onBatchDelete,
+  onDeleteAnnotations,
   showSelectAll = false,
   onExportingChange,
   onDownloadingChange,
@@ -176,6 +180,17 @@ const ProjectToolbar = ({
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
               {t('project.selected', { count: selectedCount })}
             </span>
+            {onDeleteAnnotations && (
+              <Button
+                onClick={onDeleteAnnotations}
+                size="sm"
+                variant="outline"
+                className="ml-2"
+              >
+                <Eraser className="h-4 w-4 mr-1" />
+                {t('project.deleteAnnotations')}
+              </Button>
+            )}
             <Button
               onClick={onBatchDelete}
               size="sm"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1665,6 +1665,48 @@ class ApiClient {
     await this.instance.delete(`/segmentation/images/${imageId}/results`);
   }
 
+  /**
+   * Propagate a microtubule polyline into every frame of the video after
+   * `fromFrameIndex`, overwriting the same track where present and adding it
+   * where missing. The backend returns the (possibly newly-generated) trackId
+   * so the editor can patch it onto the source polyline for stable colour.
+   */
+  async propagateTrackForward(
+    videoId: string,
+    fromFrameIndex: number,
+    polyline: {
+      trackId?: string;
+      name?: string;
+      geometry?: 'polygon' | 'polyline';
+      points: Array<{ x: number; y: number }>;
+    }
+  ): Promise<{ trackId: string; framesUpdated: number }> {
+    const response = await this.instance.post(
+      `/segmentation/videos/${videoId}/tracks/propagate`,
+      { fromFrameIndex, polyline }
+    );
+    const data = this.extractData(response);
+    return {
+      trackId: String(data?.trackId ?? polyline.trackId ?? ''),
+      framesUpdated: Number(data?.framesUpdated ?? 0),
+    };
+  }
+
+  /**
+   * Delete a whole microtubule track: remove every polyline carrying `trackId`
+   * from all frames of the video. Returns how many frames were affected.
+   */
+  async deleteTrack(
+    videoId: string,
+    trackId: string
+  ): Promise<{ framesAffected: number }> {
+    const response = await this.instance.delete(
+      `/segmentation/videos/${videoId}/tracks/${encodeURIComponent(trackId)}`
+    );
+    const data = this.extractData(response);
+    return { framesAffected: Number(data?.framesAffected ?? 0) };
+  }
+
   async getImageWithSegmentation(
     imageId: string
   ): Promise<ProjectImageDTO & { segmentation?: SegmentationResult }> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1675,8 +1675,11 @@ class ApiClient {
     videoId: string,
     fromFrameIndex: number,
     polyline: {
-      trackId?: string;
-      name?: string;
+      // Nullable to match the backend `PropagatedPolyline` contract (the wire
+      // can carry null); an untracked source sends no trackId and the backend
+      // generates one.
+      trackId?: string | null;
+      name?: string | null;
       geometry?: 'polygon' | 'polyline';
       points: Array<{ x: number; y: number }>;
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1666,6 +1666,23 @@ class ApiClient {
   }
 
   /**
+   * Delete segmentation annotations for many images at once (project-page bulk
+   * action). The images are kept; their status resets to no-segmentation.
+   */
+  async deleteSegmentationBatch(
+    imageIds: string[]
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
+    const response = await this.instance.post('/segmentation/batch/delete', {
+      imageIds,
+    });
+    const data = this.extractData(response);
+    return {
+      deletedCount: Number(data?.deletedCount ?? 0),
+      failedIds: Array.isArray(data?.failedIds) ? data.failedIds : [],
+    };
+  }
+
+  /**
    * Propagate a microtubule polyline into every frame of the video after
    * `fromFrameIndex`, overwriting the same track where present and adding it
    * where missing. The backend returns the (possibly newly-generated) trackId

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -64,6 +64,10 @@ const ProjectDetail = () => {
   );
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [isBatchDeleting, setIsBatchDeleting] = useState<boolean>(false);
+  const [showDeleteAnnotationsDialog, setShowDeleteAnnotationsDialog] =
+    useState<boolean>(false);
+  const [isDeletingAnnotations, setIsDeletingAnnotations] =
+    useState<boolean>(false);
   // Channel-picker state for Segment All on multi-channel video projects.
   // `pendingChannelChoice` is non-null while the dialog is open; resolving it
   // triggers the actual dispatch with the picked channel.
@@ -1200,6 +1204,68 @@ const ProjectDetail = () => {
     setShowDeleteDialog(true);
   };
 
+  const handleDeleteAnnotations = () => {
+    setShowDeleteAnnotationsDialog(true);
+  };
+
+  const handleDeleteAnnotationsConfirm = async () => {
+    if (!user?.id || selectedImageIds.size === 0) {
+      toast.error(t('errors.noProjectOrUser'));
+      return;
+    }
+    if (isDeletingAnnotations) {
+      return;
+    }
+    setIsDeletingAnnotations(true);
+
+    try {
+      const imageIds = Array.from(selectedImageIds);
+      const result = await apiClient.deleteSegmentationBatch(imageIds);
+
+      if (result.deletedCount > 0) {
+        toast.success(
+          t('project.annotationsDeleted', { count: result.deletedCount })
+        );
+        // Reset only the images whose annotations were actually deleted back to
+        // no-segmentation (mirror the WS-cancel reset shape) so the gallery
+        // reflects the change without a full refresh.
+        const clearedIds = new Set(
+          imageIds.filter(imageId => !result.failedIds.includes(imageId))
+        );
+        updateImages(prevImages =>
+          prevImages.map(img =>
+            clearedIds.has(img.id)
+              ? {
+                  ...img,
+                  segmentationStatus: 'no_segmentation',
+                  segmentationResult: undefined,
+                  segmentationData: undefined,
+                  segmentationThumbnailPath: undefined,
+                  segmentationThumbnailUrl: undefined,
+                  thumbnail_url: img.url,
+                  updatedAt: new Date(),
+                }
+              : img
+          )
+        );
+        setSelectedImageIds(new Set());
+      }
+
+      if (result.failedIds.length > 0) {
+        toast.warning(
+          t('project.annotationsDeleteFailed', {
+            count: result.failedIds.length,
+          })
+        );
+      }
+    } catch {
+      toast.error(t('errors.deleteAnnotations'));
+    } finally {
+      setShowDeleteAnnotationsDialog(false);
+      setIsDeletingAnnotations(false);
+    }
+  };
+
   // Calculate selection state
   const selectedCount = selectedImageIds.size;
   const isAllSelected =
@@ -1521,6 +1587,7 @@ const ProjectDetail = () => {
               isPartiallySelected={isPartiallySelected}
               onSelectAllToggle={handleSelectAllToggle}
               onBatchDelete={handleBatchDelete}
+              onDeleteAnnotations={handleDeleteAnnotations}
               showSelectAll={true}
               onExportingChange={() => {}} // No longer needed - hook handles state
               onDownloadingChange={() => {}} // No longer needed - hook handles state
@@ -1623,6 +1690,34 @@ const ProjectDetail = () => {
             <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleBatchDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete annotations (segmentation results) confirmation dialog */}
+      <AlertDialog
+        open={showDeleteAnnotationsDialog}
+        onOpenChange={setShowDeleteAnnotationsDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('project.deleteAnnotationsDialog.title')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('project.deleteAnnotationsDialog.description', {
+                count: selectedCount,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteAnnotationsConfirm}
               className="bg-red-600 hover:bg-red-700"
             >
               {t('common.delete')}

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -815,14 +815,18 @@ const SegmentationEditor = () => {
   const editorRef = useRef(editor);
   editorRef.current = editor;
 
-  // Invalidate the cached segmentation of the video's frames so a scrub after a
-  // track op refetches the mutated data. The sliding-window prefetch caches
-  // sibling frames for 60 s, which would otherwise paint stale geometry.
-  const invalidateVideoFrameSegmentationCaches = useCallback(() => {
+  // Evict the cached segmentation of the video's frames after a track op so a
+  // scrub refetches the mutated data. MUST be removeQueries, not
+  // invalidateQueries: the editor's frame loader reads the cache imperatively
+  // (`getCachedSegmentationPolygons` → getQueryData) and paints any entry that
+  // exists regardless of staleness, so merely marking it stale would keep
+  // showing the pre-op geometry until a full page reload. Removing the entry
+  // forces the loader's cache-miss path to re-fetch from the server.
+  const evictVideoFrameSegmentationCaches = useCallback(() => {
     const frames = video.container?.frames;
     if (!frames) return;
     for (const frame of frames) {
-      queryClient.invalidateQueries({
+      queryClient.removeQueries({
         queryKey: segmentationPolygonsQueryKey(frame.id),
       });
     }
@@ -875,7 +879,7 @@ const SegmentationEditor = () => {
         if (result.trackId && result.trackId !== source.trackId) {
           handleUpdatePolygonField(polygonId, { trackId: result.trackId });
         }
-        invalidateVideoFrameSegmentationCaches();
+        evictVideoFrameSegmentationCaches();
         toast.success(
           t('segmentation.trackOps.propagateSuccess', {
             count: result.framesUpdated,
@@ -890,7 +894,7 @@ const SegmentationEditor = () => {
       video.container,
       imageId,
       handleUpdatePolygonField,
-      invalidateVideoFrameSegmentationCaches,
+      evictVideoFrameSegmentationCaches,
       t,
     ]
   );
@@ -910,7 +914,7 @@ const SegmentationEditor = () => {
           // Remove it from the current frame + hidden-set locally for instant
           // feedback; the backend already purged every sibling frame.
           handleDeletePolygonFromContextMenu(polygonId);
-          invalidateVideoFrameSegmentationCaches();
+          evictVideoFrameSegmentationCaches();
           toast.success(
             t('segmentation.trackOps.deleteTrackSuccess', {
               count: result.framesAffected,
@@ -928,7 +932,7 @@ const SegmentationEditor = () => {
       video.container,
       projectType,
       handleDeletePolygonFromContextMenu,
-      invalidateVideoFrameSegmentationCaches,
+      evictVideoFrameSegmentationCaches,
       t,
     ]
   );

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -32,7 +32,10 @@ import SegmentationErrorBoundary from './components/SegmentationErrorBoundary';
 import SegmentationEditorLayout from './components/SegmentationEditorLayout';
 
 import { useVideoFrames } from './hooks/useVideoFrames';
-import { setCachedSegmentationPolygons } from './hooks/segmentationPolygonCache';
+import {
+  setCachedSegmentationPolygons,
+  segmentationPolygonsQueryKey,
+} from './hooks/segmentationPolygonCache';
 
 const SegmentationEditor = () => {
   const { projectId, imageId } = useParams<{
@@ -648,6 +651,7 @@ const SegmentationEditor = () => {
     handleRenamePolygon,
     handleChangeInstanceId,
     handleChangePartClass,
+    handleUpdatePolygonField,
   } = usePolygonHandlers({ editor, imageId });
 
   // Pure render-derivation pipeline (polyline/instance discrimination, legacy
@@ -798,6 +802,112 @@ const SegmentationEditor = () => {
   });
   // ─────────────── End resegment chain ───────────────
 
+  // ───────────────── Cross-frame track operations ─────────────────
+  // Placed AFTER `const video = useVideoFrames(...)` so they can read
+  // video.container without a TDZ (CLAUDE.md production bug #11).
+
+  // Invalidate the cached segmentation of the video's frames so a scrub after a
+  // track op refetches the mutated data. The sliding-window prefetch caches
+  // sibling frames for 60 s, which would otherwise paint stale geometry.
+  const invalidateVideoFrameSegmentationCaches = useCallback(() => {
+    const frames = video.container?.frames;
+    if (!frames) return;
+    for (const frame of frames) {
+      queryClient.invalidateQueries({
+        queryKey: segmentationPolygonsQueryKey(frame.id),
+      });
+    }
+  }, [video.container, queryClient]);
+
+  // Right-click "Propagate to following frames": stamp this microtubule's
+  // current shape into every later frame of the video.
+  const handlePropagateTrack = useCallback(
+    async (polygonId: string) => {
+      const videoId = video.container?.id;
+      const source = editor.getPolygons().find(p => p.id === polygonId);
+      const fromFrameIndex = video.container?.frames.find(
+        f => f.id === imageId
+      )?.frameIndex;
+      if (!videoId || !source || typeof fromFrameIndex !== 'number') return;
+      const points = (source.points ?? []).map(p => ({ x: p.x, y: p.y }));
+      if (points.length < 2) return;
+
+      try {
+        const result = await apiClient.propagateTrackForward(
+          videoId,
+          fromFrameIndex,
+          {
+            trackId: source.trackId,
+            name: source.name,
+            geometry: 'polyline',
+            points,
+          }
+        );
+        // When the backend generated a trackId (source had none), patch it onto
+        // the source polyline so its colour + a later save stay consistent with
+        // the propagated copies.
+        if (result.trackId && result.trackId !== source.trackId) {
+          handleUpdatePolygonField(polygonId, { trackId: result.trackId });
+        }
+        invalidateVideoFrameSegmentationCaches();
+        toast.success(
+          t('segmentation.trackOps.propagateSuccess', {
+            count: result.framesUpdated,
+          })
+        );
+      } catch (error) {
+        logger.error('Failed to propagate microtubule track', error);
+        toast.error(t('segmentation.trackOps.propagateFailed'));
+      }
+    },
+    [
+      video.container,
+      imageId,
+      editor,
+      handleUpdatePolygonField,
+      invalidateVideoFrameSegmentationCaches,
+      t,
+    ]
+  );
+
+  // Right-click delete: whole track for a tracked microtubule, else the single
+  // polyline (untracked MT or non-MT project).
+  const handleDeletePolygonOrTrack = useCallback(
+    async (polygonId: string) => {
+      const videoId = video.container?.id;
+      const target = editor.getPolygons().find(p => p.id === polygonId);
+      const trackId = target?.trackId;
+      if (projectType === 'microtubules' && videoId && trackId) {
+        try {
+          const result = await apiClient.deleteTrack(videoId, trackId);
+          // Remove it from the current frame + hidden-set locally for instant
+          // feedback; the backend already purged every sibling frame.
+          handleDeletePolygonFromContextMenu(polygonId);
+          invalidateVideoFrameSegmentationCaches();
+          toast.success(
+            t('segmentation.trackOps.deleteTrackSuccess', {
+              count: result.framesAffected,
+            })
+          );
+        } catch (error) {
+          logger.error('Failed to delete microtubule track', error);
+          toast.error(t('segmentation.trackOps.deleteTrackFailed'));
+        }
+        return;
+      }
+      handleDeletePolygonFromContextMenu(polygonId);
+    },
+    [
+      video.container,
+      editor,
+      projectType,
+      handleDeletePolygonFromContextMenu,
+      invalidateVideoFrameSegmentationCaches,
+      t,
+    ]
+  );
+  // ─────────────── End cross-frame track operations ───────────────
+
   // The overlay debounce moved into `FrameLoadingGate` — it needs
   // `visibleChannels` from ImageDisplayContext which is only mounted
   // inside the provider subtree below.
@@ -933,7 +1043,8 @@ const SegmentationEditor = () => {
         handleTogglePolygonVisibility={handleTogglePolygonVisibility}
         handleDeletePolygonFromPanel={handleDeletePolygonFromPanel}
         handleSelectPolygon={handleSelectPolygon}
-        handleDeletePolygonFromContextMenu={handleDeletePolygonFromContextMenu}
+        handleDeletePolygonOrTrack={handleDeletePolygonOrTrack}
+        handlePropagateTrack={handlePropagateTrack}
         handleSlicePolygonFromContextMenu={handleSlicePolygonFromContextMenu}
         handleEditPolygonFromContextMenu={handleEditPolygonFromContextMenu}
         handleDeleteVertexFromContextMenu={handleDeleteVertexFromContextMenu}

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -806,6 +806,15 @@ const SegmentationEditor = () => {
   // Placed AFTER `const video = useVideoFrames(...)` so they can read
   // video.container without a TDZ (CLAUDE.md production bug #11).
 
+  // `editor` is a fresh object literal every render of
+  // useEnhancedSegmentationEditor. Mirror it into a ref so the track-op handlers
+  // below stay identity-stable (they read the latest polygons via the ref) —
+  // they're compared in the CanvasPolygon React.memo comparator, so closing over
+  // `editor` directly would break the comparator and re-render every polyline on
+  // each cursor/hover/zoom tick (CLAUDE.md failure pattern #5).
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+
   // Invalidate the cached segmentation of the video's frames so a scrub after a
   // track op refetches the mutated data. The sliding-window prefetch caches
   // sibling frames for 60 s, which would otherwise paint stale geometry.
@@ -824,13 +833,30 @@ const SegmentationEditor = () => {
   const handlePropagateTrack = useCallback(
     async (polygonId: string) => {
       const videoId = video.container?.id;
-      const source = editor.getPolygons().find(p => p.id === polygonId);
+      const source = editorRef.current
+        .getPolygons()
+        .find(p => p.id === polygonId);
       const fromFrameIndex = video.container?.frames.find(
         f => f.id === imageId
       )?.frameIndex;
-      if (!videoId || !source || typeof fromFrameIndex !== 'number') return;
-      const points = (source.points ?? []).map(p => ({ x: p.x, y: p.y }));
-      if (points.length < 2) return;
+      const points = (source?.points ?? []).map(p => ({ x: p.x, y: p.y }));
+      // Guard failures are unexpected (missing video/source) or a degenerate
+      // polyline; always give feedback rather than a silent no-op.
+      if (
+        !videoId ||
+        !source ||
+        typeof fromFrameIndex !== 'number' ||
+        points.length < 2
+      ) {
+        logger.warn('Cannot propagate microtubule track', {
+          hasVideo: !!videoId,
+          hasSource: !!source,
+          fromFrameIndex,
+          points: points.length,
+        });
+        toast.error(t('segmentation.trackOps.propagateFailed'));
+        return;
+      }
 
       try {
         const result = await apiClient.propagateTrackForward(
@@ -863,7 +889,6 @@ const SegmentationEditor = () => {
     [
       video.container,
       imageId,
-      editor,
       handleUpdatePolygonField,
       invalidateVideoFrameSegmentationCaches,
       t,
@@ -875,7 +900,9 @@ const SegmentationEditor = () => {
   const handleDeletePolygonOrTrack = useCallback(
     async (polygonId: string) => {
       const videoId = video.container?.id;
-      const target = editor.getPolygons().find(p => p.id === polygonId);
+      const target = editorRef.current
+        .getPolygons()
+        .find(p => p.id === polygonId);
       const trackId = target?.trackId;
       if (projectType === 'microtubules' && videoId && trackId) {
         try {
@@ -899,7 +926,6 @@ const SegmentationEditor = () => {
     },
     [
       video.container,
-      editor,
       projectType,
       handleDeletePolygonFromContextMenu,
       invalidateVideoFrameSegmentationCaches,

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -115,7 +115,11 @@ export interface SegmentationEditorLayoutProps {
   handleTogglePolygonVisibility: PolygonHandlers['handleTogglePolygonVisibility'];
   handleDeletePolygonFromPanel: PolygonHandlers['handleDeletePolygonFromPanel'];
   handleSelectPolygon: PolygonHandlers['handleSelectPolygon'];
-  handleDeletePolygonFromContextMenu: PolygonHandlers['handleDeletePolygonFromContextMenu'];
+  /** Canvas right-click delete: removes the whole MT track (all frames) when
+   *  the polyline has a trackId, else a single-frame delete. */
+  handleDeletePolygonOrTrack: (polygonId: string) => void;
+  /** Canvas right-click: propagate this MT into all following frames. */
+  handlePropagateTrack: (polygonId: string) => void;
   handleSlicePolygonFromContextMenu: PolygonHandlers['handleSlicePolygonFromContextMenu'];
   handleEditPolygonFromContextMenu: PolygonHandlers['handleEditPolygonFromContextMenu'];
   handleDeleteVertexFromContextMenu: PolygonHandlers['handleDeleteVertexFromContextMenu'];
@@ -189,7 +193,8 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
   handleTogglePolygonVisibility,
   handleDeletePolygonFromPanel,
   handleSelectPolygon,
-  handleDeletePolygonFromContextMenu,
+  handleDeletePolygonOrTrack,
+  handlePropagateTrack,
   handleSlicePolygonFromContextMenu,
   handleEditPolygonFromContextMenu,
   handleDeleteVertexFromContextMenu,
@@ -386,7 +391,9 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                           isHovered={polygon.id === hoveredPolygonId}
                           editMode={editor.editMode}
                           onSelectPolygon={editor.handlePolygonClick}
-                          onDeletePolygon={handleDeletePolygonFromContextMenu}
+                          onDeletePolygon={handleDeletePolygonOrTrack}
+                          onPropagateTrack={handlePropagateTrack}
+                          videoFrameCount={video.container?.frameCount}
                           onSlicePolygon={handleSlicePolygonFromContextMenu}
                           onEditPolygon={handleEditPolygonFromContextMenu}
                           // Sperm-specific context-menu actions

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -30,6 +30,10 @@ interface CanvasPolygonProps {
   ) => void;
   onChangeInstanceId?: (polygonId: string, instanceId: string) => void;
   availableInstanceIds?: string[];
+  /** Propagate this microtubule into all following frames (MT only). */
+  onPropagateTrack?: (polygonId: string) => void;
+  /** Total frames in the video — shown in the "delete whole track" dialog. */
+  videoFrameCount?: number;
   onDeleteVertex?: (polygonId: string, vertexIndex: number) => void;
   onDuplicateVertex?: (polygonId: string, vertexIndex: number) => void;
   onHover?: (polygonId: string | null) => void;
@@ -58,6 +62,8 @@ const CanvasPolygon = React.memo(
     onChangePartClass,
     onChangeInstanceId,
     availableInstanceIds,
+    onPropagateTrack,
+    videoFrameCount,
     onDeleteVertex,
     onDuplicateVertex,
     onHover,
@@ -242,6 +248,10 @@ const CanvasPolygon = React.memo(
       (instanceId: string) => onChangeInstanceId?.(id, instanceId),
       [onChangeInstanceId, id]
     );
+    const handlePropagate = useCallback(
+      () => onPropagateTrack?.(id),
+      [onPropagateTrack, id]
+    );
     const handleMouseEnter = useCallback(() => onHover?.(id), [onHover, id]);
     const handleMouseLeave = useCallback(() => onHover?.(null), [onHover]);
 
@@ -277,6 +287,11 @@ const CanvasPolygon = React.memo(
         onChangeInstanceId={isPolyline ? handleChangeInstanceId : undefined}
         currentInstanceId={isPolyline ? polygon.instanceId : undefined}
         availableInstanceIds={isPolyline ? availableInstanceIds : undefined}
+        onPropagate={
+          isPolyline && onPropagateTrack ? handlePropagate : undefined
+        }
+        trackId={polygon.trackId}
+        videoFrameCount={videoFrameCount}
       >
         <g
           data-testid={id}
@@ -470,6 +485,8 @@ const CanvasPolygon = React.memo(
       prevProps.onChangePartClass === nextProps.onChangePartClass &&
       prevProps.onChangeInstanceId === nextProps.onChangeInstanceId &&
       prevProps.availableInstanceIds === nextProps.availableInstanceIds &&
+      prevProps.onPropagateTrack === nextProps.onPropagateTrack &&
+      prevProps.videoFrameCount === nextProps.videoFrameCount &&
       // Drives context-menu gating; must be in comparator.
       prevProps.projectType === nextProps.projectType &&
       // Context-menu / vertex callbacks. These are identity-stable

--- a/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
+++ b/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
@@ -46,8 +46,9 @@ interface PolygonContextMenuProps {
   /** Propagate this microtubule into all following frames (MT only). */
   onPropagate?: () => void;
   /** Cross-frame track id — when set on a microtubule, delete removes the whole
-   *  track (all frames) rather than just this polyline. */
-  trackId?: string | null;
+   *  track (all frames) rather than just this polyline. Matches the source
+   *  `polygon.trackId` (string | undefined). */
+  trackId?: string;
   /** Total frames in the video, shown in the "delete whole track" dialog. */
   videoFrameCount?: number;
 }

--- a/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
+++ b/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
@@ -6,7 +6,14 @@ import {
   ContextMenuTrigger,
   ContextMenuSeparator,
 } from '@/components/ui/context-menu';
-import { Trash, Scissors, Edit, Link, BarChart3 } from 'lucide-react';
+import {
+  Trash,
+  Scissors,
+  Edit,
+  Link,
+  BarChart3,
+  ChevronsRight,
+} from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import type { ProjectType } from '@/types';
 import {
@@ -36,6 +43,13 @@ interface PolygonContextMenuProps {
   onChangeInstanceId?: (instanceId: string) => void;
   currentInstanceId?: string;
   availableInstanceIds?: string[];
+  /** Propagate this microtubule into all following frames (MT only). */
+  onPropagate?: () => void;
+  /** Cross-frame track id — when set on a microtubule, delete removes the whole
+   *  track (all frames) rather than just this polyline. */
+  trackId?: string | null;
+  /** Total frames in the video, shown in the "delete whole track" dialog. */
+  videoFrameCount?: number;
 }
 
 const PolygonContextMenu = ({
@@ -50,9 +64,15 @@ const PolygonContextMenu = ({
   onChangeInstanceId,
   currentInstanceId,
   availableInstanceIds,
+  onPropagate,
+  trackId,
+  videoFrameCount,
 }: PolygonContextMenuProps) => {
   const isSperm = projectType === 'sperm';
   const isMicrotubules = projectType === 'microtubules';
+  // A microtubule with a cross-frame trackId: deleting it removes the whole
+  // track, and it can be propagated forward.
+  const hasTrack = isMicrotubules && !!trackId;
 
   // Fire the global "open kymograph" event that VideoModeOverlay
   // already listens for — no new prop plumbing needed. The overlay
@@ -66,6 +86,7 @@ const PolygonContextMenu = ({
     );
   }, [polygonId]);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [showPropagateDialog, setShowPropagateDialog] = React.useState(false);
   const { t } = useLanguage();
 
   return (
@@ -101,6 +122,15 @@ const PolygonContextMenu = ({
                   })}
                 </span>
               </ContextMenuItem>
+              {onPropagate && (
+                <ContextMenuItem
+                  onClick={() => setShowPropagateDialog(true)}
+                  className="cursor-pointer"
+                >
+                  <ChevronsRight className="mr-2 h-4 w-4" />
+                  <span>{t('contextMenu.propagateTrack')}</span>
+                </ContextMenuItem>
+              )}
             </>
           )}
           {isPolyline && isSperm && onChangePartClass && (
@@ -183,9 +213,11 @@ const PolygonContextMenu = ({
           >
             <Trash className="mr-2 h-4 w-4" />
             <span>
-              {isPolyline
-                ? t('contextMenu.deletePolyline')
-                : t('contextMenu.deletePolygon')}
+              {hasTrack
+                ? t('contextMenu.deleteTrack')
+                : isPolyline
+                  ? t('contextMenu.deletePolyline')
+                  : t('contextMenu.deletePolygon')}
             </span>
           </ContextMenuItem>
         </ContextMenuContent>
@@ -195,10 +227,16 @@ const PolygonContextMenu = ({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {t('contextMenu.confirmDeletePolygon')}
+              {hasTrack
+                ? t('contextMenu.confirmDeleteTrack')
+                : t('contextMenu.confirmDeletePolygon')}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('contextMenu.deletePolygonDescription')}
+              {hasTrack
+                ? t('contextMenu.deleteTrackDescription', {
+                    count: videoFrameCount ?? 0,
+                  })
+                : t('contextMenu.deletePolygonDescription')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -211,6 +249,33 @@ const PolygonContextMenu = ({
               className="bg-red-600 hover:bg-red-700"
             >
               {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={showPropagateDialog}
+        onOpenChange={setShowPropagateDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('contextMenu.confirmPropagateTrack')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('contextMenu.propagateTrackDescription')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onPropagate?.();
+                setShowPropagateDialog(false);
+              }}
+            >
+              {t('contextMenu.propagateTrack')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -610,6 +610,13 @@ export default {
     system: 'Systémový',
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess:
+        'Mikrotubulus propagován do {{count}} následujících snímků',
+      propagateFailed: 'Propagace mikrotubulu selhala',
+      deleteTrackSuccess: 'Track odstraněn z {{count}} snímků',
+      deleteTrackFailed: 'Smazání tracku selhalo',
+    },
     modelNotCompatible:
       'Model "{{model}}" není kompatibilní s typem projektu "{{type}}". Povolené: {{allowed}}.',
     incompatibleModelTitle: 'Tímto modelem nelze segmentovat',
@@ -1896,6 +1903,14 @@ export default {
     disconnected: 'Odpojeno od aktualizací v reálném čase',
   },
   contextMenu: {
+    propagateTrack: 'Propagovat do dalších snímků',
+    confirmPropagateTrack: 'Propagovat do dalších snímků?',
+    propagateTrackDescription:
+      'Přepíše tvar tohoto mikrotubulu ve všech následujících snímcích videa. Tuto akci nelze vrátit.',
+    deleteTrack: 'Smazat celý track',
+    confirmDeleteTrack: 'Smazat celý track mikrotubulu?',
+    deleteTrackDescription:
+      'Odstraní tento mikrotubulus ze všech {{count}} snímků videa. Tuto akci nelze vrátit.',
     editPolygon: 'Upravit polygon',
     splitPolygon: 'Rozdělit polygon',
     deletePolygon: 'Smazat polygon',

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -339,6 +339,7 @@ export default {
       deleteProject: 'Nepodařilo se smazat projekt',
     },
     deleteImages: 'Nepodařilo se smazat vybrané obrázky',
+    deleteAnnotations: 'Nepodařilo se smazat anotace',
     contexts: {
       dashboard: 'Chyba dashboardu',
       project: 'Chyba projektu',
@@ -1162,6 +1163,14 @@ export default {
     selected: '{{count}} obrázek vybrán',
     selected_other: '{{count}} obrázky vybrány',
     deleteSelected: 'Smazat vybrané',
+    deleteAnnotations: 'Smazat anotace',
+    annotationsDeleted: 'Anotace smazány u {{count}} obrázků',
+    annotationsDeleteFailed: 'Nepodařilo se smazat anotace u {{count}} obrázků',
+    deleteAnnotationsDialog: {
+      title: 'Smazat anotace?',
+      description:
+        'Smaže segmentační anotace u {{count}} vybraných obrázků. Obrázky zůstanou, ale jejich výsledky segmentace se odstraní. Tuto akci nelze vrátit.',
+    },
     imagesDeleted: '{{count}} obrázek smazán',
     imagesDeleted_other: '{{count}} obrázky smazány',
   },

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -771,6 +771,12 @@ export default {
     },
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess: 'Mikrotubulus in {{count}} folgende Frames übertragen',
+      propagateFailed: 'Übertragung des Mikrotubulus fehlgeschlagen',
+      deleteTrackSuccess: 'Track aus {{count}} Frames entfernt',
+      deleteTrackFailed: 'Löschen des Tracks fehlgeschlagen',
+    },
     modelNotCompatible:
       'Modell "{{model}}" ist nicht mit dem Projekttyp "{{type}}" kompatibel. Erlaubt: {{allowed}}.',
     incompatibleModelTitle: 'Mit diesem Modell kann nicht segmentiert werden',
@@ -1878,6 +1884,14 @@ export default {
     },
   },
   contextMenu: {
+    propagateTrack: 'In folgende Frames übertragen',
+    confirmPropagateTrack: 'In folgende Frames übertragen?',
+    propagateTrackDescription:
+      'Dies überschreibt die Form dieses Mikrotubulus in allen folgenden Frames des Videos. Dies kann nicht rückgängig gemacht werden.',
+    deleteTrack: 'Ganzen Track löschen',
+    confirmDeleteTrack: 'Den gesamten Mikrotubulus-Track löschen?',
+    deleteTrackDescription:
+      'Dies entfernt diesen Mikrotubulus aus allen {{count}} Frames des Videos. Dies kann nicht rückgängig gemacht werden.',
     editPolygon: 'Polygon bearbeiten',
     splitPolygon: 'Polygon teilen',
     deletePolygon: 'Polygon löschen',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -341,6 +341,7 @@ export default {
       deleteProject:
         'Das Projekt kann nicht gelöscht werden. Stellen Sie sicher, dass Sie die erforderlichen Berechtigungen haben.',
     },
+    deleteAnnotations: 'Anmerkungen konnten nicht gelöscht werden',
     deleteImages: 'Fehler beim Löschen der ausgewählten Bilder',
     contexts: {
       dashboard: 'Dashboard-Fehler',
@@ -1172,6 +1173,15 @@ export default {
     selected: '{{count}} Bild ausgewählt',
     selected_other: '{{count}} Bilder ausgewählt',
     deleteSelected: 'Ausgewählte löschen',
+    deleteAnnotations: 'Anmerkungen löschen',
+    annotationsDeleted: 'Anmerkungen für {{count}} Bild(er) gelöscht',
+    annotationsDeleteFailed:
+      'Anmerkungen für {{count}} Bild(er) konnten nicht gelöscht werden',
+    deleteAnnotationsDialog: {
+      title: 'Anmerkungen löschen?',
+      description:
+        'Dies löscht die Segmentierungsanmerkungen für {{count}} ausgewählte Bild(er). Die Bilder bleiben erhalten, ihre Segmentierungsergebnisse werden jedoch entfernt. Dies kann nicht rückgängig gemacht werden.',
+    },
     imagesDeleted: '{{count}} Bild gelöscht',
     imagesDeleted_other: '{{count}} Bilder gelöscht',
   },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -612,6 +612,13 @@ export default {
     system: 'System',
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess:
+        'Microtubule propagated to {{count}} following frame(s)',
+      propagateFailed: 'Failed to propagate the microtubule',
+      deleteTrackSuccess: 'Track removed from {{count}} frame(s)',
+      deleteTrackFailed: 'Failed to delete the track',
+    },
     modelNotCompatible:
       'Model "{{model}}" is not compatible with project type "{{type}}". Allowed: {{allowed}}.',
     incompatibleModelTitle: 'Cannot segment with this model',
@@ -1936,6 +1943,14 @@ export default {
 
   // Context menu
   contextMenu: {
+    propagateTrack: 'Propagate to following frames',
+    confirmPropagateTrack: 'Propagate to following frames?',
+    propagateTrackDescription:
+      "This overwrites this microtubule's shape in all following frames of the video. This cannot be undone.",
+    deleteTrack: 'Delete whole track',
+    confirmDeleteTrack: 'Delete the whole microtubule track?',
+    deleteTrackDescription:
+      'This removes this microtubule from all {{count}} frames of the video. This cannot be undone.',
     editPolygon: 'Edit polygon',
     splitPolygon: 'Split polygon',
     deletePolygon: 'Delete polygon',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -349,6 +349,7 @@ export default {
       settings: 'Settings error',
     },
     deleteImages: 'Failed to delete selected images',
+    deleteAnnotations: 'Failed to delete annotations',
   },
   images: {
     uploadImages: 'Upload Images or Videos',
@@ -1153,6 +1154,15 @@ export default {
     selected: '{{count}} image selected',
     selected_other: '{{count}} images selected',
     deleteSelected: 'Delete Selected',
+    deleteAnnotations: 'Delete Annotations',
+    annotationsDeleted: 'Annotations deleted for {{count}} image(s)',
+    annotationsDeleteFailed:
+      'Failed to delete annotations for {{count}} image(s)',
+    deleteAnnotationsDialog: {
+      title: 'Delete annotations?',
+      description:
+        'This deletes the segmentation annotations for {{count}} selected image(s). The images are kept but their segmentation results are removed. This cannot be undone.',
+    },
     imagesDeleted: '{{count}} image deleted',
     imagesDeleted_other: '{{count}} images deleted',
   },

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -764,6 +764,13 @@ export default {
     },
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess:
+        'Microtúbulo propagado a {{count}} fotogramas siguientes',
+      propagateFailed: 'No se pudo propagar el microtúbulo',
+      deleteTrackSuccess: 'Traza eliminada de {{count}} fotogramas',
+      deleteTrackFailed: 'No se pudo eliminar la traza',
+    },
     modelNotCompatible:
       'El modelo "{{model}}" no es compatible con el tipo de proyecto "{{type}}". Permitidos: {{allowed}}.',
     incompatibleModelTitle: 'No se puede segmentar con este modelo',
@@ -1917,6 +1924,14 @@ export default {
     },
   },
   contextMenu: {
+    propagateTrack: 'Propagar a los fotogramas siguientes',
+    confirmPropagateTrack: '¿Propagar a los fotogramas siguientes?',
+    propagateTrackDescription:
+      'Esto sobrescribe la forma de este microtúbulo en todos los fotogramas siguientes del vídeo. Esta acción no se puede deshacer.',
+    deleteTrack: 'Eliminar toda la traza',
+    confirmDeleteTrack: '¿Eliminar toda la traza del microtúbulo?',
+    deleteTrackDescription:
+      'Esto elimina este microtúbulo de los {{count}} fotogramas del vídeo. Esta acción no se puede deshacer.',
     editPolygon: 'Editar polígono',
     splitPolygon: 'Dividir polígono',
     deletePolygon: 'Eliminar polígono',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -337,6 +337,7 @@ export default {
         'No se pudo quitar el proyecto de los proyectos compartidos',
       deleteProject: 'No se pudo eliminar el proyecto',
     },
+    deleteAnnotations: 'No se pudieron eliminar las anotaciones',
     deleteImages: 'Error al eliminar las imágenes seleccionadas',
     contexts: {
       dashboard: 'Error del dashboard',
@@ -1158,6 +1159,15 @@ export default {
     selected: '{{count}} imagen seleccionada',
     selected_other: '{{count}} imágenes seleccionadas',
     deleteSelected: 'Eliminar Seleccionadas',
+    deleteAnnotations: 'Eliminar anotaciones',
+    annotationsDeleted: 'Anotaciones eliminadas de {{count}} imagen(es)',
+    annotationsDeleteFailed:
+      'No se pudieron eliminar las anotaciones de {{count}} imagen(es)',
+    deleteAnnotationsDialog: {
+      title: '¿Eliminar anotaciones?',
+      description:
+        'Esto elimina las anotaciones de segmentación de {{count}} imagen(es) seleccionada(s). Las imágenes se conservan, pero se eliminan sus resultados de segmentación. Esta acción no se puede deshacer.',
+    },
     imagesDeleted: '{{count}} imagen eliminada',
     imagesDeleted_other: '{{count}} imágenes eliminadas',
   },

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -765,6 +765,12 @@ export default {
     },
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess: 'Microtubule propagé vers {{count}} images suivantes',
+      propagateFailed: 'Échec de la propagation du microtubule',
+      deleteTrackSuccess: 'Trace supprimée de {{count}} images',
+      deleteTrackFailed: 'Échec de la suppression de la trace',
+    },
     modelNotCompatible:
       'Le modèle "{{model}}" n\'est pas compatible avec le type de projet "{{type}}". Autorisés : {{allowed}}.',
     incompatibleModelTitle: 'Impossible de segmenter avec ce modèle',
@@ -1867,6 +1873,14 @@ export default {
     },
   },
   contextMenu: {
+    propagateTrack: 'Propager aux images suivantes',
+    confirmPropagateTrack: 'Propager aux images suivantes ?',
+    propagateTrackDescription:
+      'Cela remplace la forme de ce microtubule dans toutes les images suivantes de la vidéo. Cette action est irréversible.',
+    deleteTrack: 'Supprimer toute la trace',
+    confirmDeleteTrack: 'Supprimer toute la trace du microtubule ?',
+    deleteTrackDescription:
+      'Cela supprime ce microtubule de toutes les {{count}} images de la vidéo. Cette action est irréversible.',
     editPolygon: 'Modifier le polygone',
     splitPolygon: 'Diviser le polygone',
     deletePolygon: 'Supprimer le polygone',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -336,6 +336,7 @@ export default {
       deleteProject:
         "Impossible de supprimer le projet. Assurez-vous d'avoir les permissions nécessaires.",
     },
+    deleteAnnotations: 'Échec de la suppression des annotations',
     deleteImages: 'Erreur lors de la suppression des images sélectionnées',
     contexts: {
       dashboard: 'Erreur du tableau de bord',
@@ -1162,6 +1163,15 @@ export default {
     selected: '{{count}} image sélectionnée',
     selected_other: '{{count}} images sélectionnées',
     deleteSelected: 'Supprimer la sélection',
+    deleteAnnotations: 'Supprimer les annotations',
+    annotationsDeleted: 'Annotations supprimées pour {{count}} image(s)',
+    annotationsDeleteFailed:
+      'Échec de la suppression des annotations pour {{count}} image(s)',
+    deleteAnnotationsDialog: {
+      title: 'Supprimer les annotations ?',
+      description:
+        'Cela supprime les annotations de segmentation de {{count}} image(s) sélectionnée(s). Les images sont conservées mais leurs résultats de segmentation sont supprimés. Cette action est irréversible.',
+    },
     imagesDeleted: '{{count}} image supprimée',
     imagesDeleted_other: '{{count}} images supprimées',
   },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -297,6 +297,7 @@ export default {
       unshareProject: '无法从共享项目中移除项目',
       deleteProject: '无法删除项目。请确保您有必要的权限。',
     },
+    deleteAnnotations: '删除标注失败',
     deleteImages: '删除所选图像失败',
     contexts: {
       dashboard: '仪表板错误',
@@ -1071,6 +1072,14 @@ export default {
     selected: '已选择{{count}}张图片',
     selected_other: '已选择{{count}}张图片',
     deleteSelected: '删除选中项',
+    deleteAnnotations: '删除标注',
+    annotationsDeleted: '已删除 {{count}} 张图像的标注',
+    annotationsDeleteFailed: '删除 {{count}} 张图像的标注失败',
+    deleteAnnotationsDialog: {
+      title: '删除标注？',
+      description:
+        '这将删除 {{count}} 张所选图像的分割标注。图像会保留，但其分割结果将被移除。此操作无法撤销。',
+    },
     imagesDeleted: '已删除 {{count}} 张图片',
     imagesDeleted_other: '已删除 {{count}} 张图片',
   },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -704,6 +704,12 @@ export default {
     },
   },
   segmentation: {
+    trackOps: {
+      propagateSuccess: '微管已传播到 {{count}} 个后续帧',
+      propagateFailed: '微管传播失败',
+      deleteTrackSuccess: '已从 {{count}} 帧中删除轨迹',
+      deleteTrackFailed: '删除轨迹失败',
+    },
     modelNotCompatible:
       '模型 "{{model}}" 与项目类型 "{{type}}" 不兼容。允许的: {{allowed}}。',
     incompatibleModelTitle: '无法使用此模型进行分割',
@@ -1750,6 +1756,14 @@ export default {
     },
   },
   contextMenu: {
+    propagateTrack: '传播到后续帧',
+    confirmPropagateTrack: '传播到后续帧？',
+    propagateTrackDescription:
+      '这将覆盖该微管在视频所有后续帧中的形状。此操作无法撤销。',
+    deleteTrack: '删除整条轨迹',
+    confirmDeleteTrack: '删除整条微管轨迹？',
+    deleteTrackDescription:
+      '这将从视频的全部 {{count}} 帧中删除该微管。此操作无法撤销。',
     editPolygon: '编辑多边形',
     splitPolygon: '分割多边形',
     deletePolygon: '删除多边形',


### PR DESCRIPTION
## Summary

Three microtubule (MT) features, driven by the request "for ImageJ I'd like one .nd2-style file I can drag-and-drop" plus two cross-frame editing gestures.

### A) ImageJ export → one `RoiSet.zip` per video
Replaces the thousands of loose `.roi` files (`annotations/imagej/<video>/frame_NNNN/*.roi`) with a single **`annotations/imagej/<video>_RoiSet.zip`** that biologists drag into ImageJ / Fiji → ROI Manager. Each ROI now carries:
- **slice position** (`frameIndex + 1`) so it lands on its own stack frame, and
- a **per-`trackId` stroke colour** computed with the exact hue math the editor uses (`imagejColor.ts` ports `instanceColors.ts`), so the same MT is one colour across frames.

`encodeImageJRoi()` gained optional `position` (@56) + `strokeColor` (@40) fields; omitting them keeps the exact golden-file byte layout. `buildVideoRoiEntries()` is a pure, byte-testable builder; `writeRoiSetZip()` streams the deflate archive.

### B) Right-click MT → "Propagate to following frames"
Stamps the polyline's current shape into every frame with `frameIndex > current`, overwriting the same track where present and adding it where missing — behind a confirm dialog (irreversible). Generates an `mt_<hex>` trackId when the source has none so the propagated set is one stably-coloured track.

### C) Right-click MT delete → whole track
For a tracked MT the delete dialog becomes "delete the whole track across N frames" and removes every polyline with that `trackId` from all frames (`DELETE .../tracks/:trackId`). An untracked polyline keeps the single-frame delete. Shares `removePolygonsWithTrackId` with the existing save-time delete propagation.

Both editor ops run in one Prisma transaction, are microtubules-only, verify video ownership, and invalidate the affected frames' segmentation caches so a scrub shows the change. i18n ×6.

## Verification

- **A — wire-level (independent):** decoded a produced `RoiSet.zip` with Python `roifile` — `mt_42` → `hsl(62,70,55)` → rgb(215,221,60), **identical stroke across frames**, `position` = 1-based slice, coordinates exact. Real prod export: **1 zip/video, 58 frames, 491 ROIs, 0 corrupt**.
- **B/C — cross-stack on production (real 61-frame ND2):** right-click menu shows the new items; propagate confirm + `framesUpdated: 60` written to DB; delete menu flips to "Delete whole track", dialog reads "…all 61 frames…", track removed from every frame. Round-trip left the fixture **fully restored** (non-destructive). **0 feature console errors**.
- Unit: `imagejColor` parity, `imagejRoiEncoder` (position/stroke/golden), `removePolygonsWithTrackId` / `upsertTrackPolyline`. Frontend production build (gate G) + ESLint 0-warnings + i18n complete.

## Notes
- Deployed to production for verification (additive, MT-gated). Backward propagation and "fill-only-missing" were explicitly deferred (see spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added microtubule track operations: propagate a track to following frames and delete a track across all frames (with new authenticated endpoints and editor context-menu actions).
  * Updated ImageJ ROI export to generate per-video `RoiSet.zip` archives with consistent stack slice positioning and track-based coloring.
  * Added API client support and new i18n labels for propagate/delete track actions.
* **Bug Fixes**
  * Improved validation and error handling for track edits, including corrupt/invalid frame data handling.
  * Strengthened ROI export correctness by filtering invalid geometry and ensuring stable color/label behavior.
* **Tests**
  * Added unit and integration coverage for track operations and ImageJ ROI export/color parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->