### PR TITLE
feat(mt-export): choose kymograph or per-image intensity profiles

### DIFF
--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -806,6 +806,13 @@ class KymographRequest(BaseModel):
     pixel_size_um: Optional[float] = Field(None, gt=0)
     frame_interval_ms: Optional[float] = Field(None, gt=0)
     min_net_velocity_um_s: float = Field(0.01, ge=0.0)
+    # When True, also render one matplotlib line plot per frame (intensity vs.
+    # position along the microtubule) and return them as ``profiles``. A
+    # kymograph IS a stack of these per-frame rows, so this reuses the exact
+    # same sampled ``kymo`` matrix — the profiles are just each row drawn as a
+    # 1-D plot instead of a 2-D heatmap. Used by the "intensity profiles" export
+    # mode. Independent of ``detect_velocity``.
+    render_profiles: bool = False
 
 
 class KymographTrack(BaseModel):
@@ -838,6 +845,15 @@ class KymographTrack(BaseModel):
     bright: bool = False
 
 
+class ProfilePng(BaseModel):
+    """One per-frame intensity profile rendered as a matplotlib line plot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    frame: int
+    png_base64: str
+
+
 class KymographResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -863,6 +879,10 @@ class KymographResponse(BaseModel):
     # An empty/absent field means detection either succeeded or was not requested.
     # Distinguishes "no motility detected" (tracks=[]) from "detection crashed".
     velocity_error: Optional[str] = None
+    # Populated only when ``render_profiles`` was set: one matplotlib line plot
+    # (intensity vs. position) per frame, in frame order. None otherwise, or if
+    # the (optional) profile render failed — the base kymograph is never blocked.
+    profiles: Optional[List[ProfilePng]] = None
 
 
 def _arc_length_resample_polyline(
@@ -966,6 +986,54 @@ def _linear_gradient(values: np.ndarray, hex_color: str) -> np.ndarray:
     # Broadcast (F, W) × (3,) → (F, W, 3); each pixel is intensity × color.
     rgb = clipped[..., None] * color
     return (rgb * 255.0).astype(np.uint8)
+
+
+def _render_profiles(
+    kymo: np.ndarray,
+    frames: List[KymographFrameInput],
+    px_per_column: float,
+) -> List[ProfilePng]:
+    """Render each frame's intensity profile (one row of ``kymo``) as a
+    matplotlib line plot of intensity vs. position along the microtubule.
+
+    matplotlib is imported lazily with the headless ``Agg`` backend (the ML
+    container has no display), mirroring the codebase's lazy-heavy-dep pattern
+    so process startup is unaffected. The object-oriented ``Figure`` API is
+    used instead of ``pyplot`` to avoid pyplot's non-thread-safe global state
+    (this runs inside the async request handler) and the per-figure cleanup it
+    would otherwise require.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib.figure import Figure
+
+    n_samples = int(kymo.shape[1])
+    # Column index → position in image pixels along the MT (matches the
+    # kymograph's "Along microtubule (px)" x-axis; px_per_column ≈ 1 unless a
+    # long MT was compressed to target_width).
+    x_px = np.arange(n_samples, dtype=np.float64) * float(px_per_column)
+
+    profiles: List[ProfilePng] = []
+    for i, row in enumerate(kymo):
+        fig = Figure(figsize=(6, 3), dpi=100)
+        ax = fig.subplots()
+        ax.plot(x_px, np.asarray(row, dtype=np.float64), color="#2563eb", linewidth=1.0)
+        ax.set_xlabel("Position along microtubule (px)")
+        ax.set_ylabel("Intensity")
+        ax.set_title(f"Frame {int(frames[i].frame)}")
+        ax.margins(x=0)
+        ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png")
+        profiles.append(
+            ProfilePng(
+                frame=int(frames[i].frame),
+                png_base64=base64.b64encode(buf.getvalue()).decode("ascii"),
+            )
+        )
+    return profiles
 
 
 @router.post("/kymograph", response_model=KymographResponse)
@@ -1141,6 +1209,16 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
         except Exception:
             logger.exception("kymograph overlay render failed; omitting overlay")
 
+    # OPTIONAL per-frame intensity profiles (one matplotlib plot per kymograph
+    # row). A render failure must never break the base kymograph, so degrade to
+    # ``profiles=None`` — same discipline as the overlay above.
+    profiles: Optional[List[ProfilePng]] = None
+    if req.render_profiles:
+        try:
+            profiles = _render_profiles(kymo, frames, px_per_column)
+        except Exception:
+            logger.exception("kymograph profile render failed; omitting profiles")
+
     csv_buf = io.StringIO()
     writer = csv.writer(csv_buf)
     writer.writerow(["frame", *[f"x{i}" for i in range(n_samples)]])
@@ -1159,4 +1237,5 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
         tracks=tracks,
         overlay_png_base64=overlay_b64,
         velocity_error=velocity_error,
+        profiles=profiles,
     )

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -31,6 +31,10 @@ Pillow==12.2.0
 numpy==1.26.4
 scipy==1.11.4
 scikit-image==0.22.0
+# matplotlib renders the per-frame intensity-profile plots for the "intensity
+# profiles" export mode (/kymograph render_profiles). 3.9.x supports Python 3.10
+# + numpy 1.26. Imported lazily with the Agg backend — no runtime display needed.
+matplotlib==3.9.2
 # Sperm model dependencies (Mask2Former + graph assembly)
 # ConvNeXtV2 backbone is implemented in pure PyTorch (no HF/timm needed)
 networkx>=3.0

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -44,6 +44,13 @@ const KYMOGRAPH_CONCURRENCY = 3;
  *  logged, never silent. */
 const MAX_PROFILE_FRAMES_PER_MT = 300;
 
