### PR TITLE
feat(mt): always export per-channel intensity sum + synced sidebar selection checkboxes

### DIFF
--- a/backend/src/services/__tests__/exportService.gaps.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps.test.ts
@@ -121,7 +121,9 @@ vi.mock('../export/formatConverter', () => ({
 }));
 
 vi.mock('../export/mtMetricsExporter', () => ({
-  computeMTMetrics: vi.fn().mockResolvedValue([]),
+  // Real shape is { rows, skipped }; intensity is now always attempted for MT
+  // exports, so the mock must match or the always-on call path throws.
+  computeMTMetrics: vi.fn().mockResolvedValue({ rows: [], skipped: [] }),
   computeMTGeometry: vi.fn().mockReturnValue([]),
   writeMTMetrics: vi.fn().mockResolvedValue(undefined),
 }));
@@ -173,7 +175,11 @@ import {
   sanitizeFilename,
   getProgressMessage,
 } from '../export/exportFileOperations';
-import { computeMTGeometry, writeMTMetrics } from '../export/mtMetricsExporter';
+import {
+  computeMTMetrics,
+  computeMTGeometry,
+  writeMTMetrics,
+} from '../export/mtMetricsExporter';
 import { MetricsCalculator } from '../metrics/metricsCalculator';
 import {
   FormatConverter,
@@ -785,8 +791,10 @@ describe('ExportService — generateMicrotubuleMetrics dispatch', () => {
       }
     ).generateMicrotubuleMetrics(images, '/tmp/mt-export', options, jobId);
 
-  it('uses geometry-only path when no channels selected and writes metrics', async () => {
-    // Return a non-empty row list so writeMTMetrics is called
+  it('falls back to geometry-only (and still writes metrics) when intensity yields no rows', async () => {
+    // Intensity is always attempted now, but the mocked computeMTMetrics
+    // returns no rows, so the exporter falls back to microtubule length only.
+    // Return a non-empty geometry row list so writeMTMetrics is called.
     vi.mocked(computeMTGeometry).mockReturnValueOnce([
       {
         frameIndex: 0,
@@ -813,26 +821,36 @@ describe('ExportService — generateMicrotubuleMetrics dispatch', () => {
     expect(writeMTMetrics).toHaveBeenCalledOnce();
   });
 
-  it('adds warning when no channel is selected', async () => {
-    vi.mocked(computeMTGeometry).mockReturnValueOnce([
-      {
-        frameIndex: 0,
-        imageId: 'img-1',
-        instanceId: 'inst-1',
-        trackId: null,
-        channel: '',
-        lengthPx: 10,
-        lengthUm: null,
-        areaPx: null,
-        areaUm2: null,
-        pixelCount: null,
-        sumIntensity: null,
-        meanIntensity: null,
-        stdIntensity: null,
-        medianBackground: null,
-        signalMinusBackground: null,
-      },
-    ]);
+  it('always attempts per-channel intensity (no opt-in) and adds NO "no channel" warning', async () => {
+    // Intensity is always computed for MT exports now — an empty channel list
+    // means "all channels" (resolved inside computeMTMetrics), so there is no
+    // longer a "no channel was selected" warning. Here computeMTMetrics returns
+    // one intensity row, so geometry fallback is not used.
+    vi.mocked(computeMTMetrics).mockResolvedValueOnce({
+      rows: [
+        {
+          frameIndex: 0,
+          imageId: 'img-1',
+          instanceId: 'inst-1',
+          label: 'MT1',
+          trackId: null,
+          channel: 'ch0',
+          lengthPx: 10,
+          lengthUm: null,
+          areaPx: 20,
+          areaUm2: null,
+          pixelCount: 20,
+          sumIntensity: 1000,
+          meanIntensity: 50,
+          medianIntensity: 48,
+          stdIntensity: 5,
+          medianBackground: 10,
+          meanBackground: 12,
+          signalMinusBackground: 40,
+        },
+      ],
+      skipped: [],
+    });
 
     const jobs = (service as unknown as { exportJobs: Map<string, ExportJob> })
       .exportJobs;
@@ -846,6 +864,7 @@ describe('ExportService — generateMicrotubuleMetrics dispatch', () => {
       options: {},
     });
 
+    // No mtMetrics options at all → intensity is still attempted for every channel.
     await callGenerateMT(
       service,
       [makeImage({})],
@@ -853,10 +872,18 @@ describe('ExportService — generateMicrotubuleMetrics dispatch', () => {
       'mt-job'
     );
 
+    expect(computeMTMetrics).toHaveBeenCalledOnce();
+    // Called with an empty channel list => "all channels".
+    const mtOpts = vi.mocked(computeMTMetrics).mock.calls[0][2];
+    expect(mtOpts.channels).toEqual([]);
+
     const job = jobs.get('mt-job');
     expect(
-      job?.warnings?.some(w => w.includes('no channel was selected'))
-    ).toBe(true);
+      (job?.warnings ?? []).some(w => w.includes('no channel was selected'))
+    ).toBe(false);
+    // Geometry fallback not used when intensity produced rows.
+    expect(computeMTGeometry).not.toHaveBeenCalled();
+    expect(writeMTMetrics).toHaveBeenCalledOnce();
   });
 
   it('does not write metrics file and adds warning when no polylines exist', async () => {

--- a/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
@@ -338,7 +338,9 @@ describe('computeMTMetrics — early-exit paths (no ML call)', () => {
     vi.clearAllMocks();
   });
 
-  it('returns empty array immediately when channels is empty', async () => {
+  it('returns empty array when there are no frame images (all-channels default still needs frames)', async () => {
+    // Empty `channels` no longer short-circuits (it now means "all channels");
+    // an empty FRAME list is what makes this a no-op with no ML call.
     const result = await computeMTMetrics([], 'proj-1', {
       ...BASE_OPTIONS,
       channels: [],
@@ -564,6 +566,23 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
     expect(body.original_path).toContain('projects/p1/video.nd2');
     expect(body.thickness_px).toBe(3);
     expect(body.margin_multiplier).toBe(1.5);
+  });
+
+  it('empty channels => samples ALL container channels (always-on, no opt-in)', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
+    axiosPostMock.mockResolvedValueOnce(mlResponse);
+
+    await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: frameSeg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: [] }
+    );
+
+    expect(axiosPostMock).toHaveBeenCalledOnce();
+    const [, body] = axiosPostMock.mock.calls[0];
+    // Container has [BF, DAPI]; an empty request must sample BOTH, in order.
+    expect(body.channel_indices).toEqual([0, 1]);
+    expect(body.channel_names).toEqual(['BF', 'DAPI']);
   });
 
   it('maps ML response rows to MTMetricsRow with px→µm conversion', async () => {

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -37,7 +37,8 @@ import {
 export interface MTMetricsOptions {
   thicknessPx: number;
   marginMultiplier: number;
-  /** Channel display names the user picked. Empty => exporter is a no-op. */
+  /** Channel display names to sample. Empty => ALL channels of each container
+   *  (per-channel intensity is always exported for MT projects). */
   channels: string[];
   /** From `ExportOptions.pixelToMicrometerScale`. ``null`` => no µm cols. */
   pixelToMicrometerScale: number | null;
@@ -276,20 +277,21 @@ export async function computeMTMetrics(
 ): Promise<{ rows: MTMetricsRow[]; skipped: string[] }> {
   const skipped: string[] = [];
 
-  if (!options.channels.length) {
-    logger.info(
-      'MT metrics: no channels selected; skipping',
-      'mtMetricsExporter',
-      { projectId }
-    );
-    return { rows: [], skipped };
-  }
+  // Per-channel intensity (incl. the integrated sum) is ALWAYS included for MT
+  // exports — there is no opt-in. An empty `channels` list therefore means
+  // "all channels of each container", NOT "skip". A specific subset can still
+  // be requested via the API by naming channels explicitly.
+  const requestAllChannels = options.channels.length === 0;
 
-  // Validate channel names defensively (the FE should have done this,
-  // but the export options can be POSTed directly).
-  for (const ch of options.channels) {
-    if (!CHANNEL_NAME_RE.test(ch)) {
-      throw new Error(`Invalid channel name in MT metrics options: ${ch}`);
+  // Validate any explicitly-requested channel names defensively (the FE
+  // validates too, but export options can be POSTed directly). The
+  // all-channels path derives names from stored container metadata (validated
+  // at upload), so it needs no re-check.
+  if (!requestAllChannels) {
+    for (const ch of options.channels) {
+      if (!CHANNEL_NAME_RE.test(ch)) {
+        throw new Error(`Invalid channel name in MT metrics options: ${ch}`);
+      }
     }
   }
 
@@ -365,9 +367,15 @@ export async function computeMTMetrics(
       continue;
     }
 
+    // Empty request => sample every channel this container has. A named subset
+    // is resolved against the container's own channels (a video may lack a
+    // channel that another video in the project has).
+    const selectedChannelNames = requestAllChannels
+      ? containerChannels.map(c => c.name)
+      : options.channels;
     const { indices, names, skipped: channelSkipped } = resolveChannelIndices(
       containerChannels,
-      options.channels
+      selectedChannelNames
     );
     if (channelSkipped.length) {
       logger.warn(
@@ -378,11 +386,16 @@ export async function computeMTMetrics(
     }
     if (!indices.length) {
       logger.warn(
-        'MT metrics: no overlap between selected channels and this video; skipping',
+        'MT metrics: no channels resolved for this video; skipping',
         'mtMetricsExporter',
         { projectId, videoId }
       );
-      skipped.push(`Video ${videoId}: none of the selected channels (${options.channels.join(', ')}) were found on this video — intensity metrics omitted.`);
+      const which = requestAllChannels
+        ? 'stored channels'
+        : `selected channels (${options.channels.join(', ')})`;
+      skipped.push(
+        `Video ${videoId}: none of the ${which} were found on this video — intensity metrics omitted.`
+      );
       continue;
     }
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -81,17 +81,26 @@ export interface ExportOptions {
   /**
    * Microtubule-only export options. For ``microtubules`` projects the MT
    * metrics exporter owns the standard ``metrics.{csv,xlsx,json}`` files:
-   * microtubule length is always written (geometry, no channel needed), and
-   * when ``enabled`` with one or more ``channels`` selected, the pipeline
-   * re-reads the original ND2/TIFF to add per-channel intensity + band-area
-   * columns derived from raw 16-bit signal (NOT the 8-bit display-normalised
-   * per-channel PNGs).
+   * microtubule length is always written (geometry, no channel needed), and the
+   * pipeline ALWAYS re-reads the original ND2/TIFF to add per-channel intensity
+   * + band-area columns (incl. the integrated ``sumIntensity``) for every
+   * channel, derived from raw 16-bit signal (NOT the 8-bit display-normalised
+   * per-channel PNGs). There is no opt-in — ``thicknessPx`` / ``marginMultiplier``
+   * only tune the band. All fields are optional for direct API callers.
    */
   mtMetrics?: {
-    enabled: boolean;
-    thicknessPx: number;
-    marginMultiplier: number;
-    channels: string[];
+    /**
+     * @deprecated Ignored — per-channel intensity is always computed for MT
+     * projects. Retained only for wire-compat with older clients.
+     */
+    enabled?: boolean;
+    thicknessPx?: number;
+    marginMultiplier?: number;
+    /**
+     * Optional channel subset (machine names). Empty or absent => ALL channels
+     * of each video container are sampled.
+     */
+    channels?: string[];
   };
   /**
    * Microtubule-only kymograph export. For ``microtubules`` projects, builds a
@@ -1514,12 +1523,13 @@ export class ExportService {
    * because MT annotations are open polylines with no area).
    *
    * Always writes microtubule LENGTH per (frame, polyline) — geometry only,
-   * computed Node-side from the stored polylines, no channel needed. When the
-   * user selected one or more channels it additionally re-reads the original
-   * ND2/TIFF via the ML `/mt-metrics` route to add per-channel intensity +
-   * band-area columns. If intensity can't be produced (no channel chosen, ML
-   * error, or original file missing) it falls back to length-only and records
-   * a user-facing warning rather than silently emitting nothing.
+   * computed Node-side from the stored polylines, no channel needed. It ALSO
+   * always re-reads the original ND2/TIFF via the ML `/mt-metrics` route to add
+   * per-channel intensity + band-area columns (incl. the integrated
+   * `sumIntensity`) for every channel — there is no opt-in. If intensity can't
+   * be produced (ML error, or the original file is missing / has no channel
+   * metadata) it falls back to length-only and records a user-facing warning
+   * rather than silently emitting nothing.
    */
   private async generateMicrotubuleMetrics(
     images: ImageWithSegmentation[],
@@ -1545,9 +1555,16 @@ export class ExportService {
         ? { polygons: i.segmentation.polygons }
         : null,
     }));
-    const channels = options.mtMetrics?.enabled
-      ? options.mtMetrics.channels ?? []
-      : [];
+    // Per-channel intensity (incl. the integrated sum) is ALWAYS computed for
+    // MT exports — there is no opt-in. An empty channel list means "all
+    // channels of each container" (see computeMTMetrics); the modal no longer
+    // asks the user to enable this or pick channels. Band thickness / margin
+    // still come from the modal, falling back to sensible defaults for direct
+    // API callers.
+    const channels = options.mtMetrics?.channels ?? [];
+    const thicknessPx =
+      options.mtMetrics?.thicknessPx ?? DEFAULT_MT_ROI_THICKNESS_PX;
+    const marginMultiplier = options.mtMetrics?.marginMultiplier ?? 2;
 
     const addWarning = (msg: string) => {
       if (!jobId) return;
@@ -1558,41 +1575,36 @@ export class ExportService {
     let rows: MTMetricsRow[] = [];
     let intensityIncluded = false;
 
-    if (channels.length > 0) {
-      try {
-        const mtResult = await computeMTMetrics(frameInputs, projectId, {
-          thicknessPx: options.mtMetrics!.thicknessPx,
-          marginMultiplier: options.mtMetrics!.marginMultiplier,
-          channels,
-          pixelToMicrometerScale: scale,
-        });
-        rows = mtResult.rows;
-        for (const reason of mtResult.skipped) {
-          addWarning(`MT intensity metrics skipped: ${reason}`);
-        }
-        intensityIncluded = rows.length > 0;
-      } catch (err) {
-        logger.error(
-          'MT intensity metrics failed; falling back to length-only',
-          err instanceof Error ? err : new Error(String(err)),
-          'ExportService',
-          { jobId, projectId }
-        );
-        addWarning(
-          'Per-channel signal-intensity metrics could not be computed (the original ND2/TIFF was unreadable or the ML service failed). The metrics file contains microtubule length only.'
-        );
-        rows = [];
+    try {
+      const mtResult = await computeMTMetrics(frameInputs, projectId, {
+        thicknessPx,
+        marginMultiplier,
+        channels,
+        pixelToMicrometerScale: scale,
+      });
+      rows = mtResult.rows;
+      for (const reason of mtResult.skipped) {
+        addWarning(`MT intensity metrics skipped: ${reason}`);
       }
+      intensityIncluded = rows.length > 0;
+    } catch (err) {
+      logger.error(
+        'MT intensity metrics failed; falling back to length-only',
+        err instanceof Error ? err : new Error(String(err)),
+        'ExportService',
+        { jobId, projectId }
+      );
+      addWarning(
+        'Per-channel signal-intensity metrics could not be computed (the original ND2/TIFF was unreadable or the ML service failed). The metrics file contains microtubule length only.'
+      );
+      rows = [];
     }
 
-    // Geometry-only fallback: no channel chosen, or intensity failed / empty.
+    // Geometry-only fallback: intensity failed or produced nothing (e.g. no
+    // channel metadata stored, or the ML service was unavailable). Microtubule
+    // LENGTH needs no channel, so it is always exportable.
     if (!intensityIncluded) {
       rows = computeMTGeometry(frameInputs, scale);
-      if (channels.length === 0) {
-        addWarning(
-          'Per-channel signal-intensity metrics were not exported because no channel was selected. The metrics file contains microtubule length only — enable "Calculate signal intensity for each channel" and pick a channel to include intensity.'
-        );
-      }
     }
 
     if (!rows.length) {

--- a/src/components/project/ProjectToolbar.tsx
+++ b/src/components/project/ProjectToolbar.tsx
@@ -38,12 +38,6 @@ interface ProjectToolbarProps {
   projectName?: string;
   projectType?: string | null;
   images?: unknown[];
-  /** Distinct channel names across the project's video containers
-   *  (BE-aggregated `metadata.projectChannels`). Drives the microtubule
-   *  per-channel intensity picker in the export dialog — the container rows
-   *  that carry `channels` are hidden from the gallery image list, so this
-   *  is the only path that list to the dialog. */
-  projectChannels?: string[];
   selectedImageIds?: string[];
   // Selection props
   selectedCount?: number;
@@ -81,7 +75,6 @@ const ProjectToolbar = ({
   projectName = 'Project',
   projectType,
   images = [],
-  projectChannels,
   selectedImageIds,
   selectedCount = 0,
   isAllSelected = false,
@@ -424,7 +417,6 @@ const ProjectToolbar = ({
           projectName={projectName}
           projectType={projectType ?? null}
           images={images}
-          projectChannels={projectChannels}
           selectedImageIds={selectedImageIds}
           onExportingChange={onExportingChange || setIsExporting}
           onDownloadingChange={onDownloadingChange || setIsDownloading}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1581,7 +1581,6 @@ const ProjectDetail = () => {
               projectName={projectTitle}
               projectType={projectType}
               images={images}
-              projectChannels={projectChannels}
               selectedCount={selectedCount}
               isAllSelected={isAllSelected}
               isPartiallySelected={isPartiallySelected}

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -43,16 +43,6 @@ import { ImageSelectionGrid } from './components/ImageSelectionGrid';
 import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
 import { MicrotubuleKymographsSection } from './components/MicrotubuleKymographsSection';
 import { UniversalCancelButton } from '@/components/ui/universal-cancel-button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 
 interface AdvancedExportDialogProps {
   open: boolean;
@@ -62,22 +52,16 @@ interface AdvancedExportDialogProps {
   /** Used to gate microtubule-specific export controls. */
   projectType?: string | null;
   images: ProjectImage[];
-  /** Distinct channel names across the project's video containers
-   *  (BE-aggregated `metadata.projectChannels`). The container rows that
-   *  carry the `channels` JSON are filtered out of `images` by the gallery
-   *  endpoint, so this prop is the only source the MT channel picker has. */
-  projectChannels?: string[];
   selectedImageIds?: string[];
   onExportingChange?: (isExporting: boolean) => void;
   onDownloadingChange?: (isDownloading: boolean) => void;
 }
 
-/** Default MT metrics options when the user toggles the section on. */
+/** Default MT metrics tuning. Per-channel intensity (incl. the integrated sum)
+ *  is always computed for every channel — these two only tune the band. */
 const MT_METRICS_DEFAULTS = {
-  enabled: false,
   thicknessPx: 5,
   marginMultiplier: 2,
-  channels: [] as string[],
 };
 
 const MT_KYMOGRAPHS_DEFAULTS = {
@@ -95,7 +79,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       projectName,
       projectType,
       images,
-      projectChannels,
       selectedImageIds,
       onExportingChange,
       onDownloadingChange,
@@ -105,28 +88,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       // (singular) is the model id, not the project type. Mis-comparing
       // them silently hides the MT section on every MT project.
       const isMTProject = projectType === 'microtubules';
-
-      // Distinct channels across the project's video containers. These come
-      // from the BE-aggregated `projectChannels` (metadata on the thumbnails
-      // response): the container rows that actually carry the `channels` JSON
-      // are filtered out of `images` by the gallery endpoint, so scanning
-      // `images` for `isVideoContainer` rows always yielded an empty list and
-      // the picker never rendered — leaving `channels: []` and a silent
-      // empty MT metrics export. `projectChannels` is name-only, so the
-      // machine name doubles as the display label.
-      const availableChannels = React.useMemo(() => {
-        if (!isMTProject || !projectChannels) return [];
-        const byName = new Map<
-          string,
-          { name: string; displayName?: string }
-        >();
-        for (const name of projectChannels) {
-          if (name && !byName.has(name)) {
-            byName.set(name, { name, displayName: name });
-          }
-        }
-        return Array.from(byName.values());
-      }, [projectChannels, isMTProject]);
 
       // Local snapshot of MT options. We always merge into the shared
       // exportOptions state when the user toggles or edits inputs so the
@@ -146,13 +107,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         wsConnected,
         currentJob,
       } = useSharedAdvancedExport(projectId);
-
-      // Note: export is never blocked for microtubule projects. Without a
-      // selected channel the backend still exports microtubule LENGTH
-      // (geometry) and surfaces a warning that the per-channel intensity
-      // metrics were omitted — so there's no silent-empty trap and no
-      // dead-end when a project has no channel metadata. The channel picker
-      // shows an informational hint instead (see MicrotubuleMetricsSection).
 
       const [activeTab, setActiveTab] = useState('general');
       // `pixelToMicrometerScale != null` was the old auto-fill guard, but
@@ -199,21 +153,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         }
       }, [images, exportOptions.pixelToMicrometerScale, updateExportOptions]);
 
-      const [showIncompleteWarning, setShowIncompleteWarning] = useState(false);
-
-      // Microtubule intensity columns require a selected channel. If the user
-      // requested metrics but didn't enable intensity (or pick a channel), the
-      // export still produces microtubule LENGTH but omits the per-channel
-      // intensity columns — so warn before exporting that the metric set will
-      // be incomplete.
-      const shouldWarnIncompleteMetrics =
-        isMTProject &&
-        (exportOptions.metricsFormats?.length ?? 0) > 0 &&
-        !(
-          (exportOptions.mtMetrics?.enabled ?? false) &&
-          (exportOptions.mtMetrics?.channels?.length ?? 0) > 0
-        );
-
       const handleExport = async () => {
         try {
           await startExport(projectName);
@@ -222,21 +161,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
         } catch (_error) {
           toast.error(t('toast.exportFailed'));
         }
-      };
-
-      // Intercept the Export click: on an MT project missing intensity, pop the
-      // incomplete-metrics confirmation modal first; otherwise export directly.
-      const handleExportClick = () => {
-        if (shouldWarnIncompleteMetrics) {
-          setShowIncompleteWarning(true);
-        } else {
-          void handleExport();
-        }
-      };
-
-      const confirmIncompleteExport = () => {
-        setShowIncompleteWarning(false);
-        void handleExport();
       };
 
       return (
@@ -423,11 +347,17 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                     (intensity sampling needs the raw ND2/TIFF on disk). */}
                   {isMTProject && (
                     <MicrotubuleMetricsSection
-                      value={exportOptions.mtMetrics ?? MT_METRICS_DEFAULTS}
+                      value={{
+                        thicknessPx:
+                          exportOptions.mtMetrics?.thicknessPx ??
+                          MT_METRICS_DEFAULTS.thicknessPx,
+                        marginMultiplier:
+                          exportOptions.mtMetrics?.marginMultiplier ??
+                          MT_METRICS_DEFAULTS.marginMultiplier,
+                      }}
                       onChange={next =>
                         updateExportOptions({ mtMetrics: next })
                       }
-                      availableChannels={availableChannels}
                     />
                   )}
 
@@ -1005,7 +935,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                   isOperationActive={isExporting}
                   isCancelling={isDownloading} // Use downloading state as cancelling indicator
                   onCancel={cancelExport}
-                  onPrimaryAction={handleExportClick}
+                  onPrimaryAction={() => void handleExport()}
                   primaryText={t('export.startExport')}
                   disabled={false}
                   className="w-full sm:w-auto"
@@ -1013,28 +943,6 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
               </DialogFooter>
             </DialogContent>
           </Dialog>
-
-          <AlertDialog
-            open={showIncompleteWarning}
-            onOpenChange={setShowIncompleteWarning}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  {t('export.mt.incompleteTitle')}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t('export.mt.incompleteBody')}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-                <AlertDialogAction onClick={confirmIncompleteExport}>
-                  {t('export.mt.incompleteConfirm')}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
         </>
       );
     }

--- a/src/pages/export/__tests__/AdvancedExportDialog.test.tsx
+++ b/src/pages/export/__tests__/AdvancedExportDialog.test.tsx
@@ -18,17 +18,11 @@
  *  12. Summary card on Formats tab shows selected image count.
  *  13. MicrotubuleMetricsSection is NOT rendered for non-MT project types.
  *  14. MicrotubuleMetricsSection IS rendered for projectType === 'microtubules'.
- *  15. availableChannels derivation: channels are de-duped and passed down.
- *  16. Non-MT project with empty projectChannels: availableChannels = [].
+ *      (Per-channel intensity incl. the sum is always on — no channel picker
+ *       and no incomplete-metrics warning any more.)
  *  17. Start Export button calls startExport(projectName) on success and
  *      calls toast.success + onClose.
  *  18. Start Export failure calls toast.error.
- *  19. On MT project with metricsFormats selected but no MT channels:
- *      clicking Export shows the incomplete-metrics AlertDialog.
- *  20. Confirming the incomplete-metrics dialog calls startExport.
- *  21. Cancelling the incomplete-metrics dialog does NOT call startExport.
- *  22. On MT project with mtMetrics enabled + channel selected: Export goes
- *      directly to startExport without the warning dialog.
  *  23. WebSocket-disconnected banner appears when wsConnected=false.
  *  24. WebSocket banner is absent when wsConnected=true.
  *  25. Export progress bar appears when isExporting=true.
@@ -174,19 +168,9 @@ vi.mock('../hooks/useSharedAdvancedExport', () => ({
 
 // Stub child sections that have their own test suites
 vi.mock('../components/MicrotubuleMetricsSection', () => ({
-  MicrotubuleMetricsSection: ({
-    availableChannels,
-  }: {
-    availableChannels: Array<{ name: string; displayName?: string }>;
-  }) => (
-    <div data-testid="mt-metrics-section">
-      {availableChannels.map(ch => (
-        <span key={ch.name} data-testid={`mt-channel-${ch.name}`}>
-          {ch.displayName ?? ch.name}
-        </span>
-      ))}
-    </div>
-  ),
+  // Per-channel intensity (incl. the sum) is always on now — the section takes
+  // no channel/enable props, so the mock is just a presence marker.
+  MicrotubuleMetricsSection: () => <div data-testid="mt-metrics-section" />,
 }));
 
 vi.mock('../components/ImageSelectionGrid', () => ({
@@ -296,7 +280,6 @@ const BASE_PROPS = {
       segmentationResults: [],
     },
   ],
-  projectChannels: undefined as string[] | undefined,
   selectedImageIds: undefined as string[] | undefined,
   onExportingChange: vi.fn(),
   onDownloadingChange: vi.fn(),
@@ -604,43 +587,6 @@ describe('AdvancedExportDialog', () => {
     });
   });
 
-  // ── 8. channel picker wiring ──────────────────────────────────────────────
-
-  describe('channel picker wiring to MicrotubuleMetricsSection', () => {
-    it('passes de-duplicated channels from projectChannels to MT section', () => {
-      renderDialog({
-        projectType: 'microtubules',
-        projectChannels: ['DAPI', 'GFP', 'DAPI', 'mCherry'],
-      });
-      // DAPI appears only once (de-duplicated)
-      expect(screen.getAllByTestId(/^mt-channel-/)).toHaveLength(3);
-      expect(screen.getByTestId('mt-channel-DAPI')).toBeInTheDocument();
-      expect(screen.getByTestId('mt-channel-GFP')).toBeInTheDocument();
-      expect(screen.getByTestId('mt-channel-mCherry')).toBeInTheDocument();
-    });
-
-    it('passes empty availableChannels for MT project without projectChannels', () => {
-      renderDialog({
-        projectType: 'microtubules',
-        projectChannels: undefined,
-      });
-      expect(screen.getByTestId('mt-metrics-section')).toBeInTheDocument();
-      // No channel spans rendered
-      expect(screen.queryByTestId(/^mt-channel-/)).not.toBeInTheDocument();
-    });
-
-    it('passes empty availableChannels for non-MT project even with projectChannels', () => {
-      renderDialog({
-        projectType: 'spheroid',
-        projectChannels: ['DAPI', 'GFP'],
-      });
-      // Section is absent entirely
-      expect(
-        screen.queryByTestId('mt-metrics-section')
-      ).not.toBeInTheDocument();
-    });
-  });
-
   // ── 9. start export action ────────────────────────────────────────────────
 
   describe('Start Export action', () => {
@@ -674,164 +620,6 @@ describe('AdvancedExportDialog', () => {
       await waitFor(() => {
         expect(_mockToastError).toHaveBeenCalled();
       });
-    });
-  });
-
-  // ── 10. MT incomplete-metrics warning dialog ──────────────────────────────
-
-  describe('MT incomplete-metrics warning dialog', () => {
-    /**
-     * Condition that triggers the warning:
-     *   isMTProject=true AND metricsFormats.length > 0 AND
-     *   NOT (mtMetrics.enabled && mtMetrics.channels.length > 0)
-     */
-
-    it('shows AlertDialog when MT project has metricsFormats but no channel selected', async () => {
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['excel'],
-          mtMetrics: {
-            enabled: false,
-            thicknessPx: 5,
-            marginMultiplier: 2,
-            channels: [],
-          },
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'microtubules' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      await waitFor(() => {
-        expect(
-          screen.getByText('Intensity calculation not selected')
-        ).toBeInTheDocument();
-      });
-      // startExport must NOT have been called yet
-      expect(_mockStartExport).not.toHaveBeenCalled();
-    });
-
-    it('shows AlertDialog when MT project has metricsFormats and mtMetrics enabled but no channels', async () => {
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['csv'],
-          mtMetrics: {
-            enabled: true,
-            thicknessPx: 5,
-            marginMultiplier: 2,
-            channels: [],
-          },
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'microtubules' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      await waitFor(() => {
-        expect(
-          screen.getByText('Intensity calculation not selected')
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('confirming incomplete-metrics dialog calls startExport', async () => {
-      _mockStartExport.mockResolvedValueOnce('job-999');
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['excel'],
-          mtMetrics: {
-            enabled: false,
-            thicknessPx: 5,
-            marginMultiplier: 2,
-            channels: [],
-          },
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'microtubules' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      // Wait for the AlertDialog to appear
-      await waitFor(() =>
-        expect(
-          screen.getByText('Intensity calculation not selected')
-        ).toBeInTheDocument()
-      );
-      // Click "Export anyway" confirmation
-      await user.click(screen.getByRole('button', { name: /export anyway/i }));
-      await waitFor(() => {
-        expect(_mockStartExport).toHaveBeenCalled();
-      });
-    });
-
-    it('cancelling the AlertDialog does NOT call startExport', async () => {
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['excel'],
-          mtMetrics: {
-            enabled: false,
-            thicknessPx: 5,
-            marginMultiplier: 2,
-            channels: [],
-          },
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'microtubules' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      await waitFor(() =>
-        expect(
-          screen.getByText('Intensity calculation not selected')
-        ).toBeInTheDocument()
-      );
-      await user.click(screen.getByRole('button', { name: /^cancel$/i }));
-      await waitFor(() => {
-        expect(
-          screen.queryByText('Intensity calculation not selected')
-        ).not.toBeInTheDocument();
-      });
-      expect(_mockStartExport).not.toHaveBeenCalled();
-    });
-
-    it('does NOT show warning when MT project has mtMetrics enabled with a selected channel', async () => {
-      _mockStartExport.mockResolvedValueOnce('job-ok');
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['excel'],
-          mtMetrics: {
-            enabled: true,
-            thicknessPx: 5,
-            marginMultiplier: 2,
-            channels: ['DAPI'],
-          },
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'microtubules' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      // Warning dialog should NOT appear — startExport should be called directly
-      await waitFor(() => {
-        expect(_mockStartExport).toHaveBeenCalled();
-      });
-      expect(
-        screen.queryByText('Intensity calculation not selected')
-      ).not.toBeInTheDocument();
-    });
-
-    it('does NOT show warning for non-MT projects even with metrics formats set', async () => {
-      _mockStartExport.mockResolvedValueOnce('job-ok');
-      overrideHookState({
-        exportOptions: {
-          metricsFormats: ['excel'],
-          mtMetrics: undefined,
-        },
-      });
-      const user = userEvent.setup();
-      renderDialog({ projectType: 'spheroid' });
-      await user.click(screen.getByRole('button', { name: /start export/i }));
-      await waitFor(() => {
-        expect(_mockStartExport).toHaveBeenCalled();
-      });
-      expect(
-        screen.queryByText('Intensity calculation not selected')
-      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/export/components/MicrotubuleMetricsSection.tsx
+++ b/src/pages/export/components/MicrotubuleMetricsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Wand2 } from 'lucide-react';
+import { Wand2, Info } from 'lucide-react';
 import {
   Card,
   CardContent,
@@ -7,48 +7,39 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useLanguage } from '@/contexts/useLanguage';
 
-interface VideoChannelOption {
-  /** Machine-safe identifier (matches the container.channels[].name) */
-  name: string;
-  /** Human-friendly label from TIFF/ND2 metadata */
-  displayName?: string;
-}
-
 export interface MicrotubuleMetricsOptions {
-  enabled: boolean;
+  /** @deprecated Ignored by the backend — intensity is always computed. */
+  enabled?: boolean;
   thicknessPx: number;
   marginMultiplier: number;
-  channels: string[];
+  /** Optional channel subset. Empty / absent => all channels are sampled. */
+  channels?: string[];
 }
 
 export interface MicrotubuleMetricsSectionProps {
   value: MicrotubuleMetricsOptions;
   onChange: (next: MicrotubuleMetricsOptions) => void;
-  /**
-   * All channels available across the project's video containers,
-   * de-duplicated by machine name. Empty array => the project has no
-   * channel metadata and intensity sampling is impossible.
-   */
-  availableChannels: VideoChannelOption[];
 }
 
 /**
- * MT-only export controls: band thickness, background margin
- * multiplier, channel multi-select. Renders inside the export dialog's
- * General tab when ``projectType === 'microtubule'``.
+ * MT-only export controls: band thickness + background margin multiplier.
+ * Renders inside the export dialog's General tab when
+ * ``projectType === 'microtubules'``.
  *
- * The backend re-reads the original ND2/TIFF on disk so the intensity
- * numbers are derived from raw 16-bit signal (the per-channel PNGs are
- * percentile-clipped 8-bit and unsuitable for absolute fluorescence).
+ * Per-channel signal intensity — including the integrated ``sumIntensity`` —
+ * is ALWAYS computed for every channel of every video container; there is no
+ * opt-in and no channel picker. The two inputs here only tune the sampling
+ * band. The backend re-reads the original ND2/TIFF so the intensity numbers
+ * come from raw 16-bit signal (the per-channel PNGs are percentile-clipped
+ * 8-bit and unsuitable for absolute fluorescence).
  */
 export const MicrotubuleMetricsSection: React.FC<
   MicrotubuleMetricsSectionProps
-> = ({ value, onChange, availableChannels }) => {
+> = ({ value, onChange }) => {
   const { t } = useLanguage();
 
   // Local text mirrors of the two numeric inputs. We need this because
@@ -81,8 +72,6 @@ export const MicrotubuleMetricsSection: React.FC<
         : String(value.marginMultiplier)
     );
   }, [value.marginMultiplier]);
-
-  const setEnabled = (enabled: boolean) => onChange({ ...value, enabled });
 
   // Integer-only validators. User explicitly asked for integers in both
   // fields, so the margin step changed from 0.1 (float) to 1 (integer).
@@ -125,16 +114,6 @@ export const MicrotubuleMetricsSection: React.FC<
     }
   };
 
-  const toggleChannel = (name: string, checked: boolean) => {
-    const set = new Set(value.channels);
-    if (checked) set.add(name);
-    else set.delete(name);
-    onChange({ ...value, channels: Array.from(set) });
-  };
-
-  const disabledInputs = !value.enabled;
-  const noChannels = availableChannels.length === 0;
-
   return (
     <Card className="p-3 sm:p-4">
       <CardHeader className="p-0 pb-3 sm:pb-4">
@@ -147,15 +126,12 @@ export const MicrotubuleMetricsSection: React.FC<
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 p-0">
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="mt-enabled"
-            checked={value.enabled}
-            onCheckedChange={c => setEnabled(c === true)}
-          />
-          <Label htmlFor="mt-enabled" className="text-sm">
-            {t('export.mt.enable')}
-          </Label>
+        {/* Per-channel intensity (incl. the integrated sum) is always computed
+            for every channel — no opt-in. This note replaces the old enable
+            checkbox + channel picker. */}
+        <div className="flex items-start gap-2 rounded-md bg-muted/50 p-2.5 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{t('export.mt.intensityNote')}</span>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -171,7 +147,6 @@ export const MicrotubuleMetricsSection: React.FC<
               max={100}
               step={1}
               value={thicknessText}
-              disabled={disabledInputs}
               onChange={e => onThicknessChange(e.target.value)}
               onBlur={onThicknessBlur}
               className="mt-1 text-sm"
@@ -192,7 +167,6 @@ export const MicrotubuleMetricsSection: React.FC<
               max={10}
               step={1}
               value={marginText}
-              disabled={disabledInputs}
               onChange={e => onMarginChange(e.target.value)}
               onBlur={onMarginBlur}
               className="mt-1 text-sm"
@@ -201,44 +175,6 @@ export const MicrotubuleMetricsSection: React.FC<
               {t('export.mt.marginHelp')}
             </p>
           </div>
-        </div>
-
-        <div>
-          <Label className="text-sm">{t('export.mt.channelsLabel')}</Label>
-          {noChannels ? (
-            <p className="text-xs text-muted-foreground mt-2">
-              {t('export.mt.noChannels')}
-            </p>
-          ) : (
-            <div className="mt-2 space-y-2">
-              {availableChannels.map(ch => (
-                <div key={ch.name} className="flex items-center space-x-2">
-                  <Checkbox
-                    id={`mt-channel-${ch.name}`}
-                    checked={value.channels.includes(ch.name)}
-                    disabled={disabledInputs}
-                    onCheckedChange={c => toggleChannel(ch.name, c === true)}
-                  />
-                  <Label
-                    htmlFor={`mt-channel-${ch.name}`}
-                    className="text-sm font-normal"
-                  >
-                    {ch.displayName ?? ch.name}
-                    {ch.displayName && ch.displayName !== ch.name ? (
-                      <span className="text-muted-foreground ml-1">
-                        ({ch.name})
-                      </span>
-                    ) : null}
-                  </Label>
-                </div>
-              ))}
-            </div>
-          )}
-          {value.enabled && !noChannels && value.channels.length === 0 ? (
-            <p className="text-xs text-destructive mt-2">
-              {t('export.mt.selectChannelRequired')}
-            </p>
-          ) : null}
         </div>
       </CardContent>
     </Card>

--- a/src/pages/export/components/__tests__/MicrotubuleMetricsSection.test.tsx
+++ b/src/pages/export/components/__tests__/MicrotubuleMetricsSection.test.tsx
@@ -1,19 +1,16 @@
 /**
  * MicrotubuleMetricsSection — behavioral unit tests
  *
+ * The section was simplified: per-channel intensity (incl. the integrated sum)
+ * is now ALWAYS computed for every channel, so there is no longer an enable
+ * checkbox or a channel picker. Only the band thickness + background margin
+ * inputs remain (always editable), plus an always-on info note.
+ *
  * Covered behaviours:
- *  - Section title and description render
- *  - Enable checkbox toggles enabled state
- *  - Inputs are disabled when section is not enabled
- *  - Thickness input: valid values propagate onChange, invalid values do not
- *  - Thickness input: blur with invalid value snaps back to last good value
+ *  - Section title + always-on intensity note render
+ *  - No enable checkbox / no channel checkboxes are rendered
+ *  - Thickness input: valid values propagate, invalid do not, blur snaps back
  *  - Margin input: same valid/invalid/blur rules (range 0–10, integer)
- *  - Channel list: renders each channel with displayName / name fallback
- *  - Channel checkbox toggles add/remove from value.channels
- *  - Channel checkboxes disabled when section not enabled
- *  - "no channels" message shown when availableChannels is empty
- *  - Validation hint shown when enabled but no channel selected
- *  - Validation hint hidden when disabled (even if no channel)
  *  - External value changes re-sync local text fields
  */
 
@@ -31,64 +28,36 @@ import {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-const CHANNELS = [
-  { name: 'ch1', displayName: 'Green 488' },
-  { name: 'ch2', displayName: 'Red 561' },
-  { name: 'ch3' }, // no displayName — must fall back to name
-];
-
 function makeValue(
   overrides: Partial<MicrotubuleMetricsOptions> = {}
 ): MicrotubuleMetricsOptions {
   return {
-    enabled: true,
     thicknessPx: 5,
     marginMultiplier: 2,
-    channels: [],
     ...overrides,
   };
 }
 
-/**
- * Controlled wrapper so we can observe what onChange is called with
- * without fighting stale closures.
- */
+/** Controlled wrapper so we can observe onChange without fighting stale closures. */
 function Wrapper({
   initial,
   onChange,
-  availableChannels = CHANNELS,
 }: {
   initial: MicrotubuleMetricsOptions;
   onChange?: MicrotubuleMetricsSectionProps['onChange'];
-  availableChannels?: MicrotubuleMetricsSectionProps['availableChannels'];
 }) {
   const [value, setValue] = useState(initial);
   const handleChange: MicrotubuleMetricsSectionProps['onChange'] = next => {
     setValue(next);
     onChange?.(next);
   };
-  return (
-    <MicrotubuleMetricsSection
-      value={value}
-      onChange={handleChange}
-      availableChannels={availableChannels}
-    />
-  );
+  return <MicrotubuleMetricsSection value={value} onChange={handleChange} />;
 }
 
-function setup(
-  initial: MicrotubuleMetricsOptions = makeValue(),
-  availableChannels = CHANNELS
-) {
+function setup(initial: MicrotubuleMetricsOptions = makeValue()) {
   const onChange = vi.fn();
   const user = userEvent.setup();
-  const utils = render(
-    <Wrapper
-      initial={initial}
-      onChange={onChange}
-      availableChannels={availableChannels}
-    />
-  );
+  const utils = render(<Wrapper initial={initial} onChange={onChange} />);
   return { user, onChange, ...utils };
 }
 
@@ -99,70 +68,39 @@ describe('MicrotubuleMetricsSection', () => {
     vi.clearAllMocks();
   });
 
-  // ── static content ────────────────────────────────────────────────────────
-
   describe('static content', () => {
     it('renders the section title', () => {
       setup();
       expect(screen.getByText('Microtubule metrics')).toBeInTheDocument();
     });
 
-    it('renders the enable checkbox', () => {
+    it('renders the always-on per-channel intensity note', () => {
       setup();
       expect(
-        screen.getByLabelText(/compute per-channel intensity/i)
+        screen.getByText(/always computed for every channel/i)
       ).toBeInTheDocument();
     });
-  });
 
-  // ── enable / disable toggle ────────────────────────────────────────────────
-
-  describe('enabled toggle', () => {
-    it('calls onChange with enabled: false when checkbox unchecked', async () => {
-      const { user, onChange } = setup(makeValue({ enabled: true }));
-      await user.click(screen.getByLabelText(/compute per-channel intensity/i));
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ enabled: false })
-      );
-    });
-
-    it('calls onChange with enabled: true when checkbox checked', async () => {
-      const { user, onChange } = setup(makeValue({ enabled: false }));
-      await user.click(screen.getByLabelText(/compute per-channel intensity/i));
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ enabled: true })
-      );
-    });
-
-    it('disables thickness input when section is disabled', () => {
-      setup(makeValue({ enabled: false }));
-      expect(screen.getByLabelText(/mt thickness/i)).toBeDisabled();
-    });
-
-    it('disables margin input when section is disabled', () => {
-      setup(makeValue({ enabled: false }));
-      expect(screen.getByLabelText(/background margin/i)).toBeDisabled();
-    });
-
-    it('enables inputs when section is enabled', () => {
-      setup(makeValue({ enabled: true }));
-      expect(screen.getByLabelText(/mt thickness/i)).not.toBeDisabled();
-      expect(screen.getByLabelText(/background margin/i)).not.toBeDisabled();
+    it('renders NO enable checkbox and NO channel checkboxes', () => {
+      // The simplified section has no checkboxes at all — intensity is always on.
+      setup();
+      expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
     });
   });
-
-  // ── thickness input ────────────────────────────────────────────────────────
 
   describe('thickness input', () => {
-    it('shows the initial thickness value', () => {
+    it('shows the initial thickness value and is always editable', () => {
       setup(makeValue({ thicknessPx: 5 }));
-      expect(screen.getByLabelText(/mt thickness/i)).toHaveValue(5);
+      const input = screen.getByLabelText(/mt thickness/i);
+      expect(input).toHaveValue(5);
+      expect(input).not.toBeDisabled();
     });
 
     it('propagates a valid integer change', async () => {
       const { onChange } = setup(makeValue({ thicknessPx: 5 }));
-      const input = screen.getByLabelText(/mt thickness/i);
-      fireEvent.change(input, { target: { value: '10' } });
+      fireEvent.change(screen.getByLabelText(/mt thickness/i), {
+        target: { value: '10' },
+      });
       await waitFor(() =>
         expect(onChange).toHaveBeenCalledWith(
           expect.objectContaining({ thicknessPx: 10 })
@@ -170,26 +108,29 @@ describe('MicrotubuleMetricsSection', () => {
       );
     });
 
-    it('does NOT propagate an out-of-range value (e.g. 0)', async () => {
+    it('does NOT propagate an out-of-range value (0)', () => {
       const { onChange } = setup(makeValue({ thicknessPx: 5 }));
-      const input = screen.getByLabelText(/mt thickness/i);
-      fireEvent.change(input, { target: { value: '0' } });
-      // onChange may be called for other reasons; check it was not called with
-      // thicknessPx: 0
-      const badCalls = onChange.mock.calls.filter(
-        (c: any) => c[0].thicknessPx === 0
-      );
-      expect(badCalls).toHaveLength(0);
+      fireEvent.change(screen.getByLabelText(/mt thickness/i), {
+        target: { value: '0' },
+      });
+      expect(
+        onChange.mock.calls.filter(
+          (c: unknown[]) => (c[0] as { thicknessPx?: number }).thicknessPx === 0
+        )
+      ).toHaveLength(0);
     });
 
-    it('does NOT propagate a decimal value', async () => {
+    it('does NOT propagate a decimal value', () => {
       const { onChange } = setup(makeValue({ thicknessPx: 5 }));
-      const input = screen.getByLabelText(/mt thickness/i);
-      fireEvent.change(input, { target: { value: '5.5' } });
-      const badCalls = onChange.mock.calls.filter(
-        (c: any) => String(c[0].thicknessPx) === '5.5'
-      );
-      expect(badCalls).toHaveLength(0);
+      fireEvent.change(screen.getByLabelText(/mt thickness/i), {
+        target: { value: '5.5' },
+      });
+      expect(
+        onChange.mock.calls.filter(
+          (c: unknown[]) =>
+            String((c[0] as { thicknessPx?: number }).thicknessPx) === '5.5'
+        )
+      ).toHaveLength(0);
     });
 
     it('snaps back to last good value on blur when empty', () => {
@@ -209,8 +150,6 @@ describe('MicrotubuleMetricsSection', () => {
     });
   });
 
-  // ── margin input ──────────────────────────────────────────────────────────
-
   describe('margin input', () => {
     it('shows the initial margin value', () => {
       setup(makeValue({ marginMultiplier: 2 }));
@@ -219,8 +158,9 @@ describe('MicrotubuleMetricsSection', () => {
 
     it('propagates a valid integer change (including 0)', async () => {
       const { onChange } = setup(makeValue({ marginMultiplier: 2 }));
-      const input = screen.getByLabelText(/background margin/i);
-      fireEvent.change(input, { target: { value: '0' } });
+      fireEvent.change(screen.getByLabelText(/background margin/i), {
+        target: { value: '0' },
+      });
       await waitFor(() =>
         expect(onChange).toHaveBeenCalledWith(
           expect.objectContaining({ marginMultiplier: 0 })
@@ -230,12 +170,15 @@ describe('MicrotubuleMetricsSection', () => {
 
     it('does NOT propagate an out-of-range value (> 10)', () => {
       const { onChange } = setup(makeValue({ marginMultiplier: 2 }));
-      const input = screen.getByLabelText(/background margin/i);
-      fireEvent.change(input, { target: { value: '11' } });
-      const badCalls = onChange.mock.calls.filter(
-        (c: any) => c[0].marginMultiplier === 11
-      );
-      expect(badCalls).toHaveLength(0);
+      fireEvent.change(screen.getByLabelText(/background margin/i), {
+        target: { value: '11' },
+      });
+      expect(
+        onChange.mock.calls.filter(
+          (c: unknown[]) =>
+            (c[0] as { marginMultiplier?: number }).marginMultiplier === 11
+        )
+      ).toHaveLength(0);
     });
 
     it('snaps back to last good value on blur when invalid', () => {
@@ -247,106 +190,6 @@ describe('MicrotubuleMetricsSection', () => {
     });
   });
 
-  // ── channel list ──────────────────────────────────────────────────────────
-
-  describe('channel list', () => {
-    it('renders each available channel', () => {
-      setup();
-      expect(screen.getByText('Green 488')).toBeInTheDocument();
-      expect(screen.getByText('Red 561')).toBeInTheDocument();
-    });
-
-    it('falls back to channel name when displayName absent', () => {
-      setup();
-      expect(screen.getByText('ch3')).toBeInTheDocument();
-    });
-
-    it('shows machine name in parentheses when displayName differs from name', () => {
-      setup();
-      // Green 488 has displayName !== name, so (ch1) should appear
-      expect(screen.getByText('(ch1)')).toBeInTheDocument();
-    });
-
-    it('adds channel to value.channels on checkbox click', async () => {
-      const { onChange } = setup(makeValue({ channels: [] }));
-      const checkbox = screen.getByRole('checkbox', { name: /Green 488/i });
-      fireEvent.click(checkbox);
-      await waitFor(() =>
-        expect(onChange).toHaveBeenCalledWith(
-          expect.objectContaining({ channels: expect.arrayContaining(['ch1']) })
-        )
-      );
-    });
-
-    it('removes channel from value.channels when unchecked', async () => {
-      const { onChange } = setup(makeValue({ channels: ['ch1'] }));
-      const checkbox = screen.getByRole('checkbox', { name: /Green 488/i });
-      fireEvent.click(checkbox);
-      await waitFor(() => {
-        const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
-        expect(lastCall.channels).not.toContain('ch1');
-      });
-    });
-
-    it('channel checkboxes are disabled when section not enabled', () => {
-      setup(makeValue({ enabled: false }));
-      const checkboxes = screen.getAllByRole('checkbox');
-      // First checkbox is the "enable" one; rest are channel checkboxes
-      const channelCheckboxes = checkboxes.slice(1);
-      channelCheckboxes.forEach(cb => expect(cb).toBeDisabled());
-    });
-
-    it('channel checkboxes are enabled when section is enabled', () => {
-      setup(makeValue({ enabled: true }));
-      const checkboxes = screen.getAllByRole('checkbox');
-      const channelCheckboxes = checkboxes.slice(1);
-      channelCheckboxes.forEach(cb => expect(cb).not.toBeDisabled());
-    });
-  });
-
-  // ── empty channels ────────────────────────────────────────────────────────
-
-  describe('when no channels available', () => {
-    it('shows "no channels" message', () => {
-      setup(makeValue(), []);
-      expect(screen.getByText(/no per-channel metadata/i)).toBeInTheDocument();
-    });
-
-    it('does NOT show the channel checkbox list', () => {
-      setup(makeValue(), []);
-      // Only the "enable" checkbox should be present
-      const checkboxes = screen.getAllByRole('checkbox');
-      expect(checkboxes).toHaveLength(1);
-    });
-  });
-
-  // ── validation hint ────────────────────────────────────────────────────────
-
-  describe('validation hint', () => {
-    it('shows "select at least one channel" when enabled and no channel selected', () => {
-      setup(makeValue({ enabled: true, channels: [] }));
-      expect(
-        screen.getByText(/select at least one channel/i)
-      ).toBeInTheDocument();
-    });
-
-    it('hides validation hint when a channel is selected', () => {
-      setup(makeValue({ enabled: true, channels: ['ch1'] }));
-      expect(
-        screen.queryByText(/select at least one channel/i)
-      ).not.toBeInTheDocument();
-    });
-
-    it('hides validation hint when section is disabled', () => {
-      setup(makeValue({ enabled: false, channels: [] }));
-      expect(
-        screen.queryByText(/select at least one channel/i)
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  // ── external value sync ───────────────────────────────────────────────────
-
   describe('external value changes re-sync fields', () => {
     it('updates thickness display when parent updates thicknessPx', async () => {
       const onChange = vi.fn();
@@ -354,14 +197,12 @@ describe('MicrotubuleMetricsSection', () => {
         <MicrotubuleMetricsSection
           value={makeValue({ thicknessPx: 5 })}
           onChange={onChange}
-          availableChannels={CHANNELS}
         />
       );
       rerender(
         <MicrotubuleMetricsSection
           value={makeValue({ thicknessPx: 20 })}
           onChange={onChange}
-          availableChannels={CHANNELS}
         />
       );
       await waitFor(() =>

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -83,15 +83,21 @@ export interface ExportOptions {
   /**
    * Microtubule-only metrics. Sent to the backend on POST /export and
    * consumed by the export pipeline only when the project type is
-   * ``microtubule``. Re-reads the original ND2/TIFF to compute raw
-   * intensity per band.
+   * ``microtubule``. Per-channel intensity (incl. the integrated sum) is
+   * ALWAYS computed for every channel — there is no opt-in; ``thicknessPx`` /
+   * ``marginMultiplier`` only tune the sampling band. Re-reads the original
+   * ND2/TIFF to compute raw intensity per band.
    */
   mtMetrics?: {
-    enabled: boolean;
-    thicknessPx: number;
-    marginMultiplier: number;
-    /** Channel names (machine-safe ``name`` field from container.channels). */
-    channels: string[];
+    /** @deprecated Ignored by the backend — intensity is always computed. */
+    enabled?: boolean;
+    thicknessPx?: number;
+    marginMultiplier?: number;
+    /**
+     * Optional channel subset (machine-safe ``name`` field from
+     * container.channels). Empty / absent => all channels are sampled.
+     */
+    channels?: string[];
   };
   /**
    * Microtubule-only kymograph export. When enabled (MT projects only), the

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -656,6 +656,7 @@ const SegmentationEditor = () => {
     selectedPolygonIds,
     toggleMultiSelect,
     clearMultiSelect,
+    selectAllMultiSelect,
   } = usePolygonHandlers({ editor, imageId });
 
   // Pure render-derivation pipeline (polyline/instance discrimination, legacy
@@ -998,6 +999,44 @@ const SegmentationEditor = () => {
     [toggleMultiSelect, clearMultiSelect]
   );
 
+  // Sidebar list checkbox toggle. A row is "checked" when it is the single
+  // selection OR a member of the multi-select set, so a plain left-click on the
+  // canvas also lights up its checkbox. Toggling a checkbox mirrors Shift+click:
+  // it adds/removes the row from the bulk multi-select set. When there is a lone
+  // single (vertex-edit) selection, we fold it into the bulk set first so the
+  // checked rows and the "propagate selected (N)" count always agree.
+  const handleToggleSelectedInList = useCallback(
+    (id: string) => {
+      const single = editorRef.current.selectedPolygonId;
+      if (single === id) {
+        editorRef.current.setSelectedPolygonId(null);
+        return;
+      }
+      if (single) {
+        editorRef.current.setSelectedPolygonId(null);
+        toggleMultiSelect(single);
+      }
+      toggleMultiSelect(id);
+    },
+    [toggleMultiSelect]
+  );
+
+  // Sidebar "select all": put every listed current-frame polygon id into the
+  // bulk set and drop the single selection so the whole list reads as checked.
+  const handleSelectAllInList = useCallback(
+    (ids: string[]) => {
+      editorRef.current.setSelectedPolygonId(null);
+      selectAllMultiSelect(ids);
+    },
+    [selectAllMultiSelect]
+  );
+
+  // Sidebar "deselect all": clear both selection sets.
+  const handleClearSelectionInList = useCallback(() => {
+    editorRef.current.setSelectedPolygonId(null);
+    clearMultiSelect();
+  }, [clearMultiSelect]);
+
   // Right-click "Propagate selected MTs (N)": propagate every Shift-selected
   // microtubule forward. Loops the single-track endpoint so each keeps its own
   // trackId + colour; ids read via ref to keep this handler stable.
@@ -1210,6 +1249,9 @@ const SegmentationEditor = () => {
         handleCanvasSelect={handleCanvasSelect}
         handlePropagateSelected={handlePropagateSelected}
         selectedPolygonIds={selectedPolygonIds}
+        handleToggleSelectedInList={handleToggleSelectedInList}
+        handleSelectAllInList={handleSelectAllInList}
+        handleClearSelectionInList={handleClearSelectionInList}
         handleSlicePolygonFromContextMenu={handleSlicePolygonFromContextMenu}
         handleEditPolygonFromContextMenu={handleEditPolygonFromContextMenu}
         handleDeleteVertexFromContextMenu={handleDeleteVertexFromContextMenu}

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -1,6 +1,7 @@
 import React, { useDeferredValue, useMemo } from 'react';
 import { Spline, Eye, EyeOff } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Polygon } from '@/lib/segmentation';
 import { calculatePolylineLength } from '../utils/metricCalculations';
 import {
@@ -17,6 +18,15 @@ interface MicrotubuleInstancePanelProps {
   // polyline on the canvas (not just the list row).
   hiddenPolygonIds?: Set<string>;
   onToggleVisibility?: (polygonId: string) => void;
+  /**
+   * Multi-selection (per-row checkbox), synced with the canvas selection: a row
+   * is checked when it is the single selection OR a member of the
+   * Shift+left-click multi-select set. Omit to hide the checkboxes.
+   */
+  selectedPolygonIds?: Set<string>;
+  onToggleSelected?: (id: string) => void;
+  onSelectAll?: (ids: string[]) => void;
+  onClearSelection?: () => void;
 }
 
 const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
@@ -25,6 +35,10 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   onSelectPolygon,
   hiddenPolygonIds,
   onToggleVisibility,
+  selectedPolygonIds = new Set<string>(),
+  onToggleSelected,
+  onSelectAll,
+  onClearSelection,
 }) => {
   const { t } = useLanguage();
 
@@ -78,16 +92,54 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
     }
   };
 
+  // Multi-selection checkbox column (mirrors PolygonListPanel). Checked when a
+  // row is the single selection OR in the Shift+click multi-select set.
+  const multiSelectEnabled = !!onToggleSelected;
+  const isRowSelected = (id: string) =>
+    id === selectedPolygonId || selectedPolygonIds.has(id);
+  const selectableIds = sorted.map(mt => mt.id);
+  const selectedCount = selectableIds.filter(isRowSelected).length;
+  const allSelected = sorted.length > 0 && selectedCount === sorted.length;
+  const headerCheckboxState: boolean | 'indeterminate' = allSelected
+    ? true
+    : selectedCount > 0
+      ? 'indeterminate'
+      : false;
+  const handleHeaderToggle = () => {
+    if (allSelected) onClearSelection?.();
+    else onSelectAll?.(selectableIds);
+  };
+
   return (
     <div className="shrink-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 dark:bg-gray-900">
       <div className="p-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
-        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
-          <Spline className="h-4 w-4" />
-          {t('microtubule.instancePanel')}{' '}
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            ({sorted.length})
-          </span>
-        </h4>
+        <div className="flex items-center gap-2">
+          {/* Select-all: toggles every MT into the multi-select set (also
+              driven by Shift+left-click on the canvas). */}
+          {multiSelectEnabled && sorted.length > 0 && (
+            <Checkbox
+              checked={headerCheckboxState}
+              onCheckedChange={handleHeaderToggle}
+              aria-label={
+                allSelected
+                  ? t('segmentation.selection.deselectAll')
+                  : t('segmentation.selection.selectAll')
+              }
+              title={
+                allSelected
+                  ? t('segmentation.selection.deselectAll')
+                  : t('segmentation.selection.selectAll')
+              }
+            />
+          )}
+          <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
+            <Spline className="h-4 w-4" />
+            {t('microtubule.instancePanel')}{' '}
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              ({sorted.length})
+            </span>
+          </h4>
+        </div>
         {onToggleVisibility && (
           <button
             type="button"
@@ -116,6 +168,7 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
           const colorKey = mt.trackId ?? mt.instanceId ?? '';
           const color = colorFromInstanceId(colorKey);
           const isSelected = selectedPolygonId === mt.id;
+          const isChecked = isSelected || selectedPolygonIds.has(mt.id);
           const isHidden = hiddenPolygonIds?.has(mt.id) ?? false;
           return (
             <div
@@ -126,6 +179,14 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
                   : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
               }`}
             >
+              {multiSelectEnabled && (
+                <Checkbox
+                  checked={isChecked}
+                  onCheckedChange={() => onToggleSelected?.(mt.id)}
+                  aria-label={`${t('microtubule.instance')} ${idx + 1}`}
+                  className="flex-shrink-0"
+                />
+              )}
               <button
                 type="button"
                 className={`flex flex-1 items-center gap-2 text-left ${isHidden ? 'opacity-50' : ''}`}

--- a/src/pages/segmentation/components/PolygonListPanel.tsx
+++ b/src/pages/segmentation/components/PolygonListPanel.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Polygon } from '@/lib/segmentation';
 import { motion } from 'framer-motion';
 import { ensureValidPolygonId } from '@/lib/polygonIdUtils';
@@ -30,6 +31,17 @@ interface PolygonListPanelProps {
   onTogglePolygonVisibility?: (id: string) => void;
   onRenamePolygon?: (id: string, name: string) => void;
   onDeletePolygon?: (id: string) => void;
+  /**
+   * Multi-selection (per-row checkbox column). This mirrors the canvas
+   * selection set: a row is checked when it is the single selection
+   * (`selectedPolygonId`) OR a member of the Shift+left-click multi-select set
+   * (`selectedPolygonIds`). Toggling a checkbox drives the same bulk set that
+   * Shift+left-click on the canvas drives. Omit these props to hide the column.
+   */
+  selectedPolygonIds?: Set<string>;
+  onToggleSelected?: (id: string) => void;
+  onSelectAll?: (ids: string[]) => void;
+  onClearSelection?: () => void;
 }
 
 /**
@@ -44,6 +56,10 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
   onTogglePolygonVisibility,
   onRenamePolygon,
   onDeletePolygon,
+  selectedPolygonIds = new Set<string>(),
+  onToggleSelected,
+  onSelectAll,
+  onClearSelection,
 }) => {
   const { t } = useLanguage();
   const [editingPolygonId, setEditingPolygonId] = useState<string | null>(null);
@@ -71,6 +87,26 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
       if (allHidden && isHidden) onTogglePolygonVisibility(p.id);
       else if (!allHidden && !isHidden) onTogglePolygonVisibility(p.id);
     }
+  };
+
+  // Multi-selection checkbox column. A row is "checked" when it is the single
+  // selection OR a member of the Shift+click multi-select set, so a plain
+  // left-click on the canvas also lights up its checkbox. The column is only
+  // shown when the parent wires the toggle handler.
+  const multiSelectEnabled = !!onToggleSelected;
+  const isRowSelected = (id: string) =>
+    id === selectedPolygonId || selectedPolygonIds.has(id);
+  const selectableIds = polygons.map(p => p.id);
+  const selectedCount = selectableIds.filter(isRowSelected).length;
+  const allSelected = polygons.length > 0 && selectedCount === polygons.length;
+  const headerCheckboxState: boolean | 'indeterminate' = allSelected
+    ? true
+    : selectedCount > 0
+      ? 'indeterminate'
+      : false;
+  const handleHeaderToggle = () => {
+    if (allSelected) onClearSelection?.();
+    else onSelectAll?.(selectableIds);
   };
 
   const handleStartRename = (polygon: Polygon) => {
@@ -268,6 +304,26 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
             )}
           </div>
         </div>
+
+        {/* Select-all row — toggles the whole visible list into the multi-select
+            set that Shift+left-click on the canvas also drives. */}
+        {multiSelectEnabled && polygons.length > 0 && (
+          <div className="flex items-center gap-2 mt-2">
+            <Checkbox
+              id="polygon-list-select-all"
+              checked={headerCheckboxState}
+              onCheckedChange={handleHeaderToggle}
+            />
+            <label
+              htmlFor="polygon-list-select-all"
+              className="text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none"
+            >
+              {selectedCount > 0
+                ? t('segmentation.selection.selected', { count: selectedCount })
+                : t('segmentation.selection.selectAll')}
+            </label>
+          </div>
+        )}
       </div>
 
       {/* Polygon List */}
@@ -279,6 +335,7 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
         <div className="p-2 space-y-1">
           {deferredPolygons.map((polygon, index) => {
             const isSelected = selectedPolygonId === polygon.id;
+            const isChecked = isSelected || selectedPolygonIds.has(polygon.id);
             const isHidden = hiddenPolygonIds.has(polygon.id);
             const isEditing = editingPolygonId === polygon.id;
             const isPolyline = polygon.geometry === 'polyline';
@@ -309,6 +366,18 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
               >
                 <div className="p-3">
                   <div className="flex items-center gap-3">
+                    {/* Multi-select checkbox — stops propagation so it doesn't
+                        also trigger the row's single-select onClick. */}
+                    {multiSelectEnabled && (
+                      <Checkbox
+                        checked={isChecked}
+                        onCheckedChange={() => onToggleSelected?.(polygon.id)}
+                        onClick={e => e.stopPropagation()}
+                        aria-label={polygonName}
+                        className="flex-shrink-0"
+                      />
+                    )}
+
                     {/* Color indicator */}
                     <div
                       className={`w-3 h-3 rounded-full ${getPolygonColor(polygon)}`}

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -126,6 +126,12 @@ export interface SegmentationEditorLayoutProps {
   handlePropagateSelected: () => void;
   /** Current Shift+click multi-selection (per-frame polygon ids). */
   selectedPolygonIds: Set<string>;
+  /** Sidebar checkbox toggle — mirrors Shift+click on the canvas. */
+  handleToggleSelectedInList: (id: string) => void;
+  /** Sidebar "select all" — pass the listed current-frame polygon ids. */
+  handleSelectAllInList: (ids: string[]) => void;
+  /** Sidebar "deselect all" — clear both selection sets. */
+  handleClearSelectionInList: () => void;
   handleSlicePolygonFromContextMenu: PolygonHandlers['handleSlicePolygonFromContextMenu'];
   handleEditPolygonFromContextMenu: PolygonHandlers['handleEditPolygonFromContextMenu'];
   handleDeleteVertexFromContextMenu: PolygonHandlers['handleDeleteVertexFromContextMenu'];
@@ -204,6 +210,9 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
   handleCanvasSelect,
   handlePropagateSelected,
   selectedPolygonIds,
+  handleToggleSelectedInList,
+  handleSelectAllInList,
+  handleClearSelectionInList,
   handleSlicePolygonFromContextMenu,
   handleEditPolygonFromContextMenu,
   handleDeleteVertexFromContextMenu,
@@ -499,6 +508,10 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                   onTogglePolygonVisibility={handleTogglePolygonVisibility}
                   onRenamePolygon={handleRenamePolygon}
                   onDeletePolygon={handleDeletePolygonFromPanel}
+                  selectedPolygonIds={selectedPolygonIds}
+                  onToggleSelected={handleToggleSelectedInList}
+                  onSelectAll={handleSelectAllInList}
+                  onClearSelection={handleClearSelectionInList}
                 />
                 {hasPolylines && polylineKind === 'sperm' && (
                   <SpermInstancePanel
@@ -518,6 +531,10 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                     onSelectPolygon={handleSelectPolygon}
                     hiddenPolygonIds={frameHiddenIds}
                     onToggleVisibility={handleTogglePolygonVisibility}
+                    selectedPolygonIds={selectedPolygonIds}
+                    onToggleSelected={handleToggleSelectedInList}
+                    onSelectAll={handleSelectAllInList}
+                    onClearSelection={handleClearSelectionInList}
                   />
                 )}
               </div>

--- a/src/pages/segmentation/components/__tests__/MicrotubuleInstancePanel.multiselect.test.tsx
+++ b/src/pages/segmentation/components/__tests__/MicrotubuleInstancePanel.multiselect.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * MicrotubuleInstancePanel — multi-select checkbox column
+ *
+ * Mirrors the PolygonListPanel checkbox behaviour: a row is checked when it is
+ * the single selection OR a member of the Shift+click multi-select set;
+ * toggling a checkbox calls onToggleSelected(id); the header select-all
+ * checkbox calls onSelectAll(ids) / onClearSelection; and the column is hidden
+ * when onToggleSelected is omitted.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { render as renderWithProviders } from '@/test/utils/test-utils';
+import MicrotubuleInstancePanel from '../MicrotubuleInstancePanel';
+import { Polygon } from '@/lib/segmentation';
+
+vi.mock('@/pages/segmentation/utils/metricCalculations', () => ({
+  calculatePolylineLength: vi.fn(() => 123.4),
+}));
+
+vi.mock('@/pages/segmentation/utils/instanceColors', () => ({
+  colorFromInstanceId: vi.fn(() => '#00FF00'),
+  isMicrotubuleInstance: vi.fn(
+    (id?: string) => typeof id === 'string' && id.startsWith('mt_')
+  ),
+}));
+
+function makeMT(overrides: Partial<Polygon> = {}): Polygon {
+  return {
+    id: 'mt-1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 5 },
+      { x: 20, y: 0 },
+    ],
+    geometry: 'polyline',
+    class: 'microtubule',
+    trackId: 'mt_track_1',
+    ...overrides,
+  } as Polygon;
+}
+
+// Sorted by trackId → "Microtubule 1/2/3" in this order.
+const MTS = [
+  makeMT({ id: 'mtA', trackId: 'mt_track_1' }),
+  makeMT({ id: 'mtB', trackId: 'mt_track_2' }),
+  makeMT({ id: 'mtC', trackId: 'mt_track_3' }),
+];
+
+function renderPanel(
+  props: Partial<React.ComponentProps<typeof MicrotubuleInstancePanel>> = {}
+) {
+  const onToggleSelected = vi.fn();
+  const onSelectAll = vi.fn();
+  const onClearSelection = vi.fn();
+  const onSelectPolygon = vi.fn();
+  const utils = renderWithProviders(
+    <MicrotubuleInstancePanel
+      polygons={MTS}
+      selectedPolygonId={null}
+      onSelectPolygon={onSelectPolygon}
+      selectedPolygonIds={new Set<string>()}
+      onToggleSelected={onToggleSelected}
+      onSelectAll={onSelectAll}
+      onClearSelection={onClearSelection}
+      {...props}
+    />
+  );
+  return {
+    onToggleSelected,
+    onSelectAll,
+    onClearSelection,
+    onSelectPolygon,
+    ...utils,
+  };
+}
+
+describe('MicrotubuleInstancePanel — multi-select checkboxes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the checkbox column when onToggleSelected is omitted', () => {
+    renderWithProviders(
+      <MicrotubuleInstancePanel
+        polygons={MTS}
+        selectedPolygonId={null}
+        onSelectPolygon={vi.fn()}
+      />
+    );
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  });
+
+  it('renders one checkbox per MT row plus a header select-all checkbox', () => {
+    renderPanel();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(MTS.length + 1);
+    expect(
+      screen.getByRole('checkbox', { name: /select all/i })
+    ).toBeInTheDocument();
+  });
+
+  it('checks the single-selected row and multi-selected rows', () => {
+    renderPanel({
+      selectedPolygonId: 'mtA',
+      selectedPolygonIds: new Set(['mtC']),
+    });
+    expect(
+      screen.getByRole('checkbox', { name: 'Microtubule 1' })
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Microtubule 3' })
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Microtubule 2' })
+    ).not.toBeChecked();
+  });
+
+  it('toggling a row checkbox calls onToggleSelected with that MT id', () => {
+    const { onToggleSelected, onSelectPolygon } = renderPanel();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Microtubule 2' }));
+    expect(onToggleSelected).toHaveBeenCalledWith('mtB');
+    expect(onSelectPolygon).not.toHaveBeenCalled();
+  });
+
+  it('header select-all calls onSelectAll with every MT id when none selected', () => {
+    const { onSelectAll } = renderPanel();
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectAll).toHaveBeenCalledWith(['mtA', 'mtB', 'mtC']);
+  });
+
+  it('header select-all calls onClearSelection when all are selected', () => {
+    const { onClearSelection } = renderPanel({
+      selectedPolygonIds: new Set(['mtA', 'mtB', 'mtC']),
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /deselect all/i }));
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/segmentation/components/__tests__/PolygonListPanel.multiselect.test.tsx
+++ b/src/pages/segmentation/components/__tests__/PolygonListPanel.multiselect.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * PolygonListPanel — multi-select checkbox column
+ *
+ * The checkbox column is bidirectionally synced with the canvas selection:
+ *  - A row is checked when it is the single selection (`selectedPolygonId`) OR
+ *    a member of the Shift+click multi-select set (`selectedPolygonIds`).
+ *  - Toggling a row checkbox calls `onToggleSelected(id)` and must NOT also
+ *    trigger the row's single-select `onSelectPolygon` (stopPropagation).
+ *  - The header "select all" checkbox calls `onSelectAll(ids)` / `onClearSelection`.
+ *  - The whole column is hidden when `onToggleSelected` is omitted.
+ */
+
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@/test/utils/test-utils';
+import PolygonListPanel from '../PolygonListPanel';
+import { Polygon } from '@/lib/segmentation';
+
+// framer-motion animate calls requestAnimationFrame; stub to avoid flakiness
+// and to keep the row-level onClick handler intact for propagation tests.
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      ...rest
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      children?: React.ReactNode;
+    }) => <div {...rest}>{children}</div>,
+  },
+}));
+
+function makePolygon(overrides: Partial<Polygon> = {}): Polygon {
+  return {
+    id: 'poly-1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    name: 'Test Polygon',
+    geometry: 'polygon',
+    ...overrides,
+  } as Polygon;
+}
+
+const POLYS = [
+  makePolygon({ id: 'p1', name: 'Alpha' }),
+  makePolygon({ id: 'p2', name: 'Beta' }),
+  makePolygon({ id: 'p3', name: 'Gamma' }),
+];
+
+function renderPanel(
+  props: Partial<React.ComponentProps<typeof PolygonListPanel>> = {}
+) {
+  const onToggleSelected = vi.fn();
+  const onSelectAll = vi.fn();
+  const onClearSelection = vi.fn();
+  const onSelectPolygon = vi.fn();
+  const utils = render(
+    <PolygonListPanel
+      loading={false}
+      polygons={POLYS}
+      selectedPolygonId={null}
+      onSelectPolygon={onSelectPolygon}
+      selectedPolygonIds={new Set<string>()}
+      onToggleSelected={onToggleSelected}
+      onSelectAll={onSelectAll}
+      onClearSelection={onClearSelection}
+      {...props}
+    />
+  );
+  return {
+    onToggleSelected,
+    onSelectAll,
+    onClearSelection,
+    onSelectPolygon,
+    ...utils,
+  };
+}
+
+describe('PolygonListPanel — multi-select checkboxes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the checkbox column when onToggleSelected is omitted', () => {
+    render(
+      <PolygonListPanel
+        loading={false}
+        polygons={POLYS}
+        selectedPolygonId={null}
+        onSelectPolygon={vi.fn()}
+      />
+    );
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  });
+
+  it('renders one checkbox per row plus a header select-all checkbox', () => {
+    renderPanel();
+    // 3 rows + 1 header select-all
+    expect(screen.getAllByRole('checkbox')).toHaveLength(POLYS.length + 1);
+    expect(
+      screen.getByRole('checkbox', { name: /select all/i })
+    ).toBeInTheDocument();
+  });
+
+  it('checks a row that is the single selection (selectedPolygonId)', () => {
+    renderPanel({ selectedPolygonId: 'p2' });
+    expect(screen.getByRole('checkbox', { name: 'Beta' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Alpha' })).not.toBeChecked();
+  });
+
+  it('checks a row that is in the multi-select set (selectedPolygonIds)', () => {
+    renderPanel({ selectedPolygonIds: new Set(['p1', 'p3']) });
+    expect(screen.getByRole('checkbox', { name: 'Alpha' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Gamma' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Beta' })).not.toBeChecked();
+  });
+
+  it('toggling a row checkbox calls onToggleSelected and NOT onSelectPolygon', () => {
+    const { onToggleSelected, onSelectPolygon } = renderPanel();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Beta' }));
+    expect(onToggleSelected).toHaveBeenCalledWith('p2');
+    // stopPropagation must keep the row's single-select from firing.
+    expect(onSelectPolygon).not.toHaveBeenCalled();
+  });
+
+  it('header select-all calls onSelectAll with every row id when none selected', () => {
+    const { onSelectAll } = renderPanel();
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectAll).toHaveBeenCalledWith(['p1', 'p2', 'p3']);
+  });
+
+  it('header checkbox calls onClearSelection when everything is already selected', () => {
+    const { onClearSelection, onSelectAll } = renderPanel({
+      selectedPolygonIds: new Set(['p1', 'p2', 'p3']),
+    });
+    // All rows selected → the header label shows the count and its checkbox is
+    // checked; clicking it clears the whole selection instead of re-selecting.
+    const header = screen.getByRole('checkbox', { name: /3 selected/i });
+    expect(header).toBeChecked();
+    fireEvent.click(header);
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(onSelectAll).not.toHaveBeenCalled();
+  });
+
+  it('header label shows the selected count when a subset is selected', () => {
+    renderPanel({ selectedPolygonIds: new Set(['p1']) });
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+});

--- a/src/pages/segmentation/hooks/usePolygonHandlers.ts
+++ b/src/pages/segmentation/hooks/usePolygonHandlers.ts
@@ -86,6 +86,11 @@ export function usePolygonHandlers({
   const clearMultiSelect = useCallback(() => {
     setSelectedPolygonIds(prev => (prev.size === 0 ? prev : new Set()));
   }, []);
+  // Replace the whole multi-select set (used by the sidebar "select all"
+  // control — the panel passes its full list of current-frame polygon ids).
+  const selectAllMultiSelect = useCallback((ids: string[]) => {
+    setSelectedPolygonIds(new Set(ids));
+  }, []);
 
   // Polygon ids are per-frame, so a multi-selection is meaningless after a frame
   // change — clear it when the edited image changes.
@@ -251,6 +256,7 @@ export function usePolygonHandlers({
     selectedPolygonIds,
     toggleMultiSelect,
     clearMultiSelect,
+    selectAllMultiSelect,
     handleTogglePolygonVisibility,
     handleDeletePolygonFromPanel,
     handleSelectPolygon,

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -615,6 +615,11 @@ export default {
     system: 'Systémový',
   },
   segmentation: {
+    selection: {
+      selectAll: 'Vybrat vše',
+      deselectAll: 'Zrušit výběr',
+      selected: 'Vybráno: {{count}}',
+    },
     trackOps: {
       propagateSelectedSuccess:
         '{{count}} mikrotubulů propagováno do dalších snímků',
@@ -1194,22 +1199,14 @@ export default {
       sectionTitle: 'Metriky mikrotubulů',
       sectionDescription:
         'Délka, plocha a intenzita signálu pro každý MT z původního ND2/TIFF souboru. Odečteno median pozadí (mimo dilatovanou masku MT).',
-      enable: 'Spočítat intenzitu signálu pro každý kanál',
+      intensityNote:
+        'Intenzita signálu podle kanálu — včetně součtové (integrované) intenzity — se vždy vypočítá pro každý kanál a zapíše do tabulky metrik. Není třeba nic vybírat.',
       thicknessLabel: 'Tloušťka MT (px)',
       thicknessHelp:
         'Šířka pásu podél polyline, ze kterého se sbírá signál. 5 px odpovídá běžnému průměru mikrotubulu při 100× widefield.',
       marginLabel: 'Okraj pozadí (× tloušťka)',
       marginHelp:
         'Pixely v tomto poloměru (tloušťka × násobek) od libovolného MT se z pozadí vyloučí. Vyšší = konzervativnější.',
-      channelsLabel: 'Kanály ke zpracování',
-      noChannels:
-        'Tento projekt nemá metadata o kanálech. Pro získání metrik podle kanálů znovu nahrajte video.',
-      selectChannelRequired:
-        'Pro export metrik intenzity podle kanálů vyberte alespoň jeden kanál.',
-      incompleteTitle: 'Výpočet intenzit nezvolen',
-      incompleteBody:
-        'Nemáte zapnutý výpočet intenzity signálu podle kanálů, takže exportované metriky budou neúplné: zahrnuta bude pouze délka mikrotubulů, bez sloupců s intenzitou podle kanálů. Přesto exportovat?',
-      incompleteConfirm: 'Přesto exportovat',
     },
     advancedExport: 'Pokročilý export',
     advancedOptions: 'Pokročilé možnosti exportu',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -776,6 +776,11 @@ export default {
     },
   },
   segmentation: {
+    selection: {
+      selectAll: 'Alle auswählen',
+      deselectAll: 'Auswahl aufheben',
+      selected: '{{count}} ausgewählt',
+    },
     trackOps: {
       propagateSelectedSuccess:
         '{{count}} Mikrotubuli in die folgenden Frames übertragen',
@@ -1205,22 +1210,14 @@ export default {
       sectionTitle: 'Mikrotubuli-Metriken',
       sectionDescription:
         'Pro-MT-Länge, -Fläche und kanalweise Intensität aus der rohen ND2/TIFF-Datei. Hintergrundkorrektur über den Median außerhalb der dilatierten MT-Maske.',
-      enable: 'Kanalweise Intensitätsmetriken berechnen',
+      intensityNote:
+        'Die kanalweise Signalintensität — einschließlich der summierten (integrierten) Intensität — wird immer für jeden Kanal berechnet und in die Metriktabelle geschrieben. Keine Auswahl erforderlich.',
       thicknessLabel: 'MT-Dicke (px)',
       thicknessHelp:
         'Breite des Abtastbands entlang jeder Polyline. 5 px entspricht dem typischen Mikrotubulus-Durchmesser bei 100× Widefield.',
       marginLabel: 'Hintergrundrand (× Dicke)',
       marginHelp:
         'Pixel innerhalb dieses Radius (Dicke × Multiplikator) von einem MT werden vom Hintergrund ausgeschlossen. Höher = konservativer.',
-      channelsLabel: 'Zu abtastende Kanäle',
-      noChannels:
-        'Dieses Projekt hat keine Kanal-Metadaten. Laden Sie das Video erneut hoch, um kanalspezifische Metriken zu erhalten.',
-      selectChannelRequired:
-        'Wählen Sie mindestens einen Kanal, um kanalspezifische Intensitätsmetriken zu exportieren.',
-      incompleteTitle: 'Intensitätsberechnung nicht ausgewählt',
-      incompleteBody:
-        'Sie haben die kanalweise Signalintensitätsberechnung nicht aktiviert, daher sind die exportierten Metriken unvollständig: Es wird nur die Mikrotubuli-Länge einbezogen, ohne die kanalspezifischen Intensitätsspalten. Trotzdem exportieren?',
-      incompleteConfirm: 'Trotzdem exportieren',
     },
     advancedExport: 'Erweiterter Export',
     advancedOptions: 'Erweiterte Export-Optionen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -617,6 +617,11 @@ export default {
     system: 'System',
   },
   segmentation: {
+    selection: {
+      selectAll: 'Select all',
+      deselectAll: 'Deselect all',
+      selected: '{{count}} selected',
+    },
     trackOps: {
       propagateSelectedSuccess:
         'Propagated {{count}} microtubules to the following frames',
@@ -1187,22 +1192,14 @@ export default {
       sectionTitle: 'Microtubule metrics',
       sectionDescription:
         'Per-MT length, area, and per-channel intensity from the raw ND2/TIFF file. Background-corrected using the median of pixels outside the dilated MT mask.',
-      enable: 'Compute per-channel intensity metrics',
+      intensityNote:
+        'Per-channel signal intensity — including the summed (integrated) intensity — is always computed for every channel and written to the metrics spreadsheet. No selection needed.',
       thicknessLabel: 'MT thickness (px)',
       thicknessHelp:
         'Width of the sampling band along each polyline. 5 px matches typical microtubule diameter in 100x widefield.',
       marginLabel: 'Background margin (× thickness)',
       marginHelp:
         'Excludes pixels within this radius (thickness × multiplier) of any MT from the background. Higher = more conservative.',
-      channelsLabel: 'Channels to sample',
-      noChannels:
-        'This project has no per-channel metadata. Re-upload the video to get channel-specific metrics.',
-      selectChannelRequired:
-        'Select at least one channel to export per-channel intensity metrics.',
-      incompleteTitle: 'Intensity calculation not selected',
-      incompleteBody:
-        'You have not enabled per-channel signal-intensity calculation, so the exported metrics will be incomplete: only microtubule length will be included, without the per-channel intensity columns. Export anyway?',
-      incompleteConfirm: 'Export anyway',
     },
     // Dialog headers
     advancedExport: 'Advanced Export',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -769,6 +769,11 @@ export default {
     },
   },
   segmentation: {
+    selection: {
+      selectAll: 'Seleccionar todo',
+      deselectAll: 'Deseleccionar todo',
+      selected: '{{count}} seleccionados',
+    },
     trackOps: {
       propagateSelectedSuccess:
         '{{count}} microtúbulos propagados a los fotogramas siguientes',
@@ -1191,22 +1196,14 @@ export default {
       sectionTitle: 'Métricas de microtúbulos',
       sectionDescription:
         'Longitud, área e intensidad por canal de cada MT desde el archivo ND2/TIFF original. Corregido con la mediana del fondo (fuera de la máscara MT dilatada).',
-      enable: 'Calcular métricas de intensidad por canal',
+      intensityNote:
+        'La intensidad de señal por canal —incluida la intensidad sumada (integrada)— se calcula siempre para cada canal y se escribe en la hoja de métricas. No es necesario seleccionar nada.',
       thicknessLabel: 'Grosor del MT (px)',
       thicknessHelp:
         'Ancho de la banda de muestreo a lo largo de cada polilínea. 5 px corresponde al diámetro típico del microtúbulo a 100× campo amplio.',
       marginLabel: 'Margen del fondo (× grosor)',
       marginHelp:
         'Excluye píxeles dentro de este radio (grosor × multiplicador) de cualquier MT del fondo. Mayor = más conservador.',
-      channelsLabel: 'Canales a muestrear',
-      noChannels:
-        'Este proyecto no tiene metadatos de canales. Vuelva a subir el vídeo para obtener métricas por canal.',
-      selectChannelRequired:
-        'Seleccione al menos un canal para exportar las métricas de intensidad por canal.',
-      incompleteTitle: 'Cálculo de intensidad no seleccionado',
-      incompleteBody:
-        'No ha activado el cálculo de intensidad de señal por canal, por lo que las métricas exportadas estarán incompletas: solo se incluirá la longitud de los microtúbulos, sin las columnas de intensidad por canal. ¿Exportar de todos modos?',
-      incompleteConfirm: 'Exportar de todos modos',
     },
     advancedExport: 'Exportación Avanzada',
     advancedOptions: 'Opciones Avanzadas de Exportación',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -770,6 +770,11 @@ export default {
     },
   },
   segmentation: {
+    selection: {
+      selectAll: 'Tout sélectionner',
+      deselectAll: 'Tout désélectionner',
+      selected: '{{count}} sélectionné(s)',
+    },
     trackOps: {
       propagateSelectedSuccess:
         '{{count}} microtubules propagés vers les images suivantes',
@@ -1195,22 +1200,14 @@ export default {
       sectionTitle: 'Métriques des microtubules',
       sectionDescription:
         "Longueur, aire et intensité par canal de chaque MT à partir du fichier ND2/TIFF d'origine. Corrigé par la médiane du fond (en dehors du masque MT dilaté).",
-      enable: 'Calculer les métriques d’intensité par canal',
+      intensityNote:
+        "L'intensité du signal par canal — y compris l'intensité sommée (intégrée) — est toujours calculée pour chaque canal et écrite dans la feuille de métriques. Aucune sélection n'est nécessaire.",
       thicknessLabel: 'Épaisseur du MT (px)',
       thicknessHelp:
         "Largeur de la bande d'échantillonnage le long de chaque polyligne. 5 px correspond au diamètre typique des microtubules en grand champ 100×.",
       marginLabel: 'Marge du fond (× épaisseur)',
       marginHelp:
         "Exclut du fond les pixels situés dans ce rayon (épaisseur × multiplicateur) d'un MT. Plus élevé = plus conservateur.",
-      channelsLabel: 'Canaux à échantillonner',
-      noChannels:
-        'Ce projet ne contient pas de métadonnées de canaux. Téléversez à nouveau la vidéo pour obtenir des métriques par canal.',
-      selectChannelRequired:
-        "Sélectionnez au moins un canal pour exporter les métriques d'intensité par canal.",
-      incompleteTitle: "Calcul d'intensité non sélectionné",
-      incompleteBody:
-        "Vous n'avez pas activé le calcul de l'intensité du signal par canal ; les métriques exportées seront donc incomplètes : seule la longueur des microtubules sera incluse, sans les colonnes d'intensité par canal. Exporter quand même ?",
-      incompleteConfirm: 'Exporter quand même',
     },
     advancedExport: 'Export Avancé',
     advancedOptions: "Options d'Exportation Avancées",

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -709,6 +709,11 @@ export default {
     },
   },
   segmentation: {
+    selection: {
+      selectAll: '全选',
+      deselectAll: '取消全选',
+      selected: '已选择 {{count}} 个',
+    },
     trackOps: {
       propagateSelectedSuccess: '已将 {{count}} 个微管传播到后续帧',
       propagateSelectedPartial: '已传播 {{done}}/{{total}} 个微管',
@@ -1101,20 +1106,14 @@ export default {
       sectionTitle: '微管指标',
       sectionDescription:
         '从原始 ND2/TIFF 文件计算每条微管的长度、面积及每通道强度。使用扩张 MT 掩码外的中位数进行背景校正。',
-      enable: '计算每通道强度指标',
+      intensityNote:
+        '每通道信号强度——包括总和（积分）强度——始终会为每个通道计算并写入指标表格，无需进行任何选择。',
       thicknessLabel: '微管厚度 (px)',
       thicknessHelp:
         '沿每条多边折线采样的带宽。100× 宽场下典型微管直径约为 5 px。',
       marginLabel: '背景余量 (× 厚度)',
       marginHelp:
         '将距任意 MT 此半径范围内的像素 (厚度 × 倍率) 排除出背景。越大越保守。',
-      channelsLabel: '要采样的通道',
-      noChannels: '该项目没有通道元数据。请重新上传视频以获取按通道的指标。',
-      selectChannelRequired: '请至少选择一个通道以导出按通道的强度指标。',
-      incompleteTitle: '未选择强度计算',
-      incompleteBody:
-        '您尚未启用按通道的信号强度计算，因此导出的指标将不完整：仅包含微管长度，而不含按通道的强度列。仍要导出吗？',
-      incompleteConfirm: '仍要导出',
     },
     advancedExport: '高级导出',
     advancedOptions: '高级导出选项',


### PR DESCRIPTION
## What & why

Two microtubule-focused enhancements requested together.

### 1. Per-channel intensity **sum** is always in the MT export (no opt-in)

For microtubule projects the metrics spreadsheet now **always** includes
per-channel signal intensity — including the integrated **`sumIntensity`**
column — for **every** channel, with no checkbox to tick.

- The `sumIntensity` value already existed end-to-end (`mt_metrics.py` computes
  `pixels.sum()`, and it's already a `CSV_HEADERS` column); it was just gated
  behind an opt-in. This PR removes that gate.
- `computeMTMetrics`: an **empty `channels` list now means "all channels of
  each container"** (a named subset can still be requested via the API).
- `generateMicrotubuleMetrics`: always attempts intensity for MT projects and
  only falls back to length-only on a genuine ML/file failure.
- Removed the now-obsolete **enable checkbox**, **channel picker**, and
  **incomplete-metrics confirmation modal** from the export dialog, plus the
  dead `projectChannels` prop chain (`ProjectDetail → ProjectToolbar →
  AdvancedExportDialog`).

### 2. Sidebar selection checkboxes, synced with the canvas

The polygon/polyline list **and** the microtubule instance list now have a
per-row **checkbox column**, bidirectionally synced with the canvas selection:

- A row is **checked** when it is the single selection (plain left-click) **OR**
  a member of the **Shift + left-click** multi-select set.
- Toggling a checkbox drives that same bulk set (the one `Propagate selected
  (N)` already uses), so canvas ↔ sidebar stay in agreement.
- Added a per-list **"Select all / Deselect all"** header control.
- Reuses the existing `selectedPolygonIds` machinery — new `selectAllMultiSelect`
  helper on `usePolygonHandlers`; the checkbox column is hidden when the parent
  doesn't wire the handlers.

> Note: sperm polylines already get checkboxes via the always-rendered polygon
> list; the sperm grouped-tree view was left as-is (its rows are `<button>`s,
> so a nested checkbox would need a structural rewrite — out of scope here).

## i18n
Removed obsolete `export.mt.{enable,channelsLabel,noChannels,selectChannelRequired,incomplete*}`;
added `export.mt.intensityNote` + `segmentation.selection.{selectAll,deselectAll,selected}`
across all 6 locales (EN/CS/ES/DE/FR/ZH). `check-i18n` green (1578 keys each).

## Tests & verification
- **Backend (vitest):** new `computeMTMetrics` "empty channels ⇒ all channels"
  test; updated exportService MT-dispatch tests for the always-on path; full
  export suite green (132 + 41 relevant).
- **Frontend (vitest):** rewrote `MicrotubuleMetricsSection` (14) +
  `AdvancedExportDialog` (44) suites for the new behavior; new
  `PolygonListPanel.multiselect` (8) + `MicrotubuleInstancePanel.multiselect`
  (6) checkbox tests; existing panel + `usePolygonHandlers` suites still green.
- **`make ci`** (TS + ESLint 0-warnings + i18n) green.
- **Authoritative frontend production build** (`make build-service
  SERVICE=frontend`) succeeds — the real type/bundle gate.

⚠️ **Browser E2E not run:** only the production stack is running on this host
(no dev server), so verifying the editor UX in a real browser would require
deploying the new frontend to production. Not done here — happy to deploy +
Playwright-verify on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microtubule export now computes intensity for all channels by default and simplifies the export settings.
  * Added multi-select controls in segmentation lists, including select all, deselect all, and selection counts.

* **Bug Fixes**
  * Improved export behavior so microtubule metrics still produce useful output with clearer warnings and fallback handling.
  * Removed an unnecessary export confirmation step for incomplete microtubule settings.

* **Documentation / Copy**
  * Updated on-screen text across languages to match the new export and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->