### PR TITLE
feat(polyline): generic polyline primitive + MT export/editor improvements

### DIFF
--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -220,6 +220,33 @@ def _dilate(mask: np.ndarray, radius: int) -> np.ndarray:
     return cv2.dilate(mask, kernel)
 
 
+def _vicinity_mask(
+    band: np.ndarray, not_signal: np.ndarray, margin_radius: int
+) -> np.ndarray:
+    """One microtubule's background ring: ``dilate(band, margin_radius)`` minus
+    every signal band (``not_signal`` = the complement of the union of all
+    bands).
+
+    The dilation runs only within the band's bounding box expanded by
+    ``margin_radius`` — a band is tiny relative to the frame, so this is O(bbox)
+    instead of O(H*W). Since the band's pixels sit at least ``margin_radius``
+    inside the sub-window (or at a real frame edge), the windowed dilation is
+    bit-identical to a full-frame dilate. Empty band → empty ring.
+    """
+    ys, xs = np.nonzero(band)
+    vicinity = np.zeros(band.shape, dtype=bool)
+    if ys.size == 0:
+        return vicinity
+    h, w = band.shape
+    y0 = max(0, int(ys.min()) - margin_radius)
+    y1 = min(h, int(ys.max()) + margin_radius + 1)
+    x0 = max(0, int(xs.min()) - margin_radius)
+    x1 = min(w, int(xs.max()) + margin_radius + 1)
+    capsule = _dilate(band[y0:y1, x0:x1], margin_radius)
+    vicinity[y0:y1, x0:x1] = (capsule > 0) & not_signal[y0:y1, x0:x1]
+    return vicinity
+
+
 def _normalize_axes_nd2(arr: np.ndarray, axes: str) -> np.ndarray:
     """Permute / expand an ND2 array to canonical (T, C, Y, X)."""
     if "Z" in axes and arr.ndim >= 3:
@@ -578,10 +605,10 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
         for m in band_masks:
             signal_union |= m
         not_signal = signal_union == 0
-        vicinity_masks: List[np.ndarray] = []
-        for band in band_masks:
-            capsule = _dilate(band, margin_radius)
-            vicinity_masks.append((capsule > 0) & not_signal)
+        vicinity_masks: List[np.ndarray] = [
+            _vicinity_mask(band, not_signal, margin_radius)
+            for band in band_masks
+        ]
 
         # 4. Per-channel computations.
         # Per-frame registration offsets (channel-registration at upload), one
@@ -618,9 +645,16 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
                 vicinity_masks, fr, name, rows,
             )
 
+    # Count rows whose per-MT vicinity ring came out empty (background nulled).
+    # With the local ring this is more common than the old frame-global mask
+    # (an MT hugged by neighbours or clipped at the frame edge can have no
+    # ring), so surface it — otherwise scattered blank background cells look
+    # like a bug rather than "no local background available".
+    null_bg = sum(1 for r in rows if r.median_background is None)
     logger.info(
-        "mt-metrics: produced %d rows from %d frames",
-        len(rows), len(req.frames),
+        "mt-metrics: produced %d rows from %d frames (%d with empty local "
+        "background ring → null background)",
+        len(rows), len(req.frames), null_bg,
     )
     return MTMetricsResponse(
         rows=rows,

--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -129,8 +129,10 @@ class MTMetricsRow(BaseModel):
     mean_intensity: float
     median_intensity: float
     std_intensity: float
-    # null when the background mask is empty (every pixel in the dilated
-    # signal union) or when the band mask is empty.
+    # Per-MT LOCAL background: median/mean of the pixels in THIS microtubule's
+    # own vicinity ring (out to thickness*margin_multiplier around its band,
+    # excluding every MT's signal band). null when that ring is empty or the
+    # band mask is empty.
     median_background: Optional[float] = None
     mean_background: Optional[float] = None
     signal_minus_background: Optional[float] = None
@@ -392,7 +394,7 @@ def _emit_channel_rows(
     frame_arr: np.ndarray,
     band_masks: List[np.ndarray],
     polyline_lengths: List[float],
-    background_mask: np.ndarray,
+    vicinity_masks: List[np.ndarray],
     fr: "MTFrameInput",
     channel_name: str,
     rows: List["MTMetricsRow"],
@@ -402,17 +404,20 @@ def _emit_channel_rows(
     Shared by the volume-backed and PNG-backed channel paths so both compute
     background + per-band statistics identically. ``frame_arr`` is the channel's
     raster already cast to float64 and (for volume channels) shifted into the
-    registered space.
+    registered space. Each microtubule's background is sampled from its OWN
+    local vicinity ring (``vicinity_masks[pl_idx]``), not a frame-global region.
     """
-    bg_pixels = frame_arr[background_mask]
-    has_bg = bg_pixels.size > 0
-    median_bg = float(np.median(bg_pixels)) if has_bg else None
-    mean_bg = float(bg_pixels.mean()) if has_bg else None
-
     for pl_idx, pl in enumerate(fr.polylines):
         band = band_masks[pl_idx]
         pixels = frame_arr[band > 0]
         pixel_count = int(pixels.size)
+
+        # Per-MT LOCAL background: pixels in this microtubule's vicinity ring.
+        bg_pixels = frame_arr[vicinity_masks[pl_idx]]
+        has_bg = bg_pixels.size > 0
+        median_bg = float(np.median(bg_pixels)) if has_bg else None
+        mean_bg = float(bg_pixels.mean()) if has_bg else None
+
         if pixel_count == 0:
             sum_v = mean_v = median_v = std_v = 0.0
             signal_minus_bg: Optional[float] = None
@@ -455,14 +460,15 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
 
     Algorithm per frame:
       1. Rasterise each polyline into a thickness-wide binary mask.
-      2. Union all band masks; dilate the union by
-         ``thickness * margin_multiplier`` for the background exclusion.
-      3. background_mask = NOT dilated_union.
-      4. For each requested channel:
-           - median_background / mean_background = median resp. mean of
-             pixels under background_mask.
-           - For each polyline: pixel_count / sum / mean / median / std
-             under that polyline's band; emit one row.
+      2. Union all band masks (the "signal" all MTs occupy).
+      3. Per MT: vicinity = dilate(its band, thickness*margin_multiplier) minus
+         the signal union — a local ring hugging that MT, excluding every MT's
+         band.
+      4. For each requested channel, for each polyline:
+           - median/mean_background = median resp. mean of the pixels in THAT
+             microtubule's own vicinity ring (local, not frame-global).
+           - pixel_count / sum / mean / median / std under its band.
+           - emit one row.
     """
     if len(req.channel_indices) != len(req.channel_names):
         raise HTTPException(
@@ -563,12 +569,19 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
             band_masks.append(_rasterize_band(pts, H, W, req.thickness_px))
             polyline_lengths.append(_polyline_length(pts))
 
-        # 2 + 3. Background mask = NOT (dilated union of bands).
+        # 2 + 3. Per-MT LOCAL background. Each microtubule's background is the
+        # ring within `margin_radius` of ITS OWN band (dilate(band)), minus the
+        # union of every MT's signal band — so a neighbouring microtubule never
+        # counts as background. Computed once per frame (geometry is
+        # channel-independent) and reused across channels.
         signal_union = np.zeros((H, W), dtype=np.uint8)
         for m in band_masks:
             signal_union |= m
-        signal_dilated = _dilate(signal_union, margin_radius)
-        background_mask = signal_dilated == 0
+        not_signal = signal_union == 0
+        vicinity_masks: List[np.ndarray] = []
+        for band in band_masks:
+            capsule = _dilate(band, margin_radius)
+            vicinity_masks.append((capsule > 0) & not_signal)
 
         # 4. Per-channel computations.
         # Per-frame registration offsets (channel-registration at upload), one
@@ -590,7 +603,7 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
             frame_arr = raw.astype(np.float64)
             _emit_channel_rows(
                 frame_arr, band_masks, polyline_lengths,
-                background_mask, fr, channel_name, rows,
+                vicinity_masks, fr, channel_name, rows,
             )
 
         # PNG-backed (added) channels: sampled from the per-frame PNG, already
@@ -602,7 +615,7 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
                 continue
             _emit_channel_rows(
                 frame_arr, band_masks, polyline_lengths,
-                background_mask, fr, name, rows,
+                vicinity_masks, fr, name, rows,
             )
 
     logger.info(

--- a/backend/src/services/__tests__/exportService.gaps.test.ts
+++ b/backend/src/services/__tests__/exportService.gaps.test.ts
@@ -618,7 +618,8 @@ describe('ExportService — generateAnnotations dispatch', () => {
           width: 640,
           height: 480,
         }),
-      ])
+      ]),
+      undefined // projectType (the test helper passes none)
     );
     const writeCalls = vi.mocked(fs.writeFile).mock.calls;
     expect(
@@ -641,7 +642,8 @@ describe('ExportService — generateAnnotations dispatch', () => {
     expect(mockConvertToCOCO).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ width: 320, height: 240 }),
-      ])
+      ]),
+      undefined
     );
   });
 
@@ -655,7 +657,8 @@ describe('ExportService — generateAnnotations dispatch', () => {
     expect(mockConvertToCOCO).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ segmentationResults: [] }),
-      ])
+      ]),
+      undefined
     );
   });
 