+/** Sanitise an untrusted path segment (polyline id, channel name) before it goes
+ *  into an export filename — strips anything outside ``[A-Za-z0-9_-]`` so a
+ *  crafted polyline id (e.g. ``../../evil``) can't inject a path separator or
+ *  ``..`` traversal into the write target. ``safeVideo`` is already sanitised at
+ *  the call site with the same character class. */
+const safeSegment = (s: string): string => s.replace(/[^A-Za-z0-9_-]+/g, '_');
+
 /** Which artefact the MT kymograph export produces. ``kymograph`` = the stacked
  *  heatmap + velocity metrics (default); ``profiles`` = one matplotlib
  *  intensity-vs-position plot per frame (+ the intensity CSV). */
@@ -295,7 +302,7 @@ export async function exportMicrotubuleKymographs(
             renderProfiles: true,
           });
 
-          const stem = `${job.safeVideo}__${job.polylineId}__${job.sourceChannel}`;
+          const stem = `${job.safeVideo}__${safeSegment(job.polylineId)}__${safeSegment(job.sourceChannel)}`;
 
           // Intensity matrix CSV (rows = frames, cols = position) — the raw
           // numbers behind the plots. ML returns it on every kymograph build.
@@ -375,7 +382,7 @@ export async function exportMicrotubuleKymographs(
           await fs.writeFile(
             path.join(
               outDir,
-              `${job.safeVideo}__${job.polylineId}__${job.sourceChannel}.png`
+              `${job.safeVideo}__${safeSegment(job.polylineId)}__${safeSegment(job.sourceChannel)}.png`
             ),
             Buffer.from(result.overlayPngBase64, 'base64')
           );

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -37,8 +37,21 @@ const MAX_MT_PER_CONTAINER = 60;
  *  this small — it bounds export wall-clock without overrunning inference. */
 const KYMOGRAPH_CONCURRENCY = 3;
 
+/** Per (microtubule × channel) cap on the number of frame profiles written in
+ *  ``profiles`` mode. Profiles are intended for small stacks (the single-frame
+ *  case forces this mode); a long time-lapse would otherwise emit thousands of
+ *  PNGs. Deterministic per job (every MT treated identically); truncation is
+ *  logged, never silent. */
+const MAX_PROFILE_FRAMES_PER_MT = 300;
+
+/** Which artefact the MT kymograph export produces. ``kymograph`` = the stacked
+ *  heatmap + velocity metrics (default); ``profiles`` = one matplotlib
+ *  intensity-vs-position plot per frame (+ the intensity CSV). */
+export type MTKymographMode = 'kymograph' | 'profiles';
+
 export interface MTKymographOptions {
   enabled: boolean;
+  mode: MTKymographMode;
   includeVelocityMetrics: boolean;
   includeSegmentedImages: boolean;
 }
@@ -166,10 +179,20 @@ export async function exportMicrotubuleKymographs(
   exportDir: string,
   options: MTKymographOptions
 ): Promise<void> {
-  // Nothing to produce → skip the (expensive) kymograph builds entirely.
+  // Normalise the mode: the controller casts req.body without validation, so an
+  // older cached FE bundle (or a direct API caller) may omit it. Default to the
+  // prior behaviour (kymograph) rather than trusting the raw wire value.
+  const mode: MTKymographMode =
+    options.mode === 'profiles' ? 'profiles' : 'kymograph';
+
+  // Nothing to produce → skip the (expensive) builds entirely. In kymograph
+  // mode, both sub-options off = no output. Profiles mode always writes plots +
+  // CSV, so it has no such short-circuit.
+  if (!options.enabled) return;
   if (
-    !options.enabled ||
-    (!options.includeVelocityMetrics && !options.includeSegmentedImages)
+    mode === 'kymograph' &&
+    !options.includeVelocityMetrics &&
+    !options.includeSegmentedImages
   ) {
     return;
   }
@@ -181,7 +204,10 @@ export async function exportMicrotubuleKymographs(
     });
     if (containers.length === 0) return;
 
-    const outDir = path.join(exportDir, 'kymographs');
+    const outDir = path.join(
+      exportDir,
+      mode === 'profiles' ? 'profiles' : 'kymographs'
+    );
     await fs.mkdir(outDir, { recursive: true });
 
     // --- Phase 1: resolve the (microtubule × channel) job list. ----------
@@ -251,6 +277,71 @@ export async function exportMicrotubuleKymographs(
           });
         }
       }
