### PR TITLE
fix(video): multi-channel + single-frame TIFF upload; hide-all polylines; sidebar scroll

### DIFF
--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -37,7 +37,7 @@ def _sanitize_name(raw: str | None, fallback: str) -> str:
 
 
 def _imagej_channel_labels(tf, count: int) -> list[str | None]:
-    """Best-effort ImageJ channel name extraction.
+    """Best-effort ImageJ per-slice channel label extraction.
 
     `tifffile` exposes ImageJ's tagged metadata as ``tf.imagej_metadata``.
     The conventional location for per-channel labels is ``'Labels'`` —
@@ -60,6 +60,103 @@ def _imagej_channel_labels(tf, count: int) -> list[str | None]:
         return [labels[i] if isinstance(labels[i], str) else None for i in range(count)]
     except Exception:
         return [None] * count
+
+
+def _all_distinct(names: list[str | None]) -> bool:
+    """True only when every entry is a non-empty string AND all are unique.
+    Used to reject the two failure modes that made every channel look the
+    same: a shared concatenated label ("… - a/b") and a per-slice label
+    that is just the source filename repeated for each channel."""
+    if not names or any(not (isinstance(n, str) and n.strip()) for n in names):
+        return False
+    return len({n.strip() for n in names}) == len(names)
+
+
+def _metamorph_wave_names(info: str, count: int) -> list[str] | None:
+    """Parse per-channel names from a MetaMorph ImageJ ``Info`` block.
+
+    MetaMorph stores the real per-wavelength names as
+      ``WaveName1 = "WD_LED_IRM"``
+      ``WaveName2 = "TIRF_491"``
+    which — unlike the per-slice ``Labels`` — are genuinely distinct per
+    channel. Returns ``None`` unless all ``count`` names are present and
+    distinct (so the caller keeps looking for another source)."""
+    if not isinstance(info, str) or not info:
+        return None
+    names: list[str | None] = []
+    for i in range(1, count + 1):
+        m = re.search(
+            rf'^\s*WaveName{i}\s*=\s*"?([^"\r\n]+?)"?\s*$', info, re.MULTILINE
+        )
+        names.append(m.group(1).strip() if m else None)
+    return names if _all_distinct(names) else None
+
+
+def _split_shared_label(labels: list[str | None], count: int) -> list[str] | None:
+    """Recover per-channel names from ImageJ's shared concatenated label.
+
+    Bio-Formats / MetaMorph hyperstacks write the SAME label to every
+    slice, concatenating all wavelength names after the last `` - ``:
+      ``"c:1/2 t:1/61 - WD_LED_IRM/TIRF_491"``
+    The channel names are the ``"/"``-separated tokens of that suffix, in
+    channel order. Returns ``None`` unless the split yields exactly
+    ``count`` distinct, non-empty tokens."""
+    if not labels or not isinstance(labels[0], str) or " - " not in labels[0]:
+        return None
+    suffix = labels[0].rsplit(" - ", 1)[1]
+    parts = [p.strip() for p in suffix.split("/")]
+    return parts if len(parts) == count and _all_distinct(parts) else None
+
+
+def _resolve_channel_names(tf, count: int) -> list[str | None]:
+    """Best-effort DISTINCT per-channel names, tried most-reliable first.
+
+    Order matters — the earlier sources carry the true per-wavelength
+    identity, the later ones are progressively more degenerate:
+      1. MetaMorph ``WaveNameN`` from the ImageJ ``Info`` block.
+      2. The shared ``"… - a/b"`` per-slice label split by ``"/"``.
+      3. Genuinely distinct per-slice ``Labels`` used verbatim.
+    When none yields ``count`` distinct names (e.g. an ImageJ-registered
+    stack whose only label is the source filename, repeated per channel)
+    we return all-``None`` so the caller falls back to ``"Channel N"`` —
+    two channels named ``"Channel 1"``/``"Channel 2"`` are far more useful
+    than two identical names the user can't tell apart."""
+    try:
+        meta = getattr(tf, "imagej_metadata", None)
+        info = ""
+        if isinstance(meta, dict):
+            info = meta.get("Info") or meta.get("info") or ""
+
+        wave = _metamorph_wave_names(info, count)
+        if wave:
+            return wave
+
+        labels = _imagej_channel_labels(tf, count)
+        split = _split_shared_label(labels, count)
+        if split:
+            return split
+        if _all_distinct(labels):
+            return labels
+    except Exception:
+        pass
+    return [None] * count
+
+
+def _wavelength_from_name(name: str | None) -> int | None:
+    """Parse an emission wavelength (nm) embedded in a channel name, e.g.
+    ``"TIRF_491"`` → 491, ``"w2-561"`` → 561. Only 3–4 digit tokens inside
+    the visible/NIR band (350–900 nm) count — this both distinguishes
+    fluorescence channels (which carry a λ) from label-free IRM/BF ones
+    (which don't) downstream in ``isIrmChannel``, and derives a default
+    display color. Returns ``None`` for label-free names like
+    ``"WD_LED_IRM"`` that carry no wavelength token."""
+    if not isinstance(name, str):
+        return None
+    for tok in re.findall(r"\d{3,4}", name):
+        v = int(tok)
+        if 350 <= v <= 900:
+            return v
+    return None
 
 
 def _to_png_dtype(arr: np.ndarray) -> np.ndarray:
@@ -457,7 +554,7 @@ def main() -> int:
             if "C" in axes
             else (arr.shape[0] if axes.startswith("C") else 1)
         )
-        raw_channel_labels = _imagej_channel_labels(tf, _C_for_meta)
+        raw_channel_labels = _resolve_channel_names(tf, _C_for_meta)
         # Pixel calibration + frame interval. Priority chain:
         #   1. OME-XML (most precise when present)
         #   2. ImageJ metadata (most common in microscopy)
@@ -480,6 +577,15 @@ def main() -> int:
         T, H, W = arr.shape
         C = 1
         arr = arr[:, None, :, :]