--- a/backend/src/services/export/__tests__/formatConverter.test.ts
+++ b/backend/src/services/export/__tests__/formatConverter.test.ts
@@ -94,7 +94,7 @@ describe('FormatConverter', () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       expect(coco.categories).toEqual([
         expect.objectContaining({ id: 1, name: 'cell' }),
@@ -106,7 +106,7 @@ describe('FormatConverter', () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon, spermHead]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       expect(coco.categories).toEqual([
         expect.objectContaining({ id: 1, name: 'cell' }),
@@ -118,7 +118,7 @@ describe('FormatConverter', () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       expect(coco.annotations).toHaveLength(1);
       const ann = coco.annotations[0];
@@ -136,7 +136,7 @@ describe('FormatConverter', () => {
         spermTail,
       ]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       const polylineAnns = coco.annotations.filter(a => a.category_id === 2);
       expect(polylineAnns).toHaveLength(3);
@@ -167,7 +167,7 @@ describe('FormatConverter', () => {
       };
       const data = buildImageData([closedPolygon, orphan]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       const spermAnns = coco.annotations.filter(a => a.category_id === 2);
       expect(spermAnns).toHaveLength(0);
@@ -191,7 +191,7 @@ describe('FormatConverter', () => {
       };
       const data = buildImageData([typo]);
 
-      const { data: coco } = await converter.convertToCOCO([data]);
+      const { data: coco } = await converter.convertToCOCO([data], 'sperm');
 
       expect(coco.annotations.filter(a => a.category_id === 2)).toHaveLength(0);
       expect(mockedLogger.warn).toHaveBeenCalledWith(
@@ -212,7 +212,7 @@ describe('FormatConverter', () => {
         filename: 'b.png',
       });
 
-      const { data: coco } = await converter.convertToCOCO([data1, data2]);
+      const { data: coco } = await converter.convertToCOCO([data1, data2], 'sperm');
 
       const ids = coco.annotations.map(a => a.id);
       expect(new Set(ids).size).toBe(ids.length);
@@ -278,7 +278,7 @@ describe('FormatConverter', () => {
       const converter = new FormatConverter();
       const data = buildImageData([closedPolygon]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const seg = out.images[0]?.segmentation;
 
       expect(seg?.polygons.external).toHaveLength(1);
@@ -297,7 +297,7 @@ describe('FormatConverter', () => {
         spermTail,
       ]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const seg = out.images[0]?.segmentation;
 
       expect(seg?.polygons.external).toHaveLength(1);
@@ -325,7 +325,7 @@ describe('FormatConverter', () => {
       };
       const data = buildImageData([orphan]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const seg = out.images[0]?.segmentation;
 
       expect(seg?.polylines).toHaveLength(1);
@@ -358,7 +358,7 @@ describe('FormatConverter', () => {
         sperm2Mid,
       ]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const seg = out.images[0]?.segmentation;
 
       expect(seg?.spermInstances).toHaveLength(2);
@@ -376,7 +376,7 @@ describe('FormatConverter', () => {
       const converter = new FormatConverter();
       const data = buildImageData([spermHead, spermMidpiece, spermTail]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const seg = out.images[0]?.segmentation;
 
       expect(seg?.polygons.external).toHaveLength(0);
@@ -394,7 +394,7 @@ describe('FormatConverter', () => {
       };
       const data = buildImageData([typo]);
 
-      const { data: out } = await converter.convertToJSON([data]);
+      const { data: out } = await converter.convertToJSON([data], 'sperm');
       const polylines = out.images[0]?.segmentation?.polylines;
 
       expect(polylines).toHaveLength(1);
@@ -411,7 +411,7 @@ describe('FormatConverter', () => {
         spermTail,
       ]);
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
       const ids = coco.annotations.map(a => a.id);
       expect(new Set(ids).size).toBe(ids.length);
       expect(ids).toEqual([1, 2, 3, 4]);
@@ -438,7 +438,7 @@ describe('FormatConverter', () => {
     it('COCO infers header dimensions from polygon extents when width/height are 0', async () => {
       const data = buildImageData([largePolygon], { width: 0, height: 0 });
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
 
       expect(coco.images).toHaveLength(1);
       expect(coco.images[0].width).toBeGreaterThanOrEqual(1286);
@@ -454,7 +454,7 @@ describe('FormatConverter', () => {
     it('JSON infers header dimensions from polygon extents when width/height are 0', async () => {
       const data = buildImageData([largePolygon], { width: 0, height: 0 });
 
-      const { data: json } = await new FormatConverter().convertToJSON([data]);
+      const { data: json } = await new FormatConverter().convertToJSON([data], 'sperm');
 
       expect(json.images[0].dimensions.width).toBeGreaterThanOrEqual(1286);
       expect(json.images[0].dimensions.height).toBeGreaterThanOrEqual(1293);
@@ -468,7 +468,7 @@ describe('FormatConverter', () => {
         height: 1536,
       });
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
 
       expect(coco.images[0].width).toBe(2048);
       expect(coco.images[0].height).toBe(1536);
@@ -477,7 +477,7 @@ describe('FormatConverter', () => {
     it('preserves a known axis when only the other is missing', async () => {
       const data = buildImageData([largePolygon], { width: 1286, height: 0 });
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
 
       // Known width is kept verbatim; only height is inferred from extents.
       expect(coco.images[0].width).toBe(1286);
@@ -487,7 +487,7 @@ describe('FormatConverter', () => {
     it('logs error (not warn) when no polygons and dims are missing', async () => {
       const data = buildImageData([], { width: 0, height: 0 });
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
 
       expect(coco.images[0].width).toBe(0);
       expect(coco.images[0].height).toBe(0);
@@ -528,7 +528,7 @@ describe('FormatConverter', () => {
       };
       const data = buildImageData([external, hole], { width: 0, height: 0 });
 
-      const { data: coco } = await new FormatConverter().convertToCOCO([data]);
+      const { data: coco } = await new FormatConverter().convertToCOCO([data], 'sperm');
 
       const ann = coco.annotations[0];
       expect(ann.iscrowd).toBe(1);
@@ -539,5 +539,60 @@ describe('FormatConverter', () => {
       expect(rle.size[0]).toBeGreaterThanOrEqual(101);
       expect(rle.size[1]).toBeGreaterThanOrEqual(101);
     });
+  });
+});
+
+// A polyline is a generic primitive — the converter must NOT assume sperm for a
+// microtubule (or any non-sperm) project. These lock the project-type-driven
+// category + the absence of sperm-only fields.
+describe('FormatConverter — non-sperm (generic/microtubule) polylines', () => {
+  const mtPolyline: Polygon = {
+    id: 'pl-mt',
+    type: 'external',
+    geometry: 'polyline',
+    // No partClass — microtubule polylines never carry head/midpiece/tail.
+    instanceId: 'mt_abc12345',
+    points: [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 5, y: 6 },
+    ],
+  };
+
+  it('COCO: emits MT polylines under a "microtubule" category with no partClass', async () => {
+    const data = buildImageData([closedPolygon, mtPolyline]);
+    const { data: coco } = await new FormatConverter().convertToCOCO(
+      [data],
+      'microtubules'
+    );
+
+    const polylineAnns = coco.annotations.filter(a => a.category_id === 2);
+    expect(polylineAnns).toHaveLength(1);
+    expect(polylineAnns[0].attributes?.partClass).toBeUndefined();
+    expect(polylineAnns[0].attributes?.instanceId).toBe('mt_abc12345');
+    expect(coco.categories.find(c => c.id === 2)?.name).toBe('microtubule');
+    expect(coco.categories.find(c => c.name === 'sperm')).toBeUndefined();
+  });
+
+  it('COCO: a non-sperm/non-MT project labels the polyline category "polyline"', async () => {
+    const data = buildImageData([mtPolyline]);
+    const { data: coco } = await new FormatConverter().convertToCOCO(
+      [data],
+      'spheroid'
+    );
+    expect(coco.categories.find(c => c.id === 2)?.name).toBe('polyline');
+  });
+
+  it('JSON: MT polylines are emitted flat, never grouped as spermInstances', async () => {
+    const data = buildImageData([mtPolyline]);
+    const { data: out } = await new FormatConverter().convertToJSON(
+      [data],
+      'microtubules'
+    );
+    const seg = out.images[0].segmentation;
+    expect(seg?.polylines).toHaveLength(1);
+    expect(seg?.polylines?.[0].partClass).toBeUndefined();
+    expect(seg?.spermInstances).toBeUndefined();
+    expect(seg?.statistics.totalSpermInstances).toBeUndefined();
   });
 });

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -570,14 +570,15 @@ describe('buildVideoRoiEntries', () => {
     ];
 
     const build = buildVideoRoiEntries(frames);
+    // Untyped MT (trackId '7') → `untyped_1`, stable across its frames.
     expect(build.entries.map(e => e.name)).toEqual([
-      '7__frame_0000.roi',
-      '7__frame_0002.roi',
+      'untyped_1__frame_0000.roi',
+      'untyped_1__frame_0002.roi',
     ]);
 
     const map = byName(build.entries);
-    const f0 = decodeRoi(map.get('7__frame_0000.roi')!.buffer);
-    const f2 = decodeRoi(map.get('7__frame_0002.roi')!.buffer);
+    const f0 = decodeRoi(map.get('untyped_1__frame_0000.roi')!.buffer);
+    const f2 = decodeRoi(map.get('untyped_1__frame_0002.roi')!.buffer);
     expect(f0.position).toBe(1); // frameIndex 0 → slice 1
     expect(f2.position).toBe(3); // frameIndex 2 → slice 3
     // Same track ⇒ identical colour across frames, and it must be a real
@@ -639,12 +640,12 @@ describe('buildVideoRoiEntries', () => {
     );
     expect(build.entries).toHaveLength(1);
     const d = decodeRoi(build.entries[0].buffer);
-    // Class name prefixes the ROI name…
-    expect(d.name.startsWith('alpha__')).toBe(true);
+    // Class name + per-type counter is the ROI name (first alpha ⇒ alpha_1)…
+    expect(d.name).toBe('alpha_1');
     // …and the stroke colour is the label's colour (not the per-track hue).
     expect(d.strokeColor).toBe(imageJColorFromHex('#ff0000'));
-    // The zip entry filename also carries the class prefix.
-    expect(build.entries[0].name.startsWith('alpha__')).toBe(true);
+    // The zip entry filename also carries the class name.
+    expect(build.entries[0].name.startsWith('alpha_1__')).toBe(true);
   });
 
   it('keeps the per-track hue for an untyped polyline (no palette match)', () => {
@@ -703,8 +704,9 @@ describe('buildVideoRoiEntries', () => {
       },
     ]);
     const d = decodeRoi(build.entries[0].buffer);
-    expect(d.name.startsWith('alpha__')).toBe(false);
-    expect(d.name.startsWith('t1')).toBe(true);
+    // No palette ⇒ the class can't resolve, so the MT is named as untyped.
+    expect(d.name.startsWith('alpha')).toBe(false);
+    expect(d.name).toBe('untyped_1');
   });
 
   it('processes frames in frameIndex order regardless of input order', () => {
@@ -739,8 +741,8 @@ describe('buildVideoRoiEntries', () => {
       },
     ]);
     expect(build.entries.map(e => e.name)).toEqual([
-      '7__frame_0000.roi',
-      '7__frame_0002.roi',
+      'untyped_1__frame_0000.roi',
+      'untyped_1__frame_0002.roi',
     ]);
   });
 
@@ -767,8 +769,12 @@ describe('buildVideoRoiEntries', () => {
       },
     ]);
     const names = build.entries.map(e => e.name).sort();
-    // Sorted: '2' (0x32) < '_' (0x5F), so '7_2__' precedes '7__'.
-    expect(names).toEqual(['7_2__frame_0000.roi', '7__frame_0000.roi']);
+    // Both share trackId '7' ⇒ both resolve to 'untyped_1'; the in-frame dedup
+    // suffixes the second. Sorted: '2' (0x32) < '_' (0x5F), so the _2 precedes.
+    expect(names).toEqual([
+      'untyped_1_2__frame_0000.roi',
+      'untyped_1__frame_0000.roi',
+    ]);
     expect(build.droppedPolygons).toBe(1);
     expect(build.framesWithRois).toBe(1);
   });
@@ -803,7 +809,9 @@ describe('buildVideoRoiEntries', () => {
     ]);
     expect(build.corruptFrames).toBe(1);
     expect(build.droppedPolygons).toBe(1);
-    expect(build.entries.map(e => e.name)).toEqual(['ok__frame_0001.roi']);
+    expect(build.entries.map(e => e.name)).toEqual([
+      'untyped_1__frame_0001.roi',
+    ]);
   });
 
   it('falls back to a generated label for untracked / empty-trackId polylines', () => {
@@ -831,6 +839,121 @@ describe('buildVideoRoiEntries', () => {
     expect(names).toEqual([
       'roi_0001__frame_0000.roi',
       'roi_0002__frame_0000.roi',
+    ]);
+  });
+
+  it('numbers each tubulin type from 1 (HeLa_1, HeLa_2, brain_1, brain_2)', () => {
+    const palette = new Map([
+      ['h', { name: 'HeLa', color: '#ff0000' }],
+      ['b', { name: 'brain', color: '#00ff00' }],
+    ]);
+    const mt = (trackId: string, type: string, x: number) => ({
+      trackId,
+      geometry: 'polyline' as const,
+      mtType: type,
+      points: [
+        { x: 0, y: 0 },
+        { x, y: x },
+      ],
+    });
+    const build = buildVideoRoiEntries(
+      [
+        {
+          id: 'f0',
+          name: 'v',
+          parentVideoId: 'c1',
+          frameIndex: 0,
+          segmentation: {
+            polygons: JSON.stringify([
+              mt('t1', 'h', 1),
+              mt('t2', 'b', 2),
+              mt('t3', 'h', 3),
+              mt('t4', 'b', 4),
+            ]),
+          },
+        },
+      ],
+      undefined,
+      palette
+    );
+    expect(build.entries.map(e => decodeRoi(e.buffer).name)).toEqual([
+      'HeLa_1',
+      'brain_1',
+      'HeLa_2',
+      'brain_2',
+    ]);
+  });
+
+  it('keeps one microtubule identically named across frames (trackId-keyed)', () => {
+    const palette = new Map([['h', { name: 'HeLa', color: '#ff0000' }]]);
+    const mk = (idx: number) => ({
+      id: `f${idx}`,
+      name: 'v',
+      parentVideoId: 'c1',
+      frameIndex: idx,
+      segmentation: {
+        polygons: JSON.stringify([
+          {
+            trackId: 't9',
+            geometry: 'polyline',
+            mtType: 'h',
+            points: [
+              { x: 0, y: idx },
+              { x: 5, y: idx },
+            ],
+          },
+        ]),
+      },
+    });
+    const build = buildVideoRoiEntries([mk(0), mk(1)], undefined, palette);
+    expect(build.entries.map(e => decodeRoi(e.buffer).name)).toEqual([
+      'HeLa_1',
+      'HeLa_1',
+    ]);
+  });
+
+  it('lets a manual rename override the <type>_<counter> scheme', () => {
+    const palette = new Map([['h', { name: 'HeLa', color: '#ff0000' }]]);
+    const build = buildVideoRoiEntries(
+      [
+        {
+          id: 'f0',
+          name: 'v',
+          parentVideoId: 'c1',
+          frameIndex: 0,
+          segmentation: {
+            polygons: JSON.stringify([
+              {
+                trackId: 't1',
+                geometry: 'polyline',
+                mtType: 'h',
+                name: 'spindle-pole',
+                points: [
+                  { x: 0, y: 0 },
+                  { x: 1, y: 1 },
+                ],
+              },
+              {
+                trackId: 't2',
+                geometry: 'polyline',
+                mtType: 'h',
+                points: [
+                  { x: 0, y: 0 },
+                  { x: 2, y: 2 },
+                ],
+              },
+            ]),
+          },
+        },
+      ],
+      undefined,
+      palette
+    );
+    // The renamed MT uses its name verbatim and does NOT consume a HeLa counter,
+    // so the next HeLa is HeLa_1.
+    expect(build.entries.map(e => decodeRoi(e.buffer).name)).toEqual([
+      'spindle-pole',
+      'HeLa_1',
     ]);
   });
 
@@ -952,8 +1075,8 @@ describe('exportImageJRoiSets', () => {
     expect(zip.subarray(0, 2).toString('ascii')).toBe('PK'); // local file header
     expect(zipEntryCount(zip)).toBe(2);
     expect(zipEntryNames(zip).sort()).toEqual([
-      '1__frame_0000.roi',
-      '2__frame_0000.roi',
+      'untyped_1__frame_0000.roi',
+      'untyped_2__frame_0000.roi',
     ]);
   });
 
@@ -1035,7 +1158,7 @@ describe('exportImageJRoiSets', () => {
     const zip = await fs.readFile(
       path.join(out, 'annotations', 'imagej', 'v_RoiSet.zip')
     );
-    const roi = decodeRoi(zipExtract(zip, 'mt_42__frame_0004.roi'));
+    const roi = decodeRoi(zipExtract(zip, 'untyped_1__frame_0004.roi'));
     expect(roi.type).toBe(ROI_TYPE_POLYLINE);
     expect(roi.position).toBe(5); // frameIndex 4 → slice 5
     expect(roi.coords).toEqual([
@@ -1043,11 +1166,12 @@ describe('exportImageJRoiSets', () => {
       [30.75, 40],
       [55.5, 12.5],
     ]);
-    // mt_42 → hsl(62,70%,55%) → rgb(215,221,60), opaque.
+    // Colour is still keyed on trackId: mt_42 → hsl(62,70%,55%) → rgb(215,221,60).
     expect(roi.strokeColor).toBe(
       ((0xff << 24) | (215 << 16) | (221 << 8) | 60) >>> 0
     );
-    expect(roi.name).toBe('mt_42');
+    // Untyped MT (no palette) is named untyped_1, not its raw trackId.
+    expect(roi.name).toBe('untyped_1');
   });
 
   it('threads the MT thickness through to the zipped ROIs (stroke width survives deflate)', async () => {
@@ -1073,7 +1197,7 @@ describe('exportImageJRoiSets', () => {
     const zip = await fs.readFile(
       path.join(out, 'annotations', 'imagej', 'v_RoiSet.zip')
     );
-    const roi = decodeRoi(zipExtract(zip, 'mt_1__frame_0000.roi'));
+    const roi = decodeRoi(zipExtract(zip, 'untyped_1__frame_0000.roi'));
     expect(roi.strokeWidth).toBe(8);
     expect(roi.floatStrokeWidth).toBeCloseTo(8, 5);
   });

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -957,6 +957,77 @@ describe('buildVideoRoiEntries', () => {
     ]);
   });
 
+  it('emits a wider <name>_bg background band ROI when backgroundStrokeWidth is set', () => {
+    const palette = new Map([['h', { name: 'HeLa', color: '#ff0000' }]]);
+    const build = buildVideoRoiEntries(
+      [
+        {
+          id: 'f0',
+          name: 'v',
+          parentVideoId: 'c1',
+          frameIndex: 0,
+          segmentation: {
+            polygons: JSON.stringify([
+              {
+                trackId: 't1',
+                geometry: 'polyline',
+                mtType: 'h',
+                points: [
+                  { x: 0, y: 0 },
+                  { x: 10, y: 0 },
+                ],
+              },
+            ]),
+          },
+        },
+      ],
+      5, // signal thickness
+      palette,
+      13 // background band width = thickness(5) + 2*margin(4)
+    );
+    expect(build.entries.map(e => e.name).sort()).toEqual([
+      'HeLa_1__frame_0000.roi',
+      'HeLa_1_bg__frame_0000.roi',
+    ]);
+    const map = byName(build.entries);
+    const sig = decodeRoi(map.get('HeLa_1__frame_0000.roi')!.buffer);
+    const bg = decodeRoi(map.get('HeLa_1_bg__frame_0000.roi')!.buffer);
+    // Signal band is the thickness; the background band is the wider vicinity.
+    expect(sig.strokeWidth).toBe(5);
+    expect(bg.strokeWidth).toBe(13);
+    // Same geometry (a wide-stroke polyline), same slice + colour.
+    expect(bg.type).toBe(ROI_TYPE_POLYLINE);
+    expect(bg.strokeColor).toBe(sig.strokeColor);
+    expect(bg.position).toBe(sig.position);
+  });
+
+  it('skips the background band when it is not wider than the signal (margin 0)', () => {
+    const build = buildVideoRoiEntries(
+      [
+        {
+          id: 'f0',
+          name: 'v',
+          parentVideoId: 'c1',
+          frameIndex: 0,
+          segmentation: {
+            polygons: JSON.stringify([
+              line('t1', [
+                [0, 0],
+                [10, 0],
+              ]),
+            ]),
+          },
+        },
+      ],
+      5,
+      undefined,
+      5 // background width == signal width → no bg ROI
+    );
+    expect(build.entries.map(e => e.name)).toEqual([
+      'untyped_1__frame_0000.roi',
+    ]);
+  });
+
   it('stamps the given thickness as EVERY ROI stroke width', () => {
     const build = buildVideoRoiEntries(
       [

--- a/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
+++ b/backend/src/services/export/__tests__/mtMetricsExporter.test.ts
@@ -62,14 +62,19 @@ import { logger } from '../../../utils/logger';
 function makeFrame(
   overrides: Partial<{
     id: string;
+    name: string | null;
     parentVideoId: string | null;
     frameIndex: number | null;
     isVideoContainer: boolean;
     segmentation: { polygons: string | null } | null;
   }> = {}
 ) {
+  const id = overrides.id ?? 'frame-1';
   return {
-    id: 'frame-1',
+    id,
+    // Default the human-readable name to the id so `imageName`-based
+    // assertions read the same token the tests pass as `id`.
+    name: id,
     parentVideoId: 'video-1',
     frameIndex: 0,
     isVideoContainer: false,
@@ -120,7 +125,7 @@ describe('computeMTGeometry', () => {
       null
     );
     // vidA (frame 0, 1) then vidB (frame 0, 2).
-    expect(rows.map(r => `${r.imageId}@${r.frameIndex}`)).toEqual([
+    expect(rows.map(r => `${r.imageName}@${r.frameIndex}`)).toEqual([
       'a0@0',
       'a1@1',
       'b0@0',
@@ -708,7 +713,7 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
     const r = rows[0];
 
     expect(r.frameIndex).toBe(0);
-    expect(r.imageId).toBe('frame-1');
+    expect(r.imageName).toBe('frame-1');
     // Label matches the "MT1" badge the visualization draws for this instance.
     expect(r.label).toBe('MT1');
     expect(r.instanceId).toBe('inst-1');
@@ -1029,7 +1034,7 @@ describe('computeMTMetrics — ML request payload and response mapping', () => {
     );
 
     expect(rows).toHaveLength(2);
-    expect(rows.map(r => r.imageId)).toEqual(['frame-a', 'frame-b']);
+    expect(rows.map(r => r.imageName)).toEqual(['frame-a', 'frame-b']);
   });
 });
 

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -54,7 +54,7 @@ ${options.metricsFormats?.map(f => `- ${f.toUpperCase()} format`).join('\n') || 
 * json/ - Custom JSON format
 ${
   isMicrotubuleProject(project.type)
-    ? '* imagej/ - ImageJ/Fiji ROIs, one <video>_RoiSet.zip per video (each microtubule polyline on its own stack slice, named by cross-frame trackId, coloured per track, drawn at the MT thickness)\n'
+    ? '* imagej/ - ImageJ/Fiji ROIs, one <video>_RoiSet.zip per video (each microtubule polyline on its own stack slice, named <type>_<n> per tubulin class (rename overrides; untyped_<n> otherwise), coloured per class/track, drawn at the MT thickness)\n'
     : ''
 }* metrics/ - Calculated metrics
 * documentation/ - This folder
@@ -242,9 +242,11 @@ Every microtubule export also bundles the polyline centerlines as native
 ImageJ ROIs, so you can re-open them in ImageJ / Fiji for manual
 re-measurement or line-based plugins. They are packaged as **one
 \`<video>_RoiSet.zip\` per video** under \`annotations/imagej/\`, with each ROI
-named by the cross-frame **trackId** when tracking ran (falling back to the
-polyline's name/id otherwise) — so a tracked microtubule keeps the same ROI
-name in every frame.
+named **\`<type>_<n>\`** — the microtubule's tubulin type class plus a per-type
+counter numbered from 1 (e.g. \`HeLa_1\`, \`HeLa_2\`, \`brain_1\`). A manually
+renamed microtubule uses that name verbatim, and an untyped one reads
+\`untyped_<n>\`. The name is keyed on the cross-frame trackId, so the same
+microtubule keeps one name in every frame.
 
 - Each ROI is placed on its own 1-based **stack slice** (its video frame) and
   coloured per track, matching the editor.

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -218,8 +218,12 @@ columns are filled only when a channel was selected in the export dialog
   only).
 - **sumIntensity / meanIntensity / stdIntensity** — raw 16-bit signal
   statistics inside the band for this channel (intensity exports only).
-- **medianBackground** — median signal outside the dilated band union, used
-  as the per-frame background for this channel.
+- **medianBackground / meanBackground** — median resp. mean signal in THIS
+  microtubule's own LOCAL vicinity ring: the band within
+  \`thickness * margin\` of its centerline, excluding every microtubule's signal
+  band. Each MT therefore gets a background appropriate to where it sits — a
+  bright neighbourhood no longer averages away a dim one (this changed from a
+  single frame-global background; older exports are not directly comparable).
 - **signalMinusBackground** — meanIntensity − medianBackground
   (background-corrected mean).
 
@@ -253,6 +257,10 @@ microtubule keeps one name in every frame.
 - Each polyline is drawn at the configured **MT thickness** (the "MT thickness
   (px)" export setting, default 5) as its stroke width — so ImageJ renders and
   measures each microtubule as a band of that width, not a hairline.
+- Each microtubule also gets a companion **\`<name>_bg\`** ROI — the same
+  polyline drawn at the wider **vicinity width** (\`thickness + 2*margin\`), so
+  you can see the band its LOCAL background is sampled from (the ring between
+  the signal band and this wider band). Omitted when the margin is 0.
 - Geometry is stored with sub-pixel (float) precision, in image-pixel space.
 - To load a video's ROIs: **drag its \`<video>_RoiSet.zip\` onto the ImageJ
   window**, or use *ROI Manager ▸ More ▸ Open…* and pick the \`.zip\` — either

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -295,6 +295,7 @@ export class FormatConverter {
     let annotationId = 1;
     let hasPolylines = false;
     let totalInvalidPartClass = 0;
+    let totalDegeneratePolylines = 0;
     const sampleAffectedImages: string[] = [];
     let parseFailures = 0;
 
@@ -364,6 +365,10 @@ export class FormatConverter {
               }
             } else if (p.points && p.points.length >= 2) {
               validPolylines.push(p);
+            } else {
+              // Non-sperm polyline with too few points — count it (rather than
+              // dropping it silently) so it surfaces alongside the sperm skips.
+              totalDegeneratePolylines += 1;
             }
           } else if (p.type === 'internal') {
             internalPolygons.push(p);
@@ -468,6 +473,14 @@ export class FormatConverter {
           totalSkipped: totalInvalidPartClass,
           sampleImageIds: sampleAffectedImages,
         }
+      );
+    }
+
+    if (totalDegeneratePolylines > 0) {
+      logger.warn(
+        `COCO export skipped ${totalDegeneratePolylines} degenerate polyline(s) (fewer than 2 points)`,
+        'FormatConverter',
+        { totalSkipped: totalDegeneratePolylines }
       );
     }
 

--- a/backend/src/services/export/formatConverter.ts
+++ b/backend/src/services/export/formatConverter.ts
@@ -13,6 +13,10 @@ import {
   groupPolylinesByInstanceId,
   findPart,
 } from '../../utils/spermGrouping';
+import {
+  polylineSemanticsForProjectType,
+  type PolylineSemantics,
+} from '../../utils/polylineSemantics';
 import type { BasePolygon, PolygonPoint } from '../../types/polygon';
 
 /** Local alias kept for the many call sites in this file that already
@@ -104,15 +108,26 @@ const CELL_CATEGORY: COCOCategory = {
   color: [0, 255, 0],
 };
 
-const SPERM_CATEGORY: COCOCategory = {
-  id: 2,
-  name: 'sperm',
-  supercategory: 'biological',
-  color: [255, 128, 0],
-};
+// Category #2 holds every polyline annotation. Its NAME follows the project's
+// polyline kind (`sperm`, `microtubule`, `polyline`) — a polyline is a generic
+// primitive, so the category is not hardcoded to sperm. Id + colour are stable
+// across kinds so downstream tooling keyed on id 2 keeps working.
+const POLYLINE_CATEGORY_COLOR: [number, number, number] = [255, 128, 0];
 
-const buildCocoCategories = (hasSperm: boolean): COCOCategory[] =>
-  hasSperm ? [CELL_CATEGORY, SPERM_CATEGORY] : [CELL_CATEGORY];
+const buildPolylineCategory = (name: string): COCOCategory => ({
+  id: 2,
+  name,
+  supercategory: 'biological',
+  color: POLYLINE_CATEGORY_COLOR,
+});
+
+const buildCocoCategories = (
+  hasPolylines: boolean,
+  polylineCategoryName: string
+): COCOCategory[] =>
+  hasPolylines
+    ? [CELL_CATEGORY, buildPolylineCategory(polylineCategoryName)]
+    : [CELL_CATEGORY];
 
 export interface SegmentationResult {
   polygons: string; // JSON string of Polygon[]
@@ -270,11 +285,15 @@ export class FormatConverter {
    * not be parsed — the caller should surface this as a job warning so the
    * user knows those images were emitted with zero annotations.
    */
-  async convertToCOCO(images: ImageData[]): Promise<{ data: COCOFormat; parseFailures: number }> {
+  async convertToCOCO(
+    images: ImageData[],
+    projectType?: string | null
+  ): Promise<{ data: COCOFormat; parseFailures: number }> {
+    const semantics = polylineSemanticsForProjectType(projectType);
     const annotations: COCOAnnotation[] = [];
     const imagesList: COCOImage[] = [];
     let annotationId = 1;
-    let hasSperm = false;
+    let hasPolylines = false;
     let totalInvalidPartClass = 0;
     const sampleAffectedImages: string[] = [];
     let parseFailures = 0;
@@ -333,10 +352,18 @@ export class FormatConverter {
         let invalidPartClassCount = 0;
         for (const p of polygons as Polygon[]) {
           if (isPolyline(p)) {
-            if (isValidSpermPartClass(p.partClass)) {
+            // Sperm projects require a valid head/midpiece/tail part class —
+            // a polyline without one is malformed sperm data and is skipped.
+            // Non-sperm (microtubule/generic) polylines have no part class, so
+            // every ≥2-point polyline is a valid annotation.
+            if (semantics.supportsPartClass) {
+              if (isValidSpermPartClass(p.partClass)) {
+                validPolylines.push(p);
+              } else {
+                invalidPartClassCount += 1;
+              }
+            } else if (p.points && p.points.length >= 2) {
               validPolylines.push(p);
-            } else {
-              invalidPartClassCount += 1;
             }
           } else if (p.type === 'internal') {
             internalPolygons.push(p);
@@ -351,7 +378,7 @@ export class FormatConverter {
           }
         }
         if (validPolylines.length > 0) {
-          hasSperm = true;
+          hasPolylines = true;
         }
 
         for (const polygon of closedExternalPolygons) {
@@ -420,7 +447,10 @@ export class FormatConverter {
             attributes: {
               type: 'external',
               geometry: 'polyline',
-              partClass: polyline.partClass,
+              // Part class is sperm-only; microtubule/generic polylines omit it.
+              ...(semantics.supportsPartClass && {
+                partClass: polyline.partClass,
+              }),
               ...(polyline.instanceId && { instanceId: polyline.instanceId }),
               length: polylineLength(polyline.points),
             },
@@ -451,7 +481,7 @@ export class FormatConverter {
       },
       images: imagesList,
       annotations,
-      categories: buildCocoCategories(hasSperm),
+      categories: buildCocoCategories(hasPolylines, semantics.exportCategory),
       licenses: [
         {
           id: 1,
@@ -497,7 +527,7 @@ export class FormatConverter {
     const polylines = polygons.filter((p: Polygon) => isPolyline(p));
     if (polylines.length > 0) {
       warnings.push(
-        `YOLO format does not support open polylines — skipped ${polylines.length} polyline(s). Use COCO or JSON for sperm data.`
+        `YOLO format does not support open polylines — skipped ${polylines.length} polyline(s). Use COCO or JSON for polyline data.`
       );
     }
 
@@ -541,7 +571,11 @@ export class FormatConverter {
    * Returns the export data plus a count of images whose polygon JSON could
    * not be parsed — the caller should surface this as a job warning.
    */
-  async convertToJSON(images: ImageData[]): Promise<{ data: JSONExportFormat; parseFailures: number }> {
+  async convertToJSON(
+    images: ImageData[],
+    projectType?: string | null
+  ): Promise<{ data: JSONExportFormat; parseFailures: number }> {
+    const semantics = polylineSemanticsForProjectType(projectType);
     const exportData: JSONExportFormat = {
       metadata: {
         version: '1.0',
@@ -629,8 +663,13 @@ export class FormatConverter {
           })
         );
 
+        // Head/midpiece/tail instance grouping is sperm-only. Microtubule and
+        // generic polylines are emitted flat under `polylines` above; grouping
+        // them into "spermInstances" would mislabel them as sperm.
         const { instances: spermInstances, orphanCount } =
-          this.buildSpermInstances(polylines);
+          semantics.supportsPartClass
+            ? this.buildSpermInstances(polylines)
+            : { instances: [] as JSONSpermInstance[], orphanCount: 0 };
         if (orphanCount > 0) {
           totalOrphans += orphanCount;
           if (orphanSampleImages.length < 10) {

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -357,6 +357,49 @@ function videoZipLabel(
   return `video_${videoKey.slice(0, 8)}`;
 }
 
+/**
+ * Per-video microtubule display names following `<type>_<counter>` — a per-type
+ * running counter (HeLa_1, HeLa_2, brain_1, …) assigned in first-appearance
+ * order across the ordered frames and keyed on the cross-frame-stable trackId so
+ * the SAME microtubule keeps ONE name on every slice. Rules per MT:
+ *   1. a manual rename (`polygon.name`) wins and is used verbatim;
+ *   2. otherwise `<typeName>_<n>` where n counts that type from 1;
+ *   3. an untyped MT falls into the `untyped_<n>` bucket.
+ * Keyless or degenerate polygons are absent (the caller falls back to roiLabel).
+ */
+function buildMtNameByKey(
+  orderedFrames: RoiFrameInput[],
+  labelById?: Map<string, RoiTypeLabel>
+): Map<string, string> {
+  const nameByKey = new Map<string, string>();
+  const perTypeCount = new Map<string, number>();
+  for (const frame of orderedFrames) {
+    const parsed = parseFramePolygons(frame.segmentation?.polygons);
+    if (parsed.corrupt) continue;
+    for (const p of parsed.polygons) {
+      const geometry = p.geometry === 'polygon' ? 'polygon' : 'polyline';
+      const pts = validPoints(p.points);
+      if (pts.length < (geometry === 'polyline' ? 2 : 3)) continue;
+      const key = p.trackId || p.instanceId || p.id;
+      if (!key || nameByKey.has(key)) continue;
+      // A manual rename overrides the automatic scheme.
+      const renamed = p.name?.trim();
+      if (renamed) {
+        nameByKey.set(key, renamed);
+        continue;
+      }
+      const typeName = p.mtType
+        ? labelById?.get(p.mtType)?.name?.trim()
+        : undefined;
+      const bucket = typeName || 'untyped';
+      const n = (perTypeCount.get(bucket) ?? 0) + 1;
+      perTypeCount.set(bucket, n);
+      nameByKey.set(key, `${bucket}_${n}`);
+    }
+  }
+  return nameByKey;
+}
+
 /** Sentinel bucket for the rare MT frame with no parentVideoId. */
 const NO_VIDEO_KEY = '__novideo__';
 
@@ -381,9 +424,11 @@ export interface VideoRoiBuild {
  *
  * Frames are processed in frameIndex order. Each ROI carries ``position =
  * frameIndex + 1`` (1-based ImageJ slice) and a stroke colour derived from its
- * track (identical hue to the editor). Entry names are ``<label>__frame_NNNN``
- * (MT-first) so the same microtubule's ROIs sort together in the ROI Manager
- * and every name is unique within the zip.
+ * track (identical hue to the editor). The ROI label is the per-video
+ * ``<type>_<counter>`` name (e.g. ``HeLa_1``; a manual rename overrides it, an
+ * untyped MT reads ``untyped_N``), and entry names are ``<label>__frame_NNNN``
+ * so the same microtubule's ROIs sort together in the ROI Manager and every
+ * name is unique within the zip.
  *
  * Degradation matches the rest of the export: corrupt-JSON frames are counted
  * (surfaced as a warning by the caller), and polygons with too few / non-finite
@@ -406,6 +451,11 @@ export function buildVideoRoiEntries(
   const ordered = [...frames].sort(
     (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
   );
+
+  // Per-video `<type>_<counter>` names (rename-override), keyed on the
+  // cross-frame-stable trackId so one microtubule reads identically on every
+  // slice. Computed once over all frames before per-frame ROI encoding.
+  const mtNameByKey = buildMtNameByKey(ordered, labelById);
 
   const entries: RoiZipEntry[] = [];
   let framesWithRois = 0;
@@ -431,15 +481,18 @@ export function buildVideoRoiEntries(
       .map((p, index) => {
         const geometry: RoiGeometry =
           p.geometry === 'polygon' ? 'polygon' : 'polyline';
-        // Resolve the assigned tubulin type label (if any). When present, the
-        // class name prefixes the ROI name and the label colour drives the
-        // stroke — so the ROI's identity in ImageJ reflects its class.
+        // Resolve the assigned tubulin type label (if any). Its COLOUR drives
+        // the stroke so the ROI reads as its class; its NAME feeds the
+        // `<type>_<counter>` scheme via buildMtNameByKey.
         const typeLabel = p.mtType ? labelById?.get(p.mtType) : undefined;
-        const baseLabel = roiLabel(p, index);
+        // ROI name: the per-video `<type>_<counter>` (or manual rename) when a
+        // stable key resolved, else the legacy trackId/id label as a fallback.
+        const key = p.trackId || p.instanceId || p.id;
+        const label = (key && mtNameByKey.get(key)) || roiLabel(p, index);
         return {
           geometry,
           points: validPoints(p.points),
-          label: typeLabel ? `${typeLabel.name}__${baseLabel}` : baseLabel,
+          label,
           strokeColor: typeLabel
             ? imageJColorFromHex(typeLabel.color)
             : imageJStrokeColor(colorKeyForRoi(p)),

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -446,7 +446,13 @@ export function buildVideoRoiEntries(
    *  label's COLOUR becomes the ROI stroke colour — so in ImageJ the ROI's name
    *  and colour both reflect its class. Untyped polylines keep the per-track
    *  hue. Omit for non-MT exports. */
-  labelById?: Map<string, RoiTypeLabel>
+  labelById?: Map<string, RoiTypeLabel>,
+  /** Vicinity band width (px) for the per-MT background ROI — the full width of
+   *  the region background stats are sampled from (`thickness + 2*margin`). When
+   *  set and wider than the signal thickness, each polyline also gets a
+   *  `<name>_bg` polyline drawn at this width, so ImageJ shows the background
+   *  band around the (narrower) signal band. Omit to skip background ROIs. */
+  backgroundStrokeWidth?: number
 ): VideoRoiBuild {
   const ordered = [...frames].sort(
     (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
@@ -507,24 +513,24 @@ export function buildVideoRoiEntries(
     // same base must not collide), then suffix the unique frame label.
     const usedInFrame = new Set<string>();
     let frameRois = 0;
-    for (const { geometry, points, label, strokeColor } of items) {
-      const base = sanitizeFilename(label);
-      let labelCandidate = base;
+    // Reserve a unique `<base>__<frameLabel>` entry name within the zip.
+    const reserveEntry = (base: string): string => {
+      let candidate = base;
       let dupe = 2;
-      while (usedInFrame.has(labelCandidate.toLowerCase())) {
-        labelCandidate = `${base}_${dupe++}`;
+      while (usedInFrame.has(candidate.toLowerCase())) {
+        candidate = `${base}_${dupe++}`;
       }
-      usedInFrame.add(labelCandidate.toLowerCase());
-
-      // frameLabel is unique per frame, so cross-frame collisions cannot occur;
-      // this guard only defends against a pathological repeat.
-      let entryStem = `${labelCandidate}__${frameLabel}`;
+      usedInFrame.add(candidate.toLowerCase());
+      let stem = `${candidate}__${frameLabel}`;
       let extra = 2;
-      while (usedEntryNames.has(entryStem.toLowerCase())) {
-        entryStem = `${labelCandidate}__${frameLabel}_${extra++}`;
+      while (usedEntryNames.has(stem.toLowerCase())) {
+        stem = `${candidate}__${frameLabel}_${extra++}`;
       }
-      usedEntryNames.add(entryStem.toLowerCase());
-
+      usedEntryNames.add(stem.toLowerCase());
+      return stem;
+    };
+    for (const { geometry, points, label, strokeColor } of items) {
+      const entryStem = reserveEntry(sanitizeFilename(label));
       const buffer = encodeImageJRoi(points, geometry, label, {
         position,
         strokeColor,
@@ -532,6 +538,27 @@ export function buildVideoRoiEntries(
       });
       entries.push({ name: `${entryStem}.roi`, buffer });
       frameRois++;
+
+      // Second ROI: the per-MT background band. It's the SAME polyline drawn at
+      // the vicinity width (thickness + 2*margin), so ImageJ renders the
+      // background band around the (narrower) signal band — the ring between
+      // them is where background stats come from. Only for polylines, and only
+      // when the vicinity is actually wider than the signal (margin > 0).
+      if (
+        geometry === 'polyline' &&
+        typeof backgroundStrokeWidth === 'number' &&
+        backgroundStrokeWidth > (strokeWidth ?? 0)
+      ) {
+        const bgLabel = `${label}_bg`;
+        const bgStem = reserveEntry(sanitizeFilename(bgLabel));
+        const bgBuffer = encodeImageJRoi(points, 'polyline', bgLabel, {
+          position,
+          strokeColor,
+          strokeWidth: backgroundStrokeWidth,
+        });
+        entries.push({ name: `${bgStem}.roi`, buffer: bgBuffer });
+        frameRois++;
+      }
     }
     if (frameRois > 0) framesWithRois++;
   }
@@ -602,7 +629,14 @@ export async function exportImageJRoiSets(
   frameImages: RoiFrameInput[],
   exportDir: string,
   projectId: string,
-  options: { shouldAbort?: () => boolean; strokeWidth?: number } = {}
+  options: {
+    shouldAbort?: () => boolean;
+    strokeWidth?: number;
+    /** Vicinity band width (px) for the per-MT background ROI
+     *  (`thickness + 2*margin`). When wider than `strokeWidth`, each MT also
+     *  gets a `<name>_bg` band ROI. Omit to skip background ROIs. */
+    backgroundStrokeWidth?: number;
+  } = {}
 ): Promise<ImageJRoiExportResult> {
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
 
@@ -650,7 +684,8 @@ export async function exportImageJRoiSets(
     const build = buildVideoRoiEntries(
       videoFrames,
       options.strokeWidth,
-      labelById
+      labelById,
+      options.backgroundStrokeWidth
     );
     corruptFrames += build.corruptFrames;
     droppedPolygons += build.droppedPolygons;

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -51,7 +51,9 @@ export interface MTMetricsOptions {
  */
 export interface MTMetricsRow {
   frameIndex: number;
-  imageId: string;
+  /** Human-readable image (frame) name — the frame's `Image.name`, not its DB
+   *  UUID. Combined with `frameIndex` it identifies the source frame. */
+  imageName: string;
   /** Per-frame instance badge drawn on the visualization image ("MT1",
    *  "MT2", …), matching {@link buildInstanceLabelMap}. Empty string when the
    *  polyline has no `instanceId` (no badge is drawn for it either). */
@@ -189,6 +191,9 @@ interface MLMTMetricsResponse {
 
 interface FrameImageInput {
   id: string;
+  /** The frame's human-readable `Image.name`, surfaced in the export as the
+   *  `imageName` column (replacing the old UUID `imageId`). */
+  name?: string | null;
   parentVideoId: string | null;
   frameIndex: number | null;
   isVideoContainer?: boolean;
@@ -369,6 +374,14 @@ export async function computeMTMetrics(
       { projectId }
     );
     return { rows: [], skipped, channelSummaries: [] };
+  }
+
+  // DB frame id → human-readable frame name, for the `imageName` output column.
+  // The ML response echoes `image_id` (the id we sent = fr.id), so we join the
+  // name back through this map.
+  const frameNameById = new Map<string, string>();
+  for (const img of frameImages) {
+    if (img.name) frameNameById.set(img.id, img.name);
   }
 
   // Fetch all video container rows in a single query.
@@ -616,7 +629,7 @@ export async function computeMTMetrics(
       }
       videoRows.push({
         frameIndex: row.frame_index,
-        imageId: row.image_id,
+        imageName: frameNameById.get(row.image_id) ?? '',
         label: label ?? '',
         mtType: resolveMtTypeName(
           mtTypeBySentId.get(row.image_id)?.get(row.instance_id)
@@ -725,7 +738,7 @@ export function computeMTGeometry(
       const mtTypeId = (p as { mtType?: string }).mtType;
       rows.push({
         frameIndex: fr.frameIndex,
-        imageId: fr.id,
+        imageName: fr.name ?? '',
         label: p.instanceId ? (labelMap.get(p.instanceId) ?? '') : '',
         mtType: (mtTypeId && mtTypeNameById.get(mtTypeId)) || '',
         instanceId:
@@ -761,7 +774,7 @@ export function computeMTGeometry(
  *  field names from MTMetricsRow directly. */
 const CSV_HEADERS: readonly (keyof MTMetricsRow)[] = [
   'frameIndex',
-  'imageId',
+  'imageName',
   'label',
   'mtType',
   'instanceId',

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1606,6 +1606,7 @@ export class ExportService {
     const scale = options.pixelToMicrometerScale ?? null;
     const frameInputs = images.map(i => ({
       id: i.id,
+      name: i.name,
       parentVideoId: i.parentVideoId ?? null,
       frameIndex: i.frameIndex ?? null,
       isVideoContainer: i.isVideoContainer,

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -33,10 +33,10 @@ import {
   isMicrotubuleProject as isMicrotubuleProjectType,
 } from '../types/validation';
 import {
-  MICROTUBULE_LABEL_PREFIX,
   SPERM_LABEL_PREFIX,
   type InstanceLabelPrefix,
 } from '../utils/instanceLabels';
+import { polylineSemanticsForProjectType } from '../utils/polylineSemantics';
 import {
   sanitizeFilename,
   getProgressMessage,
@@ -534,12 +534,12 @@ export class ExportService {
       // Generate visualizations (can run in parallel)
       if (options.includeVisualizations && project.images) {
         const visualizationProgressBase = 5 + progressStep * progressIncrement;
-        // Microtubule polylines reuse the sperm labeller, so badge them "MT1"
-        // instead of the sperm "S1". The MT metrics table is labelled with the
-        // same prefix so rows can be matched to badges on the image.
-        const labelPrefix = isMicrotubuleProject
-          ? MICROTUBULE_LABEL_PREFIX
-          : SPERM_LABEL_PREFIX;
+        // The per-instance badge prefix follows the PROJECT type (S=sperm,
+        // MT=microtubule, P=generic) — a polyline is a generic primitive, not a
+        // sperm one. The MT metrics table uses the same prefix so spreadsheet
+        // rows match the badges drawn on the image.
+        const labelPrefix =
+          polylineSemanticsForProjectType(project.type).labelPrefix;
         exportTasks.push(
           this.generateVisualizations(
             project.images as ImageWithSegmentation[],
@@ -594,7 +594,8 @@ export class ExportService {
                 current,
                 total,
               });
-            }
+            },
+            project.type
           ).then(() => {
             progressStep++;
             this.updateJobProgress(
@@ -1171,7 +1172,8 @@ export class ExportService {
     exportDir: string,
     formats: string[],
     jobId?: string,
-    onProgress?: (current: number, total: number) => void
+    onProgress?: (current: number, total: number) => void,
+    projectType?: string | null
   ): Promise<void> {
     for (const format of formats) {
       // Check if job was cancelled before processing each format
@@ -1202,7 +1204,7 @@ export class ExportService {
         }));
 
         const { data: cocoData, parseFailures: cocoFailures } =
-          await this.formatConverter.convertToCOCO(imageDataArray);
+          await this.formatConverter.convertToCOCO(imageDataArray, projectType);
         await fs.writeFile(
           path.join(formatDir, 'annotations.json'),
           JSON.stringify(cocoData, null, 2)
@@ -1298,7 +1300,7 @@ export class ExportService {
         }));
 
         const { data: jsonData, parseFailures: jsonFailures } =
-          await this.formatConverter.convertToJSON(imageDataArray);
+          await this.formatConverter.convertToJSON(imageDataArray, projectType);
         await fs.writeFile(
           path.join(formatDir, 'segmentation_data.json'),
           JSON.stringify(jsonData, null, 2)

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -671,6 +671,19 @@ export class ExportService {
       // export they did request: it degrades to a warning. Only a genuine
       // cancellation stays fatal.
       if (isMicrotubuleProject && project.images?.length) {
+        // MT thickness (px) → ImageJ ROI stroke width (the signal band). The
+        // background band ROI is drawn at the vicinity width
+        // (thickness + 2*margin) — the same region the metrics step samples the
+        // per-MT background from. `mtMetrics` is optional (ROI export is
+        // always-on), so fall back to the slider defaults (thickness 5,
+        // margin 2).
+        const mtThicknessPx =
+          options.mtMetrics?.thicknessPx && options.mtMetrics.thicknessPx > 0
+            ? options.mtMetrics.thicknessPx
+            : DEFAULT_MT_ROI_THICKNESS_PX;
+        const mtMarginMultiplier = options.mtMetrics?.marginMultiplier ?? 2;
+        const mtBackgroundStrokeWidth =
+          mtThicknessPx + 2 * Math.round(mtThicknessPx * mtMarginMultiplier);
         exportTasks.push(
           exportImageJRoiSets(
             project.images as ImageWithSegmentation[],
@@ -678,15 +691,8 @@ export class ExportService {
             project.id,
             {
               shouldAbort: () => this.isJobCancelled(jobId),
-              // MT thickness (px) → ImageJ ROI stroke width, so re-opened
-              // polylines draw + measure as a band of the sampled width. The
-              // ROI export is always-on but `mtMetrics` is optional, so fall
-              // back to the same default the metrics thickness slider uses (5).
-              strokeWidth:
-                options.mtMetrics?.thicknessPx &&
-                options.mtMetrics.thicknessPx > 0
-                  ? options.mtMetrics.thicknessPx
-                  : DEFAULT_MT_ROI_THICKNESS_PX,
+              strokeWidth: mtThicknessPx,
+              backgroundStrokeWidth: mtBackgroundStrokeWidth,
             }
           )
             .then(result => {

--- a/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.microcapsule.test.ts
@@ -187,7 +187,6 @@ describe('MetricsCalculator — exportMicrocapsuleMetricsToExcel', () => {
     const headers = mockWorksheet.columns.map(c => c.header);
     expect(headers).toEqual([
       'Image Name',
-      'Image ID',
       'Capsule ID',
       'Area (px^2)',
       'Perimeter (px)',

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -776,7 +776,6 @@ export class MetricsCalculator {
 
     worksheet.columns = [
       { header: 'Image Name', key: 'imageName', width: 20 },
-      { header: 'Image ID', key: 'imageId', width: 15 },
       { header: 'Polygon ID', key: 'polygonId', width: 10 },
       { header: 'Type', key: 'type', width: 10 },
       { header: `Area (${areaUnit})`, key: 'area', width: 12 },
@@ -803,9 +802,7 @@ export class MetricsCalculator {
       isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
     metrics.forEach(m => {
       worksheet.addRow({
-        imageName: m.imageName,
-        imageId: m.imageId,
-        polygonId: m.polygonId,
+        imageName: m.imageName,        polygonId: m.polygonId,
         type: m.type,
         area: safeValue(m.area, 2),
         perimeter: safeValue(m.perimeter, 2),
@@ -881,7 +878,6 @@ export class MetricsCalculator {
 
     worksheet.columns = [
       { header: 'Image Name', key: 'imageName', width: 20 },
-      { header: 'Image ID', key: 'imageId', width: 15 },
       { header: 'Capsule ID', key: 'polygonId', width: 12 },
       { header: `Area (${areaUnit})`, key: 'area', width: 14 },
       { header: `Perimeter (${lengthUnit})`, key: 'perimeter', width: 14 },
@@ -907,9 +903,7 @@ export class MetricsCalculator {
     const rows = metrics.filter(m => m.complete !== false);
     rows.forEach(m => {
       worksheet.addRow({
-        imageName: m.imageName,
-        imageId: m.imageId,
-        polygonId: m.polygonId,
+        imageName: m.imageName,        polygonId: m.polygonId,
         area: safeValue(m.area, 2),
         perimeter: safeValue(m.perimeter, 2),
         width: safeValue(m.boundingBoxWidth, 2),
@@ -977,7 +971,6 @@ export class MetricsCalculator {
     const csvStringifier = createObjectCsvStringifier({
       header: [
         { id: 'imageName', title: 'Image Name' },
-        { id: 'imageId', title: 'Image ID' },
         { id: 'polygonId', title: 'Capsule ID' },
         { id: 'area', title: `Area (${areaUnit})` },
         { id: 'perimeter', title: `Perimeter (${lengthUnit})` },
@@ -999,9 +992,7 @@ export class MetricsCalculator {
     const records = metrics
       .filter(m => m.complete !== false)
       .map(m => ({
-        imageName: m.imageName,
-        imageId: m.imageId,
-        polygonId: m.polygonId,
+        imageName: m.imageName,        polygonId: m.polygonId,
         area: m.area,
         perimeter: m.perimeter,
         width: m.boundingBoxWidth,
@@ -1115,7 +1106,6 @@ export class MetricsCalculator {
     const sheet = workbook.addWorksheet('Image Metrics');
     sheet.columns = [
       { header: 'Image Name', key: 'imageName', width: 32 },
-      { header: 'Image ID', key: 'imageId', width: 22 },
       {
         header: `Total Spheroid Area (${areaUnit})`,
         key: 'totalSpheroidArea',
@@ -1140,9 +1130,7 @@ export class MetricsCalculator {
     if (imageMetrics) {
       imageMetrics.forEach(m => {
         sheet.addRow({
-          imageName: m.imageName,
-          imageId: m.imageId,
-          totalSpheroidArea: safe(m.totalSpheroidArea, 2),
+          imageName: m.imageName,          totalSpheroidArea: safe(m.totalSpheroidArea, 2),
           coreArea: safe(m.coreArea, 2),
           invasionArea: safe(m.invasionArea, 2),
           disintegrationIndex: safe(m.disintegrationIndex, 4),
@@ -1289,7 +1277,6 @@ export class MetricsCalculator {
     const csvStringifier = createObjectCsvStringifier({
       header: [
         { id: 'imageName', title: 'Image Name' },
-        { id: 'imageId', title: 'Image ID' },
         { id: 'polygonId', title: 'Polygon ID' },
         { id: 'type', title: 'Type' },
         { id: 'area', title: `Area (${areaUnit})` },

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -802,7 +802,8 @@ export class MetricsCalculator {
       isFinite(value) ? parseFloat(value.toFixed(decimals)) : 0;
     metrics.forEach(m => {
       worksheet.addRow({
-        imageName: m.imageName,        polygonId: m.polygonId,
+        imageName: m.imageName,
+        polygonId: m.polygonId,
         type: m.type,
         area: safeValue(m.area, 2),
         perimeter: safeValue(m.perimeter, 2),
@@ -903,7 +904,8 @@ export class MetricsCalculator {
     const rows = metrics.filter(m => m.complete !== false);
     rows.forEach(m => {
       worksheet.addRow({
-        imageName: m.imageName,        polygonId: m.polygonId,
+        imageName: m.imageName,
+        polygonId: m.polygonId,
         area: safeValue(m.area, 2),
         perimeter: safeValue(m.perimeter, 2),
         width: safeValue(m.boundingBoxWidth, 2),
@@ -992,7 +994,8 @@ export class MetricsCalculator {
     const records = metrics
       .filter(m => m.complete !== false)
       .map(m => ({
-        imageName: m.imageName,        polygonId: m.polygonId,
+        imageName: m.imageName,
+        polygonId: m.polygonId,
         area: m.area,
         perimeter: m.perimeter,
         width: m.boundingBoxWidth,
@@ -1130,7 +1133,8 @@ export class MetricsCalculator {
     if (imageMetrics) {
       imageMetrics.forEach(m => {
         sheet.addRow({
-          imageName: m.imageName,          totalSpheroidArea: safe(m.totalSpheroidArea, 2),
+          imageName: m.imageName,
+          totalSpheroidArea: safe(m.totalSpheroidArea, 2),
           coreArea: safe(m.coreArea, 2),
           invasionArea: safe(m.invasionArea, 2),
           disintegrationIndex: safe(m.disintegrationIndex, 4),

--- a/backend/src/utils/__tests__/polylineSemantics.test.ts
+++ b/backend/src/utils/__tests__/polylineSemantics.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the backend polyline-semantics SSOT. Mirrors the frontend
+ * mapping and additionally pins the export-only fields (labelPrefix badge,
+ * exportCategory for COCO/JSON). A polyline is a generic primitive; the export
+ * must not assume sperm for a non-sperm project.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { polylineSemanticsForProjectType } from '../polylineSemantics';
+import {
+  SPERM_LABEL_PREFIX,
+  MICROTUBULE_LABEL_PREFIX,
+  GENERIC_LABEL_PREFIX,
+} from '../instanceLabels';
+
+describe('polylineSemanticsForProjectType (backend)', () => {
+  it('sperm → sperm category + S badge + part classes', () => {
+    const s = polylineSemanticsForProjectType('sperm');
+    expect(s.kind).toBe('sperm');
+    expect(s.labelPrefix).toBe(SPERM_LABEL_PREFIX);
+    expect(s.exportCategory).toBe('sperm');
+    expect(s.supportsPartClass).toBe(true);
+  });
+
+  it('microtubules → microtubule category + MT badge + no part classes', () => {
+    const s = polylineSemanticsForProjectType('microtubules');
+    expect(s.kind).toBe('microtubule');
+    expect(s.labelPrefix).toBe(MICROTUBULE_LABEL_PREFIX);
+    expect(s.exportCategory).toBe('microtubule');
+    expect(s.supportsPartClass).toBe(false);
+  });
+
+  it.each(['spheroid', 'wound', 'microcapsule', undefined, null, 'x'])(
+    'non-sperm/non-MT %s → generic category + P badge, never sperm',
+    type => {
+      const s = polylineSemanticsForProjectType(type);
+      expect(s.kind).toBe('generic');
+      expect(s.labelPrefix).toBe(GENERIC_LABEL_PREFIX);
+      expect(s.exportCategory).toBe('polyline');
+      expect(s.supportsPartClass).toBe(false);
+    }
+  );
+});

--- a/backend/src/utils/instanceLabels.ts
+++ b/backend/src/utils/instanceLabels.ts
@@ -14,12 +14,17 @@
 export const SPERM_LABEL_PREFIX = 'S';
 /** Prefix drawn for microtubule instances. */
 export const MICROTUBULE_LABEL_PREFIX = 'MT';
+/** Prefix for polylines in a generic (non-sperm, non-MT) project. No project
+ *  type currently draws these badges, but it keeps the primitive honest — the
+ *  labeller never assumes sperm for an unrecognised polyline project. */
+export const GENERIC_LABEL_PREFIX = 'P';
 
-/** The two valid badge prefixes. Derived from the consts so the set can't
+/** The valid badge prefixes. Derived from the consts so the set can't
  *  drift; a stray value (e.g. `'X'`) is rejected at compile time. */
 export type InstanceLabelPrefix =
   | typeof SPERM_LABEL_PREFIX
-  | typeof MICROTUBULE_LABEL_PREFIX;
+  | typeof MICROTUBULE_LABEL_PREFIX
+  | typeof GENERIC_LABEL_PREFIX;
 
 /** Minimal polyline shape the labeller needs — a subset of both the
  *  visualization `Polygon` and the exporter's `RawPolyline`. */

--- a/backend/src/utils/polylineSemantics.ts
+++ b/backend/src/utils/polylineSemantics.ts
@@ -1,0 +1,74 @@
+/**
+ * A polyline (`geometry: 'polyline'`) is a GENERIC labeling primitive shared by
+ * sperm and microtubule projects. Its export semantics — the badge prefix, the
+ * instance-id scheme used when one must be synthesised, whether head/midpiece/
+ * tail part classes apply, and the COCO/JSON category name — are a property of
+ * the PROJECT TYPE, not of an individual polyline.
+ *
+ * Resolving them here, once, from `project.type` removes the old assumption that
+ * every non-microtubule polyline is sperm (the `isMicrotubuleProject ? MT : S`
+ * branch and the hardcoded `sperm` COCO category).
+ *
+ * Mirrors the frontend SSOT at `src/lib/polylineSemantics.ts`; keep the kind
+ * mapping identical.
+ */
+
+import {
+  SPERM_LABEL_PREFIX,
+  MICROTUBULE_LABEL_PREFIX,
+  GENERIC_LABEL_PREFIX,
+  type InstanceLabelPrefix,
+} from './instanceLabels';
+
+export type PolylineKind = 'sperm' | 'microtubule' | 'generic';
+
+export interface PolylineSemantics {
+  kind: PolylineKind;
+  /** Prefix for a freshly-synthesised instance id: `sperm_`, `mt_`, `poly_`. */
+  idPrefix: string;
+  /** Sequential export badge prefix (`S`, `MT`, `P`). */
+  labelPrefix: InstanceLabelPrefix;
+  /** Only sperm carries head/midpiece/tail part classes. */
+  supportsPartClass: boolean;
+  /** COCO / JSON annotation category name for this kind's polylines. */
+  exportCategory: string;
+}
+
+const SPERM: PolylineSemantics = {
+  kind: 'sperm',
+  idPrefix: 'sperm_',
+  labelPrefix: SPERM_LABEL_PREFIX,
+  supportsPartClass: true,
+  exportCategory: 'sperm',
+};
+
+const MICROTUBULE: PolylineSemantics = {
+  kind: 'microtubule',
+  idPrefix: 'mt_',
+  labelPrefix: MICROTUBULE_LABEL_PREFIX,
+  supportsPartClass: false,
+  exportCategory: 'microtubule',
+};
+
+const GENERIC: PolylineSemantics = {
+  kind: 'generic',
+  idPrefix: 'poly_',
+  labelPrefix: GENERIC_LABEL_PREFIX,
+  supportsPartClass: false,
+  exportCategory: 'polyline',
+};
+
+/** Resolve the polyline semantics for a raw `project.type` string. Unknown /
+ *  legacy values (spheroid, wound, microcapsule, …) fall through to `generic`. */
+export function polylineSemanticsForProjectType(
+  type: string | undefined | null
+): PolylineSemantics {
+  switch (type) {
+    case 'sperm':
+      return SPERM;
+    case 'microtubules':
+      return MICROTUBULE;
+    default:
+      return GENERIC;
+  }
+}

--- a/docs/superpowers/specs/2026-07-09-polyline-primitive-and-mt-export-design.md
+++ b/docs/superpowers/specs/2026-07-09-polyline-primitive-and-mt-export-design.md
@@ -1,0 +1,228 @@
+# Polyline as a generic labeling primitive + MT export / editor improvements
+
+- **Date:** 2026-07-09
+- **Status:** Approved design (pre-implementation)
+- **Author:** Claude Code (brainstormed with @michalprusek)
+- **Implementation:** one spec, delivered as 5 sequenced, independently-verified PRs.
+
+---
+
+## 1. Motivation
+
+Five related requests, all rooted in the same architectural shortcut: the export
+and editor code treats a **polyline** (`Polygon` with `geometry: 'polyline'`) as if
+it were a sperm annotation, because it infers the polyline's _kind_ from an
+instance-ID prefix (`isMicrotubuleInstance` = id starts with `mt_`) and **falls
+through to sperm for everything else**. A polyline is actually a generic labeling
+primitive used by _both_ sperm and microtubule projects.
+
+| #   | Request                                                                                                                     | Verdict from code trace                                                                                                                                                                                                                    |
+| --- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Metrics export `image_id` should be the image **name**, not a UUID.                                                         | The general writers already have `Image Name` + `Image ID (UUID)`; the **MT exporter** (`mtMetricsExporter.ts`, `imageId: fr.id`) shows only the UUID.                                                                                     |
+| 2   | Polyline is hardcoded to sperm (sperm-flavored label + "weird" instance id even in non-sperm contexts). Fix systematically. | Kind is guessed from the ID prefix with a sperm fallthrough (`usePolygonRenderProps.ts:54-60`); new polylines default to `sperm_1` (`SegmentationEditor.tsx:300-309`); COCO/JSON emit a hardcoded `sperm` category (`formatConverter.ts`). |
+| 3   | ImageJ ROIs should also encode the region the **background** statistics are sampled from.                                   | Background was **global per frame** (`frame − dilate(∪ all MT bands)`, `mt_metrics.py:566-571`) — not what the user expected. Decision: change it to **per-MT local**.                                                                     |
+| 4   | Allow **renaming microtubules** in the segmentation editor.                                                                 | Backend persistence + cross-frame `name` mirroring already exist (`segmentationService.ts:157`, `:2146`); the generic rename UI is simply **hidden for MT** (`SegmentationEditorLayout.tsx:568`). FE-only work.                            |
+| 5   | ImageJ ROI names should be `<type>_<id>` (HeLa_1, HeLa_2, brain_1…), per-type counter from 1.                               | Current name is `<name>__<type>` (`imagejRoiEncoder.ts:442`).                                                                                                                                                                              |
+
+## 2. Decisions (locked during clarification)
+
+1. **#1** — The image **name replaces the UUID** identifier column across _all_ metric exports.
+2. **#2** — **Full** generic polyline primitive: project type is the single source of truth for polyline semantics, resolved once. The `generic` case is kept thin (no speculative UI) per YAGNI, but adding a 3rd polyline-using project type becomes a config-row change, not a rewrite.
+3. **#3** — **Change the computation**: each MT computes its background from its **own local vicinity** — a ring out to `thickness × margin_multiplier` around that MT — excluding every MT's signal band so no microtubule counts as background. The width is the existing `margin_multiplier`, already exposed in the export dialog.
+4. **#4** — Surface the existing rename in the MT panel + MT context menu (FE-only).
+5. **#5** — ImageJ name = the manual **rename if present**, else `<typeName>_<perTypeCounter>` (untyped MTs → `untyped_<counter>`).
+
+## 3. Foundation — the polyline-semantics SSOT
+
+A single resolver, mirrored on FE and BE (following the existing shared-type
+convention; keep both copies prettier-formatted identically per the
+`shared_types_prettier_wrap` gotcha), maps `Project.type → PolylineSemantics`:
+
+```
+type PolylineKind = 'sperm' | 'microtubule' | 'generic';
+
+interface PolylineSemantics {
+  kind: PolylineKind;
+  idPrefix: string;        // 'sperm_' | 'mt_' | 'poly_'
+  labelPrefix: string;     // 'S' | 'MT' | 'P'
+  supportsPartClass: boolean; // sperm head/midpiece/tail only
+  exportCategory: string;  // COCO/JSON category name
+}
+```
+
+| project type      | kind        | idPrefix | labelPrefix | partClass | category    |
+| ----------------- | ----------- | -------- | ----------- | --------- | ----------- |
+| `sperm`           | sperm       | `sperm_` | S           | yes       | sperm       |
+| `microtubules`    | microtubule | `mt_`    | MT          | no        | microtubule |
+| _(anything else)_ | generic     | `poly_`  | P           | no        | polyline    |
+
+- **FE:** `src/lib/polylineSemantics.ts` (new). Replaces the per-polygon
+  `isMicrotubuleInstance` guess used for _kind_ decisions. (`isMicrotubuleInstance`
+  may still exist for legacy id parsing, but is no longer the source of truth for kind.)
+- **BE:** `backend/src/utils/polylineSemantics.ts` (new), or extend
+  `backend/src/types/validation.ts` where `isMicrotubuleProject` already lives.
+
+The ID prefix becomes a **consequence** of the kind (used when synthesizing new
+instance IDs), never the source of it.
+
+## 4. Workstream A — de-sperm the polyline path (#2)
+
+**Frontend**
+
+- `src/pages/segmentation/hooks/usePolygonRenderProps.ts:54-60` — derive
+  `polylineKind` from the project type (threaded from editor context /
+  `SegmentationEditorLayout` which already holds `projectType`), not from
+  `isMicrotubuleInstance(p.instanceId)`. Remove the sperm fallthrough.
+- `src/pages/segmentation/SegmentationEditor.tsx:300-309, 940-942, 1151-1153` —
+  seed a new polyline's `instanceId` from `semantics.idPrefix` (so MT projects
+  produce `mt_…`, sperm produce `sperm_…`); drop the hardcoded `activeInstanceId='sperm_1'`.
+- Panel selection (`SegmentationEditorLayout.tsx:448-461, 487-498, 584, 595`) and
+  `MicrotubuleInstancePanel.tsx:80-88` membership key on `semantics.kind`, not on
+  the `mt_` id prefix.
+
+**Backend export**
+
+- `backend/src/services/exportService.ts:540-542` — label prefix from the resolver,
+  replacing `isMicrotubuleProject ? MICROTUBULE_LABEL_PREFIX : SPERM_LABEL_PREFIX`.
+- `backend/src/services/export/formatConverter.ts` — COCO/JSON category + attributes
+  chosen by `semantics.kind`: sperm keeps `sperm` category + head/midpiece/tail
+  (`buildSpermInstances`, `:721-749`); microtubule/generic get their own category and
+  skip part-class semantics. (MT already skips COCO/JSON at `exportService.ts:576-577`;
+  this makes the converter correct for any polyline project rather than assuming sperm.)
+- `backend/src/utils/instanceLabels.ts` — already generic (takes a prefix); no change
+  beyond who supplies the prefix.
+
+**Non-goal:** no new UI panels for the hypothetical `generic` kind (YAGNI). The
+`generic` row exists so the code no longer _assumes_ sperm; it is not a feature.
+
+## 5. Workstream B — image name in exports (#1)
+
+- `backend/src/services/export/mtMetricsExporter.ts` — replace the `imageId`
+  (UUID `fr.id`) output column with `imageName` (the frame's `name`), populated via a
+  `nameById` map built from the frame rows. `imageId` is dropped from CSV/XLSX/JSON
+  output (`CSV_HEADERS`, the geometry path `:728`, the intensity path `:619`).
+  `frameIndex` is retained.
+- General writers — drop the redundant `Image ID` UUID column (they already emit
+  `Image Name`): `exportPolygonMetricsToExcel` (header `:779`), spheroid `exportToExcel`
+  (`:1118`), CSV (`:1292`), microcapsule (`:884`).
+- `exportSpermToExcel` already emits `Image Name` (no UUID column) — unaffected.
+
+## 6. Workstream C — rename microtubules in the editor (#4, FE-only)
+
+- `src/pages/segmentation/components/MicrotubuleInstancePanel.tsx` — add inline
+  rename (pencil affordance mirroring `PolygonItem.tsx:164` + `:118-136`) and display
+  the stored `mt.name`, falling back to the positional `Microtubule instance {idx+1}`
+  (`:262`) when unnamed.
+- `src/pages/segmentation/components/context-menu/PolygonContextMenu.tsx` (MT branch
+  `:157-262`) — add a **Rename** item.
+- Thread the **existing** `handleRenamePolygon` (`usePolygonHandlers.ts:232` → writes
+  `{ name }`) into the MT panel/menu at `SegmentationEditorLayout.tsx:596-614`
+  (it is already imported and passed to `PolygonListPanel` at `:576`).
+- **Reuse unchanged:** `updatePolygons` → `handleSave` → PUT
+  `/segmentation/images/:id/results` → `computeCrossFrameTrackPropagation`
+  (`segmentationService.ts:1681, :2146`) mirrors the new name across every frame of the
+  same `trackId`. No backend/DB work.
+
+## 7. Workstream D — ImageJ `<type>_<counter>` naming (#5)
+
+- `backend/src/services/export/imagejRoiEncoder.ts:437-442` (`buildVideoRoiEntries`) —
+  compute a **per-type running counter** for the whole video, keyed on `trackId`,
+  ordered by first appearance. ROI name resolution:
+  1. If the MT has a manual `name` → use it verbatim (rename overrides).
+  2. Else if it has a resolved type label → `<typeName>_<counter>` where counter is
+     that type's running index from 1.
+  3. Else (untyped, unnamed) → `untyped_<counter>`.
+- Replaces the current `<name>__<type>` join. Depends on Workstream C (so a rename
+  exists to honor) and the existing mtType palette resolution (`labelById`).
+
+## 8. Workstream E — per-MT local background + ImageJ background ROI (#3)
+
+**ML — `backend/segmentation/api/mt_metrics.py`**
+
+- Replace the global background (`:566-571`) with a **per-MT vicinity**. With
+  `margin_radius = round(thickness_px × margin_multiplier)` (unchanged formula, `:539`),
+  and `signal_union = ∪ all band masks at thickness` (`:566-568`):
+  ```
+  vicinity_i = dilate(band_i, margin_radius) AND NOT signal_union
+  ```
+  Background stats (`median_background`, `mean_background`, `signal_minus_background`)
+  are sampled per-MT from `frame_arr[vicinity_i]` instead of once per frame.
+- **Return the drawn region** for the annotation: the outer contour of
+  `dilate(band_i, margin_radius)` via `cv2.findContours` (a simple "capsule" polygon
+  for an open polyline — no holes), simplified with `approxPolyDP` to bound payload
+  size. Emitted once per `(frame_index, instance_id)` as a new
+  `background_regions: [{frame_index, instance_id, contour: [[x,y],…]}]` list on the
+  response (not per-channel, to avoid redundancy).
+
+**Wire — `mtMetricsExporter.ts`**
+
+- Extend `MLMTMetricsResponseRow` / response parsing to read `background_regions`.
+  Build a `Map<`frameId + '|' + instanceId`, Point[]>` and hand it to the ImageJ step.
+
+**ImageJ — `exportService.ts` + `imagejRoiEncoder.ts`**
+
+- Thread the vicinity-contour map from the (earlier) metrics step into
+  `exportImageJRoiSets`. Per MT polyline, if a contour exists, emit a **second ROI**:
+  a closed polygon (`geometry: 'polygon'`) = the vicinity outline, named
+  `<signal-roi-name>_bg` (the Workstream D-resolved name with a `_bg` suffix, so signal
+  and its background sort together). In ImageJ the user then sees the thin
+  thickness-stroked signal polyline _inside_ the background capsule.
+- If the metrics step did not run (no contours available), skip the bg ROI and log a
+  debug note — the signal ROIs are unaffected.
+
+**Transparency note (documented, not hidden):** the _drawn_ capsule is
+`dilate(MT, margin)`; the _measured_ background additionally subtracts neighboring
+MTs' signal bands, so where MTs are close the measured pixel set is slightly smaller
+than the drawn ring. The drawn ROI is deliberately the simple capsule (encoder cannot
+represent holed/multi-part regions).
+
+## 9. Implementation sequence (each an independently-verified PR)
+
+1. **A — SSOT + de-sperm polyline path.** Foundation for the rest.
+2. **C — MT rename** (small, FE-only; unblocks D's rename-override).
+3. **B — image name in export columns.**
+4. **D — ImageJ `<type>_<counter>` naming** (depends on C + mtType).
+5. **E — per-MT local background + ImageJ bg ROI** (ML + encoder; largest single change).
+
+## 10. Testing & verification (per CLAUDE.md gates)
+
+- **A (FE + BE):** Playwright on production — in an MT project, draw a polyline via
+  `CreatePolyline`; assert it renders as a microtubule (no head/midpiece/tail UI) and
+  its synthesized id uses `mt_`. In a sperm project, assert sperm semantics persist.
+  BE: unit tests on the resolver; export a sperm project → COCO still emits `sperm`.
+- **C (FE):** Playwright — rename an MT, scrub frames, reload → the name persists on the
+  same track across frames (exercises the existing cross-frame mirror).
+- **B (BE):** trigger an MT export; `curl`/download the `.xlsx`/`.csv` → assert an
+  `imageName` column with real frame names and **no** UUID column.
+- **D (BE):** download `RoiSet.zip`; decode names with Python `roifile` → assert
+  `<type>_<counter>` per-type sequencing and that a renamed MT overrides.
+- **E (ML + BE):** `docker exec spheroseg-ml` minimal repro of `vicinity_i` on a known
+  mask; confirm per-MT background differs from the old global value; download the export
+  → `median_background` varies per MT and a `_bg` ROI is present and geometrically sane.
+
+## 11. Risks & mitigations
+
+- **Kind now depends on project type reaching the FE render hook.** `projectType` is
+  already available in `SegmentationEditorLayout`; thread it into
+  `usePolygonRenderProps`. Verify no path renders polylines before the type is known
+  (guard with the existing loading states).
+- **Existing polylines carry old `sperm_`/`mt_` ids.** The resolver keys on _project
+  type_, so legacy ids don't change kind; only _new_ ids follow the new prefix. No
+  migration required; verify old MT projects still group correctly.
+- **E couples the ImageJ step to the metrics step** (contours come from the ML metrics
+  call). Both are always-on for MT exports today; the bg ROI degrades gracefully if
+  metrics is absent. Alternative (pure-TS stroke-outline) rejected to avoid a
+  geometry re-implementation and to keep the drawn region exactly the ML-measured one.
+- **Background numbers change (E).** This is intended and user-requested; call it out in
+  the export docs (`exportDocs.ts`) so downstream analyses know the definition changed.
+- **`formatConverter.ts` change touches COCO/JSON for real sperm exports.** Regression-
+  test a sperm export end-to-end to ensure head/midpiece/tail output is byte-identical.
+
+## 12. Out of scope (YAGNI)
+
+- No UI/panels/metrics writer built for the hypothetical `generic` polyline kind beyond
+  the resolver row that removes the sperm assumption.
+- No change to closed-polygon (spheroid/microcapsule/wound) metrics beyond dropping the
+  redundant UUID column (#1).
+- No new export format; no change to the kymograph/CVAT exporters except where the
+  polyline SSOT naturally applies.

--- a/docs/superpowers/specs/2026-07-09-polyline-primitive-and-mt-export-design.md
+++ b/docs/superpowers/specs/2026-07-09-polyline-primitive-and-mt-export-design.md
@@ -146,35 +146,33 @@ instance IDs), never the source of it.
   vicinity_i = dilate(band_i, margin_radius) AND NOT signal_union
   ```
   Background stats (`median_background`, `mean_background`, `signal_minus_background`)
-  are sampled per-MT from `frame_arr[vicinity_i]` instead of once per frame.
-- **Return the drawn region** for the annotation: the outer contour of
-  `dilate(band_i, margin_radius)` via `cv2.findContours` (a simple "capsule" polygon
-  for an open polyline — no holes), simplified with `approxPolyDP` to bound payload
-  size. Emitted once per `(frame_index, instance_id)` as a new
-  `background_regions: [{frame_index, instance_id, contour: [[x,y],…]}]` list on the
-  response (not per-channel, to avoid redundancy).
+  are sampled per-MT from `frame_arr[vicinity_i]` instead of once per frame. The
+  dilation runs within each band's bounding box (`_vicinity_mask`) — O(bbox), not
+  O(frame) — bit-identical to a full-frame dilate but fast enough for many-MT videos.
 
-**Wire — `mtMetricsExporter.ts`**
-
-- Extend `MLMTMetricsResponseRow` / response parsing to read `background_regions`.
-  Build a `Map<`frameId + '|' + instanceId`, Point[]>` and hand it to the ImageJ step.
+> **Implementation note (as shipped):** an earlier draft had Python return the vicinity
+> _contour_ (`background_regions` list) for the ImageJ ROI, threaded from the metrics
+> step. That was dropped: the metrics and ImageJ export steps run in **parallel**
+> (`Promise.all`), so threading a contour between them would force serialization. The
+> ImageJ background ROI is instead drawn **decoupled**, as a wide-stroke polyline (see
+> below) — no ML contour, no cross-step coupling. Python returns only the (per-MT)
+> statistics.
 
 **ImageJ — `exportService.ts` + `imagejRoiEncoder.ts`**
 
-- Thread the vicinity-contour map from the (earlier) metrics step into
-  `exportImageJRoiSets`. Per MT polyline, if a contour exists, emit a **second ROI**:
-  a closed polygon (`geometry: 'polygon'`) = the vicinity outline, named
-  `<signal-roi-name>_bg` (the Workstream D-resolved name with a `_bg` suffix, so signal
-  and its background sort together). In ImageJ the user then sees the thin
-  thickness-stroked signal polyline _inside_ the background capsule.
-- If the metrics step did not run (no contours available), skip the bg ROI and log a
-  debug note — the signal ROIs are unaffected.
+- Each MT gets a **second ROI**: the SAME polyline drawn at the vicinity band width
+  `backgroundStrokeWidth = thickness + 2·round(thickness·margin_multiplier)` (equal to
+  the diameter of `dilate(band, margin)`), named `<signal-roi-name>_bg` (the Workstream
+  D name with a `_bg` suffix, so signal and background sort together). In ImageJ the
+  user sees the thin signal band _inside_ the wider background band — the ring between
+  them is where the background is sampled. Emitted only for polylines and only when the
+  vicinity is wider than the signal (margin > 0). Fully decoupled from the metrics step.
 
-**Transparency note (documented, not hidden):** the _drawn_ capsule is
-`dilate(MT, margin)`; the _measured_ background additionally subtracts neighboring
-MTs' signal bands, so where MTs are close the measured pixel set is slightly smaller
-than the drawn ring. The drawn ROI is deliberately the simple capsule (encoder cannot
-represent holed/multi-part regions).
+**Transparency note (documented, not hidden):** the _drawn_ band is `dilate(MT, margin)`
+(the wide stroke); the _measured_ background additionally subtracts neighboring MTs'
+signal bands, so where MTs are close the measured pixel set is slightly smaller than the
+drawn band. The `_bg` ROI is a "roughly where background comes from" visual aid, not a
+metric-bearing ROI.
 
 ## 9. Implementation sequence (each an independently-verified PR)
 

--- a/src/lib/__tests__/polylineSemantics.test.ts
+++ b/src/lib/__tests__/polylineSemantics.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the frontend polyline-semantics SSOT. A polyline is a generic
+ * labeling primitive; its kind/id-scheme/part-class support is a property of the
+ * PROJECT type, not of an individual polyline. These lock the mapping so a
+ * hand-drawn polyline in a microtubule project can never again be treated as
+ * sperm.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  polylineSemanticsForProjectType,
+  polylinePanelKind,
+} from '../polylineSemantics';
+
+describe('polylineSemanticsForProjectType', () => {
+  it('maps sperm projects to sperm semantics (part classes, sperm_ ids, S badge)', () => {
+    const s = polylineSemanticsForProjectType('sperm');
+    expect(s.kind).toBe('sperm');
+    expect(s.idPrefix).toBe('sperm_');
+    expect(s.labelPrefix).toBe('S');
+    expect(s.supportsPartClass).toBe(true);
+  });
+
+  it('maps microtubules projects to microtubule semantics (no part classes)', () => {
+    const s = polylineSemanticsForProjectType('microtubules');
+    expect(s.kind).toBe('microtubule');
+    expect(s.idPrefix).toBe('mt_');
+    expect(s.labelPrefix).toBe('MT');
+    expect(s.supportsPartClass).toBe(false);
+  });
+
+  it.each(['spheroid', 'spheroid_invasive', 'wound', 'microcapsule'])(
+    'maps non-polyline project type %s to generic (never sperm)',
+    type => {
+      const s = polylineSemanticsForProjectType(type);
+      expect(s.kind).toBe('generic');
+      expect(s.idPrefix).toBe('poly_');
+      expect(s.supportsPartClass).toBe(false);
+    }
+  );
+
+  it.each([undefined, null, '', 'garbage', 'MICROTUBULES'])(
+    'falls back to generic for unknown/legacy value %s',
+    type => {
+      expect(polylineSemanticsForProjectType(type).kind).toBe('generic');
+    }
+  );
+
+  // The singular model id `microtubule` must NOT resolve — only the plural
+  // project type `microtubules` does. Mixing them has shipped a bug before.
+  it('does not treat the singular model id "microtubule" as a MT project', () => {
+    expect(polylineSemanticsForProjectType('microtubule').kind).toBe('generic');
+  });
+});
+
+describe('polylinePanelKind', () => {
+  it('returns the panel kind for the two projects with a dedicated panel', () => {
+    expect(polylinePanelKind('sperm')).toBe('sperm');
+    expect(polylinePanelKind('microtubules')).toBe('microtubule');
+  });
+
+  it('returns null for generic projects (no polyline sidebar panel)', () => {
+    expect(polylinePanelKind('spheroid')).toBeNull();
+    expect(polylinePanelKind(undefined)).toBeNull();
+    expect(polylinePanelKind(null)).toBeNull();
+  });
+});

--- a/src/lib/polylineSemantics.ts
+++ b/src/lib/polylineSemantics.ts
@@ -1,0 +1,78 @@
+/**
+ * A polyline (`Polygon` with `geometry: 'polyline'`) is a GENERIC labeling
+ * primitive shared by sperm and microtubule projects. Its *semantics* — which
+ * instance-id scheme new polylines use, whether head/midpiece/tail part classes
+ * apply, how export badges/categories read — are a property of the PROJECT TYPE,
+ * not of an individual polyline.
+ *
+ * Deriving them here, once, from `Project.type` removes the old per-polygon
+ * guesswork (sniff an `mt_` instanceId prefix, fall back to sperm) that let a
+ * hand-drawn polyline in a microtubule project masquerade as sperm — stamping it
+ * with a `partClass` and a `sperm_1` id, and flipping the whole project's sidebar
+ * to the sperm panel.
+ *
+ * Mirrored on the backend at `backend/src/utils/polylineSemantics.ts`; keep the
+ * kind mapping identical.
+ */
+
+export type PolylineKind = 'sperm' | 'microtubule' | 'generic';
+
+export interface PolylineSemantics {
+  kind: PolylineKind;
+  /** Prefix for a freshly-synthesised instance id: `sperm_`, `mt_`, `poly_`. */
+  idPrefix: string;
+  /** Sequential export badge prefix: `S`, `MT`, `P`. */
+  labelPrefix: string;
+  /** Only sperm carries head/midpiece/tail part classes. */
+  supportsPartClass: boolean;
+}
+
+const SPERM: PolylineSemantics = {
+  kind: 'sperm',
+  idPrefix: 'sperm_',
+  labelPrefix: 'S',
+  supportsPartClass: true,
+};
+
+const MICROTUBULE: PolylineSemantics = {
+  kind: 'microtubule',
+  idPrefix: 'mt_',
+  labelPrefix: 'MT',
+  supportsPartClass: false,
+};
+
+const GENERIC: PolylineSemantics = {
+  kind: 'generic',
+  idPrefix: 'poly_',
+  labelPrefix: 'P',
+  supportsPartClass: false,
+};
+
+/** Resolve the polyline semantics for a raw `project.type` string. Unknown /
+ *  legacy values (spheroid, wound, microcapsule, …) fall through to `generic`. */
+export function polylineSemanticsForProjectType(
+  type: string | undefined | null
+): PolylineSemantics {
+  switch (type) {
+    case 'sperm':
+      return SPERM;
+    case 'microtubules':
+      return MICROTUBULE;
+    default:
+      return GENERIC;
+  }
+}
+
+/**
+ * Panel / context-menu discriminator: `'sperm'` or `'microtubule'` for the two
+ * project types that own a dedicated polyline sidebar panel, else `null`
+ * (generic projects have no polyline UI). This is the single signal the editor
+ * uses to choose the sperm vs microtubule panel — replacing the old per-polygon
+ * `class`/`partClass`/`mt_`-prefix heuristic.
+ */
+export function polylinePanelKind(
+  type: string | undefined | null
+): 'sperm' | 'microtubule' | null {
+  const { kind } = polylineSemanticsForProjectType(type);
+  return kind === 'generic' ? null : kind;
+}

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -702,6 +702,7 @@ const SegmentationEditor = () => {
     editor,
     hiddenPolygonIds,
     activeInstanceId,
+    projectType,
   });
 
   // Development-only debug logger: logs polygon rendering state.

--- a/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
+++ b/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
@@ -524,12 +524,12 @@ describe('polylineKind discriminator — sidebar panel selection', () => {
     mockParams.imageId = 'img-1';
   });
 
-  it('shows SpermInstancePanel when a polyline has class=sperm', () => {
+  it('shows SpermInstancePanel when the project type is sperm', () => {
+    mockProjectData.projectType = 'sperm';
     mockEditor.polygons = [
       {
         id: 'p1',
         geometry: 'polyline',
-        class: 'sperm',
         points: [
           { x: 0, y: 0 },
           { x: 1, y: 1 },
@@ -541,12 +541,12 @@ describe('polylineKind discriminator — sidebar panel selection', () => {
     expect(screen.queryByTestId('mt-panel')).not.toBeInTheDocument();
   });
 
-  it('shows MicrotubuleInstancePanel when a polyline has class=microtubule', () => {
+  it('shows MicrotubuleInstancePanel when the project type is microtubules', () => {
+    mockProjectData.projectType = 'microtubules';
     mockEditor.polygons = [
       {
         id: 'p1',
         geometry: 'polyline',
-        class: 'microtubule',
         points: [
           { x: 0, y: 0 },
           { x: 1, y: 1 },
@@ -558,11 +558,16 @@ describe('polylineKind discriminator — sidebar panel selection', () => {
     expect(screen.queryByTestId('sperm-panel')).not.toBeInTheDocument();
   });
 
-  it('shows SpermInstancePanel when polyline has partClass (legacy)', () => {
+  it('keys the panel on project type, NOT per-polygon class/partClass', () => {
+    // A polyline stamped microtubule-ish in a SPERM project is still sperm —
+    // the project type is the single source of truth, so one mis-stamped
+    // polyline can no longer flip the whole sidebar.
+    mockProjectData.projectType = 'sperm';
     mockEditor.polygons = [
       {
         id: 'p1',
         geometry: 'polyline',
+        class: 'microtubule',
         partClass: 'head',
         points: [
           { x: 0, y: 0 },
@@ -572,6 +577,7 @@ describe('polylineKind discriminator — sidebar panel selection', () => {
     ];
     renderEditor();
     expect(screen.getByTestId('sperm-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('mt-panel')).not.toBeInTheDocument();
   });
 
   it('shows no instance panel when there are no polylines', () => {

--- a/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
+++ b/src/pages/segmentation/components/MicrotubuleInstancePanel.tsx
@@ -32,6 +32,10 @@ interface MicrotubuleInstancePanelProps {
   /** Delete a single microtubule polyline (the generic Polygon List is hidden
    *  for MT projects, so delete lives here). Omit to hide the delete button. */
   onDeletePolygon?: (id: string) => void;
+  /** Rename a single microtubule (writes `polygon.name`). The backend mirrors
+   *  the new name onto every frame of the same trackId, so a rename survives
+   *  frame scrubbing. Omit to hide the rename affordance. */
+  onRenamePolygon?: (id: string, name: string) => void;
   // ── Type-label palette (SSOT for tubulin class name+colour) ──
   mtTypeLabels?: MTTypeLabel[];
   mtLabelById?: Map<string, MTTypeLabel>;
@@ -54,6 +58,7 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   onSelectAll,
   onClearSelection,
   onDeletePolygon,
+  onRenamePolygon,
   mtTypeLabels = [],
   mtLabelById,
   colorMode = 'instance',
@@ -67,6 +72,16 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
   const [editingLabel, setEditingLabel] = useState<MTTypeLabel | null | 'new'>(
     null
   );
+  // Inline per-instance rename: id of the MT being renamed (null = none) + the
+  // in-progress text. Commit on Enter/blur, cancel on Escape.
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+
+  const commitRename = () => {
+    if (renamingId) onRenamePolygon?.(renamingId, renameValue.trim());
+    setRenamingId(null);
+    setRenameValue('');
+  };
 
   // Defer the (filter + sort) re-derivation when polygons update
   // rapidly (e.g. during playback ticking at 10 FPS). The canvas
@@ -248,33 +263,79 @@ const MicrotubuleInstancePanel: React.FC<MicrotubuleInstancePanelProps> = ({
                   className="flex-shrink-0"
                 />
               )}
-              <button
-                type="button"
-                className={`flex flex-1 items-center gap-2 text-left ${isHidden ? 'opacity-50' : ''}`}
-                onClick={() => onSelectPolygon(isSelected ? null : mt.id)}
-              >
-                <span
-                  className="inline-block w-3 h-3 rounded-sm border border-black/10 dark:border-white/10 flex-shrink-0"
-                  style={{ backgroundColor: color }}
-                  aria-hidden
-                />
-                <span className="font-mono truncate">
-                  {t('microtubule.instance')} {idx + 1}
-                </span>
-                {typeLabel && (
+              {renamingId === mt.id ? (
+                <div className="flex flex-1 items-center gap-2">
                   <span
-                    className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-white truncate max-w-[90px]"
-                    style={{ backgroundColor: typeLabel.color }}
-                    title={typeLabel.name}
-                  >
-                    {typeLabel.name}
+                    className="inline-block w-3 h-3 rounded-sm border border-black/10 dark:border-white/10 flex-shrink-0"
+                    style={{ backgroundColor: color }}
+                    aria-hidden
+                  />
+                  <input
+                    autoFocus
+                    type="text"
+                    value={renameValue}
+                    onChange={e => setRenameValue(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        commitRename();
+                      } else if (e.key === 'Escape') {
+                        setRenamingId(null);
+                        setRenameValue('');
+                      }
+                    }}
+                    placeholder={`${t('microtubule.instance')} ${idx + 1}`}
+                    className="flex-1 min-w-0 px-1 py-0.5 text-xs bg-white dark:bg-gray-900 border border-violet-400 rounded focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    aria-label={t('microtubule.renameInstance')}
+                  />
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={`flex flex-1 items-center gap-2 text-left ${isHidden ? 'opacity-50' : ''}`}
+                  onClick={() => onSelectPolygon(isSelected ? null : mt.id)}
+                >
+                  <span
+                    className="inline-block w-3 h-3 rounded-sm border border-black/10 dark:border-white/10 flex-shrink-0"
+                    style={{ backgroundColor: color }}
+                    aria-hidden
+                  />
+                  <span className="font-mono truncate">
+                    {mt.name && mt.name.trim()
+                      ? mt.name
+                      : `${t('microtubule.instance')} ${idx + 1}`}
                   </span>
-                )}
-                <span className="flex-1" />
-                <span className="text-gray-400 whitespace-nowrap">
-                  {Math.round(calculatePolylineLength(mt.points))} px
-                </span>
-              </button>
+                  {typeLabel && (
+                    <span
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-white truncate max-w-[90px]"
+                      style={{ backgroundColor: typeLabel.color }}
+                      title={typeLabel.name}
+                    >
+                      {typeLabel.name}
+                    </span>
+                  )}
+                  <span className="flex-1" />
+                  <span className="text-gray-400 whitespace-nowrap">
+                    {Math.round(calculatePolylineLength(mt.points))} px
+                  </span>
+                </button>
+              )}
+              {onRenamePolygon && renamingId !== mt.id && (
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setRenamingId(mt.id);
+                    setRenameValue(mt.name ?? '');
+                  }}
+                  className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors flex-shrink-0"
+                  aria-label={t('microtubule.renameInstance')}
+                  title={t('microtubule.renameInstance')}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              )}
               {onToggleVisibility && (
                 <button
                   type="button"

--- a/src/pages/segmentation/components/SegmentationEditorLayout.tsx
+++ b/src/pages/segmentation/components/SegmentationEditorLayout.tsx
@@ -604,6 +604,7 @@ const SegmentationEditorLayout: React.FC<SegmentationEditorLayoutProps> = ({
                     onSelectAll={handleSelectAllInList}
                     onClearSelection={handleClearSelectionInList}
                     onDeletePolygon={handleDeletePolygonFromPanel}
+                    onRenamePolygon={handleRenamePolygon}
                     mtTypeLabels={mtTypeLabels}
                     mtLabelById={mtLabelById}
                     colorMode={mtColorMode}

--- a/src/pages/segmentation/hooks/__tests__/usePolygonRenderProps.test.ts
+++ b/src/pages/segmentation/hooks/__tests__/usePolygonRenderProps.test.ts
@@ -21,6 +21,7 @@ const run = (params: {
   hidden?: Set<PolygonKey>;
   editMode?: EditMode;
   activeInstanceId?: string;
+  projectType?: string | null;
 }) =>
   renderHook(() =>
     usePolygonRenderProps({
@@ -30,6 +31,7 @@ const run = (params: {
       },
       hiddenPolygonIds: params.hidden ?? new Set<PolygonKey>(),
       activeInstanceId: params.activeInstanceId ?? 'sperm_1',
+      projectType: params.projectType,
     })
   ).result.current;
 
@@ -39,31 +41,57 @@ describe('usePolygonRenderProps', () => {
       expect(run({ polygons: [poly()] }).hasPolylines).toBe(false);
     });
 
-    it('detects a polyline and classifies sperm via class', () => {
+    it('detects a polyline (hasPolylines) independent of the panel kind', () => {
       const r = run({
-        polygons: [poly({ geometry: 'polyline', class: 'sperm' })],
+        polygons: [poly({ geometry: 'polyline' })],
+        projectType: 'sperm',
       });
       expect(r.hasPolylines).toBe(true);
-      expect(r.polylineKind).toBe('sperm');
     });
 
-    it('classifies microtubule via class', () => {
+    it('classifies the panel kind from the SPERM project type', () => {
       expect(
         run({
-          polygons: [poly({ geometry: 'polyline', class: 'microtubule' })],
-        }).polylineKind
-      ).toBe('microtubule');
-    });
-
-    it('falls back to partClass → sperm', () => {
-      expect(
-        run({
-          polygons: [poly({ geometry: 'polyline', partClass: 'head' })],
+          polygons: [poly({ geometry: 'polyline' })],
+          projectType: 'sperm',
         }).polylineKind
       ).toBe('sperm');
     });
 
-    it('returns null when there are no polylines', () => {
+    it('classifies the panel kind from the MICROTUBULES project type', () => {
+      expect(
+        run({
+          polygons: [poly({ geometry: 'polyline' })],
+          projectType: 'microtubules',
+        }).polylineKind
+      ).toBe('microtubule');
+    });
+
+    it('keys on project type, NOT per-polygon class/partClass', () => {
+      // A polyline stamped microtubule-ish but in a SPERM project is sperm —
+      // the project type is the single source of truth, so one mis-stamped
+      // polyline can no longer flip the panel.
+      expect(
+        run({
+          polygons: [
+            poly({
+              geometry: 'polyline',
+              class: 'microtubule',
+              partClass: 'head',
+            }),
+          ],
+          projectType: 'sperm',
+        }).polylineKind
+      ).toBe('sperm');
+    });
+
+    it('returns null for a generic / undefined project type', () => {
+      expect(
+        run({
+          polygons: [poly({ geometry: 'polyline' })],
+          projectType: 'spheroid',
+        }).polylineKind
+      ).toBeNull();
       expect(run({ polygons: [poly()] }).polylineKind).toBeNull();
     });
   });

--- a/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
+++ b/src/pages/segmentation/hooks/useAdvancedInteractions.tsx
@@ -14,6 +14,7 @@ import {
   createPolygon,
 } from '@/lib/polygonGeometry';
 import { vertexSpatialIndex } from '@/lib/rendering/VertexSpatialIndex';
+import { polylineSemanticsForProjectType } from '@/lib/polylineSemantics';
 import type { ProjectType } from '@/types';
 
 /**
@@ -72,6 +73,7 @@ export const useAdvancedInteractions = ({
   isSpacePressed: isSpacePressedCallback,
   activePartClassRef,
   activeInstanceIdRef,
+  projectType,
   onPolygonSelection,
   setEditMode,
   setInteractionState,
@@ -411,12 +413,24 @@ export const useAdvancedInteractions = ({
     // No duplicate point: React 18 batching means both click setState calls share the same base snapshot
     if (tempPoints.length >= 2) {
       const newPolyline = createPolygon(tempPoints);
-      // Override with polyline-specific fields, including active part class and instance
+      // A polyline is a generic labeling primitive; its identity fields follow
+      // the PROJECT type, not a sperm default. Sperm carries head/midpiece/tail
+      // part classes and the panel-managed `sperm_N` id; microtubule / generic
+      // projects get a fresh unique kind-prefixed id and NO part class (part
+      // classes are sperm-only). This stops a hand-drawn polyline in a
+      // microtubule project from being stamped `partClass:'head'` + `sperm_1`
+      // (which used to flip the whole sidebar to the sperm panel).
+      const semantics = polylineSemanticsForProjectType(projectType);
       const polyline: Polygon = {
         ...newPolyline,
         geometry: 'polyline',
-        partClass: activePartClassRef?.current || undefined,
-        instanceId: activeInstanceIdRef?.current || undefined,
+        partClass: semantics.supportsPartClass
+          ? activePartClassRef?.current || undefined
+          : undefined,
+        instanceId:
+          semantics.kind === 'sperm'
+            ? activeInstanceIdRef?.current || undefined
+            : `${semantics.idPrefix}${newPolyline.id.replace(/^polygon_/, '')}`,
       };
       const currentPolygons = getPolygons();
       updatePolygons([...currentPolygons, polyline]);
@@ -433,6 +447,7 @@ export const useAdvancedInteractions = ({
     setEditMode,
     activePartClassRef,
     activeInstanceIdRef,
+    projectType,
   ]);
 
   /**

--- a/src/pages/segmentation/hooks/usePolygonRenderProps.ts
+++ b/src/pages/segmentation/hooks/usePolygonRenderProps.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { EditMode } from '../types';
 import { Polygon, polygonKey, type PolygonKey } from '@/lib/segmentation';
-import { isMicrotubuleInstance } from '../utils/instanceColors';
+import { polylinePanelKind } from '@/lib/polylineSemantics';
 
 /**
  * Minimal structural slice of the editor that the render pipeline reads.
@@ -18,6 +18,10 @@ interface UsePolygonRenderPropsParams {
   editor: RenderEditor;
   hiddenPolygonIds: Set<PolygonKey>;
   activeInstanceId: string;
+  /** Raw `project.type`. Drives which polyline panel (sperm vs microtubule)
+   *  the sidebar shows — the single authoritative signal, replacing the old
+   *  per-polygon `class`/`partClass`/`mt_`-prefix guess. */
+  projectType: string | undefined | null;
 }
 
 /**
@@ -38,29 +42,24 @@ export function usePolygonRenderProps({
   editor,
   hiddenPolygonIds,
   activeInstanceId,
+  projectType,
 }: UsePolygonRenderPropsParams) {
   const hasPolylines = useMemo(
     () => editor.polygons.some(p => p.geometry === 'polyline'),
     [editor.polygons]
   );
 
-  // Discriminate sperm vs microtubule projects so the sidebar shows the
-  // right panel. Authoritative signal: `polygon.class` ('sperm' or
-  // 'microtubule') is stamped by the ML model when it produces the
-  // polygon. Each project uses one model, so the first polyline whose
-  // class we recognise is sufficient — no majority-counting needed.
-  // Legacy/manually-drawn polylines without `class` fall back to
-  // `partClass` (sperm head/midpiece/tail) or `mt_` instanceId prefix.
-  const polylineKind = useMemo<'sperm' | 'microtubule' | null>(() => {
-    for (const p of editor.polygons) {
-      if (p.geometry !== 'polyline') continue;
-      if (p.class === 'microtubule') return 'microtubule';
-      if (p.class === 'sperm') return 'sperm';
-      if (p.partClass) return 'sperm';
-      if (isMicrotubuleInstance(p.instanceId)) return 'microtubule';
-    }
-    return null;
-  }, [editor.polygons]);
+  // Which polyline panel the sidebar shows is a property of the PROJECT type,
+  // not of any individual polyline. Every polyline in a sperm project is a
+  // sperm annotation; every one in a microtubule project is a microtubule.
+  // Deriving the kind from `project.type` (the same signal the layout already
+  // uses via `isMicrotubuleProject`) removes the old per-polygon guess, which
+  // sniffed `class`/`partClass`/`mt_` and let one mis-stamped hand-drawn
+  // polyline flip the whole project to the sperm panel.
+  const polylineKind = useMemo(
+    () => polylinePanelKind(projectType),
+    [projectType]
+  );
 
   // Compute available sperm instance IDs for context menu (from existing polylines + active).
   // Two-stage memo: first derive a stable string key, then split into array only when key changes.

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2160,6 +2160,7 @@ export default {
     instance: 'Mikrotubulus',
     hideInstance: 'Skrýt mikrotubulus',
     showInstance: 'Zobrazit mikrotubulus',
+    renameInstance: 'Přejmenovat mikrotubulus',
     hideAll: 'Skrýt vše',
     showAll: 'Zobrazit vše',
     type: {

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2155,6 +2155,7 @@ export default {
     instance: 'Mikrotubulus',
     hideInstance: 'Mikrotubulus ausblenden',
     showInstance: 'Mikrotubulus einblenden',
+    renameInstance: 'Mikrotubulus umbenennen',
     hideAll: 'Alle ausblenden',
     showAll: 'Alle einblenden',
     type: {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2227,6 +2227,7 @@ export default {
     instance: 'Microtubule',
     hideInstance: 'Hide microtubule',
     showInstance: 'Show microtubule',
+    renameInstance: 'Rename microtubule',
     hideAll: 'Hide all',
     showAll: 'Show all',
     type: {

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2195,6 +2195,7 @@ export default {
     instance: 'Microtúbulo',
     hideInstance: 'Ocultar microtúbulo',
     showInstance: 'Mostrar microtúbulo',
+    renameInstance: 'Renombrar microtúbulo',
     hideAll: 'Ocultar todo',
     showAll: 'Mostrar todo',
     type: {

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2144,6 +2144,7 @@ export default {
     instance: 'Microtubule',
     hideInstance: 'Masquer le microtubule',
     showInstance: 'Afficher le microtubule',
+    renameInstance: 'Renommer le microtubule',
     hideAll: 'Tout masquer',
     showAll: 'Tout afficher',
     type: {

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -2014,6 +2014,7 @@ export default {
     instance: '微管',
     hideInstance: '隐藏微管',
     showInstance: '显示微管',
+    renameInstance: '重命名微管',
     hideAll: '全部隐藏',
     showAll: '全部显示',
     type: {


### PR DESCRIPTION
## Summary

A polyline is a **generic labeling primitive** shared by sperm and microtubule projects, but the export/editor code assumed *polyline ⇒ sperm* (it guessed the kind from an `mt_` id prefix and fell through to sperm). This PR makes **project type the single source of truth** for polyline semantics and lands four related MT-export/editor improvements. Design spec: `docs/superpowers/specs/2026-07-09-polyline-primitive-and-mt-export-design.md`.

Five workstreams, one per commit:

1. **`feat(polyline)` — project-type SSOT.** New `polylineSemantics` (FE `src/lib/` + BE `backend/src/utils/`) maps `project.type → {kind, idPrefix, labelPrefix, supportsPartClass, exportCategory}`. `usePolygonRenderProps` derives the sidebar panel from project type; `useAdvancedInteractions` stamps a kind-appropriate id + no part class outside sperm (fixes a hand-drawn MT polyline getting `partClass:'head'`+`sperm_1` and flipping the whole sidebar to the sperm panel); `exportService` badge prefix and `formatConverter` COCO/JSON category are project-type-driven. **Sperm output is byte-identical** (tests pass `'sperm'` explicitly).

2. **`feat(mt-editor)` — rename microtubules.** Inline pencil-rename in `MicrotubuleInstancePanel`, showing the stored `polygon.name` (falls back to the positional label). Reuses the existing save path; the backend already mirrors the name across every frame of the same `trackId`. FE-only; i18n ×6.

3. **`feat(export)` — image name, not UUID.** MT metrics export `imageId` (UUID) column → `imageName` (the frame's `Image.name`); the general spheroid/microcapsule/CSV writers drop the redundant `Image ID` UUID column (they already emit `Image Name`).

4. **`feat(imagej)` — `<type>_<counter>` ROI names.** Per-video, per-tubulin-class counter from 1 (`HeLa_1`, `HeLa_2`, `brain_1`…), keyed on `trackId` so one MT keeps one name on every slice. A manual rename overrides it; an untyped MT reads `untyped_<n>`.

5. **`feat(mt-metrics)` — per-MT LOCAL background.** Background was frame-global (every MT shared one value = frame minus all bands). Now each MT samples its own vicinity ring `dilate(band, thickness*margin) ∖ (union of all bands)`. **This changes exported `median/mean_background` numbers** (documented). ImageJ also gets a companion `<name>_bg` band ROI — the same polyline at the vicinity width — so the background band is visible around the signal band.

## Verification

- `make ci` green (TS + ESLint 0-warn + i18n ×6, 1632 keys).
- **Unit tests** for every pure-logic change: FE+BE `polylineSemantics` (22), `formatConverter` sperm-unchanged + MT/generic cases, `mtMetricsExporter` (45, `imageName`), `metricsCalculator.microcapsule` header, `imagejRoiEncoder` (39: per-type counter, cross-frame stability, rename override, `_bg` band).
- **Production builds** pass for `frontend` and `backend` (Docker `vite build` + fresh `npm ci`/`tsc` — gate G, no bundle break, no phantom deps).
- **ML** (`mt_metrics.py`): `py_compile` clean; in-container algorithm repro confirms per-MT local background — two MTs on a 100-vs-10 frame now read **100 / 10** (was **55 / 55** globally), and the vicinity correctly excludes signal bands.

⚠️ **Pending: live browser E2E** of the two FE bits (panel-by-project-type; MT rename). It needs a running instance of this branch — the prod containers run `main` and I don't have deploy authorization for this branch, and the dev stack bind-mounts the main repo, not this worktree. Happy to run the full Playwright walkthrough against production once a deploy is authorized. The FE logic is covered by the SSOT unit tests and the clean production bundle; the rename reuses the already-tested cross-frame propagation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline renaming for microtubule instances in the segmentation editor.
  * Improved exported ROI naming with clearer, project-aware labels and optional background ROIs.

* **Bug Fixes**
  * Microtubule background metrics now use a local neighborhood around each structure for more accurate values.
  * Exported metrics now show image names instead of internal IDs.

* **Documentation**
  * Updated export guidance to match the new naming and metric behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->