+    }
+
+    // --- Phase 2 (profiles mode): one matplotlib intensity-vs-position plot
+    // per frame, plus the intensity CSV, for each (microtubule × channel).
+    // Capped per MT so a long time-lapse can't emit thousands of PNGs. --------
+    if (mode === 'profiles') {
+      let profileCount = 0;
+      await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
+        try {
+          const result = await buildKymograph({
+            videoContainerId: job.containerId,
+            polylineId: job.polylineId,
+            frameIndex: job.frameIndex,
+            sourceChannel: job.sourceChannel,
+            detectVelocity: false,
+            renderProfiles: true,
+          });
+
+          const stem = `${job.safeVideo}__${job.polylineId}__${job.sourceChannel}`;
+
+          // Intensity matrix CSV (rows = frames, cols = position) — the raw
+          // numbers behind the plots. ML returns it on every kymograph build.
+          if (result.csvBase64) {
+            await fs.writeFile(
+              path.join(outDir, `${stem}.csv`),
+              Buffer.from(result.csvBase64, 'base64')
+            );
+          }
+
+          const profiles = result.profiles ?? [];
+          const toWrite = Math.min(profiles.length, MAX_PROFILE_FRAMES_PER_MT);
+          if (profiles.length > toWrite) {
+            logger.warn(
+              `${job.videoName}/${job.polylineId}/${job.sourceChannel}: ` +
+                `${profiles.length} frame profiles, capping at ${MAX_PROFILE_FRAMES_PER_MT}`,
+              CTX
+            );
+          }
+          for (let i = 0; i < toWrite; i++) {
+            const p = profiles[i];
+            await fs.writeFile(
+              path.join(
+                outDir,
+                `${stem}__f${String(p.frame).padStart(4, '0')}.png`
+              ),
+              Buffer.from(p.pngBase64, 'base64')
+            );
+            profileCount++;
+          }
+        } catch (err) {
+          // One bad microtubule/channel must not abort the whole export.
+          logger.warn(
+            `Profile export failed for ${job.videoName}/${job.polylineId}/${job.sourceChannel}: ${(err as Error).message}`,
+            CTX
+          );
+        }
+      });
+
+      logger.info('Microtubule intensity profiles exported', CTX, {
+        projectId,
+        containers: containers.length,
+        jobs: jobs.length,
+        profiles: profileCount,
+      });
+      return;
     }
 
     // --- Phase 2: build kymographs with bounded concurrency. -------------

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -86,6 +86,17 @@ export interface KymographServiceInput {
   /** Width (kymograph position columns) of the signal band sampled around each
    *  trajectory for the background-subtracted intensity metric. Default 3. */
   intensityWidth?: number;
+  /** When true, the ML service also renders one matplotlib line plot per frame
+   *  (intensity vs. position along the microtubule) and the result carries
+   *  ``profiles``. Used by the "intensity profiles" export mode. */
+  renderProfiles?: boolean;
+}
+
+/** One per-frame intensity profile rendered as a matplotlib PNG. Mirrors the ML
+ *  ``ProfilePng`` (frame index + base64 PNG). */
+export interface KymographProfile {
+  frame: number;
+  pngBase64: string;
 }
 
 /** A sub-pixel trajectory sample: `[frame, xPosition]` along the polyline. */
@@ -134,6 +145,8 @@ export interface KymographServiceResult {
   velocityError?: string;
   /** Base64 PNG of the kymograph + tracks; present only with ``renderOverlay``. */
   overlayPngBase64?: string;
+  /** Per-frame intensity-profile plots; present only with ``renderProfiles``. */
+  profiles?: KymographProfile[];
 }
 
 /** Resolves the on-disk PNG path for a given frame + channel. */
@@ -177,6 +190,7 @@ export async function buildKymograph(
     detectVelocity,
     renderOverlay,
     intensityWidth,
+    renderProfiles,
   } = input;
 
   // Defence in depth: reject any sourceChannel containing path separators
@@ -300,6 +314,7 @@ export async function buildKymograph(
       ...(channelColor ? { channel_color: channelColor } : {}),
       ...(detectVelocity ? { detect_velocity: true } : {}),
       ...(detectVelocity && renderOverlay ? { render_overlay: true } : {}),
+      ...(renderProfiles ? { render_profiles: true } : {}),
     },
     { timeout: 120_000 }
   );
@@ -371,12 +386,24 @@ export async function buildKymograph(
       }))
     : undefined;
 
+  // Map per-frame intensity profiles (present only when renderProfiles was set).
+  // ML shape: [{ frame, png_base64 }]. Anything malformed degrades to undefined
+  // rather than throwing — profiles are an optional add-on.
+  const profiles: KymographProfile[] | undefined = Array.isArray(
+    payload.profiles
+  )
+    ? (payload.profiles as Array<{ frame: number; png_base64: string }>)
+        .filter(p => typeof p?.png_base64 === 'string')
+        .map(p => ({ frame: Number(p.frame), pngBase64: p.png_base64 }))
+    : undefined;
+
   logger.info('Kymograph generated', 'KymographService', {
     videoContainerId,
     polylineId,
     tracked: trackedMode,
     frames: framesPayload.length,
     velocityTracks: tracks?.length,
+    profiles: profiles?.length,
   });
 
   return {
@@ -397,5 +424,6 @@ export async function buildKymograph(
     ...(typeof payload.overlay_png_base64 === 'string'
       ? { overlayPngBase64: payload.overlay_png_base64 }
       : {}),
+    ...(profiles ? { profiles } : {}),
   };
 }

