### PR TITLE
feat(mt-editor): show vertices on multi-select + apply propagate immediately

### DIFF
--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -73,6 +73,7 @@ const SegmentationEditor = () => {
     images,
     loading: projectLoading,
     refreshImageSegmentation,
+    updateImages,
     // useProjectData always fetches metadata only (lod: 'low') and loads
     // segmentation geometry on demand — there is no fetch-all path to disable,
     // so no options arg is passed. Adjacent-frame prefetch is handled separately.
@@ -835,6 +836,30 @@ const SegmentationEditor = () => {
     }
   }, [video.container, queryClient]);
 
+  // After a propagate, the following frames now have segmentation (created or
+  // updated). Bump their status in the in-memory project images so the frame
+  // loader's `hasSegmentation` gate passes on a scrub — otherwise a frame whose
+  // cached status is still `no_segmentation` (e.g. its annotations were just
+  // deleted) never re-fetches and stays blank until a full page reload.
+  const markFollowingFramesSegmented = useCallback(
+    (fromFrameIndex: number) => {
+      const frames = video.container?.frames;
+      if (!frames) return;
+      const followingIds = new Set(
+        frames.filter(f => f.frameIndex > fromFrameIndex).map(f => f.id)
+      );
+      if (followingIds.size === 0) return;
+      updateImages(prev =>
+        prev.map(img =>
+          followingIds.has(img.id) && img.segmentationStatus !== 'segmented'
+            ? { ...img, segmentationStatus: 'segmented' }
+            : img
+        )
+      );
+    },
+    [video.container, updateImages]
+  );
+
   // Right-click "Propagate to following frames": stamp this microtubule's
   // current shape into every later frame of the video.
   const handlePropagateTrack = useCallback(
@@ -883,6 +908,7 @@ const SegmentationEditor = () => {
           handleUpdatePolygonField(polygonId, { trackId: result.trackId });
         }
         evictVideoFrameSegmentationCaches();
+        markFollowingFramesSegmented(fromFrameIndex);
         toast.success(
           t('segmentation.trackOps.propagateSuccess', {
             count: result.framesUpdated,
@@ -898,6 +924,7 @@ const SegmentationEditor = () => {
       imageId,
       handleUpdatePolygonField,
       evictVideoFrameSegmentationCaches,
+      markFollowingFramesSegmented,
       t,
     ]
   );
@@ -1003,6 +1030,7 @@ const SegmentationEditor = () => {
     }
 
     evictVideoFrameSegmentationCaches();
+    markFollowingFramesSegmented(fromFrameIndex);
     clearMultiSelect();
     if (failed === 0) {
       toast.success(
@@ -1023,6 +1051,7 @@ const SegmentationEditor = () => {
     imageId,
     handleUpdatePolygonField,
     evictVideoFrameSegmentationCaches,
+    markFollowingFramesSegmented,
     clearMultiSelect,
     t,
   ]);

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -437,6 +437,7 @@ const CanvasPolygon = React.memo(
               points={points}
               polygonType={type}
               isSelected={isSelected}
+              isMultiSelected={isMultiSelected}
               isHovered={isHovered}
               hoveredVertex={hoveredVertex}
               vertexDragState={vertexDragState}

--- a/src/pages/segmentation/components/canvas/PolygonVertices.tsx
+++ b/src/pages/segmentation/components/canvas/PolygonVertices.tsx
@@ -9,6 +9,9 @@ interface PolygonVerticesProps {
   points: Point[];
   polygonType: 'external' | 'internal';
   isSelected: boolean;
+  /** Shift+click multi-selection: show the same vertex dots as a single
+   *  selection so the user can see every point of each selected microtubule. */
+  isMultiSelected?: boolean;
   isHovered: boolean;
   hoveredVertex: { polygonId: string | null; vertexIndex: number | null };
   vertexDragState: VertexDragState;
@@ -28,6 +31,7 @@ const PolygonVertices = React.memo(
     points,
     polygonType,
     isSelected,
+    isMultiSelected = false,
     isHovered: _isHovered,
     hoveredVertex,
     vertexDragState,
@@ -37,8 +41,10 @@ const PolygonVertices = React.memo(
     onDeleteVertex,
     editMode,
   }: PolygonVerticesProps) => {
-    // Always show vertices for selected polygons to enable dragging
-    const shouldShowVertices = isSelected;
+    // Show vertices for the single-selected polygon (to enable dragging) and
+    // for every Shift+click multi-selected microtubule (so all selected MTs
+    // display their individual points, like a single selection).
+    const shouldShowVertices = isSelected || isMultiSelected;
 
     // Get all vertices without decimation or approximation
     const visibleVertices = React.useMemo(() => {
@@ -103,7 +109,7 @@ const PolygonVertices = React.memo(
                   point={point}
                   polygonId={polygonId}
                   vertexIndex={originalIndex}
-                  isSelected={isSelected}
+                  isSelected={isSelected || isMultiSelected}
                   isHovered={isVertexHovered}
                   isDragging={isDragging}
                   dragOffset={dragOffset}
@@ -129,6 +135,7 @@ const PolygonVertices = React.memo(
       prevProps.polygonId !== nextProps.polygonId ||
       prevProps.polygonType !== nextProps.polygonType ||
       prevProps.isSelected !== nextProps.isSelected ||
+      prevProps.isMultiSelected !== nextProps.isMultiSelected ||
       prevProps.isHovered !== nextProps.isHovered ||
       prevProps.isUndoRedoInProgress !== nextProps.isUndoRedoInProgress ||
       // onDeleteVertex backs the per-vertex context menu and editMode gates


### PR DESCRIPTION
## Summary

Two editor UX follow-ups on the microtubule track ops.

### 1. Multi-selected microtubules show their vertices
Shift+click multi-selected MTs now render their individual vertex dots — the same as a single selection — not just a dashed outline. `PolygonVertices` shows the dots when `isSelected || isMultiSelected` (memo comparator updated).

### 2. Propagate applies immediately (no page refresh)
After a propagate that **created** segmentation on previously-empty frames (e.g. their annotations were just deleted), scrubbing to a following frame showed nothing until a full page reload. The frame loader gates the fetch on `selectedImage.segmentationStatus`, which stayed `no_segmentation` in the in-memory project images after a create-into-empty propagate, so the scrub skipped the fetch entirely (before even reaching the — already evicted — geometry cache). `markFollowingFramesSegmented()` now bumps the affected frames' status to `segmented` via `updateImages` after every propagate (single and multi-select), so the gate passes and the evicted cache re-fetches → the microtubule appears on scrub without a refresh.

## Verification (production, non-destructive)

- **#1:** Shift-selected 2 MTs → both show the dashed outline **and** their vertex circles (2 vertex groups, 10 dots).
- **#2:** reset a frame to empty (404) → confirmed the editor shows it blank on scrub (reproducing the reported "no segmentation data" 404s) → propagate one MT from frame 0 → scrub to the frame → it now renders the propagated MT (rendered 1, DB 1) **without a refresh**. Restored the fixture afterward.
- FE build + ESLint + editor/canvas test suites (167 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved polygon editing to better support multi-selection, including clearer vertex display and selection feedback.
  * Updated segmentation propagation so newly processed frames are reflected immediately in the current project view.

* **Bug Fixes**
  * Fixed frame segmentation status updates after propagation, helping keep the interface in sync with recent changes.
  * Ensured selected points and vertices remain visibly highlighted during multi-select actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->