### PR TITLE
fix(upload): abort on Cancel, register prompt, remove dead X, MT sidebar cleanup

### DIFF
--- a/src/components/FloatingUploadProgress.tsx
+++ b/src/components/FloatingUploadProgress.tsx
@@ -208,15 +208,21 @@ const FloatingUploadProgress: React.FC = () => {
             </button>
           )}
 
-          <button
-            onClick={e => {
-              e.stopPropagation();
-              handleClose();
-            }}
-            className="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          {/* The close (X) only dismisses a FINISHED card. While uploading it
+              did nothing useful (it just hid the card, which the active-session
+              logic re-showed) — so it read as unresponsive. Hide it during
+              upload; use "Cancel" to stop an in-flight upload instead. */}
+          {status !== 'uploading' && (
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                handleClose();
+              }}
+              className="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
         </div>
 
         {/* Progress bar — shown when uploading */}

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -6,7 +6,17 @@ import { useLanguage } from '@/contexts/useLanguage';
 import { useUpload } from '@/contexts/useUpload';
 import DropZone from '@/components/upload/DropZone';
 import UploaderOptions from '@/components/upload/UploaderOptions';
-import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { apiClient } from '@/lib/api';
 import { logger } from '@/lib/logger';
 
@@ -33,9 +43,10 @@ const ImageUploader = ({ onUploadComplete }: ImageUploaderProps) => {
   });
   const isMicrotubuleProject = project?.type === 'microtubules';
 