--- a/docs/superpowers/specs/2026-07-08-kymograph-profile-export-design.md
+++ b/docs/superpowers/specs/2026-07-08-kymograph-profile-export-design.md
@@ -1,0 +1,137 @@
+# Kymograph vs. per-image intensity profiles — batch export
+
+**Date:** 2026-07-08
+**Branch:** `feat/kymograph-profile-export`
+**Surface:** project export dialog only (the editor's per-MT `KymographModal` is untouched).
+
+## Goal
+
+In the microtubule batch export, let the user choose **whether to export the
+kymograph** (current behaviour) **or per-image intensity profiles**. When the
+project has no time-lapse (every MT container is a single frame) a kymograph is
+degenerate, so only the profile option is offered. A profile is always a
+matplotlib line plot of **intensity vs. position along the microtubule**, one
+plot per frame.
+
+## Key facts (verified 2026-07-08)
+
+- A kymograph **is** a stack of per-frame intensity profiles. In
+  `tracker_kymograph.py` the `/kymograph` handler builds `rows` where each row is
+  `profile = map_coordinates(image, coords)` (intensity along the polyline for
+  one frame), then `kymo = np.stack(rows)` → the `(frames × position)` heatmap.
+  So a "profile of one image" is exactly **one row** of the kymograph — same
+  sampled data, drawn as a 1-D line instead of a 2-D heatmap. Profiles reuse the
+  existing sampling/geometry/calibration path (no drift).
+- **matplotlib is NOT installed** in the ML container. The kymograph PNG is drawn
+  with PIL + a hardcoded 16-stop viridis table specifically to avoid matplotlib.
+  This feature adds `matplotlib` to `backend/segmentation/requirements.txt` and
+  requires an ML image rebuild + redeploy.
+- `ProjectImage` already carries `frameCount` and `isVideoContainer`
+  (`src/types/index.ts:549`), so the frontend gates single-frame → profile-only
+  with data already on the wire — no extra fetch.
+
+## Decisions (confirmed with user)
+
+| Question                   | Decision                                                                   |
+| -------------------------- | -------------------------------------------------------------------------- |
+| Which surface              | Batch export dialog only.                                                  |
+| Profile granularity        | One matplotlib plot per frame (per MT × channel).                          |
+| When to force profile-only | When the project has no container with ≥ 2 frames.                         |
+| Profiles output            | matplotlib **PNG plots + CSV** of the intensity matrix.                    |
+| Deploy                     | Implement → verify E2E → build + deploy ML/BE/FE from a main-based branch. |
+
+## Design
+
+### 1. Frontend — `src/pages/export/components/MicrotubuleKymographsSection.tsx`
+
+- Options type gains `mode: 'kymograph' | 'profiles'`:
+
+  ```ts
+  export type MtKymographMode = 'kymograph' | 'profiles';
+  export interface MicrotubuleKymographsOptions {
+    enabled: boolean;
+    mode: MtKymographMode; // NEW
+    includeVelocityMetrics: boolean; // kymograph mode only
+    includeSegmentedImages: boolean; // kymograph mode only
+  }
+  ```
+
+- Under the existing "Include kymograph analysis" checkbox, render a **mode
+  radio**: _Kymograph_ ⟷ _Intensity profiles (per image)_.
+  - Kymograph mode → existing two checkboxes.
+  - Profiles mode → no sub-options (plots + CSV are always written).
+- New prop `canBuildKymograph: boolean`. When `false`, disable the _Kymograph_
+  radio, force `mode: 'profiles'`, and show a hint ("single frame — kymograph
+  cannot be built, exporting profile"). Default `mode` is `'kymograph'` when a
+  time-lapse exists (no behaviour change for existing users).
+- i18n keys added to all six translation files.
+
+### 2. Frontend — `src/pages/export/AdvancedExportDialog.tsx`
+
+- Derive `hasTimelapse = images.some(i => i.isVideoContainer && (i.frameCount ?? 1) > 1)`
+  and pass `canBuildKymograph={hasTimelapse}` into the section. If `frameCount`
+  is not reliably populated, default `canBuildKymograph` to `true` (never hide a
+  working option) — verify during implementation.
+- Extend `MT_KYMOGRAPHS_DEFAULTS` with `mode: 'kymograph'`.
+
+### 3. Backend — `src/services/kymographService.ts`
+
+- `KymographServiceInput` gains `renderProfiles?: boolean`.
+- When set, forward `render_profiles: true` to ML and map
+  `payload.profiles` → `result.profiles: Array<{ frame: number; pngBase64: string }>`.
+- `KymographServiceResult` gains optional `profiles`.
+
+### 4. Backend — `src/services/export/mtKymographExporter.ts`
+
+- `MTKymographOptions` gains `mode: 'kymograph' | 'profiles'`.
+- Branch on mode:
+  - **kymograph** — unchanged (PNG overlays + `velocity_metrics.xlsx`).
+  - **profiles** — for each (container × MT × channel) call `buildKymograph({
+renderProfiles: true, detectVelocity: false })`, then write: - `profiles/<video>__<mt>__<channel>__f<NNNN>.png` — one matplotlib plot per
+    frame. - `profiles/<video>__<mt>__<channel>.csv` — the intensity matrix
+    (`csv_base64` the ML already returns; rows = frames, cols = position).
+- Add `MAX_PROFILE_PLOTS_PER_CONTAINER` cap with a `logger.warn` on truncation
+  (no silent drop), mirroring `MAX_MT_PER_CONTAINER`.
+- The early-return guard (`!includeVelocityMetrics && !includeSegmentedImages`)
+  must not skip profiles mode — guard becomes mode-aware.
+
+### 5. ML — `backend/segmentation/api/tracker_kymograph.py`
+
+- `KymographRequest` gains `render_profiles: bool = False`.
+- `KymographResponse` gains `profiles: Optional[List[ProfilePng]]` where
+  `ProfilePng = { frame: int, png_base64: str }`.
+- After `kymo` is built, if `render_profiles`, render one matplotlib line plot
+  per frame row: x = position along MT (px, sample index × `px_per_column`),
+  y = intensity; titled `<frame N>`. Use `matplotlib.use("Agg")`, import
+  **lazily** inside the render helper (mirrors the lazy-`exceljs` pattern) so ML
+  startup is not slowed.
+- Rendering must never break the base kymograph: wrap in try/except, log, and
+  return `profiles: None` on failure.
+
+### 6. ML deps / build
+
+- Add `matplotlib` (pinned to a current, non-yanked version) to
+  `backend/segmentation/requirements.txt`.
+- Rebuild `ml` image; redeploy `ml` (and `backend`/`frontend` for the wire +
+  UI changes) from a branch 0 commits behind `origin/main`.
+
+## Verification (per CLAUDE.md gates)
+
+- **E (ML):** `docker exec spheroseg-ml python -c` — call `/kymograph` with
+  `render_profiles: true` on a real MT frame; assert `profiles` length ==
+  frame count and each PNG decodes.
+- **B (API):** `curl` the backend kymograph path / inspect export network
+  request for the new option.
+- **A (UI):** Playwright on the export dialog — toggle to Profiles, confirm the
+  radio + gating render; screenshot; zero console errors.
+- **F (cross-stack):** run a real profiles export on a single-frame MT project
+  and on a multi-frame one; open the ZIP; confirm `profiles/*.png` are matplotlib
+  intensity-vs-position plots + the CSV matrix.
+- **G (build):** `make build-service SERVICE=ml` (and frontend) succeed before
+  deploy.
+
+## Out of scope
+
+- The editor `KymographModal` (per-MT viewer) — unchanged.
+- Overlaid / averaged profile variants (user chose per-frame plots).
+- Changing the kymograph algorithm, calibration, or velocity detection.

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -66,6 +66,7 @@ const MT_METRICS_DEFAULTS = {
 
 const MT_KYMOGRAPHS_DEFAULTS = {
   enabled: false,
+  mode: 'kymograph' as const,
   includeVelocityMetrics: true,
   includeSegmentedImages: true,
 };
@@ -88,6 +89,16 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       // (singular) is the model id, not the project type. Mis-comparing
       // them silently hides the MT section on every MT project.
       const isMTProject = projectType === 'microtubules';
+
+      // A kymograph needs a time axis (≥ 2 frames). Force profile-only ONLY on
+      // positive evidence that every video container is single-frame; a missing
+      // frameCount or an empty container list must never hide a working option
+      // (worst case there, the backend just yields a 1-row kymograph).
+      const canBuildKymograph = React.useMemo(() => {
+        const containers = images.filter(img => img.isVideoContainer);
+        if (containers.length === 0) return true;
+        return containers.some(c => c.frameCount == null || c.frameCount > 1);
+      }, [images]);
 
       // Local snapshot of MT options. We always merge into the shared
       // exportOptions state when the user toggles or edits inputs so the
@@ -366,6 +377,7 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
                       value={
                         exportOptions.mtKymographs ?? MT_KYMOGRAPHS_DEFAULTS
                       }
+                      canBuildKymograph={canBuildKymograph}
                       onChange={next =>
                         updateExportOptions({ mtKymographs: next })
                       }

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -42,6 +42,7 @@ import { EXPORT_DEFAULTS } from '@/lib/export-config';
 import { ImageSelectionGrid } from './components/ImageSelectionGrid';
 import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
 import { MicrotubuleKymographsSection } from './components/MicrotubuleKymographsSection';
+import { projectCanBuildKymograph } from './utils/kymographGating';
 import { UniversalCancelButton } from '@/components/ui/universal-cancel-button';
 
 interface AdvancedExportDialogProps {
@@ -90,15 +91,15 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       // them silently hides the MT section on every MT project.
       const isMTProject = projectType === 'microtubules';
 
-      // A kymograph needs a time axis (≥ 2 frames). Force profile-only ONLY on
-      // positive evidence that every video container is single-frame; a missing
-      // frameCount or an empty container list must never hide a working option
-      // (worst case there, the backend just yields a 1-row kymograph).
-      const canBuildKymograph = React.useMemo(() => {
-        const containers = images.filter(img => img.isVideoContainer);
-        if (containers.length === 0) return true;
-        return containers.some(c => c.frameCount == null || c.frameCount > 1);
-      }, [images]);
+      // A kymograph needs a time axis (≥ 2 frames). The images listing returns
+      // per-frame rows, not container rows, so this counts frames per container
+      // (see projectCanBuildKymograph). When no multi-frame video exists — a
+      // single-frame container or only standalone images — the section forces
+      // profile-only.
+      const canBuildKymograph = React.useMemo(
+        () => projectCanBuildKymograph(images),
+        [images]
+      );
 
       // Local snapshot of MT options. We always merge into the shared
       // exportOptions state when the user toggles or edits inputs so the

--- a/src/pages/export/components/MicrotubuleKymographsSection.tsx
+++ b/src/pages/export/components/MicrotubuleKymographsSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { LineChart } from 'lucide-react';
 import {
   Card,
@@ -9,29 +9,60 @@ import {
 } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { useLanguage } from '@/contexts/useLanguage';
+
+export type MtKymographMode = 'kymograph' | 'profiles';
 
 export interface MicrotubuleKymographsOptions {
   enabled: boolean;
+  /** ``kymograph`` = the stacked space×time heatmap + velocity metrics;
+   *  ``profiles`` = one matplotlib intensity-vs-position plot per frame. */
+  mode: MtKymographMode;
   includeVelocityMetrics: boolean;
   includeSegmentedImages: boolean;
 }
 
 export interface MicrotubuleKymographsSectionProps {
   value: MicrotubuleKymographsOptions;
+  /** False when the project has no multi-frame video (every container is a
+   *  single image). A kymograph needs a time axis, so the ``kymograph`` mode is
+   *  then disabled and the section forces ``profiles``. */
+  canBuildKymograph: boolean;
   onChange: (next: MicrotubuleKymographsOptions) => void;
 }
 
 /**
- * MT-only export controls for kymograph velocity analysis. Renders inside the
- * export dialog's General tab when ``projectType === 'microtubules'``. The
- * backend builds one kymograph per microtubule, detects moving particles, and
- * ships the segmented kymograph PNGs and/or a velocity-metrics CSV.
+ * MT-only export controls. Renders inside the export dialog's General tab when
+ * ``projectType === 'microtubules'``. The user picks one of two outputs:
+ *
+ *  - **Kymograph** — the backend builds one space×time kymograph per microtubule
+ *    (blob-motion velocities + segmented kymograph PNGs, per the sub-toggles).
+ *  - **Intensity profiles** — one matplotlib plot of intensity vs. position
+ *    along the microtubule, per frame (a kymograph is a stack of exactly these
+ *    rows), plus the intensity CSV.
+ *
+ * When the project is single-frame (``!canBuildKymograph``) only profiles are
+ * offered, since a kymograph has no time axis to build.
  */
 export const MicrotubuleKymographsSection: React.FC<
   MicrotubuleKymographsSectionProps
-> = ({ value, onChange }) => {
+> = ({ value, canBuildKymograph, onChange }) => {
   const { t } = useLanguage();
+
+  // Force profile mode when a kymograph can't be built (single-frame project).
+  // Persists the corrected mode so the exact value POSTed to the backend is the
+  // one the UI shows — a displayed-but-unpersisted override would ship the wrong
+  // mode. Guarded so it fires once, not in a loop.
+  useEffect(() => {
+    if (value.enabled && !canBuildKymograph && value.mode !== 'profiles') {
+      onChange({ ...value, mode: 'profiles' });
+    }
+  }, [value, canBuildKymograph, onChange]);
+
+  const effectiveMode: MtKymographMode = canBuildKymograph
+    ? value.mode
+    : 'profiles';
 
   return (
     <Card>
@@ -64,41 +95,106 @@ export const MicrotubuleKymographsSection: React.FC<
         </div>
 
         {value.enabled && (
-          <div className="ml-6 space-y-2">
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="mt-kymo-velocity"
-                checked={value.includeVelocityMetrics}
-                onCheckedChange={v =>
-                  onChange({ ...value, includeVelocityMetrics: v === true })
-                }
-              />
-              <Label
-                htmlFor="mt-kymo-velocity"
-                className="cursor-pointer text-sm"
-              >
-                {t('export.mtKymographs.velocityMetrics', {
-                  defaultValue: 'Velocity metrics (CSV)',
+          <div className="ml-6 space-y-3">
+            {/* Output mode: kymograph vs. per-image intensity profiles. */}
+            <RadioGroup
+              value={effectiveMode}
+              onValueChange={v =>
+                onChange({ ...value, mode: v as MtKymographMode })
+              }
+              className="space-y-1"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem
+                  value="kymograph"
+                  id="mt-kymo-mode-kymograph"
+                  disabled={!canBuildKymograph}
+                />
+                <Label
+                  htmlFor="mt-kymo-mode-kymograph"
+                  className={
+                    canBuildKymograph
+                      ? 'cursor-pointer text-sm'
+                      : 'text-sm text-muted-foreground'
+                  }
+                >
+                  {t('export.mtKymographs.modeKymograph', {
+                    defaultValue: 'Kymograph (space × time)',
+                  })}
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="profiles" id="mt-kymo-mode-profiles" />
+                <Label
+                  htmlFor="mt-kymo-mode-profiles"
+                  className="cursor-pointer text-sm"
+                >
+                  {t('export.mtKymographs.modeProfiles', {
+                    defaultValue: 'Intensity profiles (per image)',
+                  })}
+                </Label>
+              </div>
+            </RadioGroup>
+
+            {!canBuildKymograph && (
+              <p className="text-xs text-muted-foreground">
+                {t('export.mtKymographs.singleFrameHint', {
+                  defaultValue:
+                    'Single frame — a kymograph needs a time series, so only the intensity profile is exported.',
                 })}
-              </Label>
-            </div>
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="mt-kymo-images"
-                checked={value.includeSegmentedImages}
-                onCheckedChange={v =>
-                  onChange({ ...value, includeSegmentedImages: v === true })
-                }
-              />
-              <Label
-                htmlFor="mt-kymo-images"
-                className="cursor-pointer text-sm"
-              >
-                {t('export.mtKymographs.segmentedImages', {
-                  defaultValue: 'Segmented kymograph images (PNG)',
+              </p>
+            )}
+
+            {/* Kymograph sub-options. */}
+            {effectiveMode === 'kymograph' && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="mt-kymo-velocity"
+                    checked={value.includeVelocityMetrics}
+                    onCheckedChange={v =>
+                      onChange({ ...value, includeVelocityMetrics: v === true })
+                    }
+                  />
+                  <Label
+                    htmlFor="mt-kymo-velocity"
+                    className="cursor-pointer text-sm"
+                  >
+                    {t('export.mtKymographs.velocityMetrics', {
+                      defaultValue: 'Velocity metrics (CSV)',
+                    })}
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="mt-kymo-images"
+                    checked={value.includeSegmentedImages}
+                    onCheckedChange={v =>
+                      onChange({ ...value, includeSegmentedImages: v === true })
+                    }
+                  />
+                  <Label
+                    htmlFor="mt-kymo-images"
+                    className="cursor-pointer text-sm"
+                  >
+                    {t('export.mtKymographs.segmentedImages', {
+                      defaultValue: 'Segmented kymograph images (PNG)',
+                    })}
+                  </Label>
+                </div>
+              </div>
+            )}
+
+            {/* Profiles mode: no sub-options — the matplotlib plots and the
+                intensity CSV are always written. Describe what ships. */}
+            {effectiveMode === 'profiles' && (
+              <p className="text-xs text-muted-foreground">
+                {t('export.mtKymographs.profilesHint', {
+                  defaultValue:
+                    'Exports one matplotlib plot of intensity vs. position per frame, plus the intensity CSV.',
                 })}
-              </Label>
-            </div>
+              </p>
+            )}
           </div>
         )}
       </CardContent>

--- a/src/pages/export/utils/__tests__/kymographGating.test.ts
+++ b/src/pages/export/utils/__tests__/kymographGating.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import type { ProjectImage } from '@/types';
+import { projectCanBuildKymograph } from '../kymographGating';
+
+/**
+ * The project images listing returns per-frame rows (parentVideoId set), NOT the
+ * video-container rows — a shape confirmed against the production wire. These
+ * tests lock the gating against the original bug, where filtering on
+ * `isVideoContainer` (never present in that listing) made the single-frame
+ * forced-profile path unreachable.
+ */
+
+// Minimal ProjectImage factory — only the fields the gating reads.
+const img = (over: Partial<ProjectImage>): ProjectImage =>
+  ({
+    id: Math.random().toString(36).slice(2),
+    name: 'x',
+    ...over,
+  }) as ProjectImage;
+
+const frames = (parentVideoId: string, count: number): ProjectImage[] =>
+  Array.from({ length: count }, (_, i) =>
+    img({ parentVideoId, frameIndex: i, isVideoContainer: false })
+  );
+
+describe('projectCanBuildKymograph', () => {
+  it('is true when a container has ≥ 2 frames (frame rows share parentVideoId)', () => {
+    expect(projectCanBuildKymograph(frames('c1', 3))).toBe(true);
+  });
+
+  it('is false for a single-frame container (one frame row)', () => {
+    expect(projectCanBuildKymograph(frames('c1', 1))).toBe(false);
+  });
+
+  it('is true when ANY container is multi-frame (mixed project)', () => {
+    expect(
+      projectCanBuildKymograph([...frames('single', 1), ...frames('video', 5)])
+    ).toBe(true);
+  });
+
+  it('is false for only standalone images (no parentVideoId)', () => {
+    expect(
+      projectCanBuildKymograph([
+        img({ isVideoContainer: false, parentVideoId: undefined }),
+        img({ isVideoContainer: false, parentVideoId: undefined }),
+      ])
+    ).toBe(false);
+  });
+
+  it('is false for an empty project', () => {
+    expect(projectCanBuildKymograph([])).toBe(false);
+  });
+
+  it('honours a container row that carries frameCount > 1', () => {
+    expect(
+      projectCanBuildKymograph([
+        img({ isVideoContainer: true, frameCount: 61 }),
+      ])
+    ).toBe(true);
+  });
+
+  it('treats a container row with frameCount 1 as single-frame', () => {
+    expect(
+      projectCanBuildKymograph([img({ isVideoContainer: true, frameCount: 1 })])
+    ).toBe(false);
+  });
+});

--- a/src/pages/export/utils/kymographGating.ts
+++ b/src/pages/export/utils/kymographGating.ts
@@ -1,0 +1,26 @@
+import type { ProjectImage } from '@/types';
+
+/**
+ * True when the project contains at least one video container with ≥ 2 frames —
+ * i.e. a kymograph (which needs a time axis) can be built.
+ *
+ * The project images listing returns per-FRAME rows (each with `parentVideoId`
+ * set), not the video-container rows, so `container.frameCount` is not available
+ * here. The reliable signal is therefore "≥ 2 frames share a `parentVideoId`".
+ * A container row that happens to carry `frameCount > 1` is also honoured.
+ *
+ * When this is false — a single-frame container, or only standalone images —
+ * the export dialog offers per-image intensity profiles only.
+ */
+export function projectCanBuildKymograph(images: ProjectImage[]): boolean {
+  const framesPerContainer = new Map<string, number>();
+  for (const img of images) {
+    if (img.isVideoContainer && (img.frameCount ?? 0) > 1) return true;
+    if (img.parentVideoId) {
+      const n = (framesPerContainer.get(img.parentVideoId) ?? 0) + 1;
+      if (n > 1) return true;
+      framesPerContainer.set(img.parentVideoId, n);
+    }
+  }
+  return false;
+}

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1196,6 +1196,12 @@ export default {
       enable: 'Zahrnout analýzu kymografů',
       velocityMetrics: 'Metriky rychlosti (CSV)',
       segmentedImages: 'Segmentované kymografy (PNG)',
+      modeKymograph: 'Kymograf (prostor × čas)',
+      modeProfiles: 'Profily intenzity (na obrázek)',
+      singleFrameHint:
+        'Jen jeden snímek — kymograf potřebuje časovou řadu, proto se exportuje pouze profil intenzity.',
+      profilesHint:
+        'Exportuje jeden matplotlib graf intenzity v závislosti na pozici pro každý snímek a k tomu CSV s intenzitami.',
     },
     mt: {
       sectionTitle: 'Metriky mikrotubulů',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1207,6 +1207,12 @@ export default {
       enable: 'Kymograph-Analyse einbeziehen',
       velocityMetrics: 'Geschwindigkeitsmetriken (CSV)',
       segmentedImages: 'Segmentierte Kymograph-Bilder (PNG)',
+      modeKymograph: 'Kymograph (Raum × Zeit)',
+      modeProfiles: 'Intensitätsprofile (pro Bild)',
+      singleFrameHint:
+        'Einzelbild — ein Kymograph benötigt eine Zeitreihe, daher wird nur das Intensitätsprofil exportiert.',
+      profilesHint:
+        'Exportiert pro Bild ein matplotlib-Diagramm der Intensität gegen die Position sowie die Intensitäts-CSV.',
     },
     mt: {
       sectionTitle: 'Mikrotubuli-Metriken',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1189,6 +1189,12 @@ export default {
       enable: 'Include kymograph analysis',
       velocityMetrics: 'Velocity metrics (CSV)',
       segmentedImages: 'Segmented kymograph images (PNG)',
+      modeKymograph: 'Kymograph (space × time)',
+      modeProfiles: 'Intensity profiles (per image)',
+      singleFrameHint:
+        'Single frame — a kymograph needs a time series, so only the intensity profile is exported.',
+      profilesHint:
+        'Exports one matplotlib plot of intensity vs. position per frame, plus the intensity CSV.',
     },
     mt: {
       sectionTitle: 'Microtubule metrics',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1193,6 +1193,12 @@ export default {
       enable: 'Incluir análisis de kimografía',
       velocityMetrics: 'Métricas de velocidad (CSV)',
       segmentedImages: 'Imágenes de kimograma segmentadas (PNG)',
+      modeKymograph: 'Kimograma (espacio × tiempo)',
+      modeProfiles: 'Perfiles de intensidad (por imagen)',
+      singleFrameHint:
+        'Un solo fotograma: un kimograma necesita una serie temporal, por lo que solo se exporta el perfil de intensidad.',
+      profilesHint:
+        'Exporta un gráfico de matplotlib de intensidad frente a posición por fotograma, además del CSV de intensidad.',
     },
     mt: {
       sectionTitle: 'Métricas de microtúbulos',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1197,6 +1197,12 @@ export default {
       enable: 'Inclure l’analyse de kymographie',
       velocityMetrics: 'Métriques de vitesse (CSV)',
       segmentedImages: 'Images de kymographe segmentées (PNG)',
+      modeKymograph: 'Kymographe (espace × temps)',
+      modeProfiles: 'Profils d’intensité (par image)',
+      singleFrameHint:
+        'Image unique — un kymographe nécessite une série temporelle, seul le profil d’intensité est donc exporté.',
+      profilesHint:
+        'Exporte un tracé matplotlib de l’intensité en fonction de la position par image, ainsi que le CSV d’intensité.',
     },
     mt: {
       sectionTitle: 'Métriques des microtubules',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1103,6 +1103,11 @@ export default {
       enable: '包含微管图分析',
       velocityMetrics: '速度指标 (CSV)',
       segmentedImages: '分割的微管图图像 (PNG)',
+      modeKymograph: '微管图（空间 × 时间）',
+      modeProfiles: '强度剖面（逐图像）',
+      singleFrameHint: '单帧图像 — 微管图需要时间序列，因此仅导出强度剖面。',
+      profilesHint:
+        '为每一帧导出一张强度随位置变化的 matplotlib 图，并附带强度 CSV。',
     },
     mt: {
       sectionTitle: '微管指标',


### PR DESCRIPTION
## What

Adds a **mode toggle** to the microtubule batch export: export the stacked
space×time **kymograph** (existing behaviour) or per-frame **intensity profiles**
— one matplotlib plot of intensity vs. position along each microtubule, per
frame, plus the intensity CSV.

Single-frame projects (no video container with ≥ 2 frames) can only produce a
profile, so the kymograph option is disabled and profile mode is forced.

## Why

A kymograph needs a time axis. For a single snapshot — or when the user just
wants the raw intensity trace — a 1-D profile is the right artefact. A kymograph
*is* a stack of these per-frame profiles, so profiles reuse the exact same ML
sampling path (no drift).

## Changes

- **ML** (`tracker_kymograph.py`): `/kymograph` gains `render_profiles` → renders
  one matplotlib line plot per frame row (headless `Agg`, lazy import, OO
  `Figure` API). Adds `matplotlib==3.9.2` to `requirements.txt` (the kymograph
  PNG previously used PIL + a hardcoded viridis table specifically to avoid
  matplotlib, so this is a genuine new dependency → ML rebuild).
- **Backend**: `kymographService` forwards the flag + maps `profiles`;
  `mtKymographExporter` writes `profiles/<video>__<mt>__<channel>__fNNNN.png` +
  the intensity CSV, with a mode-aware guard and a per-MT plot cap
  (`MAX_PROFILE_FRAMES_PER_MT=300`, truncation logged).
- **Frontend**: `MicrotubuleKymographsSection` gains the Kymograph⟷Profiles
  radio. Single-frame gating lives in a unit-tested pure helper
  (`projectCanBuildKymograph`) — it counts frames per `parentVideoId`, because
  the project images listing returns per-frame rows, **not** container rows
  (the original `isVideoContainer`/`frameCount` gate never matched). i18n ×6.

## Verification (all against real production data)

- ML `render_profiles` on the real 3-frame TIFF → viewed the matplotlib
  intensity-vs-position PNG.
- Exporter on "Marika" (61 frames) → 1525 profile PNGs + 25 CSVs, correct naming.
- UI: radio renders + toggles + hint; 0 feature console errors (screenshot).
- FE POST payload intercepted → carries `mtKymographs.mode:"profiles"` (field
  not stripped).
- `projectCanBuildKymograph`: 7 unit tests + verified true on real multi-frame,
  false on single-frame data shape.

Deployed to production (ml + backend + frontend + nginx restart, health green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new export mode for intensity profiles alongside the existing kymograph export.
  * Users can now choose between kymograph output and per-frame profile plots, with matching CSV data.
  * Updated the export screen with mode selection and helpful guidance when only profile export is available.
* **Bug Fixes**
  * Improved export behavior for projects that can’t generate kymographs, so the profile option remains available.
  * Export generation now handles profile rendering issues without interrupting the main output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->