+    elif axes == "CYX" and arr.ndim == 3:
+        # Single time-point, multi-channel (e.g. a 2-channel IRM+TIRF frame
+        # exported as one ImageJ slice per channel). Without this explicit
+        # case the leading-axis heuristic below misreads the C channels as
+        # C separate time frames — destroying the channel split and turning
+        # a still into a bogus "video" the browser can't display.
+        C, H, W = arr.shape
+        T = 1
+        arr = arr[None, :, :, :]
     elif arr.ndim == 3 and arr.shape[0] > 1 and arr.shape[-1] not in (3, 4):
         # Heuristic: leading axis is time, single channel.
         T, H, W = arr.shape
@@ -501,19 +607,31 @@ def main() -> int:
     if len(raw_channel_labels) != C:
         raw_channel_labels = (raw_channel_labels + [None] * C)[:C]
 
+    # Final safety net: guarantee the channels are DISTINGUISHABLE. If the
+    # resolver couldn't produce distinct names (collision after realignment,
+    # or a degenerate source), drop to all-``None`` so every channel gets a
+    # unique ``"Channel N"`` below — never two identical names.
+    if not _all_distinct(raw_channel_labels):
+        raw_channel_labels = [None] * C
+
     # Two parallel names per channel:
     #  - `name`        : path-safe, used in URLs + PNG filenames
     #  - `display_name`: human-readable, shown in the UI
     # When metadata gives us a label, use it for both (sanitised in `name`).
     # When no metadata is present, fall back to "Channel N" (1-based) so
     # the UI doesn't surface implementation-y identifiers like "ch0".
+    # `wavelengthNm` is parsed from the resolved name (e.g. "TIRF_491"→491)
+    # so fluorescence channels type correctly downstream; label-free names
+    # (IRM/BF) yield None and stay IRM.
     channel_names: list[str] = []
     display_names: list[str] = []
+    wavelengths: list[int | None] = []
     for i in range(C):
         raw = raw_channel_labels[i]
         display = raw if (isinstance(raw, str) and raw.strip()) else f"Channel {i + 1}"
         display_names.append(display)
         channel_names.append(_sanitize_name(raw, f"Channel_{i + 1}"))
+        wavelengths.append(_wavelength_from_name(raw))
 
     for t in range(T):
         frame_dir = dest / "frames" / f"{t:04d}"
@@ -544,7 +662,7 @@ def main() -> int:
             {
                 "name": channel_names[i],
                 "displayName": display_names[i],
-                "wavelengthNm": None,
+                "wavelengthNm": wavelengths[i],
             }
             for i in range(C)
         ],

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -58,7 +58,11 @@ def _imagej_channel_labels(tf, count: int) -> list[str | None]:
         # ImageJ often writes per-slice labels (one per T×C); the first
         # C entries are the channel names for the first time-point.
         return [labels[i] if isinstance(labels[i], str) else None for i in range(count)]
-    except Exception:
+    except Exception as exc:
+        # Match the file's convention: every metadata parser emits a one-line
+        # stderr diagnostic before degrading, so a genuine parse bug isn't
+        # indistinguishable from "no labels present".
+        sys.stderr.write(f"ImageJ channel-label parse failed: {exc}\n")
         return [None] * count
 
 
@@ -137,8 +141,12 @@ def _resolve_channel_names(tf, count: int) -> list[str | None]:
             return split
         if _all_distinct(labels):
             return labels
-    except Exception:
-        pass
+    except Exception as exc:
+        # A regex/type/index bug in the helpers above would otherwise be
+        # indistinguishable from "no metadata" and silently collapse every
+        # channel to wavelengthNm=null → all typed IRM (wrong segmentation
+        # source). Surface it like the other parsers in this file.
+        sys.stderr.write(f"channel-name resolution failed: {exc}\n")
     return [None] * count
 
 
