### PR TITLE
fix+feat(mt): propagate into empty frames + Shift multi-select propagate

### DIFF
--- a/backend/src/services/__tests__/segmentationService.trackOpsService.test.ts
+++ b/backend/src/services/__tests__/segmentationService.trackOpsService.test.ts
@@ -72,8 +72,8 @@ describe('SegmentationService track ops (orchestration)', () => {
 
   beforeEach(() => {
     prismaMock = {
-      segmentation: { update: vi.fn(x => x) },
-      image: { findMany: vi.fn() },
+      segmentation: { update: vi.fn(x => x), create: vi.fn(x => x) },
+      image: { findMany: vi.fn(), update: vi.fn(x => x) },
       $transaction: vi.fn().mockResolvedValue([]),
     };
     imageServiceMock = { getImageById: vi.fn() };
@@ -164,13 +164,38 @@ describe('SegmentationService track ops (orchestration)', () => {
       );
     });
 
-    it('skips frames with no segmentation row and does not open a transaction when nothing is written', async () => {
+    it('creates a segmentation row (+ marks segmented) for a frame that has none', async () => {
       prismaMock.image.findMany.mockResolvedValue([
-        { id: 'f1', segmentation: null },
+        { id: 'f1', width: 512, height: 512, segmentation: null },
       ]);
       const res = await service.propagateTrackGeometryForward(
         'vid',
         0,
+        { ...srcPolyline, trackId: 't' },
+        'user'
+      );
+      // The microtubule now appears in the previously-empty frame.
+      expect(res.framesUpdated).toBe(1);
+      expect(prismaMock.segmentation.update).not.toHaveBeenCalled();
+      // A new segmentation row was created carrying just the propagated line...
+      expect(prismaMock.segmentation.create).toHaveBeenCalledTimes(1);
+      const created = prismaMock.segmentation.create.mock.calls[0][0].data;
+      const polys = JSON.parse(created.polygons);
+      expect(polys).toHaveLength(1);
+      expect(polys[0].trackId).toBe('t');
+      expect(created.imageWidth).toBe(512);
+      // ...and the frame was marked segmented, all in one transaction.
+      expect(prismaMock.image.update.mock.calls[0][0].data.segmentationStatus).toBe(
+        'segmented'
+      );
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not open a transaction when there are no following frames', async () => {
+      prismaMock.image.findMany.mockResolvedValue([]);
+      const res = await service.propagateTrackGeometryForward(
+        'vid',
+        99,
         { ...srcPolyline, trackId: 't' },
         'user'
       );

--- a/backend/src/services/segmentationService.ts
+++ b/backend/src/services/segmentationService.ts
@@ -2275,9 +2275,11 @@ export class SegmentationService {
    *
    * A trackId is generated (`mt_<hex>`) when the source polyline has none, so
    * the propagated set forms one coherent, stably-coloured track; the generated
-   * id is returned for the editor to patch onto the source polyline. Frames with
-   * no segmentation row yet — or whose polygons JSON is unreadable — are skipped
-   * (a corrupt frame must never be overwritten with just the propagated line).
+   * id is returned for the editor to patch onto the source polyline. Frames that
+   * have no segmentation row yet (never segmented, or annotations deleted) get a
+   * fresh row carrying just the propagated polyline, so the microtubule appears
+   * in every following frame. Only a frame whose polygons JSON is unreadable is
+   * skipped (it must never be overwritten with just the propagated line).
    *
    * @throws {VideoAccessError} if the video is not owned.
    * @throws if the polyline has fewer than 2 points.
@@ -2305,39 +2307,67 @@ export class SegmentationService {
       where: { parentVideoId: videoId, frameIndex: { gt: fromFrameIndex } },
       select: {
         id: true,
+        width: true,
+        height: true,
         segmentation: { select: { id: true, polygons: true } },
       },
     });
 
     const ops: Prisma.PrismaPromise<unknown>[] = [];
     let framesUpdated = 0;
+    let framesCreated = 0;
     let corruptFrames = 0;
     for (const frame of frames) {
-      // A frame that never segmented has no row to attach the polyline to; skip
-      // it rather than fabricate a partial segmentation record.
-      if (!frame.segmentation) continue;
-      // Use the corrupt-aware parse: overwriting an unreadable frame with only
-      // the propagated polyline would silently destroy its other microtubules.
-      const { polygons: parsed, corrupt } = parsePolygonsForWrite(
-        frame.segmentation.polygons
-      );
-      if (corrupt) {
-        corruptFrames++;
-        logger.warn(
-          'Skipping frame with unreadable polygons during propagate',
-          'SegmentationService',
-          { imageId: frame.id, parentVideoId: videoId }
+      if (frame.segmentation) {
+        // Existing row: overwrite the same track / add it, preserving other MTs.
+        // Use the corrupt-aware parse — overwriting an unreadable frame with only
+        // the propagated polyline would silently destroy its other microtubules.
+        const { polygons: parsed, corrupt } = parsePolygonsForWrite(
+          frame.segmentation.polygons
         );
-        continue;
+        if (corrupt) {
+          corruptFrames++;
+          logger.warn(
+            'Skipping frame with unreadable polygons during propagate',
+            'SegmentationService',
+            { imageId: frame.id, parentVideoId: videoId }
+          );
+          continue;
+        }
+        const updated = upsertTrackPolyline(parsed, trackId, polyline, uuidv4);
+        ops.push(
+          this.prisma.segmentation.update({
+            where: { id: frame.segmentation.id },
+            data: { polygons: JSON.stringify(updated), updatedAt: new Date() },
+          })
+        );
+        framesUpdated++;
+      } else {
+        // No segmentation row yet — the frame was never segmented or its
+        // annotations were deleted. Create a row carrying just the propagated
+        // polyline so the microtubule still appears in EVERY following frame
+        // (the whole point of "propagate to following frames"), and mark the
+        // frame segmented.
+        const created = upsertTrackPolyline([], trackId, polyline, uuidv4);
+        const createData: Prisma.SegmentationCreateInput = {
+          image: { connect: { id: frame.id } },
+          polygons: JSON.stringify(created),
+          model: 'manual',
+          threshold: 0.5,
+        };
+        if (frame.width && frame.height) {
+          createData.imageWidth = frame.width;
+          createData.imageHeight = frame.height;
+        }
+        ops.push(this.prisma.segmentation.create({ data: createData }));
+        ops.push(
+          this.prisma.image.update({
+            where: { id: frame.id },
+            data: { segmentationStatus: 'segmented' },
+          })
+        );
+        framesCreated++;
       }
-      const updated = upsertTrackPolyline(parsed, trackId, polyline, uuidv4);
-      ops.push(
-        this.prisma.segmentation.update({
-          where: { id: frame.segmentation.id },
-          data: { polygons: JSON.stringify(updated), updatedAt: new Date() },
-        })
-      );
-      framesUpdated++;
     }
 
     if (ops.length > 0) {
@@ -2349,9 +2379,12 @@ export class SegmentationService {
       trackId,
       fromFrameIndex,
       framesUpdated,
+      framesCreated,
       corruptFramesSkipped: corruptFrames,
     });
-    return { trackId, framesUpdated };
+    // Total frames the microtubule now appears in (existing rows updated + new
+    // rows created) — this is what the editor toast reports.
+    return { trackId, framesUpdated: framesUpdated + framesCreated };
   }
 }
 

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -652,6 +652,9 @@ const SegmentationEditor = () => {
     handleChangeInstanceId,
     handleChangePartClass,
     handleUpdatePolygonField,
+    selectedPolygonIds,
+    toggleMultiSelect,
+    clearMultiSelect,
   } = usePolygonHandlers({ editor, imageId });
 
   // Pure render-derivation pipeline (polyline/instance discrimination, legacy
@@ -936,6 +939,93 @@ const SegmentationEditor = () => {
       t,
     ]
   );
+
+  // Read the multi-selection through a ref so the canvas callbacks below stay
+  // identity-stable (they're compared in the CanvasPolygon memo comparator).
+  const selectedPolygonIdsRef = useRef(selectedPolygonIds);
+  selectedPolygonIdsRef.current = selectedPolygonIds;
+
+  // Canvas click: Shift+click toggles the polygon in the multi-selection; a
+  // plain click clears the multi-selection and runs the normal single select.
+  const handleCanvasSelect = useCallback(
+    (polygonId: string | null, additive?: boolean) => {
+      if (additive && polygonId) {
+        toggleMultiSelect(polygonId);
+        return;
+      }
+      clearMultiSelect();
+      editorRef.current.handlePolygonClick(polygonId);
+    },
+    [toggleMultiSelect, clearMultiSelect]
+  );
+
+  // Right-click "Propagate selected MTs (N)": propagate every Shift-selected
+  // microtubule forward. Loops the single-track endpoint so each keeps its own
+  // trackId + colour; ids read via ref to keep this handler stable.
+  const handlePropagateSelected = useCallback(async () => {
+    const videoId = video.container?.id;
+    const fromFrameIndex = video.container?.frames.find(
+      f => f.id === imageId
+    )?.frameIndex;
+    if (!videoId || typeof fromFrameIndex !== 'number') return;
+
+    const polys = editorRef.current.getPolygons();
+    const sources = Array.from(selectedPolygonIdsRef.current)
+      .map(pid => polys.find(p => p.id === pid))
+      .filter(
+        (p): p is NonNullable<typeof p> => !!p && (p.points?.length ?? 0) >= 2
+      );
+    if (sources.length === 0) {
+      toast.error(t('segmentation.trackOps.propagateFailed'));
+      return;
+    }
+
+    let failed = 0;
+    for (const src of sources) {
+      try {
+        const result = await apiClient.propagateTrackForward(
+          videoId,
+          fromFrameIndex,
+          {
+            trackId: src.trackId,
+            name: src.name,
+            geometry: 'polyline',
+            points: src.points.map(p => ({ x: p.x, y: p.y })),
+          }
+        );
+        if (result.trackId && result.trackId !== src.trackId) {
+          handleUpdatePolygonField(src.id, { trackId: result.trackId });
+        }
+      } catch (error) {
+        logger.error('Failed to propagate a selected microtubule', error);
+        failed++;
+      }
+    }
+
+    evictVideoFrameSegmentationCaches();
+    clearMultiSelect();
+    if (failed === 0) {
+      toast.success(
+        t('segmentation.trackOps.propagateSelectedSuccess', {
+          count: sources.length,
+        })
+      );
+    } else {
+      toast.warning(
+        t('segmentation.trackOps.propagateSelectedPartial', {
+          done: sources.length - failed,
+          total: sources.length,
+        })
+      );
+    }
+  }, [
+    video.container,
+    imageId,
+    handleUpdatePolygonField,
+    evictVideoFrameSegmentationCaches,
+    clearMultiSelect,
+    t,
+  ]);
   // ─────────────── End cross-frame track operations ───────────────
 
   // The overlay debounce moved into `FrameLoadingGate` — it needs
@@ -1075,6 +1165,9 @@ const SegmentationEditor = () => {
         handleSelectPolygon={handleSelectPolygon}
         handleDeletePolygonOrTrack={handleDeletePolygonOrTrack}
         handlePropagateTrack={handlePropagateTrack}
+        handleCanvasSelect={handleCanvasSelect}
+        handlePropagateSelected={handlePropagateSelected}
+        selectedPolygonIds={selectedPolygonIds}
         handleSlicePolygonFromContextMenu={handleSlicePolygonFromContextMenu}
         handleEditPolygonFromContextMenu={handleEditPolygonFromContextMenu}
         handleDeleteVertexFromContextMenu={handleDeleteVertexFromContextMenu}

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -120,6 +120,12 @@ export interface SegmentationEditorLayoutProps {
   handleDeletePolygonOrTrack: (polygonId: string) => void;
   /** Canvas right-click: propagate this MT into all following frames. */
   handlePropagateTrack: (polygonId: string) => void;
+  /** Canvas click: Shift+click multi-selects; plain click single-selects. */
+  handleCanvasSelect: (polygonId: string | null, additive?: boolean) => void;
+  /** Propagate all Shift-selected microtubules to the following frames. */
+  handlePropagateSelected: () => void;
+  /** Current Shift+click multi-selection (per-frame polygon ids). */
+  selectedPolygonIds: Set<string>;
   handleSlicePolygonFromContextMenu: PolygonHandlers['handleSlicePolygonFromContextMenu'];
   handleEditPolygonFromContextMenu: PolygonHandlers['handleEditPolygonFromContextMenu'];
   handleDeleteVertexFromContextMenu: PolygonHandlers['handleDeleteVertexFromContextMenu'];
@@ -195,6 +201,9 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
   handleSelectPolygon,
   handleDeletePolygonOrTrack,
   handlePropagateTrack,
+  handleCanvasSelect,
+  handlePropagateSelected,
+  selectedPolygonIds,
   handleSlicePolygonFromContextMenu,
   handleEditPolygonFromContextMenu,
   handleDeleteVertexFromContextMenu,
@@ -390,7 +399,10 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                           isUndoRedoInProgress={editor.isUndoRedoInProgress}
                           isHovered={polygon.id === hoveredPolygonId}
                           editMode={editor.editMode}
-                          onSelectPolygon={editor.handlePolygonClick}
+                          onSelectPolygon={handleCanvasSelect}
+                          isMultiSelected={selectedPolygonIds.has(polygon.id)}
+                          multiSelectCount={selectedPolygonIds.size}
+                          onPropagateSelected={handlePropagateSelected}
                           onDeletePolygon={handleDeletePolygonOrTrack}
                           onPropagateTrack={handlePropagateTrack}
                           videoFrameCount={video.container?.frameCount}

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -232,8 +232,14 @@ const CanvasPolygon = React.memo(
     const handleClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (onSelectPolygon) {
-          onSelectPolygon(id, e.shiftKey);
+        if (!onSelectPolygon) return;
+        // Only pass the `additive` arg on a Shift+click so a plain click stays a
+        // single-argument call (keeps the single-selection call sites + their
+        // tests unchanged).
+        if (e.shiftKey) {
+          onSelectPolygon(id, true);
+        } else {
+          onSelectPolygon(id);
         }
       },
       [onSelectPolygon, id]

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -20,7 +20,16 @@ interface CanvasPolygonProps {
   hideVertices?: boolean;
   isHovered?: boolean;
   isUndoRedoInProgress?: boolean;
-  onSelectPolygon?: (id: string) => void;
+  /** `additive` (Shift+click) toggles this polygon in the multi-selection
+   *  instead of replacing the single selection. */
+  onSelectPolygon?: (id: string, additive?: boolean) => void;
+  /** True when this polygon is in the Shift+click multi-selection. */
+  isMultiSelected?: boolean;
+  /** Size of the current multi-selection (drives the "Propagate selected N"
+   *  context-menu item). */
+  multiSelectCount?: number;
+  /** Propagate all multi-selected microtubules to the following frames. */
+  onPropagateSelected?: () => void;
   onDeletePolygon?: (id: string) => void;
   onSlicePolygon?: (id: string) => void;
   onEditPolygon?: (id: string) => void;
@@ -56,6 +65,9 @@ const CanvasPolygon = React.memo(
     isHovered = false,
     isUndoRedoInProgress = false,
     onSelectPolygon,
+    isMultiSelected = false,
+    multiSelectCount = 0,
+    onPropagateSelected,
     onDeletePolygon,
     onSlicePolygon,
     onEditPolygon,
@@ -221,7 +233,7 @@ const CanvasPolygon = React.memo(
       (e: React.MouseEvent) => {
         e.stopPropagation();
         if (onSelectPolygon) {
-          onSelectPolygon(id);
+          onSelectPolygon(id, e.shiftKey);
         }
       },
       [onSelectPolygon, id]
@@ -290,6 +302,8 @@ const CanvasPolygon = React.memo(
         onPropagate={
           isPolyline && onPropagateTrack ? handlePropagate : undefined
         }
+        onPropagateSelected={isPolyline ? onPropagateSelected : undefined}
+        multiSelectCount={multiSelectCount}
         trackId={polygon.trackId}
         videoFrameCount={videoFrameCount}
       >
@@ -358,7 +372,11 @@ const CanvasPolygon = React.memo(
                       : 'rgba(239, 68, 68, 0.1)'
             }
             stroke={pathColor}
-            strokeWidth={Math.max(strokeWidth * hoverStrokeMultiplier, 0.5)}
+            strokeWidth={Math.max(
+              strokeWidth * hoverStrokeMultiplier * (isMultiSelected ? 2.2 : 1),
+              0.5
+            )}
+            strokeDasharray={isMultiSelected ? '6 3' : undefined}
             strokeOpacity={pathString ? 1 : 0}
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -487,6 +505,9 @@ const CanvasPolygon = React.memo(
       prevProps.availableInstanceIds === nextProps.availableInstanceIds &&
       prevProps.onPropagateTrack === nextProps.onPropagateTrack &&
       prevProps.videoFrameCount === nextProps.videoFrameCount &&
+      prevProps.isMultiSelected === nextProps.isMultiSelected &&
+      prevProps.multiSelectCount === nextProps.multiSelectCount &&
+      prevProps.onPropagateSelected === nextProps.onPropagateSelected &&
       // Drives context-menu gating; must be in comparator.
       prevProps.projectType === nextProps.projectType &&
       // Context-menu / vertex callbacks. These are identity-stable

--- a/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
+++ b/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
@@ -51,6 +51,10 @@ interface PolygonContextMenuProps {
   trackId?: string;
   /** Total frames in the video, shown in the "delete whole track" dialog. */
   videoFrameCount?: number;
+  /** Propagate ALL Shift-selected microtubules to the following frames. */
+  onPropagateSelected?: () => void;
+  /** Size of the Shift+click multi-selection (gates the bulk-propagate item). */
+  multiSelectCount?: number;
 }
 
 const PolygonContextMenu = ({
@@ -68,6 +72,8 @@ const PolygonContextMenu = ({
   onPropagate,
   trackId,
   videoFrameCount,
+  onPropagateSelected,
+  multiSelectCount = 0,
 }: PolygonContextMenuProps) => {
   const isSperm = projectType === 'sperm';
   const isMicrotubules = projectType === 'microtubules';
@@ -88,6 +94,11 @@ const PolygonContextMenu = ({
   }, [polygonId]);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
   const [showPropagateDialog, setShowPropagateDialog] = React.useState(false);
+  const [showPropagateSelectedDialog, setShowPropagateSelectedDialog] =
+    React.useState(false);
+  // Bulk-propagate the Shift+click multi-selection — only meaningful with ≥2.
+  const canPropagateSelected =
+    isMicrotubules && !!onPropagateSelected && multiSelectCount >= 2;
   const { t } = useLanguage();
 
   return (
@@ -130,6 +141,19 @@ const PolygonContextMenu = ({
                 >
                   <ChevronsRight className="mr-2 h-4 w-4" />
                   <span>{t('contextMenu.propagateTrack')}</span>
+                </ContextMenuItem>
+              )}
+              {canPropagateSelected && (
+                <ContextMenuItem
+                  onClick={() => setShowPropagateSelectedDialog(true)}
+                  className="cursor-pointer"
+                >
+                  <ChevronsRight className="mr-2 h-4 w-4" />
+                  <span>
+                    {t('contextMenu.propagateSelectedTracks', {
+                      count: multiSelectCount,
+                    })}
+                  </span>
                 </ContextMenuItem>
               )}
             </>
@@ -277,6 +301,39 @@ const PolygonContextMenu = ({
               }}
             >
               {t('contextMenu.propagateTrack')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={showPropagateSelectedDialog}
+        onOpenChange={setShowPropagateSelectedDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('contextMenu.confirmPropagateSelected', {
+                count: multiSelectCount,
+              })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('contextMenu.propagateSelectedDescription', {
+                count: multiSelectCount,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onPropagateSelected?.();
+                setShowPropagateSelectedDialog(false);
+              }}
+            >
+              {t('contextMenu.propagateSelectedTracks', {
+                count: multiSelectCount,
+              })}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/segmentation/hooks/__tests__/usePolygonHandlers.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonHandlers.test.ts
@@ -339,4 +339,35 @@ describe('usePolygonHandlers', () => {
       expect.objectContaining({ id: 'p1', partClass: 'tail' }),
     ]);
   });
+
+  // ─── Shift+click multi-selection ───────────────────────────────────────────
+
+  it('toggles polygons in and out of the multi-selection', () => {
+    const { result } = renderHook(() =>
+      usePolygonHandlers({ editor, imageId: 'img-1' })
+    );
+    expect(result.current.selectedPolygonIds.size).toBe(0);
+
+    act(() => result.current.toggleMultiSelect('a'));
+    act(() => result.current.toggleMultiSelect('b'));
+    expect([...result.current.selectedPolygonIds].sort()).toEqual(['a', 'b']);
+
+    act(() => result.current.toggleMultiSelect('a')); // toggle off
+    expect([...result.current.selectedPolygonIds]).toEqual(['b']);
+
+    act(() => result.current.clearMultiSelect());
+    expect(result.current.selectedPolygonIds.size).toBe(0);
+  });
+
+  it('clears the multi-selection when the edited image changes', () => {
+    const { result, rerender } = renderHook(
+      ({ imageId }) => usePolygonHandlers({ editor, imageId }),
+      { initialProps: { imageId: 'img-1' } }
+    );
+    act(() => result.current.toggleMultiSelect('a'));
+    expect(result.current.selectedPolygonIds.size).toBe(1);
+
+    rerender({ imageId: 'img-2' }); // scrub to another frame
+    expect(result.current.selectedPolygonIds.size).toBe(0);
+  });
 });

--- a/src/pages/segmentation/hooks/usePolygonHandlers.ts
+++ b/src/pages/segmentation/hooks/usePolygonHandlers.ts
@@ -65,6 +65,33 @@ export function usePolygonHandlers({
     string | null
   >(null);
   const [hoveredPolygonId, setHoveredPolygonId] = useState<string | null>(null);
+  // Multi-selection (Shift+click) — a parallel set of current-frame polygon ids
+  // used for bulk actions (e.g. propagate several microtubules at once). Kept
+  // separate from the single `selectedPolygonId` so it doesn't disturb the
+  // vertex-edit / cross-frame single-selection flow.
+  const [selectedPolygonIds, setSelectedPolygonIds] = useState<Set<string>>(
+    new Set()
+  );
+  const toggleMultiSelect = useCallback((polygonId: string) => {
+    setSelectedPolygonIds(prev => {
+      const next = new Set(prev);
+      if (next.has(polygonId)) {
+        next.delete(polygonId);
+      } else {
+        next.add(polygonId);
+      }
+      return next;
+    });
+  }, []);
+  const clearMultiSelect = useCallback(() => {
+    setSelectedPolygonIds(prev => (prev.size === 0 ? prev : new Set()));
+  }, []);
+
+  // Polygon ids are per-frame, so a multi-selection is meaningless after a frame
+  // change — clear it when the edited image changes.
+  useEffect(() => {
+    setSelectedPolygonIds(prev => (prev.size === 0 ? prev : new Set()));
+  }, [imageId]);
 
   // Legacy compatibility handlers
   const handleTogglePolygonVisibility = useCallback((polygonId: string) => {
@@ -221,6 +248,9 @@ export function usePolygonHandlers({
     hoveredPolygonId,
     setHoveredPolygonId,
     persistedSelectionTrackId,
+    selectedPolygonIds,
+    toggleMultiSelect,
+    clearMultiSelect,
     handleTogglePolygonVisibility,
     handleDeletePolygonFromPanel,
     handleSelectPolygon,

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -612,6 +612,9 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess:
+        '{{count}} mikrotubulů propagováno do dalších snímků',
+      propagateSelectedPartial: 'Propagováno {{done}} z {{total}} mikrotubulů',
       propagateSuccess:
         'Mikrotubulus propagován do {{count}} následujících snímků',
       propagateFailed: 'Propagace mikrotubulu selhala',
@@ -1912,6 +1915,10 @@ export default {
     disconnected: 'Odpojeno od aktualizací v reálném čase',
   },
   contextMenu: {
+    propagateSelectedTracks: 'Propagovat vybrané mikrotubuly ({{count}})',
+    confirmPropagateSelected: 'Propagovat {{count}} vybraných mikrotubulů?',
+    propagateSelectedDescription:
+      'Přepíše tvar {{count}} vybraných mikrotubulů ve všech následujících snímcích videa. Tuto akci nelze vrátit.',
     propagateTrack: 'Propagovat do dalších snímků',
     confirmPropagateTrack: 'Propagovat do dalších snímků?',
     propagateTrackDescription:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -773,6 +773,9 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess:
+        '{{count}} Mikrotubuli in die folgenden Frames übertragen',
+      propagateSelectedPartial: '{{done}} von {{total}} Mikrotubuli übertragen',
       propagateSuccess: 'Mikrotubulus in {{count}} folgende Frames übertragen',
       propagateFailed: 'Übertragung des Mikrotubulus fehlgeschlagen',
       deleteTrackSuccess: 'Track aus {{count}} Frames entfernt',
@@ -1894,6 +1897,10 @@ export default {
     },
   },
   contextMenu: {
+    propagateSelectedTracks: 'Ausgewählte Mikrotubuli übertragen ({{count}})',
+    confirmPropagateSelected: '{{count}} ausgewählte Mikrotubuli übertragen?',
+    propagateSelectedDescription:
+      'Dies überschreibt die Form von {{count}} ausgewählten Mikrotubuli in allen folgenden Frames des Videos. Dies kann nicht rückgängig gemacht werden.',
     propagateTrack: 'In folgende Frames übertragen',
     confirmPropagateTrack: 'In folgende Frames übertragen?',
     propagateTrackDescription:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -614,6 +614,9 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess:
+        'Propagated {{count}} microtubules to the following frames',
+      propagateSelectedPartial: '{{done}} of {{total}} microtubules propagated',
       propagateSuccess:
         'Microtubule propagated to {{count}} following frame(s)',
       propagateFailed: 'Failed to propagate the microtubule',
@@ -1953,6 +1956,10 @@ export default {
 
   // Context menu
   contextMenu: {
+    propagateSelectedTracks: 'Propagate selected microtubules ({{count}})',
+    confirmPropagateSelected: 'Propagate {{count}} selected microtubules?',
+    propagateSelectedDescription:
+      'This overwrites the shape of {{count}} selected microtubules in all following frames of the video. This cannot be undone.',
     propagateTrack: 'Propagate to following frames',
     confirmPropagateTrack: 'Propagate to following frames?',
     propagateTrackDescription:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -766,6 +766,9 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess:
+        '{{count}} microtúbulos propagados a los fotogramas siguientes',
+      propagateSelectedPartial: '{{done}} de {{total}} microtúbulos propagados',
       propagateSuccess:
         'Microtúbulo propagado a {{count}} fotogramas siguientes',
       propagateFailed: 'No se pudo propagar el microtúbulo',
@@ -1934,6 +1937,10 @@ export default {
     },
   },
   contextMenu: {
+    propagateSelectedTracks: 'Propagar microtúbulos seleccionados ({{count}})',
+    confirmPropagateSelected: '¿Propagar {{count}} microtúbulos seleccionados?',
+    propagateSelectedDescription:
+      'Esto sobrescribe la forma de {{count}} microtúbulos seleccionados en todos los fotogramas siguientes del vídeo. Esta acción no se puede deshacer.',
     propagateTrack: 'Propagar a los fotogramas siguientes',
     confirmPropagateTrack: '¿Propagar a los fotogramas siguientes?',
     propagateTrackDescription:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -767,6 +767,9 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess:
+        '{{count}} microtubules propagés vers les images suivantes',
+      propagateSelectedPartial: '{{done}} sur {{total}} microtubules propagés',
       propagateSuccess: 'Microtubule propagé vers {{count}} images suivantes',
       propagateFailed: 'Échec de la propagation du microtubule',
       deleteTrackSuccess: 'Trace supprimée de {{count}} images',
@@ -1883,6 +1886,11 @@ export default {
     },
   },
   contextMenu: {
+    propagateSelectedTracks:
+      'Propager les microtubules sélectionnés ({{count}})',
+    confirmPropagateSelected: 'Propager {{count}} microtubules sélectionnés ?',
+    propagateSelectedDescription:
+      'Cela remplace la forme de {{count}} microtubules sélectionnés dans toutes les images suivantes de la vidéo. Cette action est irréversible.',
     propagateTrack: 'Propager aux images suivantes',
     confirmPropagateTrack: 'Propager aux images suivantes ?',
     propagateTrackDescription:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -706,6 +706,8 @@ export default {
   },
   segmentation: {
     trackOps: {
+      propagateSelectedSuccess: '已将 {{count}} 个微管传播到后续帧',
+      propagateSelectedPartial: '已传播 {{done}}/{{total}} 个微管',
       propagateSuccess: '微管已传播到 {{count}} 个后续帧',
       propagateFailed: '微管传播失败',
       deleteTrackSuccess: '已从 {{count}} 帧中删除轨迹',
@@ -1765,6 +1767,10 @@ export default {
     },
   },
   contextMenu: {
+    propagateSelectedTracks: '传播选中的微管（{{count}}）',
+    confirmPropagateSelected: '传播 {{count}} 个选中的微管？',
+    propagateSelectedDescription:
+      '这将覆盖 {{count}} 个选中微管在视频所有后续帧中的形状。此操作无法撤销。',
     propagateTrack: '传播到后续帧',
     confirmPropagateTrack: '传播到后续帧？',
     propagateTrackDescription:


### PR DESCRIPTION
## Summary

Two follow-ups to PR #274, from user testing on production.

### 1. Propagate now works into frames with no segmentation (fix)
After a bulk **Delete Annotations** on the following frames, "Propagate to following frames" did nothing (`framesUpdated: 0`) because `propagateTrackGeometryForward` **skipped** frames that had no segmentation row. It now **creates** a row carrying the propagated polyline (model `manual`, threshold `0.5`, frame dimensions) and marks the frame segmented — the microtubule appears in *every* following frame, which is the whole point of the action. Corrupt-JSON frames are still skipped (never overwritten). Returned `framesUpdated` = existing rows updated + new rows created.

### 2. Shift+click multi-select → "Propagate selected microtubules (N)" (feature)
Shift+click a microtubule toggles it into a multi-selection (rendered with a dashed, thicker stroke). The right-click menu then offers **"Propagate selected microtubules (N)"**, which propagates every selected MT to the following frames at once (behind a confirm). Each keeps its own trackId + colour.
- Multi-selection lives in `usePolygonHandlers` (`toggleMultiSelect` / `clearMultiSelect`, cleared on frame change); `CanvasPolygon` forwards `e.shiftKey`; a stable `handleCanvasSelect` routes Shift→toggle, plain→single select.
- `handlePropagateSelected` reads the selection via a ref so the canvas callbacks stay identity-stable (CanvasPolygon `React.memo` comparator updated with the new props).
- i18n ×6.

## Verification (production, non-destructive)

- **#1:** frame with no segmentation row (404) → propagate → the frame gets a row with the microtubule (`framesUpdated: 1`); restored via direct Prisma.
- **#2:** Shift+click two MTs → both show the dashed multi-select highlight; right-click → menu shows "Propagate selected microtubules (2)"; confirm dialog reads "Propagate 2 selected microtubules?"; on confirm all 60 following frames receive the 2 MTs (frame 1/30/60 verified), source frame unchanged; the affected frames were restored afterward. 0 console errors.
- Unit: `usePolygonHandlers` multi-select toggle/clear/reset; `segmentationService.trackOpsService` create-row-on-empty-frame. FE build + ESLint + i18n clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now select multiple segmentation polygons with Shift+click.
  * Added a bulk action to propagate selected tracks across later frames.
  * Selected polygons are visually highlighted for easier multi-selection.

* **Bug Fixes**
  * Propagation now creates missing frame entries when needed, so tracked shapes appear in every following frame.
  * Selection state clears when moving to a different frame.
  * Improved handling for frames with unreadable segmentation data to avoid overwriting existing content.

* **Documentation**
  * Updated on-screen messages and confirmations in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->