-  // Opt-in (default off): the user is prompted per the requirement rather than
-  // silently registering every upload.
-  const [registerChannels, setRegisterChannels] = useState(false);
+  // For MT projects we ask the user — right after they drop files — whether to
+  // register the channels, instead of a persistent checkbox. The dropped files
+  // wait here until they answer. `null` = no pending prompt.
+  const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
 
   useEffect(() => {
     if (currentProjectId) {
@@ -53,27 +64,33 @@ const ImageUploader = ({ onUploadComplete }: ImageUploaderProps) => {
         toast.error(t('images.selectProjectFirst'));
         return;
       }
+      // MT projects: ask explicitly whether to register channels before the
+      // upload starts (backend re-gates to MT + multi-channel anyway). Other
+      // project types have no channel registration, so upload straight away.
+      if (isMicrotubuleProject) {
+        setPendingFiles(acceptedFiles);
+        return;
+      }
+      startUpload(projectId, acceptedFiles, undefined, onUploadComplete, false);
+    },
+    [projectId, t, startUpload, onUploadComplete, isMicrotubuleProject]
+  );
 
-      // Pass raw File objects directly to context — no staging needed.
-      // The FloatingUploadProgress component shows upload status globally.
-      // registerChannels only takes effect for MT projects (and the backend
-      // re-gates by project type), so a stale toggle can't leak to others.
+  // Answer to the register-channels prompt → kick off the upload with the
+  // chosen flag and clear the pending files.
+  const beginUpload = useCallback(
+    (registerChannels: boolean) => {
+      if (!projectId || !pendingFiles) return;
       startUpload(
         projectId,
-        acceptedFiles,
+        pendingFiles,
         undefined,
         onUploadComplete,
-        isMicrotubuleProject && registerChannels
+        registerChannels
       );
+      setPendingFiles(null);
     },
-    [
-      projectId,
-      t,
-      startUpload,
-      onUploadComplete,
-      isMicrotubuleProject,
-      registerChannels,
-    ]
+    [projectId, pendingFiles, startUpload, onUploadComplete]
   );
 
   const handleProjectChange = useCallback((value: string) => {
@@ -88,26 +105,10 @@ const ImageUploader = ({ onUploadComplete }: ImageUploaderProps) => {
         onProjectChange={handleProjectChange}
       />
 
-      {isMicrotubuleProject && (
-        <label className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/40 cursor-pointer">
-          <Checkbox
-            checked={registerChannels}
-            onCheckedChange={v => setRegisterChannels(v === true)}
-            disabled={isUploading}
-            className="mt-0.5"
-          />
-          <span className="text-sm">
-            <span className="font-medium text-gray-900 dark:text-gray-100">
-              {t('images.registerChannels.label')}
-            </span>
-            <span className="block text-xs text-gray-500 dark:text-gray-400">
-              {t('images.registerChannels.help')}
-            </span>
-          </span>
-        </label>
-      )}
-
-      <DropZone disabled={!projectId || isUploading} onDrop={onDrop} />
+      <DropZone
+        disabled={!projectId || isUploading || pendingFiles !== null}
+        onDrop={onDrop}
+      />
 
       {isUploading && (
         <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
@@ -118,6 +119,36 @@ const ImageUploader = ({ onUploadComplete }: ImageUploaderProps) => {
           </p>
         </div>
       )}
+
+      {/* MT-only: after a drop, ask whether to register channels. */}
+      <AlertDialog
+        open={pendingFiles !== null}
+        onOpenChange={open => {
+          if (!open) setPendingFiles(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('images.registerChannels.promptTitle')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('images.registerChannels.help')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2 sm:gap-2">
+            <AlertDialogCancel onClick={() => setPendingFiles(null)}>
+              {t('common.cancel')}
+            </AlertDialogCancel>
+            <Button variant="outline" onClick={() => beginUpload(false)}>
+              {t('images.registerChannels.decline')}
+            </Button>
+            <AlertDialogAction onClick={() => beginUpload(true)}>
+              {t('images.registerChannels.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/components/__tests__/FloatingUploadProgress.test.tsx
+++ b/src/components/__tests__/FloatingUploadProgress.test.tsx
@@ -203,14 +203,12 @@ describe('FloatingUploadProgress', () => {
   });
 
   describe('Expand / collapse', () => {
-    it('chevron button is shown during uploading', () => {
+    it('shows only the chevron toggle during uploading (no close X)', () => {
       setActive(baseSession({ status: 'uploading' }));
       render(<FloatingUploadProgress />);
-      // ChevronUp is the initial icon (collapsed state shows "expand" arrow)
-      // Both chevron variants are Lucide SVGs; assert the toggle button exists
-      const buttons = screen.getAllByRole('button');
-      // There should be at least the chevron + close buttons
-      expect(buttons.length).toBeGreaterThanOrEqual(2);
+      // During upload the close (X) is hidden — only the expand/collapse
+      // chevron remains (use "Cancel" to stop an in-flight upload).
+      expect(screen.getAllByRole('button')).toHaveLength(1);
     });
 
     it('chevron button is NOT shown for completed status', () => {
@@ -231,10 +229,9 @@ describe('FloatingUploadProgress', () => {
       // Project name not visible before expanding
       expect(screen.queryByText('Test Project')).not.toBeInTheDocument();
 
-      // Find the chevron toggle button (not the X close button)
-      const buttons = screen.getAllByRole('button');
-      // The chevron button is the second-to-last button (before X)
-      const chevronBtn = buttons[buttons.length - 2];
+      // During upload the chevron is the only header button (the close X is
+      // hidden while uploading).
+      const chevronBtn = screen.getAllByRole('button')[0];
       fireEvent.click(chevronBtn);
 
       expect(screen.getByText('Test Project')).toBeInTheDocument();
@@ -247,9 +244,8 @@ describe('FloatingUploadProgress', () => {
       setActive(baseSession({ status: 'uploading', id: 'sess-abc' }));
       render(<FloatingUploadProgress />);
 
-      // Expand first
-      const buttons = screen.getAllByRole('button');
-      const chevronBtn = buttons[buttons.length - 2];
+      // Expand first (chevron is the only header button during upload)
+      const chevronBtn = screen.getAllByRole('button')[0];
       fireEvent.click(chevronBtn);
 
       fireEvent.click(screen.getByRole('button', { name: /Cancel Upload/i }));
@@ -258,14 +254,15 @@ describe('FloatingUploadProgress', () => {
   });
 
   describe('Close button', () => {
-    it('during uploading, close hides card but does NOT call clearSession', () => {
+    it('during uploading, there is NO close (X) button — only the chevron', () => {
       setActive(baseSession({ status: 'uploading' }));
       render(<FloatingUploadProgress />);
 
-      // X is the last button
+      // The X was unresponsive during upload, so it is hidden there now. Only
+      // the chevron toggle remains; clicking it expands and never clears.
       const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[buttons.length - 1]);
-
+      expect(buttons).toHaveLength(1);
+      fireEvent.click(buttons[0]);
       expect(mockClearSession).not.toHaveBeenCalled();
     });
 

--- a/src/components/__tests__/ImageUploader.registration.test.tsx
+++ b/src/components/__tests__/ImageUploader.registration.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import ImageUploader from '@/components/ImageUploader';
+
+// Capture the onDrop the parent hands to DropZone so tests can trigger a drop.
+let capturedOnDrop: ((files: File[]) => void) | null = null;
+vi.mock('@/components/upload/DropZone', () => ({
+  default: ({ onDrop }: { onDrop: (files: File[]) => void }) => {
+    capturedOnDrop = onDrop;
+    return <div data-testid="dropzone" />;
+  },
+}));
+vi.mock('@/components/upload/UploaderOptions', () => ({
+  default: () => <div data-testid="uploader-options" />,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useParams: () => ({ id: 'p1' }) };
+});
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockStartUpload = vi.fn().mockReturnValue('up_1');
+vi.mock('@/contexts/useUpload', () => ({
+  useUpload: () => ({
+    startUpload: mockStartUpload,
+    isUploading: false,
+    cancelUpload: vi.fn(),
+    clearSession: vi.fn(),
+    activeSession: null,
+    sessions: {},
+  }),
+}));
+
+// t(key) → key, so dialog text is the raw i18n key we can query on.
+vi.mock('@/contexts/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (k: string) => k,
+    language: 'en',
+    setLanguage: vi.fn(),
+  }),
+}));
+
+let mockProjectType = 'microtubules';
+const mockGetProject = vi.fn(() =>
+  Promise.resolve({ id: 'p1', type: mockProjectType })
+);
+vi.mock('@/lib/api', () => ({
+  apiClient: { getProject: (...a: unknown[]) => mockGetProject(...a) },
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+const PROMPT = 'images.registerChannels.promptTitle';
+const files = [new File([new Blob(['x'])], 'v.mp4', { type: 'video/mp4' })];
+const onUploadComplete = vi.fn();
+
+function renderUploader() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return rtlRender(
+    <QueryClientProvider client={qc}>
+      <ImageUploader onUploadComplete={onUploadComplete} />
+    </QueryClientProvider>
+  );
+}
+
+// Render, then flush the project-type query so `isMicrotubuleProject` is
+// resolved before we trigger the drop (onDrop closes over it).
+async function renderAndSettle() {
+  renderUploader();
+  await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith('p1'));
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('ImageUploader — register-channels prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnDrop = null;
+    mockProjectType = 'microtubules';
+  });
+
+  it('drops into an MT project → shows the prompt, no persistent checkbox', async () => {
+    await renderAndSettle();
+    // No checkbox in the uploader anymore.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+    act(() => capturedOnDrop!(files));
+    expect(await screen.findByText(PROMPT)).toBeInTheDocument();
+    // Not uploaded yet — waiting for the answer.
+    expect(mockStartUpload).not.toHaveBeenCalled();
+  });
+
+  it('confirm → startUpload WITH registration', async () => {
+    await renderAndSettle();
+    act(() => capturedOnDrop!(files));
+    await screen.findByText(PROMPT);
+    fireEvent.click(screen.getByText('images.registerChannels.confirm'));
+    expect(mockStartUpload).toHaveBeenCalledWith(
+      'p1',
+      files,
+      undefined,
+      onUploadComplete,
+      true
+    );
+  });
+
+  it('decline → startUpload WITHOUT registration', async () => {
+    await renderAndSettle();
+    act(() => capturedOnDrop!(files));
+    await screen.findByText(PROMPT);
+    fireEvent.click(screen.getByText('images.registerChannels.decline'));
+    expect(mockStartUpload).toHaveBeenCalledWith(
+      'p1',
+      files,
+      undefined,
+      onUploadComplete,
+      false
+    );
+  });
+
+  it('cancel → nothing is uploaded', async () => {
+    await renderAndSettle();
+    act(() => capturedOnDrop!(files));
+    await screen.findByText(PROMPT);
+    fireEvent.click(screen.getByText('common.cancel'));
+    expect(mockStartUpload).not.toHaveBeenCalled();
+  });
+
+  it('non-MT project → uploads directly, no prompt', async () => {
+    mockProjectType = 'spheroid';
+    await renderAndSettle();
+    act(() => capturedOnDrop!(files));
+    expect(screen.queryByText(PROMPT)).not.toBeInTheDocument();
+    expect(mockStartUpload).toHaveBeenCalledWith(
+      'p1',
+      files,
+      undefined,
+      onUploadComplete,
+      false
+    );
+  });
+});

--- a/src/components/__tests__/ImageUploader.test.tsx
+++ b/src/components/__tests__/ImageUploader.test.tsx
@@ -88,9 +88,10 @@ vi.mock('@/contexts/useLanguage', () => ({
 }));
 
 // Minimal wrapper — no Router, but a QueryClientProvider is required because
-// ImageUploader uses `useQuery` (to read the project type for the MT-only
-// channel-registration checkbox). The query is disabled here (useParams()→{},
-// so projectId is null) but `useQuery` still calls `useQueryClient()`.
+// ImageUploader uses `useQuery` (to read the project type, which decides
+// whether to show the MT-only "register channels?" prompt after a drop). The
+// query is disabled here (useParams()→{}, so projectId is null) but `useQuery`
+// still calls `useQueryClient()`.
 const render = (ui: React.ReactElement) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/src/contexts/UploadContext.tsx
+++ b/src/contexts/UploadContext.tsx
@@ -371,7 +371,8 @@ export const UploadProvider: React.FC<{ children: React.ReactNode }> = ({
                     };
                   });
                 },
-                registerChannels
+                registerChannels,
+                signal
               );
               videoSuccess++;
             } catch (err) {
@@ -580,7 +581,8 @@ export const UploadProvider: React.FC<{ children: React.ReactNode }> = ({
                     },
                   };
                 });
-              }
+              },
+              signal
             );
 
             setSessions(prev => ({

--- a/src/lib/__tests__/api-upload-signal.test.ts
+++ b/src/lib/__tests__/api-upload-signal.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiClient } from '@/lib/api';
+
+// Mirrors the mock setup in api-chunked-upload.test.ts: point the singleton's
+// axios instance at a mock so we can inspect the exact request config.
+const mockAxiosInstance = vi.hoisted(() => ({
+  post: vi.fn(),
+  get: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn(),
+  interceptors: {
+    request: { use: vi.fn() },
+    response: { use: vi.fn() },
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: { create: vi.fn(() => mockAxiosInstance) },
+}));
+
+vi.mock('@/lib/api', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual };
+});
+
+vi.mock('../config', () => ({
+  default: { apiBaseUrl: 'http://localhost:3001/api' },
+}));
+
+vi.mock('../logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+/**
+ * Regression: the "Cancel" button did nothing for an in-flight video upload
+ * because `uploadVideo` never forwarded an AbortSignal into the axios config,
+ * so aborting the controller couldn't cancel the request. These pin the signal
+ * through to axios for both the video and plain-image upload paths.
+ */
+describe('ApiClient upload — AbortSignal forwarding (cancel support)', () => {
+  const lastPostConfig = () => {
+    const call = mockAxiosInstance.post.mock.calls.at(-1);
+    return call?.[2] as { signal?: AbortSignal } | undefined;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (apiClient as unknown as { instance: unknown }).instance =
+      mockAxiosInstance;
+    (apiClient as unknown as { accessToken: string }).accessToken = 'tok';
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  test('uploadVideo forwards the AbortSignal to the axios request config', async () => {
+    mockAxiosInstance.post.mockResolvedValue({
+      data: { data: { videoContainerId: 'v', frameCount: 1, channels: [] } },
+    });
+    const controller = new AbortController();
+    const file = new File([new Blob(['x'])], 'v.mp4', { type: 'video/mp4' });
+
+    await apiClient
+      .uploadVideo('p1', file, undefined, false, controller.signal)
+      .catch(() => {});
+
+    expect(lastPostConfig()?.signal).toBe(controller.signal);
+  });
+
+  test('uploadImages forwards the AbortSignal to the axios request config', async () => {
+    mockAxiosInstance.post.mockResolvedValue({ data: { data: [] } });
+    const controller = new AbortController();
+    const file = new File([new Blob(['x'])], 'i.jpg', { type: 'image/jpeg' });
+
+    await apiClient
+      .uploadImages('p1', [file], undefined, controller.signal)
+      .catch(() => {});
+
+    expect(lastPostConfig()?.signal).toBe(controller.signal);
+  });
+
+  test('uploadVideo without a signal leaves config.signal undefined', async () => {
+    mockAxiosInstance.post.mockResolvedValue({
+      data: { data: { videoContainerId: 'v', frameCount: 1, channels: [] } },
+    });
+    const file = new File([new Blob(['x'])], 'v.mp4', { type: 'video/mp4' });
+
+    await apiClient.uploadVideo('p1', file).catch(() => {});
+
+    expect(lastPostConfig()?.signal).toBeUndefined();
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1127,7 +1127,8 @@ class ApiClient {
   async uploadImages(
     projectId: string,
     files: File[],
-    onProgress?: (progressPercent: number) => void
+    onProgress?: (progressPercent: number) => void,
+    signal?: AbortSignal
   ): Promise<ProjectImageDTO[]> {
     const formData = new FormData();
     files.forEach(file => {
@@ -1156,6 +1157,9 @@ class ApiClient {
           'Content-Type': 'multipart/form-data',
         },
         timeout: TIMEOUTS.FILE_UPLOAD_LARGE,
+        // Wire the abort signal so Cancel aborts the in-flight image batch too
+        // (the chunked path already does this; the plain path didn't).
+        signal,
         onUploadProgress: progressEvent => {
           if (onProgress && progressEvent.total) {
             const percentCompleted = Math.round(
@@ -1196,7 +1200,8 @@ class ApiClient {
     projectId: string,
     file: File,
     onProgress?: (progressPercent: number) => void,
-    registerChannels?: boolean
+    registerChannels?: boolean,
+    signal?: AbortSignal
   ): Promise<{
     videoContainerId: string;
     frameCount: number;
@@ -1234,6 +1239,10 @@ class ApiClient {
         // multi-GB ND2 uploads mid-transfer); small clips still get a 20-min
         // floor, huge files up to a 4-hour ceiling.
         timeout: videoUploadTimeoutMs(payload.size),
+        // Lets the "Cancel" button actually abort the in-flight upload. Without
+        // this the video POST is a single blocking request the loop can't
+        // interrupt (it only guards BETWEEN files), so Cancel was a no-op.
+        signal,
         onUploadProgress: progressEvent => {
           if (onProgress && progressEvent.total) {
             const percentCompleted = Math.round(

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -1,5 +1,5 @@
 import React, { useDeferredValue, useMemo } from 'react';
-import { Spline, Eye, EyeOff } from 'lucide-react';
+import { Spline, Eye, EyeOff, Trash2 } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Polygon } from '@/lib/segmentation';
@@ -27,6 +27,9 @@ interface MicrotubuleInstancePanelProps {
   onToggleSelected?: (id: string) => void;
   onSelectAll?: (ids: string[]) => void;
   onClearSelection?: () => void;
+  /** Delete a single microtubule polyline (the generic Polygon List is hidden
+   *  for MT projects, so delete lives here). Omit to hide the delete button. */
+  onDeletePolygon?: (id: string) => void;
 }
 
 const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
@@ -39,6 +42,7 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   onToggleSelected,
   onSelectAll,
   onClearSelection,
+  onDeletePolygon,
 }) => {
   const { t } = useLanguage();
 
@@ -228,6 +232,20 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
                   ) : (
                     <Eye className="h-3.5 w-3.5" />
                   )}
+                </button>
+              )}
+              {onDeletePolygon && (
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDeletePolygon(mt.id);
+                  }}
+                  className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors flex-shrink-0"
+                  aria-label={t('common.delete')}
+                  title={t('common.delete')}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
                 </button>
               )}
             </div>

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -499,20 +499,26 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                     <DisplaySection />
                   </>
                 )}
-                <PolygonListPanel
-                  loading={projectLoading}
-                  polygons={editor.polygons}
-                  selectedPolygonId={editor.selectedPolygonId}
-                  onSelectPolygon={handleSelectPolygon}
-                  hiddenPolygonIds={frameHiddenIds}
-                  onTogglePolygonVisibility={handleTogglePolygonVisibility}
-                  onRenamePolygon={handleRenamePolygon}
-                  onDeletePolygon={handleDeletePolygonFromPanel}
-                  selectedPolygonIds={selectedPolygonIds}
-                  onToggleSelected={handleToggleSelectedInList}
-                  onSelectAll={handleSelectAllInList}
-                  onClearSelection={handleClearSelectionInList}
-                />
+                {/* Microtubule projects use the purpose-built Microtubule
+                    Instances panel below (trackId order, per-instance colour,
+                    length, delete) — the generic Polygon List would just
+                    duplicate it, so it's hidden for MT projects. */}
+                {projectType !== 'microtubules' && (
+                  <PolygonListPanel
+                    loading={projectLoading}
+                    polygons={editor.polygons}
+                    selectedPolygonId={editor.selectedPolygonId}
+                    onSelectPolygon={handleSelectPolygon}
+                    hiddenPolygonIds={frameHiddenIds}
+                    onTogglePolygonVisibility={handleTogglePolygonVisibility}
+                    onRenamePolygon={handleRenamePolygon}
+                    onDeletePolygon={handleDeletePolygonFromPanel}
+                    selectedPolygonIds={selectedPolygonIds}
+                    onToggleSelected={handleToggleSelectedInList}
+                    onSelectAll={handleSelectAllInList}
+                    onClearSelection={handleClearSelectionInList}
+                  />
+                )}
                 {hasPolylines && polylineKind === 'sperm' && (
                   <SpermInstancePanel
                     polygons={editor.polygons}
@@ -535,6 +541,7 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                     onToggleSelected={handleToggleSelectedInList}
                     onSelectAll={handleSelectAllInList}
                     onClearSelection={handleClearSelectionInList}
+                    onDeletePolygon={handleDeletePolygonFromPanel}
                   />
                 )}
               </div>

--- a/src/pages/segmentation/components/__tests__/MicrotubuleInstancePanel.multiselect.test.tsx
+++ b/src/pages/segmentation/components/__tests__/MicrotubuleInstancePanel.multiselect.test.tsx
@@ -136,4 +136,35 @@ describe('MicrotubuleInstancePanel — multi-select checkboxes', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /deselect all/i }));
     expect(onClearSelection).toHaveBeenCalledTimes(1);
   });
+
+  // Delete lives in this panel now that the generic Polygon List is hidden for
+  // MT projects.
+  it('renders a delete button per row and calls onDeletePolygon with the MT id', () => {
+    const onDeletePolygon = vi.fn();
+    renderWithProviders(
+      <MicrotubuleInstancePanel
+        polygons={MTS}
+        selectedPolygonId={null}
+        onSelectPolygon={vi.fn()}
+        onDeletePolygon={onDeletePolygon}
+      />
+    );
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    expect(deleteButtons).toHaveLength(MTS.length);
+    fireEvent.click(deleteButtons[0]);
+    expect(onDeletePolygon).toHaveBeenCalledWith('mtA');
+  });
+
+  it('hides the delete button when onDeletePolygon is omitted', () => {
+    renderWithProviders(
+      <MicrotubuleInstancePanel
+        polygons={MTS}
+        selectedPolygonId={null}
+        onSelectPolygon={vi.fn()}
+      />
+    );
+    expect(screen.queryAllByRole('button', { name: /delete/i })).toHaveLength(
+      0
+    );
+  });
 });

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -373,8 +373,10 @@ export default {
     dropImagesHere: 'Přetáhněte soubory sem...',
     selectProjectFirst: 'Nejprve vyberte projekt',
     registerChannels: {
-      label: 'Registrovat kanály (zarovnat translací)',
+      promptTitle: 'Registrovat kanály?',
       help: 'Při nahrání opraví malé posuny mezi kanály zarovnáním každého k prvnímu (pouze translace).',
+      confirm: 'Registrovat a nahrát',
+      decline: 'Nahrát bez registrace',
     },
     projectRequired: 'Před nahráním obrázků musíte vybrat projekt',
     pending: 'Čekající',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -376,8 +376,10 @@ export default {
     dropImagesHere: 'Dateien hier ablegen...',
     selectProjectFirst: 'Bitte wählen Sie zuerst ein Projekt aus',
     registerChannels: {
-      label: 'Kanäle registrieren (per Translation ausrichten)',
+      promptTitle: 'Kanäle registrieren?',
       help: 'Korrigiert beim Hochladen kleine Verschiebungen zwischen Kanälen, indem jeder am ersten ausgerichtet wird (nur Translation).',
+      confirm: 'Registrieren & hochladen',
+      decline: 'Ohne Registrierung hochladen',
     },
     projectRequired:
       'Sie müssen ein Projekt auswählen, bevor Sie Bilder hochladen können',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -373,8 +373,10 @@ export default {
     dropImagesHere: 'Drop the files here...',
     selectProjectFirst: 'Please select a project first',
     registerChannels: {
-      label: 'Register channels (align by translation)',
+      promptTitle: 'Register channels?',
       help: 'Correct small shifts between channels at upload by aligning each to the first (translation only).',
+      confirm: 'Register & upload',
+      decline: 'Upload without registering',
     },
     projectRequired: 'You must select a project before you can upload images',
     pending: 'Pending',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -372,8 +372,10 @@ export default {
     dropImagesHere: 'Suelta los archivos aquí...',
     selectProjectFirst: 'Por favor selecciona un proyecto primero',
     registerChannels: {
-      label: 'Registrar canales (alinear por traslación)',
+      promptTitle: '¿Registrar canales?',
       help: 'Corrige pequeños desplazamientos entre canales al subir, alineando cada uno al primero (solo traslación).',
+      confirm: 'Registrar y subir',
+      decline: 'Subir sin registrar',
     },
     projectRequired:
       'Debes seleccionar un proyecto antes de poder subir imágenes',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -371,8 +371,10 @@ export default {
     dropImagesHere: 'Déposez les fichiers ici...',
     selectProjectFirst: "Veuillez d'abord sélectionner un projet",
     registerChannels: {
-      label: 'Recaler les canaux (alignement par translation)',
+      promptTitle: 'Recaler les canaux ?',
       help: 'Corrige les petits décalages entre canaux au téléversement en alignant chacun sur le premier (translation uniquement).',
+      confirm: 'Recaler et téléverser',
+      decline: 'Téléverser sans recalage',
     },
     projectRequired:
       'Vous devez sélectionner un projet avant de pouvoir télécharger des images',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -332,8 +332,10 @@ export default {
     dropImagesHere: '将文件放在这里...',
     selectProjectFirst: '请先选择项目',
     registerChannels: {
-      label: '通道配准（平移对齐）',
+      promptTitle: '配准通道？',
       help: '上传时通过将每个通道对齐到第一个通道来校正通道间的微小偏移（仅平移）。',
+      confirm: '配准并上传',
+      decline: '不配准直接上传',
     },
     projectRequired: '您必须先选择项目才能上传图像',
     pending: '等待中',


### PR DESCRIPTION
## Three upload / editor fixes

### 1. Cancel now actually aborts an in-flight upload (bug)

The "Cancel" button in the floating upload card was a no-op for videos. Root
cause: `apiClient.uploadVideo` never forwarded an `AbortSignal` to axios, so the
`AbortController` the context aborts had nothing wired to it — the single
blocking video POST ran to completion (or its size-proportional timeout). The
loop's `if (signal?.aborted) break` only guards *between* files.

Fix: thread `signal` from `UploadContext` → `apiClient.uploadVideo`/`uploadImages`
into the axios request config (the chunked-image path already did this). Aborting
now throws `CanceledError`, which the existing catch maps to a "cancelled"
session.

### 2. Channel registration: pop-up after drop instead of a checkbox (UX)

Removed the persistent MT-only "Register channels" checkbox. Now, when files are
dropped into a **microtubule** project, a confirmation dialog asks **"Register
channels?"** with **Register & upload** / **Upload without registering** /
**Cancel**. Non-MT projects upload straight away (no registration concept). The
backend still re-gates registration to MT + multi-channel, so nothing leaks.

### 3. Removed the dead close (X) from the upload card while uploading

The X in the floating upload card did nothing during an upload — it only hid the
card, which the active-session logic immediately re-showed, so it read as
unresponsive. It's now hidden while `status === 'uploading'` (use **Cancel** to
stop an upload); it stays on finished cards so they're still dismissible.

### 4. MT projects: one polyline list, not two

For microtubule projects the generic **Polygon List** just duplicated the
purpose-built **Microtubule Instances** panel (same polylines). Hidden it for MT
projects; to keep parity, added a per-row **delete** button to the Microtubule
Instances panel (the generic list's only unique actions were rename + delete;
delete is also on the canvas). Non-MT projects are unchanged.

## i18n
`images.registerChannels`: removed `label` (checkbox gone); added `promptTitle`,
`confirm`, `decline` across all 6 locales (1580 keys each, `check-i18n` green).

## Tests & verification
- **New:** `api-upload-signal` (signal forwarded to axios for video + image, and
  absent when not passed); `ImageUploader.registration` (prompt on MT drop,
  confirm→register, decline→no-register, cancel→no upload, non-MT→direct); MT
  panel delete-button tests.
- Existing ImageUploader / cancel / MT-panel suites still green.
- `make ci` (TS + ESLint 0 + i18n) + FE production build green.
- Deployed FE and E2E-verified on Marika (see thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt for microtubule image uploads, letting users choose whether to register channels before upload starts.
  * Added per-item delete controls in the microtubule instance list during segmentation.

* **Bug Fixes**
  * Prevented the floating upload header close button from appearing during active uploads.
  * Improved upload cancellation so in-progress image and video uploads can be stopped more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->