@@ -152,10 +160,17 @@ def _wavelength_from_name(name: str | None) -> int | None:
     ``"WD_LED_IRM"`` that carry no wavelength token."""
     if not isinstance(name, str):
         return None
-    for tok in re.findall(r"\d{3,4}", name):
-        v = int(tok)
-        if 350 <= v <= 900:
-            return v
+    for m in re.finditer(r"\d{3,4}", name):
+        v = int(m.group())
+        if not (350 <= v <= 900):
+            continue
+        # Reject an exposure-time token like ``"IRM_500ms"`` — a digit run
+        # immediately followed by ``ms`` is a duration, not an emission λ,
+        # and would otherwise mis-type a label-free channel as fluorescent.
+        # ``"491nm"`` (n) and a bare ``"491"`` still count.
+        if name[m.end() : m.end() + 2].lower() == "ms":
+            continue
+        return v
     return None
 
 

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
@@ -33,9 +33,14 @@ sys.path.insert(0, HELPERS_DIR)
 sys.modules.setdefault("tifffile", MagicMock())
 
 from extract_tiff_stack import (  # noqa: E402
+    _all_distinct,
     _detect_frame_interval_ms,
     _imagej_label_to_seconds,
     _median_interval_ms,
+    _metamorph_wave_names,
+    _resolve_channel_names,
+    _split_shared_label,
+    _wavelength_from_name,
 )
 
 
@@ -224,3 +229,129 @@ def test_malformed_ome_does_not_raise(capsys):
 def test_empty_metadata_returns_none():
     assert _detect_frame_interval_ms(_tf()) is None
     assert _detect_frame_interval_ms(_tf(ij={})) is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Channel-name resolution — _wavelength_from_name / _split_shared_label /
+# _metamorph_wave_names / _all_distinct / _resolve_channel_names.
+# These feed wavelengthNm → isIrmChannel (channel typing + segmentation
+# source). A regression silently reverts the "every channel looks the
+# same" fix. See memory project_tiff_channel_naming_bug. Order-sensitive:
+# _resolve_channel_names tries WaveNameN → shared-label split → distinct
+# Labels → all-None; the priority test below pins that contract.
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("TIRF_491", 491),
+        ("w2-561", 561),
+        ("GFP488", 488),
+        ("Cy5_670", 670),
+        ("491nm", 491),
+        ("WD_LED_IRM", None),  # label-free, no wavelength token
+        ("DAPI", None),
+        ("IRM_500ms", None),  # exposure time — not an emission wavelength
+        ("channel_1200", None),  # out of the 350–900 nm band
+        ("ch_12", None),  # too few digits
+        (None, None),
+        (123, None),  # non-string
+    ],
+)
+def test_wavelength_from_name(name, expected):
+    assert _wavelength_from_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    "names, expected",
+    [
+        (["a", "b"], True),
+        (["a", "a"], False),  # duplicate
+        (["a", None], False),  # None present
+        (["a", ""], False),  # empty
+        (["a", "  "], False),  # whitespace-only
+        ([], False),
+        (["only"], True),
+    ],
+)
+def test_all_distinct(names, expected):
+    assert _all_distinct(names) is expected
+
+
+def test_split_shared_label_metamorph():
+    labels = [
+        "c:1/2 t:1/61 - WD_LED_IRM/TIRF_491",
+        "c:2/2 t:1/61 - WD_LED_IRM/TIRF_491",
+    ]
+    assert _split_shared_label(labels, 2) == ["WD_LED_IRM", "TIRF_491"]
+
+
+@pytest.mark.parametrize(
+    "labels, count",
+    [
+        (["no dash separator here"], 1),  # no " - "
+        (["a - one/two/three"], 2),  # wrong token count
+        (["a - dup/dup"], 2),  # non-distinct tokens
+        ([None], 1),  # not a string
+        ([], 1),  # empty
+    ],
+)
+def test_split_shared_label_rejects(labels, count):
+    assert _split_shared_label(labels, count) is None
+
+
+def test_metamorph_wave_names():
+    info = 'WaveName1 = "WD_LED_IRM"\nWaveName2 = "TIRF_491"\n'
+    assert _metamorph_wave_names(info, 2) == ["WD_LED_IRM", "TIRF_491"]
+
+
+@pytest.mark.parametrize(
+    "info, count",
+    [
+        ("", 2),  # empty
+        ('WaveName1 = "A"\n', 2),  # missing WaveName2
+        ('WaveName1 = "same"\nWaveName2 = "same"\n', 2),  # not distinct
+    ],
+)
+def test_metamorph_wave_names_rejects(info, count):
+    assert _metamorph_wave_names(info, count) is None
+
+
+def test_resolve_channel_names_prefers_wavename_over_label():
+    # Both a MetaMorph Info block AND a shared label are present; WaveNameN
+    # must win (more reliable per-wavelength source). Pins the docstring's
+    # "Order matters" contract — the thing a refactor is most likely to flip.
+    tf = _tf(
+        ij={
+            "Info": 'WaveName1 = "IRM_A"\nWaveName2 = "FLUOR_B"\n',
+            "Labels": [
+                "c:1/2 - WD_LED_IRM/TIRF_491",
+                "c:2/2 - WD_LED_IRM/TIRF_491",
+            ],
+        }
+    )
+    assert _resolve_channel_names(tf, 2) == ["IRM_A", "FLUOR_B"]
+
+
+def test_resolve_channel_names_splits_shared_label():
+    tf = _tf(
+        ij={
+            "Labels": [
+                "c:1/2 t:1/61 - WD_LED_IRM/TIRF_491",
+                "c:2/2 t:1/61 - WD_LED_IRM/TIRF_491",
+            ]
+        }
+    )
+    assert _resolve_channel_names(tf, 2) == ["WD_LED_IRM", "TIRF_491"]
+
+
+def test_resolve_channel_names_identical_labels_fall_back_to_none():
+    # ImageJ-registered stack: the only label is the filename, repeated per
+    # channel → no distinct source → all-None so the caller uses "Channel N".
+    tf = _tf(ij={"Labels": ["stack.tif", "stack.tif"]})
+    assert _resolve_channel_names(tf, 2) == [None, None]
+
+
+def test_resolve_channel_names_no_metadata():
+    assert _resolve_channel_names(_tf(), 2) == [None, None]

--- a/src/contexts/UploadContext.tsx
+++ b/src/contexts/UploadContext.tsx
@@ -15,7 +15,7 @@ import { logger } from '@/lib/logger';
 import {
   ChunkProgress,
   DEFAULT_CHUNKING_CONFIG,
-  isVideoLikeUpload,
+  shouldRouteAsVideo,
 } from '@/lib/uploadUtils';
 
 export interface UploadSession {
@@ -295,21 +295,24 @@ export const UploadProvider: React.FC<{ children: React.ReactNode }> = ({
       onCompleteRef.current = onComplete ?? null;
       activeSessionIdRef.current = sessionId;
 
-      // Split files into video / single-image groups. Videos take a
-      // different round-trip (one-at-a-time POST /videos with server-side
-      // ffmpeg/nd2/tifffile extraction); throwing them through the bulk
-      // /images endpoint would either be rejected by the smaller multer
-      // budget or trigger a broken Sharp thumbnail pass on opaque bytes.
-      // Shared with DropZone via isVideoLikeUpload — keeps DropZone's
-      // size-budget decision and this routing decision in lockstep, so a
-      // file accepted at drop time always reaches a matching endpoint.
-      const videoFiles = files.filter(isVideoLikeUpload);
-      const imageFiles = files.filter(f => !isVideoLikeUpload(f));
-
       // Run the actual upload asynchronously
       const doUpload = async () => {
         try {
           const signal = abortControllerRef.current?.signal;
+
+          // Split files into video / single-image groups. Videos take a
+          // different round-trip (one-at-a-time POST /videos with
+          // server-side ffmpeg/nd2/tifffile extraction); throwing them
+          // through the bulk /images endpoint would either be rejected by
+          // the smaller multer budget or trigger a broken Sharp thumbnail
+          // pass on opaque bytes (a multi-page 16-bit TIFF renders
+          // near-black there). `shouldRouteAsVideo` is async because it
+          // sniffs the TIFF IFD chain — a small multi-channel stack that
+          // slips under the size cap must still reach the extractor, not
+          // the single-image path.
+          const routeAsVideo = await Promise.all(files.map(shouldRouteAsVideo));
+          const videoFiles = files.filter((_, i) => routeAsVideo[i]);
+          const imageFiles = files.filter((_, i) => !routeAsVideo[i]);
 
           // Videos first — sequential, single endpoint per file. We
           // accumulate counts so the session card reports a single

--- a/src/lib/__tests__/uploadUtils.test.ts
+++ b/src/lib/__tests__/uploadUtils.test.ts
@@ -7,6 +7,9 @@ import {
   validateFiles,
   formatFileSize,
   formatUploadSpeed,
+  isVideoLikeUpload,
+  isMultiPageTiff,
+  shouldRouteAsVideo,
   DEFAULT_CHUNKING_CONFIG,
   type ChunkingConfig,
 } from '@/lib/uploadUtils';
@@ -253,6 +256,119 @@ describe('formatFileSize', () => {
 
   it('formats gigabytes', () => {
     expect(formatFileSize(2 * 1024 * 1024 * 1024)).toBe('2.0 GB');
+  });
+});
+
+// Build a minimal but structurally-valid classic TIFF with `pages` IFDs.
+// Each IFD here has zero entries: 2 bytes count (0) + 4 bytes next-IFD
+// offset — enough for the IFD-chain walk in isMultiPageTiff. Bytes are
+// real, so File.slice(...).arrayBuffer() reads them like a browser would.
+const makeTiff = (
+  pages: number,
+  endian: 'II' | 'MM' = 'II',
+  bigTiff = false
+): File => {
+  const le = endian === 'II';
+  const IFD_SIZE = 6; // 2 (count=0) + 4 (next offset)
+  const buf = new ArrayBuffer(8 + pages * IFD_SIZE);
+  const dv = new DataView(buf);
+  dv.setUint8(0, endian.charCodeAt(0));
+  dv.setUint8(1, endian.charCodeAt(1));
+  dv.setUint16(2, bigTiff ? 43 : 42, le);
+  dv.setUint32(4, 8, le); // first IFD immediately after the header
+  for (let p = 0; p < pages; p++) {
+    const off = 8 + p * IFD_SIZE;
+    dv.setUint16(off, 0, le); // entry count = 0
+    dv.setUint32(off + 2, p < pages - 1 ? off + IFD_SIZE : 0, le); // next IFD
+  }
+  const bytes = new Uint8Array(buf);
+  const f = new File([bytes], 'stack.tif', { type: 'image/tiff' });
+  // jsdom's Blob polyfill omits `arrayBuffer()`, so back slice()/arrayBuffer()
+  // with the known bytes. This exercises the sniff LOGIC (IFD walk / endian /
+  // BigTIFF); the native byte transport is covered by the Playwright pass.
+  Object.defineProperty(f, 'arrayBuffer', {
+    value: async () => bytes.buffer.slice(0),
+    configurable: true,
+  });
+  Object.defineProperty(f, 'slice', {
+    value: (start = 0, end = bytes.length) => {
+      const sub = bytes.slice(start, end);
+      return {
+        byteLength: sub.length,
+        arrayBuffer: async () => sub.buffer.slice(0),
+      };
+    },
+    configurable: true,
+  });
+  return f;
+};
+
+describe('isMultiPageTiff', () => {
+  it('returns true for a multi-page TIFF (2 IFDs)', async () => {
+    await expect(isMultiPageTiff(makeTiff(2))).resolves.toBe(true);
+  });
+
+  it('returns true for a big-endian multi-page TIFF', async () => {
+    await expect(isMultiPageTiff(makeTiff(3, 'MM'))).resolves.toBe(true);
+  });
+
+  it('returns false for a single-page TIFF', async () => {
+    await expect(isMultiPageTiff(makeTiff(1))).resolves.toBe(false);
+  });
+
+  it('treats BigTIFF as a stack (conservative)', async () => {
+    await expect(isMultiPageTiff(makeTiff(1, 'II', true))).resolves.toBe(true);
+  });
+
+  it('returns false for non-TIFF bytes', async () => {
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0]); // JPEG magic
+    const jpeg = new File([bytes], 'x.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(jpeg, 'slice', {
+      value: (start = 0, end = bytes.length) => {
+        const sub = bytes.slice(start, end);
+        return {
+          byteLength: sub.length,
+          arrayBuffer: async () => sub.buffer.slice(0),
+        };
+      },
+      configurable: true,
+    });
+    await expect(isMultiPageTiff(jpeg)).resolves.toBe(false);
+  });
+});
+
+describe('shouldRouteAsVideo', () => {
+  it('routes a small multi-page TIFF to the video pipeline', async () => {
+    // The exact Marika bug: a ~1 MB 2-channel frame slips under the size
+    // cap, so isVideoLikeUpload is false, but the IFD sniff catches it.
+    const frame = makeTiff(2);
+    expect(isVideoLikeUpload(frame)).toBe(false);
+    await expect(shouldRouteAsVideo(frame)).resolves.toBe(true);
+  });
+
+  it('keeps a single-page TIFF on the image route', async () => {
+    await expect(shouldRouteAsVideo(makeTiff(1))).resolves.toBe(false);
+  });
+
+  it('routes an ND2 by extension without sniffing', async () => {
+    const nd2 = new File(['x'], 'movie.nd2', {
+      type: 'application/octet-stream',
+    });
+    await expect(shouldRouteAsVideo(nd2)).resolves.toBe(true);
+  });
+
+  it('routes a large TIFF via the size heuristic', async () => {
+    const big = new File(['x'], 'big.tif', { type: 'image/tiff' });
+    Object.defineProperty(big, 'size', {
+      value: 21 * 1024 * 1024,
+      configurable: true,
+    });
+    await expect(shouldRouteAsVideo(big)).resolves.toBe(true);
+  });
+
+  it('leaves a plain image on the image route', async () => {
+    const jpg = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+    await expect(shouldRouteAsVideo(jpg)).resolves.toBe(false);
   });
 });
 

--- a/src/lib/__tests__/uploadUtils.test.ts
+++ b/src/lib/__tests__/uploadUtils.test.ts
@@ -266,10 +266,14 @@ describe('formatFileSize', () => {
 const makeTiff = (
   pages: number,
   endian: 'II' | 'MM' = 'II',
-  bigTiff = false
+  bigTiff = false,
+  entries = 0
 ): File => {
   const le = endian === 'II';
-  const IFD_SIZE = 6; // 2 (count=0) + 4 (next offset)
+  // Each IFD: 2-byte count + entries*12-byte entry block + 4-byte next offset.
+  // A real TIFF page always has entries (8–15 tags); the `entries` param
+  // exercises the `ifdOffset + 2 + entryCount*12` arithmetic in the sniff.
+  const IFD_SIZE = 2 + entries * 12 + 4;
   const buf = new ArrayBuffer(8 + pages * IFD_SIZE);
   const dv = new DataView(buf);
   dv.setUint8(0, endian.charCodeAt(0));
@@ -278,8 +282,14 @@ const makeTiff = (
   dv.setUint32(4, 8, le); // first IFD immediately after the header
   for (let p = 0; p < pages; p++) {
     const off = 8 + p * IFD_SIZE;
-    dv.setUint16(off, 0, le); // entry count = 0
-    dv.setUint32(off + 2, p < pages - 1 ? off + IFD_SIZE : 0, le); // next IFD
+    dv.setUint16(off, entries, le); // entry count
+    // Fill the entry block with non-zero bytes: if the sniff's `*12` offset
+    // math were wrong it would read HERE (a non-zero "next offset") instead
+    // of the real next-IFD field after the block, so a single page would be
+    // misreported as multi-page. The real next-IFD field follows the block.
+    for (let b = 0; b < entries * 12; b++) dv.setUint8(off + 2 + b, 0xab);
+    const nextOff = off + 2 + entries * 12;
+    dv.setUint32(nextOff, p < pages - 1 ? off + IFD_SIZE : 0, le); // next IFD
   }
   const bytes = new Uint8Array(buf);
   const f = new File([bytes], 'stack.tif', { type: 'image/tiff' });
@@ -314,6 +324,27 @@ describe('isMultiPageTiff', () => {
 
   it('returns false for a single-page TIFF', async () => {
     await expect(isMultiPageTiff(makeTiff(1))).resolves.toBe(false);
+  });
+
+  it('returns false for a single-page TIFF with real IFD entries', async () => {
+    // A real still has 8+ tags; this exercises the entryCount*12 offset math.
+    // If that arithmetic were wrong, the sniff would read the 0xab entry
+    // bytes as a non-zero next-IFD offset and wrongly report multi-page.
+    await expect(isMultiPageTiff(makeTiff(1, 'II', false, 8))).resolves.toBe(
+      false
+    );
+    await expect(isMultiPageTiff(makeTiff(1, 'MM', false, 12))).resolves.toBe(
+      false
+    );
+  });
+
+  it('returns true for a multi-page TIFF with real IFD entries', async () => {
+    await expect(isMultiPageTiff(makeTiff(2, 'II', false, 10))).resolves.toBe(
+      true
+    );
+    await expect(isMultiPageTiff(makeTiff(3, 'MM', false, 10))).resolves.toBe(
+      true
+    );
   });
 
   it('treats BigTIFF as a stack (conservative)', async () => {

--- a/src/lib/uploadUtils.ts
+++ b/src/lib/uploadUtils.ts
@@ -33,6 +33,73 @@ export function isVideoLikeUpload(file: File): boolean {
   return false;
 }
 
+function hasTiffExtension(file: File): boolean {
+  const lower = file.name.toLowerCase();
+  return MULTI_PAGE_TIFF_EXTENSIONS.some(ext => lower.endsWith(ext));
+}
+
+/**
+ * Detect a multi-page (stack / multi-channel) TIFF by walking its IFD
+ * chain directly from the file bytes. ImageJ / MetaMorph store every
+ * channel *and* every timepoint as its own IFD ("page"), so page-count
+ * > 1 ⇔ the file is a microscopy stack that must go through the frame
+ * extractor — even when it's small. A 2-channel 512×512 IRM+TIRF frame
+ * is only ~1 MB, well under the image cap, so the size heuristic in
+ * `isVideoLikeUpload` alone would misroute it to the single-image Sharp
+ * path (which reads only page 0 and renders 16-bit data near-black).
+ *
+ * Reads only a few bytes per IFD via `Blob.slice`, so it stays cheap
+ * even for the largest classic TIFF. Ambiguity resolves conservatively:
+ *  - BigTIFF (magic 43): always a stack in practice → multi-page.
+ *  - non-TIFF / unreadable header / no Blob API → `false` (fall back to
+ *    the size heuristic).
+ */
+export async function isMultiPageTiff(file: File): Promise<boolean> {
+  try {
+    if (typeof file.slice !== 'function') return false;
+    const head = new DataView(await file.slice(0, 8).arrayBuffer());
+    if (head.byteLength < 8) return false;
+    const le = head.getUint8(0) === 0x49 && head.getUint8(1) === 0x49; // 'II'
+    const be = head.getUint8(0) === 0x4d && head.getUint8(1) === 0x4d; // 'MM'
+    if (!le && !be) return false;
+    const magic = head.getUint16(2, le);
+    if (magic === 43) return true; // BigTIFF → always a stack
+    if (magic !== 42) return false; // not a classic TIFF
+    let ifdOffset = head.getUint32(4, le);
+    // Walk the IFD chain; the existence of a 2nd IFD is all we need.
+    // Cap the walk to guard against a malformed self-referential chain.
+    for (let seen = 0; ifdOffset !== 0 && seen < 4; seen++) {
+      if (seen >= 1) return true; // reached a 2nd IFD → multi-page
+      const cntBuf = await file.slice(ifdOffset, ifdOffset + 2).arrayBuffer();
+      if (cntBuf.byteLength < 2) break;
+      const entryCount = new DataView(cntBuf).getUint16(0, le);
+      // Next-IFD offset sits right after the entry block (12 bytes each).
+      const nextPos = ifdOffset + 2 + entryCount * 12;
+      const nextBuf = await file.slice(nextPos, nextPos + 4).arrayBuffer();
+      if (nextBuf.byteLength < 4) break;
+      ifdOffset = new DataView(nextBuf).getUint32(0, le);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Async routing decision for the upload pipeline: is this file a video /
+ * microscopy stack that must go through the `/videos` extractor endpoint?
+ *
+ * Superset of `isVideoLikeUpload` — adds an IFD-chain sniff so a *small*
+ * multi-page TIFF (which the size heuristic would leave on the image
+ * route) is routed to the extractor. Single-page TIFF stills stay on the
+ * bulk image route unchanged.
+ */
+export async function shouldRouteAsVideo(file: File): Promise<boolean> {
+  if (isVideoLikeUpload(file)) return true;
+  if (hasTiffExtension(file)) return isMultiPageTiff(file);
+  return false;
+}
+
 export interface ChunkingConfig {
   chunkSize: number;
   maxConcurrentChunks: number;

--- a/src/lib/uploadUtils.ts
+++ b/src/lib/uploadUtils.ts
@@ -4,22 +4,24 @@
 
 import UPLOAD_CONFIG from './uploadConfig';
 import { sleep } from './retryUtils';
+import { logger } from './logger';
 
 const TRUE_VIDEO_EXTENSIONS = ['.mp4', '.avi', '.mov', '.mkv', '.webm', '.nd2'];
 
 const MULTI_PAGE_TIFF_EXTENSIONS = ['.tif', '.tiff'];
 
-// SSOT for "is this upload a video / microscopy stack". A bare extension
-// check was duplicated in DropZone + UploadContext; both must agree on
-// the routing (image multer caps at 20 MB, video multer at 100 GB), so
-// any drift between the two manifests as "small TIFF fails to upload"
-// or "large TIFF silently rejected client-side".
+// Synchronous "is this obviously a video / microscopy stack" check, used
+// by DropZone for its size-budget decision (image multer caps at 20 MB,
+// video multer at 100 GB). Multi-page TIFFs share the .tif extension with
+// single-page stills, so the only cheap sync signal is size: a .tif over
+// the image cap is assumed to be a stack.
 //
-// Multi-page TIFFs are extension-ambiguous with single-page TIFFs (same
-// .tif extension), so the heuristic is size-based: anything over the
-// image cap is assumed to be a multi-page stack and routed through the
-// video pipeline (`tifffile`-driven extractor on the backend). This
-// keeps single-image TIFF uploads (< 20 MB) on the bulk image route.
+// This is NOT the full routing decision — UploadContext routes via the
+// async `shouldRouteAsVideo` below, which additionally sniffs the IFD
+// chain so a *small* multi-page TIFF still reaches the extractor. The two
+// intentionally differ: a small multi-page TIFF is under the image budget
+// (so DropZone accepts it) yet is routed to /videos by UploadContext, so
+// the divergence never rejects a file that should upload.
 export function isVideoLikeUpload(file: File): boolean {
   if (file.type.startsWith('video/')) return true;
   const lower = file.name.toLowerCase();
@@ -48,11 +50,14 @@ function hasTiffExtension(file: File): boolean {
  * `isVideoLikeUpload` alone would misroute it to the single-image Sharp
  * path (which reads only page 0 and renders 16-bit data near-black).
  *
- * Reads only a few bytes per IFD via `Blob.slice`, so it stays cheap
- * even for the largest classic TIFF. Ambiguity resolves conservatively:
+ * Only needs to confirm a 2nd IFD exists, so it returns as soon as the
+ * chain advances once — reading just the 8-byte header plus the first
+ * IFD's count + next-offset field (~14 bytes) via `Blob.slice`, cheap
+ * regardless of file size. Ambiguity resolves conservatively:
  *  - BigTIFF (magic 43): always a stack in practice → multi-page.
  *  - non-TIFF / unreadable header / no Blob API → `false` (fall back to
- *    the size heuristic).
+ *    the size heuristic). Note a corrupt/truncated stack can also land
+ *    here; the log below makes a systematic misroute diagnosable.
  */
 export async function isMultiPageTiff(file: File): Promise<boolean> {
   try {
@@ -66,8 +71,10 @@ export async function isMultiPageTiff(file: File): Promise<boolean> {
     if (magic === 43) return true; // BigTIFF → always a stack
     if (magic !== 42) return false; // not a classic TIFF
     let ifdOffset = head.getUint32(4, le);
-    // Walk the IFD chain; the existence of a 2nd IFD is all we need.
-    // Cap the walk to guard against a malformed self-referential chain.
+    // We only need the existence of a 2nd IFD, so we return the moment the
+    // chain advances once (`seen >= 1`). That early return also neutralises
+    // a malformed self-referential chain; the `seen < 4` bound is a
+    // belt-and-suspenders stop that the early return makes unreachable.
     for (let seen = 0; ifdOffset !== 0 && seen < 4; seen++) {
       if (seen >= 1) return true; // reached a 2nd IFD → multi-page
       const cntBuf = await file.slice(ifdOffset, ifdOffset + 2).arrayBuffer();
@@ -80,7 +87,15 @@ export async function isMultiPageTiff(file: File): Promise<boolean> {
       ifdOffset = new DataView(nextBuf).getUint32(0, le);
     }
     return false;
-  } catch {
+  } catch (err) {
+    // A read error / offset throw falls back to the single-image route.
+    // Log it so a systematic misroute (a real stack silently rendering
+    // near-black — the exact bug this sniff fixes) is diagnosable rather
+    // than invisible.
+    logger.debug(
+      `[uploadUtils] TIFF IFD sniff failed for "${file.name}"; treating as single-page`,
+      err
+    );
     return false;
   }
 }

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -777,8 +777,19 @@ const SegmentationEditor = () => {
   // (kymograph modal + key bindings) read from the same source.
   // useVideoFrames(null) short-circuits internally via `enabled: !!id`.
   const video = useVideoFrames(videoContainerId);
+  // A container is in video / multi-channel mode when it has more than one
+  // frame (the classic time-lapse) OR any channels to composite. The
+  // channel clause is load-bearing for SINGLE-FRAME multi-channel stacks
+  // (e.g. a 2-channel IRM+TIRF frame extracted from a 1-timepoint TIFF):
+  // without it, frameCount === 1 fell through to the plain <img> path,
+  // which naively 8-bit-downcasts the 16-bit frame PNG and renders
+  // low-signal channels near-black — the "frame not showing any image"
+  // report. Any video container has ≥1 channel, so this also routes a
+  // single-channel single frame through the auto-scaling canvas.
   const isVideoMode =
-    !!videoContainerId && (video.container?.frameCount ?? 0) > 1;
+    !!videoContainerId &&
+    ((video.container?.frameCount ?? 0) > 1 ||
+      (video.container?.channels?.length ?? 0) > 0);
 
   // ───────────────── Resegment chain ─────────────────
   // Lives HERE (after `const video = useVideoFrames`) to avoid the TDZ that

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -79,7 +79,7 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+    <div className="shrink-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 dark:bg-gray-900">
       <div className="p-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
           <Spline className="h-4 w-4" />

--- a/src/pages/segmentation/components/PolygonListPanel.tsx
+++ b/src/pages/segmentation/components/PolygonListPanel.tsx
@@ -57,6 +57,22 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
   // during fast updates.
   const deferredPolygons = useDeferredValue(polygons);
 
+  // Bulk visibility toggle. When every polygon/polyline in the list is
+  // already hidden, the control flips to "show all"; otherwise it hides the
+  // whole set. Iterating the per-item toggle is the only API we have — the
+  // current all-hidden state drives the direction so a single click reaches
+  // a consistent end-state without flicker between mixed states.
+  const allHidden =
+    polygons.length > 0 && polygons.every(p => hiddenPolygonIds.has(p.id));
+  const handleToggleAllVisibility = () => {
+    if (!onTogglePolygonVisibility) return;
+    for (const p of polygons) {
+      const isHidden = hiddenPolygonIds.has(p.id);
+      if (allHidden && isHidden) onTogglePolygonVisibility(p.id);
+      else if (!allHidden && !isHidden) onTogglePolygonVisibility(p.id);
+    }
+  };
+
   const handleStartRename = (polygon: Polygon) => {
     setEditingPolygonId(polygon.id);
     setEditingName(
@@ -137,7 +153,7 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
 
   if (loading) {
     return (
-      <div className="w-full flex-1 min-h-0 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex items-center justify-center dark:bg-gray-900">
+      <div className="w-full flex-1 min-h-[8rem] bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex items-center justify-center dark:bg-gray-900">
         <div className="text-gray-500">{t('common.loading')}</div>
       </div>
     );
@@ -145,7 +161,7 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
 
   if (!polygons || polygons.length === 0) {
     return (
-      <div className="w-full flex-1 min-h-0 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
+      <div className="w-full flex-1 min-h-[8rem] bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
             {t('segmentation.status.polygons')}
@@ -164,7 +180,7 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
   }
 
   return (
-    <div className="w-full flex-1 min-h-0 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
+    <div className="w-full flex-1 min-h-[8rem] bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between mb-2 lg:mb-0">
@@ -172,57 +188,85 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
             {t('segmentation.status.polygonList')} ({polygons.length})
           </h3>
 
-          {/* Mobile polygon navigation - only visible on mobile */}
-          {polygons.length > 0 && (
-            <div className="flex items-center gap-1 lg:hidden">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  const currentIndex = polygons.findIndex(
-                    p => p.id === selectedPolygonId
-                  );
-                  if (currentIndex > 0) {
-                    onSelectPolygon(polygons[currentIndex - 1].id);
-                  }
-                }}
-                disabled={
-                  !selectedPolygonId ||
-                  polygons.findIndex(p => p.id === selectedPolygonId) === 0
+          <div className="flex items-center gap-2">
+            {/* Bulk hide/show — mirrors the microtubule instance panel so
+                every list (polygons or polylines) has a one-click toggle. */}
+            {onTogglePolygonVisibility && polygons.length > 0 && (
+              <button
+                type="button"
+                onClick={handleToggleAllVisibility}
+                className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+                title={
+                  allHidden
+                    ? t('microtubule.showAll')
+                    : t('microtubule.hideAll')
                 }
-                className="h-8 w-8 p-0"
               >
-                <ChevronUp className="h-4 w-4" />
-              </Button>
+                {allHidden ? (
+                  <EyeOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5" />
+                )}
+                <span>
+                  {allHidden
+                    ? t('microtubule.showAll')
+                    : t('microtubule.hideAll')}
+                </span>
+              </button>
+            )}
 
-              <span className="text-xs text-gray-500 dark:text-gray-400 min-w-[3rem] text-center">
-                {selectedPolygonId
-                  ? `${polygons.findIndex(p => p.id === selectedPolygonId) + 1}/${polygons.length}`
-                  : `0/${polygons.length}`}
-              </span>
-
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  const currentIndex = polygons.findIndex(
-                    p => p.id === selectedPolygonId
-                  );
-                  if (currentIndex < polygons.length - 1) {
-                    onSelectPolygon(polygons[currentIndex + 1].id);
+            {/* Mobile polygon navigation - only visible on mobile */}
+            {polygons.length > 0 && (
+              <div className="flex items-center gap-1 lg:hidden">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    const currentIndex = polygons.findIndex(
+                      p => p.id === selectedPolygonId
+                    );
+                    if (currentIndex > 0) {
+                      onSelectPolygon(polygons[currentIndex - 1].id);
+                    }
+                  }}
+                  disabled={
+                    !selectedPolygonId ||
+                    polygons.findIndex(p => p.id === selectedPolygonId) === 0
                   }
-                }}
-                disabled={
-                  !selectedPolygonId ||
-                  polygons.findIndex(p => p.id === selectedPolygonId) ===
-                    polygons.length - 1
-                }
-                className="h-8 w-8 p-0"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
+                  className="h-8 w-8 p-0"
+                >
+                  <ChevronUp className="h-4 w-4" />
+                </Button>
+
+                <span className="text-xs text-gray-500 dark:text-gray-400 min-w-[3rem] text-center">
+                  {selectedPolygonId
+                    ? `${polygons.findIndex(p => p.id === selectedPolygonId) + 1}/${polygons.length}`
+                    : `0/${polygons.length}`}
+                </span>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    const currentIndex = polygons.findIndex(
+                      p => p.id === selectedPolygonId
+                    );
+                    if (currentIndex < polygons.length - 1) {
+                      onSelectPolygon(polygons[currentIndex + 1].id);
+                    }
+                  }}
+                  disabled={
+                    !selectedPolygonId ||
+                    polygons.findIndex(p => p.id === selectedPolygonId) ===
+                      polygons.length - 1
+                  }
+                  className="h-8 w-8 p-0"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/pages/segmentation/components/__tests__/PolygonListPanel.test.tsx
+++ b/src/pages/segmentation/components/__tests__/PolygonListPanel.test.tsx
@@ -159,6 +159,65 @@ describe('PolygonListPanel', () => {
     });
   });
 
+  describe('Bulk visibility toggle', () => {
+    const three = () => [
+      makePolygon({ id: 'p1' }),
+      makePolygon({ id: 'p2' }),
+      makePolygon({ id: 'p3' }),
+    ];
+
+    it('hides every polygon when none is hidden ("Hide all")', () => {
+      const onToggle = vi.fn();
+      render(
+        <PolygonListPanel
+          {...DEFAULT_PROPS}
+          polygons={three()}
+          onTogglePolygonVisibility={onToggle}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /hide all/i }));
+      expect(onToggle.mock.calls.map(c => c[0]).sort()).toEqual([
+        'p1',
+        'p2',
+        'p3',
+      ]);
+    });
+
+    it('toggles only the still-visible polygons from a mixed state', () => {
+      const onToggle = vi.fn();
+      render(
+        <PolygonListPanel
+          {...DEFAULT_PROPS}
+          polygons={three()}
+          hiddenPolygonIds={new Set(['p2'])}
+          onTogglePolygonVisibility={onToggle}
+        />
+      );
+      // Not all hidden → "Hide all"; the already-hidden p2 must NOT flip back.
+      fireEvent.click(screen.getByRole('button', { name: /hide all/i }));
+      expect(onToggle.mock.calls.map(c => c[0]).sort()).toEqual(['p1', 'p3']);
+      expect(onToggle).not.toHaveBeenCalledWith('p2');
+    });
+
+    it('un-hides everything when all are hidden ("Show all")', () => {
+      const onToggle = vi.fn();
+      render(
+        <PolygonListPanel
+          {...DEFAULT_PROPS}
+          polygons={three()}
+          hiddenPolygonIds={new Set(['p1', 'p2', 'p3'])}
+          onTogglePolygonVisibility={onToggle}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /show all/i }));
+      expect(onToggle.mock.calls.map(c => c[0]).sort()).toEqual([
+        'p1',
+        'p2',
+        'p3',
+      ]);
+    });
+  });
+
   describe('Delete callback', () => {
     it('calls onDeletePolygon when delete menu item is clicked', async () => {
       const user = userEvent.setup();

--- a/src/pages/segmentation/components/sidebar/ChannelsSection.tsx
+++ b/src/pages/segmentation/components/sidebar/ChannelsSection.tsx
@@ -26,7 +26,7 @@ export default function ChannelsSection({
   if (!channels || channels.length === 0) return null;
 
   return (
-    <div className="w-full bg-white dark:bg-gray-800 border-l border-b border-gray-200 dark:border-gray-700">
+    <div className="w-full shrink-0 bg-white dark:bg-gray-800 border-l border-b border-gray-200 dark:border-gray-700">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
           {t('editor.channelSwitcher.title')}

--- a/src/pages/segmentation/components/sidebar/DisplaySection.tsx
+++ b/src/pages/segmentation/components/sidebar/DisplaySection.tsx
@@ -90,7 +90,7 @@ export default function DisplaySection() {
   } = useImageDisplay();
 
   return (
-    <div className="w-full bg-white dark:bg-gray-800 border-l border-b border-gray-200 dark:border-gray-700">
+    <div className="w-full shrink-0 bg-white dark:bg-gray-800 border-l border-b border-gray-200 dark:border-gray-700">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
           {t('editor.windowLevel.title')}


### PR DESCRIPTION
Fixes two production bug reports from Marika (ImageJ-registered MetaMorph TIFF uploads) plus two editor UX asks. Branched from `main` and reviewed by the multi-agent PR review (no Critical/Important correctness bugs).

## Bug 1 — video shows the same channel twice instead of TIRF + IRM
`extract_tiff_stack.py` read ImageJ per-slice `Labels`, which for MetaMorph hyperstacks concatenate every wavelength name into every slice → both channels got the identical name, and `wavelengthNm` was hardcoded null → both typed IRM. Now a channel-name resolver (WaveNameN → split shared `a/b` label → distinct labels → `Channel N` fallback) yields distinct names, and a wavelength parse (`TIRF_491`→491) types fluorescence correctly.

## Bug 2 — single frame "not showing any image"
Three layers:
- **Routing**: a small (<20 MB) multi-page TIFF fell under the size-only heuristic → single-image Sharp path (reads page 0, 8-bit-downcasts 16-bit → near-black). Added `isMultiPageTiff` (browser IFD-chain sniff) + async `shouldRouteAsVideo`.
- **Extraction**: a 2-channel single-timepoint TIFF (`axes=CYX`) was misread as a 2-frame 1-channel video. Added an explicit `CYX` branch → 1 frame, C channels.
- **Display**: the editor's `isVideoMode` required `frameCount > 1`, so single-frame containers skipped the channel picker + auto-scale canvas. Now `frameCount > 1 || channels.length > 0`.

## Editor UX
- **Hide-all / Show-all** toggle in the Polygon List header (mirrors the MT instance panel) so any list of polylines/polygons can be hidden in one click.
- **Right-sidebar scroll**: fixed control sections (`shrink-0`) + a `min-h` floor on the polygon list so on a short viewport the sidebar scrolls to reach channels/contrast instead of flex-compressing them out of view.

## Review fixes (commit `95621a4`)
Silent-failure logs (Python resolver + JS sniff), an exposure-token guard (`IRM_500ms`→None), 3 comment corrections, and test gaps filled: non-zero-`entryCount` TIFF fixture, Python helper unit tests, PolygonListPanel bulk-toggle tests.

## Verification
Deployed to production and verified: extractor yields `WD_LED_IRM`+`TIRF_491`; single frame → 1 frame/2 channels rendered bright via the auto-scale canvas; hide-all toggles 0-visible/all-hidden; sidebar reaches all controls at 480px. FE 38 + 18 tests, Python helpers, prod 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk show/hide control for polygon lists to quickly toggle visibility for all items.
  * Improved handling of multi-channel and multi-page TIFF uploads, including better stack detection and channel labeling.

* **Bug Fixes**
  * Fixed cases where single-frame multi-channel data was misclassified, improving the segmentation editor’s display behavior.
  * Upload routing is now more accurate for TIFF stacks, reducing the chance of files going to the wrong pipeline.

* **UI**
  * Adjusted panel layout behavior for more stable spacing and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->