### PR TITLE
feat(mt-export): whole-video per-channel total intensity + wider polygon-list sidebar

### DIFF
--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -128,10 +128,29 @@ class MTMetricsRow(BaseModel):
     signal_minus_background: Optional[float] = None
 
 
+class MTChannelSummary(BaseModel):
+    """Whole-video, whole-image total for one channel.
+
+    Sum / mean over EVERY pixel of the channel across ALL frames of the video —
+    independent of the microtubules. A global "how bright is this channel over
+    the whole recording" measure, distinct from the per-MT band sums.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    channel: str
+    total_intensity: float
+    mean_intensity: float
+    pixel_count: int
+    frames: int
+
+
 class MTMetricsResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     rows: List[MTMetricsRow]
+    # Per-channel whole-image totals over the whole video (one per requested
+    # channel). Empty only when no channels were requested.
+    channel_summaries: List[MTChannelSummary]
     frames_processed: int
     frame_height: int
     frame_width: int
@@ -377,6 +396,23 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
                 detail=f"channel_index {ci} out of bounds [0, {C - 1}]",
             )
 
+    # Whole-image per-channel totals over the whole video: sum of EVERY pixel of
+    # the channel across ALL frames (not just the MT bands). Uses the RAW file
+    # (no registration offset) — this is a global channel measure and the
+    # zero-filled borders of a shifted channel would understate its true total.
+    channel_summaries: List[MTChannelSummary] = []
+    for ci_idx, ci in enumerate(req.channel_indices):
+        chan = volume[:, ci].astype(np.float64)
+        pix = int(chan.size)
+        total = float(chan.sum())
+        channel_summaries.append(MTChannelSummary(
+            channel=req.channel_names[ci_idx],
+            total_intensity=total,
+            mean_intensity=(total / pix) if pix else 0.0,
+            pixel_count=pix,
+            frames=int(T),
+        ))
+
     margin_radius = int(round(req.thickness_px * req.margin_multiplier))
     rows: List[MTMetricsRow] = []
 
@@ -477,6 +513,7 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
     )
     return MTMetricsResponse(
         rows=rows,
+        channel_summaries=channel_summaries,
         frames_processed=len(req.frames),
         frame_height=int(H),
         frame_width=int(W),

--- a/backend/src/services/__tests__/exportService.gaps3.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps3.test.ts
@@ -840,11 +840,13 @@ describe('ExportService — generateMicrotubuleMetrics channel intensity path', 
 
     await callGenerateMT(service, [makeImage()], {});
 
-    // writeMTMetrics should have been called with ['csv'] default
+    // writeMTMetrics should have been called with ['csv'] default + the
+    // per-channel totals summary (4th arg).
     expect(writeMTMetrics).toHaveBeenCalledWith(
       expect.any(Array),
       expect.any(String),
-      expect.arrayContaining(['csv'])
+      expect.arrayContaining(['csv']),
+      expect.any(Array)
     );
   });
 

--- a/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
@@ -585,6 +585,55 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
     expect(body.channel_names).toEqual(['BF', 'DAPI']);
   });
 
+  it('maps channel_summaries (whole-image per-channel totals) from ML', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([
+      { ...containerRow, name: 'video.nd2' },
+    ]);
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        ...mlResponse.data,
+        channel_summaries: [
+          {
+            channel: 'DAPI',
+            total_intensity: 123456,
+            mean_intensity: 6.7,
+            pixel_count: 18432,
+            frames: 3,
+          },
+        ],
+      },
+    });
+
+    const { channelSummaries } = await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: frameSeg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: ['DAPI'] }
+    );
+
+    expect(channelSummaries).toHaveLength(1);
+    expect(channelSummaries[0]).toEqual({
+      video: 'video.nd2',
+      channel: 'DAPI',
+      totalIntensity: 123456,
+      meanIntensity: 6.7,
+      pixelCount: 18432,
+      frames: 3,
+    });
+  });
+
+  it('tolerates an ML response without channel_summaries (stale ML build)', async () => {
+    prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
+    axiosPostMock.mockResolvedValueOnce(mlResponse); // no channel_summaries field
+
+    const { channelSummaries } = await computeMTMetrics(
+      [makeFrame({ segmentation: { polygons: frameSeg } })],
+      'proj-1',
+      { ...BASE_OPTIONS, channels: ['DAPI'] }
+    );
+
+    expect(channelSummaries).toEqual([]);
+  });
+
   it('maps ML response rows to MTMetricsRow with px→µm conversion', async () => {
     prismaMock.image.findMany.mockResolvedValueOnce([containerRow]);
     axiosPostMock.mockResolvedValueOnce(mlResponse);

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -76,6 +76,22 @@ export interface MTMetricsRow {
   signalMinusBackground: number | null;
 }
 
+/**
+ * One row of the whole-video, whole-image per-channel total (the "channel
+ * totals" summary sheet). Distinct from the per-MT band sums: this is the sum
+ * of EVERY pixel of the channel across all frames of the video, independent of
+ * the microtubules — a global "how bright is this channel overall" measure.
+ */
+export interface MTChannelSummaryRow {
+  /** Source video container's file name (or id fallback) for readability. */
+  video: string;
+  channel: string;
+  totalIntensity: number;
+  meanIntensity: number;
+  pixelCount: number;
+  frames: number;
+}
+
 interface VideoChannelMeta {
   name: string;
   displayName?: string;
@@ -133,8 +149,19 @@ interface MLMTMetricsResponseRow {
   signal_minus_background: number | null;
 }
 
+interface MLMTMetricsResponseChannelSummary {
+  channel: string;
+  total_intensity: number;
+  mean_intensity: number;
+  pixel_count: number;
+  frames: number;
+}
+
 interface MLMTMetricsResponse {
   rows: MLMTMetricsResponseRow[];
+  /** Whole-image per-channel totals over the whole video. Optional so a stale
+   *  ML build (pre-channel-summary) doesn't break the export. */
+  channel_summaries?: MLMTMetricsResponseChannelSummary[];
   frames_processed: number;
   frame_height: number;
   frame_width: number;
@@ -274,7 +301,11 @@ export async function computeMTMetrics(
   frameImages: FrameImageInput[],
   projectId: string,
   options: MTMetricsOptions
-): Promise<{ rows: MTMetricsRow[]; skipped: string[] }> {
+): Promise<{
+  rows: MTMetricsRow[];
+  skipped: string[];
+  channelSummaries: MTChannelSummaryRow[];
+}> {
   const skipped: string[] = [];
 
   // Per-channel intensity (incl. the integrated sum) is ALWAYS included for MT
@@ -313,7 +344,7 @@ export async function computeMTMetrics(
       'mtMetricsExporter',
       { projectId }
     );
-    return { rows: [], skipped };
+    return { rows: [], skipped, channelSummaries: [] };
   }
 
   // Fetch all video container rows in a single query.
@@ -322,6 +353,7 @@ export async function computeMTMetrics(
     where: { id: { in: containerIds } },
     select: {
       id: true,
+      name: true,
       originalPath: true,
       mimeType: true,
       channels: true,
@@ -332,6 +364,7 @@ export async function computeMTMetrics(
   const mlBaseUrl = config.SEGMENTATION_SERVICE_URL;
   const mlUrl = `${mlBaseUrl}/api/v1/mt-metrics`;
   const allRows: MTMetricsRow[] = [];
+  const allChannelSummaries: MTChannelSummaryRow[] = [];
 
   for (const [videoId, frames] of framesByVideo.entries()) {
     const container = containerMap.get(videoId);
@@ -547,14 +580,33 @@ export async function computeMTMetrics(
     // appended whole) since rows carry no video id to sort across.
     videoRows.sort((a, b) => a.frameIndex - b.frameIndex);
     for (const r of videoRows) allRows.push(r);
+
+    // Whole-image per-channel totals for this video (sum of every pixel of the
+    // channel across all frames — independent of the microtubules). `?? []`
+    // keeps a stale pre-summary ML build from breaking the export.
+    for (const cs of mlResponse.channel_summaries ?? []) {
+      allChannelSummaries.push({
+        video: container.name ?? videoId,
+        channel: cs.channel,
+        totalIntensity: cs.total_intensity,
+        meanIntensity: cs.mean_intensity,
+        pixelCount: cs.pixel_count,
+        frames: cs.frames,
+      });
+    }
   }
 
   logger.info(
     'MT metrics: total rows produced',
     'mtMetricsExporter',
-    { projectId, rows: allRows.length, skippedVideos: skipped.length }
+    {
+      projectId,
+      rows: allRows.length,
+      channelSummaries: allChannelSummaries.length,
+      skippedVideos: skipped.length,
+    }
   );
-  return { rows: allRows, skipped };
+  return { rows: allRows, skipped, channelSummaries: allChannelSummaries };
 }
 
 /** Arc length in pixels = sum of consecutive segment lengths. */
@@ -682,7 +734,29 @@ function rowsToCSV(rows: MTMetricsRow[]): string {
   return lines.join('\n') + '\n';
 }
 
-async function writeXLSX(rows: MTMetricsRow[], filePath: string): Promise<void> {
+/** Column order for the whole-video per-channel totals summary. */
+const CHANNEL_SUMMARY_HEADERS: readonly (keyof MTChannelSummaryRow)[] = [
+  'video',
+  'channel',
+  'totalIntensity',
+  'meanIntensity',
+  'pixelCount',
+  'frames',
+] as const;
+
+function channelSummariesToCSV(rows: MTChannelSummaryRow[]): string {
+  const lines: string[] = [CHANNEL_SUMMARY_HEADERS.join(',')];
+  for (const row of rows) {
+    lines.push(CHANNEL_SUMMARY_HEADERS.map(h => csvCell(row[h])).join(','));
+  }
+  return lines.join('\n') + '\n';
+}
+
+async function writeXLSX(
+  rows: MTMetricsRow[],
+  channelSummaries: MTChannelSummaryRow[],
+  filePath: string
+): Promise<void> {
   // exceljs is CJS; mirror the dynamic-import idiom used by exportService.
   const excelMod = (await import('exceljs')) as unknown as {
     default?: typeof import('exceljs');
@@ -697,20 +771,39 @@ async function writeXLSX(rows: MTMetricsRow[], filePath: string): Promise<void> 
   }
   // Bold header row.
   sheet.getRow(1).font = { bold: true };
+
+  // Second sheet: whole-video per-channel totals (independent of the MTs).
+  if (channelSummaries.length) {
+    const summary = workbook.addWorksheet('Channel Totals');
+    summary.columns = CHANNEL_SUMMARY_HEADERS.map(h => ({
+      header: h,
+      key: h,
+      width: 22,
+    }));
+    for (const row of channelSummaries) {
+      summary.addRow(row);
+    }
+    summary.getRow(1).font = { bold: true };
+  }
+
   await workbook.xlsx.writeFile(filePath);
 }
 
 /**
  * Persist the metric rows to disk in any subset of {excel, csv, json}.
  *
- * @param rows     Output from {@link computeMTMetrics}.
- * @param destDir  Target directory (created if absent).
- * @param formats  Same formats list the user picked for general metrics.
+ * @param rows              Output from {@link computeMTMetrics}.
+ * @param destDir           Target directory (created if absent).
+ * @param formats           Same formats list the user picked for general metrics.
+ * @param channelSummaries  Whole-video per-channel totals. In Excel these go on
+ *                          a second "Channel Totals" sheet; in CSV/JSON they get
+ *                          a companion `metrics_channel_totals.*` file.
  */
 export async function writeMTMetrics(
   rows: MTMetricsRow[],
   destDir: string,
-  formats: ReadonlyArray<'excel' | 'csv' | 'json'>
+  formats: ReadonlyArray<'excel' | 'csv' | 'json'>,
+  channelSummaries: MTChannelSummaryRow[] = []
 ): Promise<void> {
   if (!rows.length || !formats.length) return;
   await fs.mkdir(destDir, { recursive: true });
@@ -726,14 +819,28 @@ export async function writeMTMetrics(
         rowsToCSV(rows),
         'utf8'
       );
+      if (channelSummaries.length) {
+        await fs.writeFile(
+          path.join(destDir, 'metrics_channel_totals.csv'),
+          channelSummariesToCSV(channelSummaries),
+          'utf8'
+        );
+      }
     } else if (fmt === 'json') {
       await fs.writeFile(
         path.join(destDir, 'metrics.json'),
         JSON.stringify(rows, null, 2),
         'utf8'
       );
+      if (channelSummaries.length) {
+        await fs.writeFile(
+          path.join(destDir, 'metrics_channel_totals.json'),
+          JSON.stringify(channelSummaries, null, 2),
+          'utf8'
+        );
+      }
     } else if (fmt === 'excel') {
-      await writeXLSX(rows, path.join(destDir, 'metrics.xlsx'));
+      await writeXLSX(rows, channelSummaries, path.join(destDir, 'metrics.xlsx'));
     }
   }
 }

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -43,6 +43,7 @@ import {
   computeMTGeometry,
   writeMTMetrics,
   type MTMetricsRow,
+  type MTChannelSummaryRow,
 } from './export/mtMetricsExporter';
 import {
   exportMicrotubuleKymographs,
@@ -1573,6 +1574,9 @@ export class ExportService {
     };
 
     let rows: MTMetricsRow[] = [];
+    // Whole-video per-channel totals (independent of the MTs) → second sheet /
+    // companion file. Empty on the geometry-only fallback.
+    let channelSummaries: MTChannelSummaryRow[] = [];
     let intensityIncluded = false;
 
     try {
@@ -1583,6 +1587,7 @@ export class ExportService {
         pixelToMicrometerScale: scale,
       });
       rows = mtResult.rows;
+      channelSummaries = mtResult.channelSummaries ?? [];
       for (const reason of mtResult.skipped) {
         addWarning(`MT intensity metrics skipped: ${reason}`);
       }
@@ -1620,11 +1625,18 @@ export class ExportService {
     }
 
     const metricsDir = path.join(exportDir, 'metrics');
-    await writeMTMetrics(rows, metricsDir, formats);
+    await writeMTMetrics(rows, metricsDir, formats, channelSummaries);
     logger.info(
       'MT metrics: wrote files',
       'ExportService',
-      { jobId, projectId, rows: rows.length, intensityIncluded, formats }
+      {
+        jobId,
+        projectId,
+        rows: rows.length,
+        channelSummaries: channelSummaries.length,
+        intensityIncluded,
+        formats,
+      }
     );
   }
 

--- a/src/pages/segmentation/components/PolygonListPanel.tsx
+++ b/src/pages/segmentation/components/PolygonListPanel.tsx
@@ -216,7 +216,12 @@ const PolygonListPanel: React.FC<PolygonListPanelProps> = ({
   }
 
   return (
-    <div className="w-full flex-1 min-h-[8rem] bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
+    // min-h-[20rem]: when the sidebar also stacks Channels + Display + the MT
+    // instance panel (video/MT projects), this panel's flex-1 gets squeezed and
+    // the header (title + select-all row) ate almost all of the old 8rem, leaving
+    // ~1 visible row. A 20rem floor keeps ~6-7 rows scrollable; the whole sidebar
+    // column scrolls to reach the sections below.
+    <div className="w-full flex-1 min-h-[20rem] bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col dark:bg-gray-900">
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between mb-2 lg:mb-0">


### PR DESCRIPTION
## What & why

Two follow-ups to #282, both requested by the user.

### 1. Editor sidebar — polygon/polyline list is no longer squeezed to ~1 row

On video / microtubule projects the right sidebar stacks Channels + Display +
**Polygon List** + Microtubule Instances. The polygon list was
`flex-1 min-h-[8rem]`; once the header (title + the new select-all row) took its
share, the scrollable body collapsed to **~39 px ≈ one visible item** even
though it held 28 rows.

Fix: raise the panel floor to `min-h-[20rem]` so the list body keeps **~6–7
rows** scrollable, and the whole sidebar column scrolls to reach the sections
below. (Verified on Marika: body went from ~39 px to a multi-row viewport.)

### 2. New: whole-video per-channel total intensity ("Channel Totals")

Clarified intent from the user: the per-MT `sumIntensity`/`meanIntensity`
columns are per-instance-per-channel (kept **unchanged**). Separately, the user
wants the **sum of all channels of the video** — a global, whole-image measure.

Added a **per-channel whole-image total** to the MT export: for every channel,
the sum (and mean) of **every pixel of the whole frame across all frames** of
the video, independent of the microtubules.

- **ML** (`mt_metrics.py`): the endpoint already loads the `(T,C,Y,X)` volume,
  so it now also returns `channel_summaries` — `total_intensity` / `mean` /
  `pixel_count` / `frames` per requested channel (computed on the **raw** file,
  no registration offset, since it's a global measure).
- **Backend** (`mtMetricsExporter.ts`): maps them per video container and writes
  them as a second **"Channel Totals"** sheet in `metrics.xlsx`, and a companion
  `metrics_channel_totals.{csv,json}` for those formats. `?? []` tolerates a
  stale (pre-summary) ML build.

## Export layout

```
<export>.zip/metrics/
├── metrics.xlsx          # sheet 1: per-MT per-channel (unchanged)
│                         # sheet 2: "Channel Totals" (NEW)  ← sum of all channels
├── metrics_channel_totals.csv   # if CSV selected
└── metrics_channel_totals.json  # if JSON selected
```
`Channel Totals` columns: `video, channel, totalIntensity, meanIntensity, pixelCount, frames`.

## Tests & verification
- **Backend (vitest):** new tests for `channel_summaries` mapping + stale-ML
  tolerance; updated the `writeMTMetrics` arg-shape assertion. `make ci`
  (TS + ESLint 0 + i18n), backend `tsc`, FE production build all green.
- **ML:** functional check of the whole-image per-channel sum (c0/c1 totals).
- Deployed FE + BE + ML and E2E-verified on Marika (see PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microtubule metrics exports now include per-channel whole-video intensity totals alongside the existing detailed metrics.
  * Exported files can now include a new “Channel Totals” view, with CSV/JSON output when available.

* **Bug Fixes**
  * Metrics export now safely handles cases where channel summary data is missing.
  * The segmentation sidebar list has a larger minimum height, improving visibility when multiple panels are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->