### PR TITLE
refactor(project-types): consolidate MT predicate + registry reuse + dead-code cleanup

### DIFF
--- a/backend/src/api/controllers/projectController.ts
+++ b/backend/src/api/controllers/projectController.ts
@@ -264,17 +264,18 @@ export const getMtTypeLabels = asyncHandler(
 
 /**
  * PUT /api/projects/:id/mt-type-labels — replace the palette (create / rename /
- * reorder). body: `{ labels: MTTypeLabel[] }`.
+ * reorder / remove). body: `{ labels: MTTypeLabel[] }`. A label dropped by the
+ * new set has its references cleaned (framesCleaned reported).
  */
 export const putMtTypeLabels = asyncHandler(
   async (req: Request, res: Response): Promise<void> => {
     const projectId = req.params.id;
     if (!(await ensureProjectAccess(req, res, projectId))) return;
-    const { labels } = await MtTypeLabelService.putLabels(
+    const { labels, framesCleaned } = await MtTypeLabelService.putLabels(
       projectId,
       (req.body as { labels?: unknown })?.labels
     );
-    ResponseHelper.success(res, { labels }, 'Palette uložena');
+    ResponseHelper.success(res, { labels, framesCleaned }, 'Palette uložena');
   }
 );
 

--- a/backend/src/api/routes/projectRoutes.ts
+++ b/backend/src/api/routes/projectRoutes.ts
@@ -28,6 +28,7 @@ import {
   projectQuerySchema,
   projectIdSchema,
   projectLabelParamsSchema,
+  mtTypeLabelsPutSchema,
 } from '../../types/validation';
 import imageRoutes from './imageRoutes';
 
@@ -119,6 +120,7 @@ router.get(
 router.put(
   '/:id/mt-type-labels',
   validateParams(projectIdSchema),
+  validateBody(mtTypeLabelsPutSchema),
   putMtTypeLabels
 );
 router.delete(

--- a/backend/src/services/__tests__/exportService.gaps.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps.test.ts
@@ -167,6 +167,7 @@ vi.mock('../../utils/concurrency', () => ({
 
 vi.mock('../../types/validation', () => ({
   coerceProjectType: vi.fn((t: string) => t ?? 'spheroid'),
+  isMicrotubuleProject: (t: string | undefined | null) => t === 'microtubules',
 }));
 
 // ---- Imports (after mocks) ----

--- a/backend/src/services/__tests__/exportService.gaps2.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps2.test.ts
@@ -168,6 +168,7 @@ vi.mock('../../utils/concurrency', () => ({
 }));
 
 vi.mock('../../types/validation', () => ({
+  isMicrotubuleProject: (t: string | undefined | null) => t === 'microtubules',
   coerceProjectType: vi.fn((t: string) => t ?? 'spheroid'),
 }));
 

--- a/backend/src/services/__tests__/exportService.gaps3.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps3.test.ts
@@ -190,6 +190,7 @@ vi.mock('../../utils/concurrency', () => ({
 }));
 
 vi.mock('../../types/validation', () => ({
+  isMicrotubuleProject: (t: string | undefined | null) => t === 'microtubules',
   coerceProjectType: vi.fn((t: string) => t ?? 'spheroid'),
 }));
 

--- a/backend/src/services/__tests__/exportService.gaps4.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps4.test.ts
@@ -188,6 +188,7 @@ vi.mock('../../utils/concurrency', () => ({
 }));
 
 vi.mock('../../types/validation', () => ({
+  isMicrotubuleProject: (t: string | undefined | null) => t === 'microtubules',
   coerceProjectType: vi.fn((t: string) => t ?? 'spheroid'),
 }));
 

--- a/backend/src/services/__tests__/exportService.gaps5.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps5.test.ts
@@ -178,6 +178,7 @@ vi.mock('../../utils/concurrency', () => ({
 }));
 
 vi.mock('../../types/validation', () => ({
+  isMicrotubuleProject: (t: string | undefined | null) => t === 'microtubules',
   coerceProjectType: vi.fn((t: string) => t ?? 'spheroid'),
 }));
 

--- a/backend/src/services/__tests__/mtTypeLabelService.async.test.ts
+++ b/backend/src/services/__tests__/mtTypeLabelService.async.test.ts
@@ -55,12 +55,58 @@ describe('putLabels', () => {
         { id: 'b', name: 'beta', color: '#00ff00' },
       ],
     });
+    prismaMock.image.findMany.mockResolvedValue([]); // no frames to clean
     const res = await putLabels('p1', [
       { id: 'a', name: 'alpha', color: '#ff0000' },
     ]);
     expect(res.labels).toEqual([{ id: 'a', name: 'alpha', color: '#ff0000' }]);
     expect(res.removedIds).toEqual(['b']);
     expect(prismaMock.project.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans mtType references for labels dropped by a PUT (not just DELETE)', async () => {
+    prismaMock.project.findUnique.mockResolvedValue({
+      mtTypeLabels: [
+        { id: 'a', name: 'alpha', color: '#ff0000' },
+        { id: 'b', name: 'beta', color: '#00ff00' },
+      ],
+    });
+    // Two frames reference the dropped label 'b'.
+    prismaMock.image.findMany.mockResolvedValue([
+      {
+        id: 'f1',
+        segmentation: {
+          id: 's1',
+          polygons: JSON.stringify([{ id: 'p', mtType: 'b', trackId: 't' }]),
+        },
+      },
+      {
+        id: 'f2',
+        segmentation: {
+          id: 's2',
+          polygons: JSON.stringify([{ id: 'q', mtType: 'a' }]), // survivor, untouched
+        },
+      },
+    ]);
+    const res = await putLabels('p1', [
+      { id: 'a', name: 'alpha', color: '#ff0000' },
+    ]);
+    expect(res.removedIds).toEqual(['b']);
+    expect(res.framesCleaned).toBe(1); // only f1 carried 'b'
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not scan when a PUT removes nothing', async () => {
+    prismaMock.project.findUnique.mockResolvedValue({
+      mtTypeLabels: [{ id: 'a', name: 'alpha', color: '#ff0000' }],
+    });
+    const res = await putLabels('p1', [
+      { id: 'a', name: 'alpha', color: '#ff0000' },
+      { id: 'b', name: 'beta', color: '#00ff00' }, // added, none removed
+    ]);
+    expect(res.removedIds).toEqual([]);
+    expect(res.framesCleaned).toBe(0);
+    expect(prismaMock.image.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/services/addChannelService.ts
+++ b/backend/src/services/addChannelService.ts
@@ -26,6 +26,7 @@ import { prisma } from '../db/prismaClient';
 import { config } from '../utils/config';
 import { logger } from '../utils/logger';
 import { ChannelMeta, defaultColorForWavelength } from './video/types';
+import { isMicrotubuleProject } from '../types/validation';
 import { detectVideoKind, extractVideoSafe } from './video/videoExtractor';
 import { alignChannelFrames, ChannelAlignJob } from './video/pythonExtractor';
 import { frameStorageKey } from './videoUploadService';
@@ -184,7 +185,7 @@ export async function addChannelToFrames(
       where: { id: projectId },
       select: { type: true },
     });
-    if ((project?.type ?? '') !== 'microtubules') {
+    if (!isMicrotubuleProject(project?.type)) {
       throw new Error('Add channel is only available for microtubule projects');
     }
 

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -11,7 +11,10 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 import type { ExportOptions, ProjectWithImages } from '../exportService';
-import type { ProjectType } from '../../types/validation';
+import {
+  isMicrotubuleProject,
+  type ProjectType,
+} from '../../types/validation';
 
 export function generateReadme(
   project: ProjectWithImages,
@@ -50,7 +53,7 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 * yolo/ - YOLO format annotations
 * json/ - Custom JSON format
 ${
-  project.type === 'microtubules'
+  isMicrotubuleProject(project.type)
     ? '* imagej/ - ImageJ/Fiji ROIs, one <video>_RoiSet.zip per video (each microtubule polyline on its own stack slice, named by cross-frame trackId, coloured per track, drawn at the MT thickness)\n'
     : ''
 }* metrics/ - Calculated metrics

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -28,7 +28,10 @@ import {
   generateMetricsGuide,
   generateAnnotationGuides,
 } from './export/exportDocs';
-import { coerceProjectType } from '../types/validation';
+import {
+  coerceProjectType,
+  isMicrotubuleProject as isMicrotubuleProjectType,
+} from '../types/validation';
 import {
   MICROTUBULE_LABEL_PREFIX,
   SPERM_LABEL_PREFIX,
@@ -524,16 +527,19 @@ export class ExportService {
         );
       }
 
+      // Whether this is a microtubule project — drives which exporters run
+      // (skip standard annotations/metrics, add MT-metrics/kymograph/ImageJ/CVAT).
+      const isMicrotubuleProject = isMicrotubuleProjectType(project.type);
+
       // Generate visualizations (can run in parallel)
       if (options.includeVisualizations && project.images) {
         const visualizationProgressBase = 5 + progressStep * progressIncrement;
         // Microtubule polylines reuse the sperm labeller, so badge them "MT1"
         // instead of the sperm "S1". The MT metrics table is labelled with the
         // same prefix so rows can be matched to badges on the image.
-        const labelPrefix =
-          (project.type ?? '') === 'microtubules'
-            ? MICROTUBULE_LABEL_PREFIX
-            : SPERM_LABEL_PREFIX;
+        const labelPrefix = isMicrotubuleProject
+          ? MICROTUBULE_LABEL_PREFIX
+          : SPERM_LABEL_PREFIX;
         exportTasks.push(
           this.generateVisualizations(
             project.images as ImageWithSegmentation[],
@@ -567,7 +573,6 @@ export class ExportService {
       // tracks, so they are NOT emitted for microtubule projects — MT annotation
       // export is ImageJ RoiSet + CVAT (both always-on, below), each of which
       // carries the tubulin type class natively.
-      const isMicrotubuleProject = (project.type ?? '') === 'microtubules';
       if (
         !isMicrotubuleProject &&
         options.annotationFormats?.length &&
@@ -625,10 +630,9 @@ export class ExportService {
       // no area). Runs whenever metrics are requested for an MT project, not
       // just when the intensity section is on: it always writes microtubule
       // LENGTH (geometry, no channel needed) and adds per-channel intensity
-      // columns only when a channel was selected. ProjectType is
-      // `'microtubules'` (plural) — `'microtubule'` is the model id.
+      // columns only when a channel was selected.
       if (
-        (project.type ?? '') === 'microtubules' &&
+        isMicrotubuleProject &&
         options.metricsFormats?.length &&
         project.images?.length
       ) {
@@ -643,10 +647,7 @@ export class ExportService {
       }
 
       // MT kymographs (segmented images + velocity metrics) — MT projects only.
-      if (
-        (project.type ?? '') === 'microtubules' &&
-        options.mtKymographs?.enabled
-      ) {
+      if (isMicrotubuleProject && options.mtKymographs?.enabled) {
         exportTasks.push(
           exportMicrotubuleKymographs(
             project.id,
@@ -668,7 +669,7 @@ export class ExportService {
       // always-on (the user did not opt in), a failure must NOT sink the whole
       // export they did request: it degrades to a warning. Only a genuine
       // cancellation stays fatal.
-      if ((project.type ?? '') === 'microtubules' && project.images?.length) {
+      if (isMicrotubuleProject && project.images?.length) {
         exportTasks.push(
           exportImageJRoiSets(
             project.images as ImageWithSegmentation[],
@@ -1335,7 +1336,7 @@ export class ExportService {
     // intensity exporter (`generateMTIntensityMetrics`) writes the
     // metrics.{csv,xlsx,json} files for MT projects instead. Skip here to
     // avoid emitting empty files and racing the MT writer on the same paths.
-    if (projectType === 'microtubules') {
+    if (isMicrotubuleProjectType(projectType)) {
       logger.info(
         'Microtubule project: standard polygon metrics skipped; the MT intensity exporter owns the metrics files',
         'ExportService',

--- a/backend/src/services/mtTypeLabelService.ts
+++ b/backend/src/services/mtTypeLabelService.ts
@@ -59,35 +59,96 @@ export function diffRemovedIds(
 }
 
 /** Lenient parse of a frame's polygons JSON to an array (empty on null/corrupt).
- *  Cleanup must never throw on one bad frame. */
-function parseFramePolygons(json: string | null | undefined): unknown[] {
+ *  Cleanup must never throw on one bad frame, but a parse failure is logged so
+ *  a frame silently skipped during cleanup is diagnosable. */
+function parseFramePolygons(
+  json: string | null | undefined,
+  ctx?: { segmentationId?: string; projectId?: string }
+): unknown[] {
   if (!json) return [];
   try {
     const parsed = JSON.parse(json);
     return Array.isArray(parsed) ? parsed : [];
-  } catch {
+  } catch (err) {
+    logger.warn(
+      'MT label cleanup: unreadable polygons JSON on a frame; left unchanged',
+      'MtTypeLabelService',
+      { ...ctx, error: err instanceof Error ? err.message : String(err) }
+    );
     return [];
   }
 }
 
 /**
- * Clear `mtType` on every polygon whose `mtType` equals `labelId`. Pure — changed
- * polygons are shallow-copied. Returns the new array + how many changed.
+ * Clear `mtType` on every polygon whose `mtType` is in `idSet`. Pure — changed
+ * polygons are shallow-copied. The `typeof === 'string'` guard means an empty
+ * `idSet` (or one containing '') never touches untyped polygons. Returns the new
+ * array + how many changed.
  */
-export function clearMtTypeById(
+export function clearMtTypesByIds(
   polys: unknown[],
-  labelId: string
+  idSet: Set<string>
 ): { polygons: unknown[]; changed: number } {
   let changed = 0;
   const polygons = polys.map(p => {
     const rec = p as Record<string, unknown>;
-    if (rec.mtType !== labelId) return p;
+    if (typeof rec.mtType !== 'string' || !idSet.has(rec.mtType)) return p;
     changed++;
     const copy = { ...rec };
     delete copy.mtType;
     return copy;
   });
   return { polygons, changed };
+}
+
+/** Single-id convenience wrapper over {@link clearMtTypesByIds}. */
+export function clearMtTypeById(
+  polys: unknown[],
+  labelId: string
+): { polygons: unknown[]; changed: number } {
+  return clearMtTypesByIds(polys, new Set(labelId ? [labelId] : []));
+}
+
+/**
+ * Null every `mtType` reference to any id in `labelIds` across the project's
+ * frames, in a single transaction. Shared by DELETE and the PUT-removal path so
+ * a label removed by EITHER endpoint can never leave dangling references.
+ * Returns the number of frames written.
+ */
+async function clearLabelReferences(
+  projectId: string,
+  labelIds: string[]
+): Promise<number> {
+  const idSet = new Set(labelIds.filter(Boolean));
+  if (idSet.size === 0) return 0;
+  const frames = await prisma.image.findMany({
+    where: { projectId },
+    select: {
+      id: true,
+      segmentation: { select: { id: true, polygons: true } },
+    },
+  });
+  const ops: Prisma.PrismaPromise<unknown>[] = [];
+  let framesCleaned = 0;
+  for (const frame of frames) {
+    if (!frame.segmentation) continue;
+    const parsed = parseFramePolygons(frame.segmentation.polygons, {
+      segmentationId: frame.segmentation.id,
+      projectId,
+    });
+    const { polygons, changed } = clearMtTypesByIds(parsed, idSet);
+    if (changed > 0) {
+      framesCleaned++;
+      ops.push(
+        prisma.segmentation.update({
+          where: { id: frame.segmentation.id },
+          data: { polygons: JSON.stringify(polygons), updatedAt: new Date() },
+        })
+      );
+    }
+  }
+  if (ops.length > 0) await prisma.$transaction(ops);
+  return framesCleaned;
 }
 
 export async function getLabels(projectId: string): Promise<MTTypeLabel[]> {
@@ -98,19 +159,35 @@ export async function getLabels(projectId: string): Promise<MTTypeLabel[]> {
   return sanitizeLabels(project?.mtTypeLabels ?? []);
 }
 
-/** Replace the whole palette (create / rename / reorder). Ids are stable, so no
- *  polyline rewrite is needed. Returns the sanitized set stored + ids removed. */
+/** Replace the whole palette (create / rename / reorder / remove). Ids are
+ *  stable, so a rename/reorder needs no polyline rewrite — but a label DROPPED
+ *  by the new set has its `mtType` references nulled across the project's frames
+ *  (same cleanup as DELETE), so a PUT-removal can never leave dangling ids.
+ *  Returns the stored set + removed ids + frames cleaned. */
 export async function putLabels(
   projectId: string,
   labels: unknown
-): Promise<{ labels: MTTypeLabel[]; removedIds: string[] }> {
+): Promise<{
+  labels: MTTypeLabel[];
+  removedIds: string[];
+  framesCleaned: number;
+}> {
   const prev = await getLabels(projectId);
   const next = sanitizeLabels(labels);
   await prisma.project.update({
     where: { id: projectId },
     data: { mtTypeLabels: next as unknown as Prisma.InputJsonValue },
   });
-  return { labels: next, removedIds: diffRemovedIds(prev, next) };
+  const removedIds = diffRemovedIds(prev, next);
+  const framesCleaned = await clearLabelReferences(projectId, removedIds);
+  if (removedIds.length > 0) {
+    logger.info('Cleaned references for PUT-removed MT labels', 'MtTypeLabelService', {
+      projectId,
+      removedIds,
+      framesCleaned,
+    });
+  }
+  return { labels: next, removedIds, framesCleaned };
 }
 
 /** Delete one label and null its `mtType` references on every frame of the
@@ -132,30 +209,7 @@ export async function deleteLabel(
     data: { mtTypeLabels: next as unknown as Prisma.InputJsonValue },
   });
 
-  const frames = await prisma.image.findMany({
-    where: { projectId },
-    select: {
-      id: true,
-      segmentation: { select: { id: true, polygons: true } },
-    },
-  });
-  const ops: Prisma.PrismaPromise<unknown>[] = [];
-  let framesCleaned = 0;
-  for (const frame of frames) {
-    if (!frame.segmentation) continue;
-    const parsed = parseFramePolygons(frame.segmentation.polygons);
-    const { polygons, changed } = clearMtTypeById(parsed, labelId);
-    if (changed > 0) {
-      framesCleaned++;
-      ops.push(
-        prisma.segmentation.update({
-          where: { id: frame.segmentation.id },
-          data: { polygons: JSON.stringify(polygons), updatedAt: new Date() },
-        })
-      );
-    }
-  }
-  if (ops.length > 0) await prisma.$transaction(ops);
+  const framesCleaned = await clearLabelReferences(projectId, [labelId]);
 
   logger.info('Deleted MT type label', 'MtTypeLabelService', {
     projectId,

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -153,6 +153,13 @@ export const isProjectType = (v: unknown): v is ProjectType =>
 export const coerceProjectType = (v: unknown): ProjectType =>
   isProjectType(v) ? v : 'spheroid';
 
+/** True for microtubule projects. Prefer over a bare `t === 'microtubules'`:
+ *  the project type is PLURAL `microtubules` while the model id is SINGULAR
+ *  `microtubule`, and mixing them has shipped a bug before. Accepts a raw
+ *  `project.type` (`string | undefined | null`) — no `?? ''` needed. */
+export const isMicrotubuleProject = (v: string | undefined | null): boolean =>
+  v === 'microtubules';
+
 /** Model identifiers and the model↔project-type compatibility map now derive
  *  from the single source of truth in `../constants/modelRegistry`. Adding or
  *  removing a model there updates this automatically — no more hand-synced
@@ -266,6 +273,14 @@ export const projectIdSchema = z.object({
 export const projectLabelParamsSchema = z.object({
   id: z.string().uuid('Neplatné ID projektu'),
   labelId: z.string().min(1, 'ID labelu je povinné').max(100),
+});
+
+// PUT …/mt-type-labels body. Loose on purpose: `labels` must be an array (gross
+// error → 400), but per-entry validation/sanitization (id/name/#RRGGBB, dedupe)
+// lives in mtTypeLabelService.sanitizeLabels so a partially-malformed palette is
+// cleaned rather than wholesale rejected. Cap the count to bound the payload.
+export const mtTypeLabelsPutSchema = z.object({
+  labels: z.array(z.unknown()).max(500),
 });
 
 // Image validation schemas

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -46,6 +46,7 @@ import {
   isModelCompatibleWithType,
   MODEL_TYPE_COMPATIBILITY,
   getErrorMessage,
+  isMicrotubuleProject,
 } from '@/types';
 
 const ProjectDetail = () => {
@@ -1646,7 +1647,7 @@ const ProjectDetail = () => {
               onBatchDelete={handleBatchDelete}
               onDeleteAnnotations={handleDeleteAnnotations}
               onAddChannel={() => setShowAddChannelDialog(true)}
-              canAddChannel={projectType === 'microtubules'}
+              canAddChannel={isMicrotubuleProject(projectType)}
               showSelectAll={true}
               onExportingChange={() => {}} // No longer needed - hook handles state
               onDownloadingChange={() => {}} // No longer needed - hook handles state

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -37,7 +37,7 @@ import {
 } from 'lucide-react';
 import { useSharedAdvancedExport } from './hooks/useSharedAdvancedExport';
 import { useLanguage } from '@/contexts/useLanguage';
-import { ProjectImage } from '@/types';
+import { ProjectImage, isMicrotubuleProject } from '@/types';
 import { EXPORT_DEFAULTS } from '@/lib/export-config';
 import { ImageSelectionGrid } from './components/ImageSelectionGrid';
 import { MicrotubuleMetricsSection } from './components/MicrotubuleMetricsSection';
@@ -86,10 +86,9 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
       onDownloadingChange,
     }) => {
       const { t } = useLanguage();
-      // ProjectType is `'microtubules'` (plural) — `'microtubule'`
-      // (singular) is the model id, not the project type. Mis-comparing
-      // them silently hides the MT section on every MT project.
-      const isMTProject = projectType === 'microtubules';
+      // Shared predicate guards the plural-`microtubules`-vs-singular-
+      // `microtubule`-model-id footgun that once silently hid this section.
+      const isMTProject = isMicrotubuleProject(projectType);
 
       // A kymograph needs a time axis (≥ 2 frames). The images listing returns
       // per-frame rows, not container rows, so this counts frames per container

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -22,6 +22,7 @@ import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { handleCancelledError } from '@/lib/errorUtils';
 import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
+import { resolveTargetTrackIds } from './utils/mtTypeTargets';
 import { usePolygonHandlers } from './hooks/usePolygonHandlers';
 import { useSegmentationLoader } from './hooks/useSegmentationLoader';
 import { useResegment } from './hooks/useResegment';
@@ -1038,16 +1039,10 @@ const SegmentationEditor = () => {
       const videoId = video.container?.id;
       if (!videoId) return;
       const polys = editorRef.current.getPolygons();
-      const selected = selectedPolygonIdsRef.current;
-      const targetIds = selected.size >= 2 ? [...selected] : [polygonId];
-      const trackIds = Array.from(
-        new Set(
-          targetIds
-            .map(id => polys.find(p => p.id === id)?.trackId)
-            .filter(
-              (tid): tid is string => typeof tid === 'string' && tid.length > 0
-            )
-        )
+      const trackIds = resolveTargetTrackIds(
+        polygonId,
+        selectedPolygonIdsRef.current,
+        polys
       );
       if (trackIds.length === 0) {
         toast.error(t('microtubule.type.noTrack'));

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -63,7 +63,7 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   onDeleteLabel,
 }) => {
   const { t } = useLanguage();
-  // Label-management dialog state: null = closed, {} = create, {id,…} = rename.
+  // Label-management dialog state: null = closed, 'new' = create, MTTypeLabel = rename.
   const [editingLabel, setEditingLabel] = useState<MTTypeLabel | null | 'new'>(
     null
   );

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shouldPreventCanvasDeselection } from '../config/modeConfig';
 import { generateSafePolygonKey } from '@/lib/polygonIdUtils';
 import { ensureBrowserCompatibleUrl } from '@/lib/tiffUtils';
+import { isMicrotubuleProject } from '@/types';
 import { resolveMtColor } from '../utils/instanceColors';
 
 import VerticalToolbar from './VerticalToolbar';
@@ -466,12 +467,16 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                           // by-label colour; CanvasPolygon uses it only when
                           // colorMode === 'semantic'.
                           colorMode={
-                            projectType === 'microtubules'
+                            isMicrotubuleProject(projectType)
                               ? mtColorMode
                               : 'instance'
                           }
                           semanticColor={
-                            projectType === 'microtubules'
+                            // Only resolve the by-label colour when it will be
+                            // used (semantic mode); in the default instance mode
+                            // CanvasPolygon ignores it, so skip the Map lookup.
+                            isMicrotubuleProject(projectType) &&
+                            mtColorMode === 'semantic'
                               ? resolveMtColor(polygon.mtType, mtColorById, {
                                   selected:
                                     polygon.id === editor.selectedPolygonId,
@@ -560,7 +565,7 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                     Instances panel below (trackId order, per-instance colour,
                     length, delete) — the generic Polygon List would just
                     duplicate it, so it's hidden for MT projects. */}
-                {projectType !== 'microtubules' && (
+                {!isMicrotubuleProject(projectType) && (
                   <PolygonListPanel
                     loading={projectLoading}
                     polygons={editor.polygons}

--- a/src/pages/segmentation/components/VideoModeOverlay.tsx
+++ b/src/pages/segmentation/components/VideoModeOverlay.tsx
@@ -22,15 +22,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { KymographModal } from './KymographModal';
 import { useImageDisplay } from '../contexts/ImageDisplayContext';
-import { useVideoFrames, VideoFrame } from '../hooks/useVideoFrames';
-import type { ProjectType } from '@/types';
+import { useVideoFrames } from '../hooks/useVideoFrames';
+import { isMicrotubuleProject, type ProjectType } from '@/types';
 
 interface VideoModeOverlayProps {
   videoContainerId: string;
   projectType?: ProjectType;
-  /** Called whenever the editor should reload its polygons for a different
-   *  frame imageId. */
-  onActiveFrameChange?: (frame: VideoFrame | null) => void;
 }
 
 /** Keyboard handler: ←/→ step frames, Space toggle playback. Mounted on
@@ -66,23 +63,19 @@ function useFrameNavigationKeys(
 export function VideoModeOverlay({
   videoContainerId,
   projectType,
-  onActiveFrameChange,
 }: VideoModeOverlayProps) {
-  const { container, frameIndex, currentFrame, step, toggle } =
+  const { container, frameIndex, step, toggle } =
     useVideoFrames(videoContainerId);
   const { setFrameIndex: setDisplayFrame } = useImageDisplay();
 
   useFrameNavigationKeys(step, toggle);
 
-  // Propagate frame changes outward: tell the editor "load polygons for
-  // this image id" and update the display context. The editor itself
-  // also calls useVideoFrames (lifted in commit 3) — both calls share
-  // React Query cache via the queryKey, but each has its own local
-  // frameIndex state. We only sync the *displayed* index here.
+  // Sync the displayed frameIndex into ImageDisplayContext so the canvas +
+  // sidebar consume one source of truth. (The editor calls useVideoFrames too;
+  // both share the React Query cache but keep their own local frameIndex.)
   useEffect(() => {
     setDisplayFrame(frameIndex);
-    onActiveFrameChange?.(currentFrame);
-  }, [frameIndex, currentFrame, setDisplayFrame, onActiveFrameChange]);
+  }, [frameIndex, setDisplayFrame]);
 
   // Kymograph modal state — selected polyline + open flag. The editor
   // wires PolygonContextMenu around its polyline-body hit area and calls
@@ -108,7 +101,7 @@ export function VideoModeOverlay({
   }, [openKymograph]);
 
   if (!container) return null;
-  if (!kymographFor || projectType !== 'microtubules') return null;
+  if (!kymographFor || !isMicrotubuleProject(projectType)) return null;
 
   return (
     <KymographModal
@@ -120,17 +113,4 @@ export function VideoModeOverlay({
       channels={container.channels}
     />
   );
-}
-
-/** Convenience helper for the editor: returns the overlay props bundle
- *  if the given image is a video container, null otherwise. The editor
- *  can early-return without any video pieces when null. */
-// eslint-disable-next-line react-refresh/only-export-components
-export function useVideoModeProps(
-  imageId: string | null | undefined,
-  isVideoContainer: boolean | undefined,
-  projectType?: ProjectType
-): VideoModeOverlayProps | null {
-  if (!imageId || !isVideoContainer) return null;
-  return { videoContainerId: imageId, projectType };
 }

--- a/src/pages/segmentation/components/__tests__/VideoModeOverlay.test.tsx
+++ b/src/pages/segmentation/components/__tests__/VideoModeOverlay.test.tsx
@@ -10,17 +10,12 @@
  *  - Arrow keys are ignored when the event target is an INPUT element
  *  - Arrow keys are ignored when the event target is a TEXTAREA element
  *  - Arrow keys are ignored when the event target is contentEditable
- *  - On mount, calls onActiveFrameChange with the currentFrame value
- *  - On frameIndex change, calls onActiveFrameChange again with new frame
  *  - On mount, calls setFrameIndex (ImageDisplayContext) with frameIndex
  *  - Kymograph modal is NOT rendered for non-microtubule projectType even
  *    if 'segmentation:open-kymograph' event is dispatched
  *  - Kymograph modal IS rendered for projectType='microtubules' after
  *    'segmentation:open-kymograph' CustomEvent
  *  - KymographModal receives correct polylineId from CustomEvent detail
- *  - useVideoModeProps returns null when isVideoContainer=false
- *  - useVideoModeProps returns null when imageId is null
- *  - useVideoModeProps returns correct props when both args are truthy
  *
  * NOT tested:
  *  - Actual keyboard trusted events on canvas (jsdom limitation — covered by E2E)
@@ -29,8 +24,8 @@
 
 import React, { act } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, renderHook } from '@testing-library/react';
-import { VideoModeOverlay, useVideoModeProps } from '../VideoModeOverlay';
+import { render, screen } from '@testing-library/react';
+import { VideoModeOverlay } from '../VideoModeOverlay';
 
 // ---------------------------------------------------------------------------
 // Mock heavy internal dependencies
@@ -256,30 +251,10 @@ describe('VideoModeOverlay', () => {
   });
 
   // -------------------------------------------------------------------------
-  // onActiveFrameChange / setDisplayFrame sync
+  // setDisplayFrame sync
   // -------------------------------------------------------------------------
 
   describe('frame change propagation', () => {
-    it('calls onActiveFrameChange with currentFrame on mount', () => {
-      const frame = {
-        id: 'frame-0',
-        frameIndex: 0,
-        segmentationStatus: 'not_started' as const,
-      };
-      videoFramesMock.container = makeContainer();
-      videoFramesMock.currentFrame = frame;
-      videoFramesMock.frameIndex = 0;
-
-      const onActiveFrameChange = vi.fn();
-      render(
-        <VideoModeOverlay
-          videoContainerId="vid-1"
-          onActiveFrameChange={onActiveFrameChange}
-        />
-      );
-      expect(onActiveFrameChange).toHaveBeenCalledWith(frame);
-    });
-
     it('calls setFrameIndex (display context) with frameIndex on mount', () => {
       videoFramesMock.container = makeContainer();
       videoFramesMock.frameIndex = 2;
@@ -378,51 +353,6 @@ describe('VideoModeOverlay', () => {
           })
         );
       }).not.toThrow();
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// useVideoModeProps helper
-// ---------------------------------------------------------------------------
-
-describe('useVideoModeProps', () => {
-  it('returns null when imageId is null', () => {
-    const { result } = renderHook(() =>
-      useVideoModeProps(null, true, 'microtubules')
-    );
-    expect(result.current).toBeNull();
-  });
-
-  it('returns null when imageId is undefined', () => {
-    const { result } = renderHook(() =>
-      useVideoModeProps(undefined, true, 'microtubules')
-    );
-    expect(result.current).toBeNull();
-  });
-
-  it('returns null when isVideoContainer=false', () => {
-    const { result } = renderHook(() =>
-      useVideoModeProps('img-1', false, 'microtubules')
-    );
-    expect(result.current).toBeNull();
-  });
-
-  it('returns correct props when imageId and isVideoContainer are truthy', () => {
-    const { result } = renderHook(() =>
-      useVideoModeProps('img-1', true, 'microtubules')
-    );
-    expect(result.current).toEqual({
-      videoContainerId: 'img-1',
-      projectType: 'microtubules',
-    });
-  });
-
-  it('returns props without projectType when projectType is undefined', () => {
-    const { result } = renderHook(() => useVideoModeProps('img-2', true));
-    expect(result.current).toEqual({
-      videoContainerId: 'img-2',
-      projectType: undefined,
     });
   });
 });

--- a/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
+++ b/src/pages/segmentation/components/canvas/CanvasPolygon.tsx
@@ -4,11 +4,12 @@ import { Polygon } from '@/lib/segmentation';
 import PolygonVertices from './PolygonVertices';
 import PolygonContextMenu from '../context-menu/PolygonContextMenu';
 import { VertexDragState, EditMode } from '@/pages/segmentation/types';
-import type { ProjectType } from '@/types';
+import { isMicrotubuleProject, type ProjectType } from '@/types';
 import type { MTTypeLabel } from '@/lib/api';
 import {
   colorFromInstanceId,
   isMicrotubuleInstance,
+  NEUTRAL_COLOR,
 } from '@/pages/segmentation/utils/instanceColors';
 
 interface CanvasPolygonProps {
@@ -209,7 +210,9 @@ const CanvasPolygon = React.memo(
         // label. `semanticColor` is pre-resolved by the parent (label colour, or
         // neutral gray when untyped), so this branch just returns it.
         if (colorMode === 'semantic') {
-          return semanticColor ?? 'hsl(0, 0%, 60%)';
+          // Shared NEUTRAL_COLOR (not a literal) so the untyped-MT gray here
+          // can't drift from resolveMtColor's untyped fallback.
+          return semanticColor ?? NEUTRAL_COLOR;
         }
         // Instance mode — seed priority: cross-frame trackId, then MT-prefixed
         // instanceId, then per-polygon UUID — guarantees a distinct colour per
@@ -446,7 +449,7 @@ const CanvasPolygon = React.memo(
           {isPolyline &&
             !isSelected &&
             validPoints.length >= 2 &&
-            projectType !== 'microtubules' && (
+            !isMicrotubuleProject(projectType) && (
               <>
                 <circle
                   cx={validPoints[0].x}

--- a/src/pages/segmentation/components/canvas/ModeInstructions.tsx
+++ b/src/pages/segmentation/components/canvas/ModeInstructions.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { EditMode, InteractionState } from '../../types';
 import { Point } from '@/lib/segmentation';
 import { useLanguage } from '@/contexts/useLanguage';
-import type { ProjectType } from '@/types';
+import { isMicrotubuleProject, type ProjectType } from '@/types';
 
 interface ModeInstructionsProps {
   editMode: EditMode;
@@ -31,7 +31,7 @@ const ModeInstructions: React.FC<ModeInstructionsProps> = ({
   // Microtubule annotations are open polylines: creation/extension is committed
   // with Enter (or double-click), not by closing back onto the first point. The
   // hints branch on this so MT users aren't told to "close the polygon".
-  const isMicrotubule = projectType === 'microtubules';
+  const isMicrotubule = isMicrotubuleProject(projectType);
   const [isVisible, setIsVisible] = useState(true);
 
   // Auto-hide instructions after 5 seconds in View mode

--- a/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
+++ b/src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx
@@ -20,7 +20,7 @@ import {
   Plus,
 } from 'lucide-react';
 import { useLanguage } from '@/contexts/useLanguage';
-import type { ProjectType } from '@/types';
+import { isMicrotubuleProject, type ProjectType } from '@/types';
 import type { MTTypeLabel } from '@/lib/api';
 import MtTypeLabelDialog from './MtTypeLabelDialog';
 import {
@@ -99,7 +99,7 @@ const PolygonContextMenu = ({
   onCreateMtLabel,
 }: PolygonContextMenuProps) => {
   const isSperm = projectType === 'sperm';
-  const isMicrotubules = projectType === 'microtubules';
+  const isMicrotubules = isMicrotubuleProject(projectType);
   // A microtubule with a cross-frame trackId: deleting it removes the whole
   // track, and it can be propagated forward.
   const hasTrack = isMicrotubules && !!trackId;

--- a/src/pages/segmentation/hooks/__tests__/useMtTypeLabels.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/useMtTypeLabels.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { apiMock, toastMock } = vi.hoisted(() => ({
+  apiMock: {
+    getMtTypeLabels: vi.fn(),
+    putMtTypeLabels: vi.fn(),
+    deleteMtTypeLabel: vi.fn(),
+  },
+  toastMock: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/lib/api', () => ({ default: apiMock }));
+vi.mock('sonner', () => ({ toast: toastMock }));
+vi.mock('@/contexts/useLanguage', () => ({
+  useLanguage: () => ({ t: (k: string) => k }),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { useMtTypeLabels } from '../useMtTypeLabels';
+
+const A = { id: 'a', name: 'alpha', color: '#ff0000' };
+const B = { id: 'b', name: 'beta', color: '#00ff00' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.getMtTypeLabels.mockResolvedValue([A]);
+  apiMock.putMtTypeLabels.mockImplementation(async (_p, labels) => labels);
+  apiMock.deleteMtTypeLabel.mockResolvedValue([]);
+});
+
+const load = async () => {
+  const hook = renderHook(() => useMtTypeLabels('p1', true));
+  await waitFor(() => expect(hook.result.current.labels).toEqual([A]));
+  return hook;
+};
+
+describe('useMtTypeLabels', () => {
+  it('loads the palette on mount when enabled', async () => {
+    const { result } = await load();
+    expect(apiMock.getMtTypeLabels).toHaveBeenCalledWith('p1');
+    expect(result.current.colorById.get('a')).toBe('#ff0000');
+  });
+
+  it('does not fetch when disabled', async () => {
+    renderHook(() => useMtTypeLabels('p1', false));
+    await Promise.resolve();
+    expect(apiMock.getMtTypeLabels).not.toHaveBeenCalled();
+  });
+
+  it('toasts on a failed palette load', async () => {
+    apiMock.getMtTypeLabels.mockRejectedValueOnce(new Error('boom'));
+    renderHook(() => useMtTypeLabels('p1', true));
+    await waitFor(() =>
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'microtubule.type.loadFailed'
+      )
+    );
+  });
+
+  it('createLabel persists a new label and returns it', async () => {
+    const { result } = await load();
+    let created: unknown;
+    await act(async () => {
+      created = await result.current.createLabel('EB3', '#123456');
+    });
+    expect(apiMock.putMtTypeLabels).toHaveBeenCalledTimes(1);
+    expect((created as { name: string }).name).toBe('EB3');
+  });
+
+  it('createLabel reuses an existing label with the same (case-insensitive) name', async () => {
+    const { result } = await load();
+    let created: unknown;
+    await act(async () => {
+      created = await result.current.createLabel('ALPHA', '#000000');
+    });
+    expect(created).toEqual(A); // reused, not a new id
+    expect(apiMock.putMtTypeLabels).not.toHaveBeenCalled();
+  });
+
+  it('createLabel returns null for a blank name without persisting', async () => {
+    const { result } = await load();
+    let created: unknown = 'x';
+    await act(async () => {
+      created = await result.current.createLabel('   ', '#000000');
+    });
+    expect(created).toBeNull();
+    expect(apiMock.putMtTypeLabels).not.toHaveBeenCalled();
+  });
+
+  it('createLabel toasts and returns null when the PUT fails', async () => {
+    apiMock.putMtTypeLabels.mockRejectedValueOnce(new Error('500'));
+    const { result } = await load();
+    let created: unknown = 'x';
+    await act(async () => {
+      created = await result.current.createLabel('EB3', '#123456');
+    });
+    expect(created).toBeNull();
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'microtubule.type.createFailed'
+    );
+  });
+
+  it('renameLabel blocks a rename onto another label’s name', async () => {
+    apiMock.getMtTypeLabels.mockResolvedValue([A, B]);
+    const hook = renderHook(() => useMtTypeLabels('p1', true));
+    await waitFor(() => expect(hook.result.current.labels).toHaveLength(2));
+    await act(async () => {
+      await hook.result.current.renameLabel('b', 'Alpha', '#00ff00');
+    });
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'microtubule.type.duplicateName'
+    );
+    expect(apiMock.putMtTypeLabels).not.toHaveBeenCalled();
+  });
+
+  it('deleteLabel toasts on failure and leaves labels unchanged', async () => {
+    apiMock.deleteMtTypeLabel.mockRejectedValueOnce(new Error('nope'));
+    const { result } = await load();
+    await act(async () => {
+      await result.current.deleteLabel('a');
+    });
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'microtubule.type.deleteFailed'
+    );
+    expect(result.current.labels).toEqual([A]); // unchanged
+  });
+});

--- a/src/pages/segmentation/hooks/__tests__/useResegment.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/useResegment.test.ts
@@ -92,16 +92,22 @@ describe('useResegment', () => {
   // ─── effectiveResegmentModel gating ────────────────────────────────────────
 
   it.each([
-    ['microtubules', 'microtubule'],
-    ['sperm', 'sperm'],
-    ['wound', 'wound'],
-    ['spheroid_invasive', 'unet_attention_aspp'],
-    ['spheroid', 'hrnet'],
+    // [projectType, selectedModel, expected] — single-model types force their
+    // whitelisted model regardless of selectedModel.
+    ['microtubules', 'hrnet', 'microtubule'],
+    ['sperm', 'hrnet', 'sperm'],
+    ['wound', 'hrnet', 'wound'],
+    ['microcapsule', 'hrnet', 'microcapsule'],
+    ['spheroid_invasive', 'hrnet', 'unet_attention_aspp'],
+    // spheroid has >1 compatible model → the user's pick is honored. Use a model
+    // distinct from compat[0] ('hrnet') so this proves selectedModel wins,
+    // rather than coincidentally matching the first registry entry.
+    ['spheroid', 'cbam_resunet', 'cbam_resunet'],
   ])(
-    'maps projectType=%s → effectiveResegmentModel=%s',
-    (projectType, expected) => {
+    'maps projectType=%s (selectedModel=%s) → effectiveResegmentModel=%s',
+    (projectType, selectedModel, expected) => {
       const { result } = renderHook(() =>
-        useResegment(makeParams({ projectType, selectedModel: 'hrnet' }))
+        useResegment(makeParams({ projectType, selectedModel }))
       );
       expect(result.current.effectiveResegmentModel).toBe(expected);
     }

--- a/src/pages/segmentation/hooks/useMtTypeLabels.ts
+++ b/src/pages/segmentation/hooks/useMtTypeLabels.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 // the named `{ apiClient }` import broke test mocks that only expose `default`.
 import apiClient, { type MTTypeLabel } from '@/lib/api';
 import { logger } from '@/lib/logger';
+import { toast } from 'sonner';
+import { useLanguage } from '@/contexts/useLanguage';
 
 /** Short unique id for a new label. Prefers crypto.randomUUID (secure context),
  *  falls back to a timestamp+random string for older/non-secure runtimes. */
@@ -33,6 +35,7 @@ export function useMtTypeLabels(
   projectId: string | undefined,
   enabled: boolean
 ): UseMtTypeLabelsResult {
+  const { t } = useLanguage();
   const [labels, setLabels] = useState<MTTypeLabel[]>([]);
 
   useEffect(() => {
@@ -43,13 +46,17 @@ export function useMtTypeLabels(
       .then(l => {
         if (alive) setLabels(l);
       })
-      .catch(err =>
-        logger.error('Failed to load MT type labels', err as Error)
-      );
+      .catch(err => {
+        logger.error('Failed to load MT type labels', err as Error);
+        // Surface the failure — otherwise the panel shows an empty label list
+        // for a project that HAS labels, and typed MTs render neutral, which
+        // reads as "labels were wiped".
+        if (alive) toast.error(t('microtubule.type.loadFailed'));
+      });
     return () => {
       alive = false;
     };
-  }, [projectId, enabled]);
+  }, [projectId, enabled, t]);
 
   const colorById = useMemo(
     () => new Map(labels.map(l => [l.id, l.color])),
@@ -80,28 +87,55 @@ export function useMtTypeLabels(
       );
       if (existing) return existing;
       const label: MTTypeLabel = { id: newLabelId(), name: trimmed, color };
-      await persist([...labels, label]);
-      return label;
+      try {
+        await persist([...labels, label]);
+        return label;
+      } catch (err) {
+        logger.error('Failed to create MT type label', err as Error);
+        toast.error(t('microtubule.type.createFailed'));
+        return null;
+      }
     },
-    [labels, persist]
+    [labels, persist, t]
   );
 
   const renameLabel = useCallback(
     async (id: string, name: string, color: string) => {
-      await persist(
-        labels.map(l => (l.id === id ? { ...l, name: name.trim(), color } : l))
+      const trimmed = name.trim();
+      // Guard against renaming onto ANOTHER label's name: the server dedupes by
+      // case-insensitive name (first wins), which would silently drop this label
+      // and dangle every MT pointing at its id.
+      const clash = labels.some(
+        l => l.id !== id && l.name.toLowerCase() === trimmed.toLowerCase()
       );
+      if (clash) {
+        toast.error(t('microtubule.type.duplicateName'));
+        return;
+      }
+      try {
+        await persist(
+          labels.map(l => (l.id === id ? { ...l, name: trimmed, color } : l))
+        );
+      } catch (err) {
+        logger.error('Failed to rename MT type label', err as Error);
+        toast.error(t('microtubule.type.renameFailed'));
+      }
     },
-    [labels, persist]
+    [labels, persist, t]
   );
 
   const deleteLabel = useCallback(
     async (id: string) => {
       if (!projectId) return;
-      const saved = await apiClient.deleteMtTypeLabel(projectId, id);
-      setLabels(saved);
+      try {
+        const saved = await apiClient.deleteMtTypeLabel(projectId, id);
+        setLabels(saved);
+      } catch (err) {
+        logger.error('Failed to delete MT type label', err as Error);
+        toast.error(t('microtubule.type.deleteFailed'));
+      }
     },
-    [projectId]
+    [projectId, t]
   );
 
   return {

--- a/src/pages/segmentation/hooks/useResegment.ts
+++ b/src/pages/segmentation/hooks/useResegment.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useMemo } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
+import { MODEL_TYPE_COMPATIBILITY, isProjectType } from '@/types';
 import apiClient, { type SegmentationPolygon } from '@/lib/api';
 import { logger } from '@/lib/logger';
 import { handleCancelledError } from '@/lib/errorUtils';
@@ -79,18 +80,17 @@ export function useResegment({
   // resegment (or image switch) invalidates a still-running poll.
   const resegPollSeqRef = useRef(0);
 
-  // The backend enforces a per-project-type model whitelist. The
-  // user-chosen `selectedModel` is meaningful only for the generic
-  // spheroid project — typed projects must use their matching model
-  // (`spheroid_invasive` → `unet_attention_aspp` per backend's
-  // MODEL_TYPE_COMPATIBILITY) or the request gets rejected.
+  // The backend enforces a per-project-type model whitelist
+  // (MODEL_TYPE_COMPATIBILITY). The user-chosen `selectedModel` is meaningful
+  // only where a type has >1 compatible model (the generic spheroid project);
+  // every other type has exactly one whitelisted model and must use it or the
+  // request is rejected. Read the SSOT registry directly rather than duplicating
+  // the type→model map, so it can never drift when a model is added/renamed.
   const effectiveResegmentModel = useMemo(() => {
-    if (projectType === 'microtubules') return 'microtubule';
-    if (projectType === 'sperm') return 'sperm';
-    if (projectType === 'wound') return 'wound';
-    if (projectType === 'microcapsule') return 'microcapsule';
-    if (projectType === 'spheroid_invasive') return 'unet_attention_aspp';
-    return selectedModel;
+    const compat = isProjectType(projectType)
+      ? MODEL_TYPE_COMPATIBILITY[projectType]
+      : undefined;
+    return compat && compat.length === 1 ? compat[0] : selectedModel;
   }, [projectType, selectedModel]);
 
   // Background poll that refreshes the editor when a resegment completes.

--- a/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
+++ b/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTargetTrackIds } from '../mtTypeTargets';
+
+const polys = [
+  { id: 'a', trackId: 't1' },
+  { id: 'b', trackId: 't2' },
+  { id: 'c', trackId: 't1' }, // same track as 'a'
+  { id: 'd', trackId: null }, // untracked
+  { id: 'e' }, // no trackId at all
+];
+
+describe('resolveTargetTrackIds', () => {
+  it('resolves the single right-clicked polygon to its track', () => {
+    expect(resolveTargetTrackIds('a', new Set(), polys)).toEqual(['t1']);
+  });
+
+  it('ignores a 1-element selection and uses the clicked polygon', () => {
+    // A lone selection must not shadow a right-click on a different MT.
+    expect(resolveTargetTrackIds('b', new Set(['a']), polys)).toEqual(['t2']);
+  });
+
+  it('acts on the whole selection once it has ≥2 members', () => {
+    const out = resolveTargetTrackIds('a', new Set(['a', 'b']), polys);
+    expect(out.sort()).toEqual(['t1', 't2']);
+  });
+
+  it('dedupes tracks when several selected polygons share one', () => {
+    expect(resolveTargetTrackIds('a', new Set(['a', 'c']), polys)).toEqual([
+      't1',
+    ]);
+  });
+
+  it('returns [] for an untracked polygon (caller aborts with a toast)', () => {
+    expect(resolveTargetTrackIds('d', new Set(), polys)).toEqual([]);
+    expect(resolveTargetTrackIds('e', new Set(), polys)).toEqual([]);
+  });
+
+  it('drops untracked members from a multi-selection', () => {
+    const out = resolveTargetTrackIds('a', new Set(['a', 'd', 'e']), polys);
+    expect(out).toEqual(['t1']);
+  });
+
+  it('returns [] when the clicked id is not among the polygons', () => {
+    expect(resolveTargetTrackIds('ghost', new Set(), polys)).toEqual([]);
+  });
+});

--- a/src/pages/segmentation/utils/mtTypeTargets.ts
+++ b/src/pages/segmentation/utils/mtTypeTargets.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure resolution of which microtubule *tracks* a "change type" action targets.
+ *
+ * The context-menu action can fire on a single polygon (right-clicked) or on a
+ * multi-selection. Type is a whole-track property, so we map the affected
+ * polygons to their `trackId`s and dedupe. Polylines without a `trackId` (never
+ * tracked, or a stray un-tracked draw) contribute nothing — an empty result is
+ * the caller's signal to abort with a "no track" toast rather than PATCH with an
+ * empty id list.
+ */
+export interface TrackedPolygon {
+  id: string;
+  trackId?: string | null;
+}
+
+export function resolveTargetTrackIds(
+  polygonId: string,
+  selectedIds: ReadonlySet<string>,
+  polygons: ReadonlyArray<TrackedPolygon>
+): string[] {
+  // A lone right-click acts on that polygon; a real multi-selection (≥2) acts
+  // on the whole selection. A 1-element selection is treated as the single
+  // case so right-clicking an unselected MT still works.
+  const targetIds = selectedIds.size >= 2 ? [...selectedIds] : [polygonId];
+  return Array.from(
+    new Set(
+      targetIds
+        .map(id => polygons.find(p => p.id === id)?.trackId)
+        .filter(
+          (tid): tid is string => typeof tid === 'string' && tid.length > 0
+        )
+    )
+  );
+}

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2176,6 +2176,11 @@ export default {
       labelDialogDescription: 'Pojmenujte typ tubulinu a vyberte barvu.',
       updated: 'Typ mikrotubulu upraven',
       updateFailed: 'Nepodařilo se upravit typ mikrotubulu',
+      createFailed: 'Nepodařilo se vytvořit label',
+      renameFailed: 'Nepodařilo se přejmenovat label',
+      deleteFailed: 'Nepodařilo se smazat label',
+      loadFailed: 'Nepodařilo se načíst typové labely',
+      duplicateName: 'Label s tímto názvem už existuje',
       noTrack:
         'Tento mikrotubulus zatím nemá track — nejprve spusťte trackování.',
     },

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2172,6 +2172,11 @@ export default {
         'Benennen Sie den Tubulin-Typ und wählen Sie eine Farbe.',
       updated: 'Mikrotubulus-Typ aktualisiert',
       updateFailed: 'Mikrotubulus-Typ konnte nicht aktualisiert werden',
+      createFailed: 'Label konnte nicht erstellt werden',
+      renameFailed: 'Label konnte nicht umbenannt werden',
+      deleteFailed: 'Label konnte nicht gelöscht werden',
+      loadFailed: 'Typ-Labels konnten nicht geladen werden',
+      duplicateName: 'Ein Label mit diesem Namen existiert bereits',
       noTrack:
         'Dieser Mikrotubulus hat noch keinen Track — führen Sie zuerst das Tracking aus.',
     },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2243,6 +2243,11 @@ export default {
       labelDialogDescription: 'Name the tubulin type and pick a colour.',
       updated: 'Microtubule type updated',
       updateFailed: 'Failed to update microtubule type',
+      createFailed: 'Failed to create label',
+      renameFailed: 'Failed to rename label',
+      deleteFailed: 'Failed to delete label',
+      loadFailed: 'Failed to load type labels',
+      duplicateName: 'A label with this name already exists',
       noTrack: 'This microtubule has no track yet — run tracking first.',
     },
     color: {

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2211,6 +2211,11 @@ export default {
       labelDialogDescription: 'Nombre el tipo de tubulina y elija un color.',
       updated: 'Tipo de microtúbulo actualizado',
       updateFailed: 'No se pudo actualizar el tipo de microtúbulo',
+      createFailed: 'No se pudo crear la etiqueta',
+      renameFailed: 'No se pudo renombrar la etiqueta',
+      deleteFailed: 'No se pudo eliminar la etiqueta',
+      loadFailed: 'No se pudieron cargar las etiquetas de tipo',
+      duplicateName: 'Ya existe una etiqueta con este nombre',
       noTrack:
         'Este microtúbulo aún no tiene seguimiento — ejecute primero el seguimiento.',
     },

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2161,6 +2161,11 @@ export default {
         'Nommez le type de tubuline et choisissez une couleur.',
       updated: 'Type de microtubule mis à jour',
       updateFailed: 'Échec de la mise à jour du type de microtubule',
+      createFailed: 'Échec de la création du label',
+      renameFailed: 'Échec du renommage du label',
+      deleteFailed: 'Échec de la suppression du label',
+      loadFailed: 'Échec du chargement des labels de type',
+      duplicateName: 'Un label portant ce nom existe déjà',
       noTrack:
         'Ce microtubule n’a pas encore de piste — lancez d’abord le suivi.',
     },

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -2030,6 +2030,11 @@ export default {
       labelDialogDescription: '为微管蛋白类型命名并选择颜色。',
       updated: '微管类型已更新',
       updateFailed: '更新微管类型失败',
+      createFailed: '创建标签失败',
+      renameFailed: '重命名标签失败',
+      deleteFailed: '删除标签失败',
+      loadFailed: '加载类型标签失败',
+      duplicateName: '已存在同名标签',
       noTrack: '该微管尚无轨迹 — 请先运行追踪。',
     },
     color: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -354,6 +354,13 @@ export type ProjectType = (typeof PROJECT_TYPES)[number];
 export const isProjectType = (v: unknown): v is ProjectType =>
   typeof v === 'string' && (PROJECT_TYPES as readonly string[]).includes(v);
 
+/** True for microtubule projects. Prefer this shared predicate over a bare
+ *  `t === 'microtubules'` literal: the project type is the PLURAL `microtubules`
+ *  while the model id is the SINGULAR `microtubule`, and mixing them up has
+ *  already shipped a bug (silently hiding the MT export section). */
+export const isMicrotubuleProject = (t: string | undefined | null): boolean =>
+  t === 'microtubules';
+
 /** All known model identifiers, derived from the frontend model registry
  *  SSOT (`@/lib/models/modelRegistry`), which mirrors the backend SSOT.
  *  Re-exported as `KnownModelId` so existing `@/types` consumers are


### PR DESCRIPTION
## Project-type consolidation + dead-code cleanup

Quality-only refactor (no behavior change, not deployed) from a `/simplify` pass with 4 parallel review agents. Consolidates scattered project-type branching and removes dead code.

### Consolidated
- **Shared `isMicrotubuleProject(t)` predicate** (FE `@/types`, BE `types/validation`) replacing ~11 hand-written `=== 'microtubules'` literals across the editor, export, and upload paths — removes the documented **plural-type (`microtubules`) vs singular-model-id (`microtubule`) footgun** that once silently hid the MT export section.
- **`useResegment`** now derives the effective model from `MODEL_TYPE_COMPATIBILITY` (the model-registry SSOT) instead of a hand-maintained type→model ladder that could drift when a model is added/renamed.
- **`exportService`**: hoist the `isMicrotubuleProject` flag and reuse it at all 5 sites (was re-inlined with `?? ''` noise).

### Efficiency
- `resolveMtColor` is no longer computed per microtubule on every render in the default **instance** colour mode (CanvasPolygon only reads it in **semantic** mode).

### Dead code removed
- `VideoModeOverlay.useVideoModeProps` (zero production callers) and the always-no-op `onActiveFrameChange` prop path (+ their now-obsolete tests).

### Verification
BE `tsc` clean, FE ESLint clean, and every affected FE+BE test updated and passing (6 test mocks that the new shared export otherwise broke were fixed).

### Deliberately deferred (noted, not in this PR)
- Palette fetched 3–4× per export job → fetch-once (export-pipeline change; needs export E2E).
- A `PROJECT_TYPE_DESCRIPTOR` / `ProjectTypeExportSpec` capability table (larger refactor; needs per-project-type E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved microtubule label management with clearer feedback when creating, renaming, deleting, or loading labels.
  * Added better handling for label replacement, including reporting how many frames were cleaned up.
* **Bug Fixes**
  * Fixed microtubule-specific actions and export behavior to use consistent project detection across the app.
  * Improved segmentation workflows so track changes target the correct items more reliably.
  * Added validation for label updates to prevent oversized requests and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->