### PR TITLE
feat(export): write MT thickness as ImageJ ROI stroke width

### DIFF
--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -63,6 +63,10 @@ interface DecodedRoi {
   position: number;
   /** ARGB stroke colour (@40, unsigned); 0 when unset. */
   strokeColor: number;
+  /** int16 stroke width (@34); 0 when unset. */
+  strokeWidth: number;
+  /** float32 stroke width from header2 (+36); 0 when unset. */
+  floatStrokeWidth: number;
   name: string;
 }
 
@@ -81,6 +85,7 @@ function decodeRoi(buf: Buffer): DecodedRoi {
     right: readShort(buf, 14),
   };
   const n = buf.readUInt16BE(16);
+  const strokeWidth = readShort(buf, 34);
   const strokeColor = buf.readUInt32BE(40);
   const options = buf.readUInt16BE(50);
   const subPixel = (options & 128) !== 0;
@@ -103,6 +108,7 @@ function decodeRoi(buf: Buffer): DecodedRoi {
   }
 
   const header2Offset = buf.readInt32BE(60);
+  const floatStrokeWidth = buf.readFloatBE(header2Offset + 36);
   const nameOffset = buf.readInt32BE(header2Offset + 16);
   const nameLength = buf.readInt32BE(header2Offset + 20);
   let name = '';
@@ -122,6 +128,8 @@ function decodeRoi(buf: Buffer): DecodedRoi {
     coords,
     position,
     strokeColor,
+    strokeWidth,
+    floatStrokeWidth,
     name,
   };
 }
@@ -340,6 +348,75 @@ describe('encodeImageJRoi', () => {
       )
     );
     expect(d.position).toBe(0);
