### PR TITLE
fix(mt-export): scope kymographs/profiles to the selected images

### DIFF
--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -82,6 +82,9 @@ interface KymographJob {
   polylineId: string;
   frameIndex: number;
   sourceChannel: string;
+  /** Selected frame indices for this container (export image selection), or
+   *  undefined when the whole video is in scope. */
+  frameFilter?: number[];
 }
 
 function parsePolylines(
@@ -184,13 +187,21 @@ async function writeVelocityWorkbook(
 export async function exportMicrotubuleKymographs(
   projectId: string,
   exportDir: string,
-  options: MTKymographOptions
+  options: MTKymographOptions,
+  selectedImageIds?: string[] | null
 ): Promise<void> {
   // Normalise the mode: the controller casts req.body without validation, so an
   // older cached FE bundle (or a direct API caller) may omit it. Default to the
   // prior behaviour (kymograph) rather than trusting the raw wire value.
   const mode: MTKymographMode =
     options.mode === 'profiles' ? 'profiles' : 'kymograph';
+
+  // Honour the export image selection: kymographs/profiles are built only from
+  // the selected frames (mirrors the other MT exporters, which already scope via
+  // the filtered project.images). null = whole video (no selection). When active
+  // it scopes the seed enumeration, the rendered frames AND the ML render cost.
+  const hasSelection =
+    Array.isArray(selectedImageIds) && selectedImageIds.length > 0;
 
   // Nothing to produce → skip the (expensive) builds entirely. In kymograph
   // mode, both sub-options off = no output. Profiles mode always writes plots +
@@ -238,13 +249,29 @@ export async function exportMicrotubuleKymographs(
       // first frame that has a segmentation record" would skip the whole
       // container. Scan in frameIndex order and take the first non-empty one.
       const segmentedFrames = await prisma.image.findMany({
-        where: { parentVideoId: container.id, segmentation: { isNot: null } },
+        where: {
+          parentVideoId: container.id,
+          segmentation: { isNot: null },
+          // Restrict to the selected frames when the export carried a selection.
+          ...(hasSelection ? { id: { in: selectedImageIds! } } : {}),
+        },
         orderBy: { frameIndex: 'asc' },
         select: {
           frameIndex: true,
           segmentation: { select: { polygons: true } },
         },
       });
+
+      // Frames to render: the selected (+segmented) frames when a selection is
+      // active, else undefined = every frame (buildKymograph's full-video path).
+      const frameFilter = hasSelection
+        ? segmentedFrames
+            .map(f => f.frameIndex)
+            .filter((i): i is number => i != null)
+        : undefined;
+      // A selection that excludes every segmented frame of this container ⇒
+      // nothing to export for it.
+      if (hasSelection && (!frameFilter || frameFilter.length === 0)) continue;
 
       let seedFrameIndex: number | null = null;
       let polylines: PolylineRecord[] = [];
@@ -281,6 +308,7 @@ export async function exportMicrotubuleKymographs(
             polylineId: poly.id,
             frameIndex: seedFrameIndex,
             sourceChannel,
+            frameFilter,
           });
         }
       }
@@ -300,6 +328,7 @@ export async function exportMicrotubuleKymographs(
             sourceChannel: job.sourceChannel,
             detectVelocity: false,
             renderProfiles: true,
+            frameFilter: job.frameFilter,
           });
 
           const stem = `${job.safeVideo}__${safeSegment(job.polylineId)}__${safeSegment(job.sourceChannel)}`;