+  });
+
+  it('writes the MT thickness to BOTH the int16 (@34) and header2 float32 fields', () => {
+    // ImageJ stores stroke width twice for reader compatibility; both must
+    // carry the thickness so the polyline draws as a band, not a hairline.
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt',
+        { strokeWidth: 7 }
+      )
+    );
+    expect(d.strokeWidth).toBe(7);
+    expect(d.floatStrokeWidth).toBeCloseTo(7, 5);
+  });
+
+  it('leaves both stroke-width fields at 0 when thickness is omitted (byte back-compat)', () => {
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt'
+      )
+    );
+    expect(d.strokeWidth).toBe(0);
+    expect(d.floatStrokeWidth).toBe(0);
+  });
+
+  it('rounds a fractional thickness for the int16 field but keeps the float exact', () => {
+    // thicknessPx is an integer in practice; this guards the rounding path so
+    // the legacy int16 and the authoritative float never disagree by surprise.
+    const d = decodeRoi(
+      encodeImageJRoi(
+        [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+        'polyline',
+        'mt',
+        { strokeWidth: 3.6 }
+      )
+    );
+    expect(d.strokeWidth).toBe(4); // Math.round(3.6)
+    expect(d.floatStrokeWidth).toBeCloseTo(3.6, 5);
+  });
+
+  it('ignores a non-positive / non-finite thickness (stays unset)', () => {
+    for (const bad of [0, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const d = decodeRoi(
+        encodeImageJRoi(
+          [
+            { x: 1, y: 1 },
+            { x: 2, y: 2 },
+          ],
+          'polyline',
+          'mt',
+          { strokeWidth: bad }
+        )
+      );
+      expect(d.strokeWidth).toBe(0);
+      expect(d.floatStrokeWidth).toBe(0);
+    }
   });
 
   it('throws when given fewer than the geometry minimum points', () => {
@@ -659,6 +736,58 @@ describe('buildVideoRoiEntries', () => {
       'roi_0002__frame_0000.roi',
     ]);
   });
+
+  it('stamps the given thickness as EVERY ROI stroke width', () => {
+    const build = buildVideoRoiEntries(
+      [
+        {
+          id: 'f0',
+          name: 'v',
+          parentVideoId: 'c1',
+          frameIndex: 0,
+          segmentation: {
+            polygons: JSON.stringify([
+              line('a', [
+                [1, 1],
+                [2, 2],
+              ]),
+              line('b', [
+                [3, 3],
+                [4, 4],
+              ]),
+            ]),
+          },
+        },
+      ],
+      6
+    );
+    expect(build.entries).toHaveLength(2);
+    for (const e of build.entries) {
+      const d = decodeRoi(e.buffer);
+      expect(d.strokeWidth).toBe(6);
+      expect(d.floatStrokeWidth).toBeCloseTo(6, 5);
+    }
+  });
+
+  it('leaves stroke width unset when no thickness is passed', () => {
+    const build = buildVideoRoiEntries([
+      {
+        id: 'f0',
+        name: 'v',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('a', [
+              [1, 1],
+              [2, 2],
+            ]),
+          ]),
+        },
+      },
+    ]);
+    expect(decodeRoi(build.entries[0].buffer).strokeWidth).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -822,6 +951,34 @@ describe('exportImageJRoiSets', () => {
       ((0xff << 24) | (215 << 16) | (221 << 8) | 60) >>> 0
     );
     expect(roi.name).toBe('mt_42');
+  });
+
+  it('threads the MT thickness through to the zipped ROIs (stroke width survives deflate)', async () => {
+    const out = await mkTmp();
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'v.nd2', isVideoContainer: true, segmentation: null },
+      {
+        id: 'f0',
+        name: 'v.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('mt_1', [
+              [1, 1],
+              [2, 2],
+            ]),
+          ]),
+        },
+      },
+    ];
+    await exportImageJRoiSets(frames, out, 'proj', { strokeWidth: 8 });
+    const zip = await fs.readFile(
+      path.join(out, 'annotations', 'imagej', 'v_RoiSet.zip')
+    );
+    const roi = decodeRoi(zipExtract(zip, 'mt_1__frame_0000.roi'));
+    expect(roi.strokeWidth).toBe(8);
+    expect(roi.floatStrokeWidth).toBeCloseTo(8, 5);
   });
 
   it('skips a corrupt-JSON frame with a warning while exporting valid frames', async () => {

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -51,7 +51,7 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 * json/ - Custom JSON format
 ${
   project.type === 'microtubules'
-    ? '* imagej/ - ImageJ/Fiji .roi files (one file per microtubule, grouped as <video>/frame_NNNN/, named by cross-frame trackId when tracking ran)\n'
+    ? '* imagej/ - ImageJ/Fiji ROIs, one <video>_RoiSet.zip per video (each microtubule polyline on its own stack slice, named by cross-frame trackId, coloured per track, drawn at the MT thickness)\n'
     : ''
 }* metrics/ - Calculated metrics
 * documentation/ - This folder
@@ -236,18 +236,22 @@ The JSON format preserves the full microtubule structure:
 ## ImageJ / Fiji ROIs (\`annotations/imagej/\`)
 
 Every microtubule export also bundles the polyline centerlines as native
-ImageJ \`.roi\` files, so you can re-open them in ImageJ / Fiji for manual
-re-measurement or line-based plugins. Files are loose (one \`.roi\` per
-microtubule), grouped as \`annotations/imagej/<video>/frame_NNNN/\`, and named
-by the cross-frame **trackId** when tracking ran (falling back to the
+ImageJ ROIs, so you can re-open them in ImageJ / Fiji for manual
+re-measurement or line-based plugins. They are packaged as **one
+\`<video>_RoiSet.zip\` per video** under \`annotations/imagej/\`, with each ROI
+named by the cross-frame **trackId** when tracking ran (falling back to the
 polyline's name/id otherwise) — so a tracked microtubule keeps the same ROI
 name in every frame.
 
+- Each ROI is placed on its own 1-based **stack slice** (its video frame) and
+  coloured per track, matching the editor.
+- Each polyline is drawn at the configured **MT thickness** (the "MT thickness
+  (px)" export setting, default 5) as its stroke width — so ImageJ renders and
+  measures each microtubule as a band of that width, not a hairline.
 - Geometry is stored with sub-pixel (float) precision, in image-pixel space.
-- To load a frame's ROIs: open the frame image in ImageJ and **drag the
-  frame's \`.roi\` files onto the ImageJ window** — this accepts multiple files
-  at once and adds them to the ROI Manager. (ImageJ's *ROI Manager ▸ More ▸
-  Open…* loads only a single \`.roi\`, or a single RoiSet \`.zip\`, at a time.)
+- To load a video's ROIs: **drag its \`<video>_RoiSet.zip\` onto the ImageJ
+  window**, or use *ROI Manager ▸ More ▸ Open…* and pick the \`.zip\` — either
+  loads every microtubule across all frames into the ROI Manager at once.
 
 ## Kymograph velocity metrics
 

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -13,6 +13,8 @@
  *   6    ROI type (uint8): 0 = polygon, 5 = polyline  (on-disk codes)
  *   8    top / 10 left / 12 bottom / 14 right  (int16 integer bounding box)
  *   16   nCoordinates (int16)
+ *   34   stroke width (int16): 0 = unset; the line thickness (MT thickness in
+ *        px) so a re-opened polyline draws + measures as a band of that width
  *   40   stroke colour (uint32 ARGB): 0 = unset; set for per-track colouring
  *   50   options (int16): SUB_PIXEL_RESOLUTION (128) is always set here
  *   56   position (int32): 0 = unset; the 1-based stack slice for RoiSet.zip
@@ -20,8 +22,12 @@
  *   60   header2 offset (int32)
  *   64   integer coords: x[n] then y[n] (int16; x relative to left, y to top)
  *   64+4n  float32 x[n] (absolute), then float32 y[n]  ← authoritative geometry
- *   +HEADER2  header2 block (name offset/length live here)
+ *   +HEADER2  header2 block (name offset/length; +36 float32 stroke width)
  *   +name   ROI name as UTF-16BE code units
+ *
+ * Stroke width is stored twice, matching ImageJ's own RoiEncoder: an int16 at
+ * @34 for legacy readers and a float32 in header2 (+36) that modern ImageJ
+ * prefers when > 0. Both are written together so every reader version agrees.
  *
  * The sub-pixel float block preserves the true polyline geometry (tracking
  * works in float space); the legacy integer block is required by the format
@@ -56,7 +62,8 @@ const HEADER2_SIZE = 64;
 const ROI_TYPE_POLYGON = 0;
 const ROI_TYPE_POLYLINE = 5;
 
-// header field offsets used for the optional stroke colour + slice position.
+// header field offsets used for the optional stroke width, colour + position.
+const STROKE_WIDTH_OFFSET = 34;
 const STROKE_COLOR_OFFSET = 40;
 const POSITION_OFFSET = 56;
 
@@ -66,6 +73,7 @@ const SUB_PIXEL_RESOLUTION = 128;
 // header2 field offsets (relative to the header2 block start)
 const H2_NAME_OFFSET = 16;
 const H2_NAME_LENGTH = 20;
+const H2_FLOAT_STROKE_WIDTH = 36;
 
 /**
  * Write the low 16 bits of ``value`` as a big-endian short. Mirrors ImageJ's
@@ -90,6 +98,14 @@ export interface RoiEncodeOptions {
    * leave the ROI at ImageJ's default colour.
    */
   strokeColor?: number;
+  /**
+   * Line thickness in pixels (the microtubule "thickness" — the same band width
+   * used for intensity sampling). Written to both the int16 @34 and the header2
+   * float32 fields so ImageJ draws + measures the polyline as a band of this
+   * width. Omit / ≤0 / non-finite leaves both fields at 0 (ImageJ's default
+   * hairline), keeping the no-thickness byte layout unchanged.
+   */
+  strokeWidth?: number;
 }
 
 /**
@@ -161,6 +177,18 @@ export function encodeImageJRoi(
     // POSITION is an int32 slice index; truncate defensively so a fractional
     // value never reaches writeInt32BE (which would throw).
     buf.writeInt32BE(Math.trunc(options.position), POSITION_OFFSET);
+  }
+  // Optional stroke width (MT thickness). Written only for a finite positive
+  // value so the omitted / non-positive case leaves both fields 0 (golden-file
+  // safe). int16 for legacy readers, header2 float32 for modern ImageJ.
+  const strokeWidth = options?.strokeWidth;
+  if (
+    typeof strokeWidth === 'number' &&
+    Number.isFinite(strokeWidth) &&
+    strokeWidth > 0
+  ) {
+    putShort(buf, STROKE_WIDTH_OFFSET, Math.round(strokeWidth));
+    buf.writeFloatBE(strokeWidth, header2Offset + H2_FLOAT_STROKE_WIDTH);
   }
 
   // ---- Coordinates (64..) ----
@@ -345,8 +373,15 @@ export interface VideoRoiBuild {
  * Degradation matches the rest of the export: corrupt-JSON frames are counted
  * (surfaced as a warning by the caller), and polygons with too few / non-finite
  * points are dropped and counted.
+ *
+ * @param strokeWidth Optional line thickness (px) stamped as every ROI's stroke
+ *                    width — the microtubule thickness, uniform across the export
+ *                    (see `encodeImageJRoi`). Omit / ≤0 leaves ImageJ's default.
  */
-export function buildVideoRoiEntries(frames: RoiFrameInput[]): VideoRoiBuild {
+export function buildVideoRoiEntries(
+  frames: RoiFrameInput[],
+  strokeWidth?: number
+): VideoRoiBuild {
   const ordered = [...frames].sort(
     (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
   );
@@ -412,6 +447,7 @@ export function buildVideoRoiEntries(frames: RoiFrameInput[]): VideoRoiBuild {
       const buffer = encodeImageJRoi(points, geometry, label, {
         position,
         strokeColor,
+        strokeWidth,
       });
       entries.push({ name: `${entryStem}.roi`, buffer });
       frameRois++;
@@ -476,13 +512,16 @@ async function writeRoiSetZip(
  * data — its caller treats a rejection as non-fatal — but a genuine
  * cancellation stays fatal.
  *
+ * @param options.strokeWidth Uniform microtubule thickness (px) stamped as each
+ *        ROI's stroke width, so re-opened polylines render/measure as a band of
+ *        that width. Omit / ≤0 leaves ImageJ's default hairline.
  * @returns Counts + non-fatal warnings for the caller to fold into job.warnings.
  */
 export async function exportImageJRoiSets(
   frameImages: RoiFrameInput[],
   exportDir: string,
   projectId: string,
-  options: { shouldAbort?: () => boolean } = {}
+  options: { shouldAbort?: () => boolean; strokeWidth?: number } = {}
 ): Promise<ImageJRoiExportResult> {
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
 
@@ -519,7 +558,7 @@ export async function exportImageJRoiSets(
       throw new Error('Export cancelled by user');
     }
 
-    const build = buildVideoRoiEntries(videoFrames);
+    const build = buildVideoRoiEntries(videoFrames, options.strokeWidth);
     corruptFrames += build.corruptFrames;
     droppedPolygons += build.droppedPolygons;
     if (build.entries.length === 0) continue;

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -52,6 +52,14 @@ import { exportImageJRoiSets } from './export/imagejRoiEncoder';
 
 const YOLO_WRITE_CONCURRENCY = 16;
 
+/**
+ * Default microtubule thickness (px) written as the ImageJ ROI stroke width when
+ * the export request carries no `mtMetrics.thicknessPx` (the ROI export is
+ * always-on for MT projects, but the MT-metrics block is optional). Matches the
+ * export dialog's own thickness-slider default so the two never disagree.
+ */
+const DEFAULT_MT_ROI_THICKNESS_PX = 5;
+
 export interface ExportOptions {
   includeOriginalImages?: boolean;
   includeVisualizations?: boolean;
@@ -642,7 +650,18 @@ export class ExportService {
             project.images as ImageWithSegmentation[],
             exportDir,
             project.id,
-            { shouldAbort: () => this.isJobCancelled(jobId) }
+            {
+              shouldAbort: () => this.isJobCancelled(jobId),
+              // MT thickness (px) → ImageJ ROI stroke width, so re-opened
+              // polylines draw + measure as a band of the sampled width. The
+              // ROI export is always-on but `mtMetrics` is optional, so fall
+              // back to the same default the metrics thickness slider uses (5).
+              strokeWidth:
+                options.mtMetrics?.thicknessPx &&
+                options.mtMetrics.thicknessPx > 0
+                  ? options.mtMetrics.thicknessPx
+                  : DEFAULT_MT_ROI_THICKNESS_PX,
+            }
           )
             .then(result => {
               if (result.warnings.length) {


### PR DESCRIPTION
## What

Encode the **MT thickness** (the "MT thickness (px)" export setting — `thicknessPx`, default 5, the band width used for intensity sampling) as the **stroke width** of every microtubule polyline in the always-on ImageJ `RoiSet.zip` export (`annotations/imagej/<video>_RoiSet.zip`).

Before: Fiji drew each microtubule as a hairline. After: Fiji renders **and measures** each MT as a band of the configured thickness (area = length × width), matching how our own MT metrics sample intensity.

## How

- **`imagejRoiEncoder.ts`** — new `strokeWidth?` encode option, written to **both** the int16 field (`@34`) and the header2 `float32` (`+36`), exactly as ImageJ's own `RoiEncoder` does (the float wins on modern readers, the int16 covers old ones). Only written when finite & > 0, so the no-thickness byte layout is unchanged. Threaded `buildVideoRoiEntries` → `exportImageJRoiSets`.
- **`exportService.ts`** — feeds `options.mtMetrics?.thicknessPx` into the ROI export, falling back to a new `DEFAULT_MT_ROI_THICKNESS_PX = 5` (matching the slider default) since the ROI export is always-on while `mtMetrics` is optional.
- **`exportDocs.ts`** — corrected stale docs (they described loose per-frame `.roi` files; the code writes one `RoiSet.zip` per video) and documented the thickness/stroke-width behavior.

## Uniform, not per-MT

Thickness is uniform across the export (there's no per-microtubule measured width in the pipeline — MTs are stored as centerline polylines). This was the chosen scope.

## Tests

- Decoder extended to read both stroke-width fields.
- +7 cases: int16 + header2-float write, `Math.round` on fractional thickness (int16) with exact float, non-positive/non-finite rejection, **byte back-compat** (omitted → both fields 0), per-entry stamping, and an **end-to-end** test running the real `exportImageJRoiSets` → deflated zip → decode → asserts `strokeWidth`.
- **31/31 pass**, including the independent `roifile` golden-file test (proves the no-thickness path is byte-identical — existing exports unaffected).
- Backend `tsc --noEmit` clean; Prettier clean.

## Verification

Deployed to production and verified against a real MT export (decoded a `.roi` from the produced `RoiSet.zip`; stroke width = configured thickness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ImageJ/Fiji ROI exports now preserve microtubule thickness, so exported ROIs render with the intended line width.
  * ROI sets are now packaged per video into a single downloadable `.zip` for easier loading in ImageJ/Fiji.

* **Bug Fixes**
  * Thickness values now stay consistent across exported ROIs, including fractional widths and default handling.

* **Documentation**
  * Updated export guidance to match the new ROI bundle format and loading workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->