@@ -365,6 +394,7 @@ export async function exportMicrotubuleKymographs(
           sourceChannel: job.sourceChannel,
           detectVelocity: true,
           renderOverlay: options.includeSegmentedImages,
+          frameFilter: job.frameFilter,
         });
 
         // buildKymograph degrades a velocity-detection crash to empty tracks

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -640,7 +640,10 @@ export class ExportService {
           exportMicrotubuleKymographs(
             project.id,
             exportDir,
-            options.mtKymographs
+            options.mtKymographs,
+            // Scope kymographs/profiles to the selected frames, like the other
+            // MT exporters (which already scope via the filtered project.images).
+            options.selectedImageIds
           )
         );
       }

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -90,6 +90,12 @@ export interface KymographServiceInput {
    *  (intensity vs. position along the microtubule) and the result carries
    *  ``profiles``. Used by the "intensity profiles" export mode. */
   renderProfiles?: boolean;
+  /** Restrict the kymograph/profiles to these frame indices (the export image
+   *  selection). When omitted, every frame of the container is used (the editor
+   *  modal's full-kymograph behaviour). Frames not in the set are excluded from
+   *  the sampled matrix, so both the ML render cost and the output scope shrink
+   *  to the selection. */
+  frameFilter?: number[];
 }
 
 /** One per-frame intensity profile rendered as a matplotlib PNG. Mirrors the ML
@@ -191,7 +197,13 @@ export async function buildKymograph(
     renderOverlay,
     intensityWidth,
     renderProfiles,
+    frameFilter,
   } = input;
+
+  // Selected-frame scope (export image selection). A Set for O(1) membership;
+  // null means "all frames" (editor modal / unfiltered export).
+  const frameFilterSet =
+    frameFilter && frameFilter.length > 0 ? new Set(frameFilter) : null;
 
   // Defence in depth: reject any sourceChannel containing path separators
   // or other unsafe characters. The route layer also validates, but this
@@ -263,6 +275,8 @@ export async function buildKymograph(
 
   for (const f of allFrames) {
     if (f.frameIndex == null) continue;
+    // Restrict to the selected frames when the export passed a filter.
+    if (frameFilterSet && !frameFilterSet.has(f.frameIndex)) continue;
     let geometry: Array<{ x: number; y: number }> | null = null;
     if (trackedMode) {
       const polygons = parsePolygons(f.segmentation?.polygons ?? null);


### PR DESCRIPTION
## Problem

Exporting a microtubule project in **Intensity profiles** mode ignored the image
selection: selecting one frame still rendered every microtubule across every
frame (e.g. Marika → **1525** profiles / ~3 min, appearing "stuck at 95%").

Root cause: `exportMicrotubuleKymographs` did its **own** DB query for all
containers + all frames, bypassing the export image selection. The other MT
exporters (metrics, ImageJ ROI, images, visualizations) already scope via the
filtered `project.images` (`exportService.ts:427`) — only kymographs/profiles
did not.

## Fix

- `buildKymograph` gains an optional `frameFilter` (selected frame indices); the
  editor's live kymograph modal passes none → full kymograph, unchanged.
- `mtKymographExporter` scopes its seed enumeration + rendered frames to the
  selected frames, and forwards `options.selectedImageIds`.
- `exportService` passes `options.selectedImageIds` through.

Applies to **both** modes (kymograph + profiles). It also fixes the perceived
"stuck at 95%": a scoped export renders only the selected frames, so it's ~28×
faster (no long silent tail on the un-instrumented MT phase).

## Verification (real production data)

- Direct: `selectedImageIds=[frame1]` → **25 profiles in 4.1s**; no selection →
  1525 (backward-compatible).
- Real browser export (Marika, default all-selected) → **25 profiles in ~5s**,
  0 console errors.
- Full ZIP scoped: `profiles/*__f0001.png` (25), `RoiSet.zip` 25× `frame_0001`,
  `metrics.xlsx` all `frameIndex=1`.

Already deployed to production (backend rebuilt + recreated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kymograph and profile exports now honor selected frames, letting you generate results from only the images you choose.
  * Exported output is now scoped more precisely, which can reduce processing time and unnecessary data in the results.

* **Bug Fixes**
  * Fixed exports so frame selections are consistently applied across microtubule kymograph workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->