### PR TITLE
feat(metrics): core-required disintegration index matching paper eq (1)

### DIFF
--- a/backend/segmentation/api/metrics_endpoint.py
+++ b/backend/segmentation/api/metrics_endpoint.py
@@ -7,7 +7,6 @@ import cv2
 import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from scipy.stats import wasserstein_distance
 
 # Import characteristic_functions from utils package
 from utils.characteristic_functions import calculate_all
@@ -42,7 +41,7 @@ class DisintegrationRequest(BaseModel):
 class DisintegrationResponse(BaseModel):
     di: float
     w1: float
-    reference: str  # 'core' | 'r_eff' | 'r_eff_fallback' | 'none'
+    reference: str  # 'core' | 'no_core' | 'none'
     n_pixels: int
 
 class Point(BaseModel):
@@ -169,13 +168,27 @@ async def batch_calculate_metrics(polygons: List[MetricsRequest]) -> List[Metric
 
 @router.post("/disintegration-index", response_model=DisintegrationResponse)
 async def disintegration_index(request: DisintegrationRequest):
-    """Compute the per-image Disintegration Index (DI).
+    """Compute the per-image core-anchored Disintegration Index (DI).
 
-    Reduces the binary mask polygon to a 1-D radial distribution of pixel
-    distances from the centroid, normalises by R_ref (derived from core
-    area if provided, else from mask area), and measures the
-    1-Wasserstein distance to the analytical CDF of a uniform disk
-    `F_ref(d̃) = d̃²`. The raw W1 is squashed via `tanh` into `[0, 1)`.
+    Implements the paper's core-anchored DI. Radial distances of every
+    foreground pixel are measured from the **core centroid** and normalised by
+    the core's effective radius ``R_C = sqrt(N_core / pi)`` to give
+    ``d̃ = d / R_C``. The empirical CDF of ``{d̃}`` is compared, via the
+    1-Wasserstein distance in inverse-cumulative (quantile) form, to the
+    analytical CDF of a uniform filled disk ``F_ref(d̃) = min(d̃², 1)`` whose
+    inverse is ``F_ref⁻¹(u) = sqrt(u)``::
+
+        W1 = ∫₀¹ |d̃(u) − sqrt(u)| du ≈ (1/N) Σ_i |d̃₍ᵢ₎ − sqrt((i + 0.5) / N)|
+        DI = tanh(W1)  ∈ [0, 1)
+
+    An intact spheroid (foreground ≈ core) gives ``d̃ ≤ 1`` distributed as a
+    filled disk and ``DI ≈ 0``; as mass disperses to ``d̃ ≫ 1``, ``DI → 1``.
+
+    A valid core is **required** — the DI is undefined without one. When no
+    usable core polygon is supplied (or it rasterises to zero pixels) the
+    endpoint returns ``reference='no_core'`` with ``di=0.0`` as an N/A
+    sentinel; callers must render it as N/A, never as a computed zero. There
+    is deliberately no equivalent-disk (``r_eff``) fallback.
     """
     try:
         H = int(request.image_height)
@@ -218,85 +231,64 @@ async def disintegration_index(request: DisintegrationRequest):
                 di=0.0, w1=0.0, reference="none", n_pixels=0
             )
 
-        # Step 1: rasterise the optional core polygon(s). The core's centroid,
-        # when available, is the *anchor* for both d_mask and d_core — that
-        # way the metric measures "how far did mass spread from where the
-        # dense core sits", not the smeared mass centroid that drifts toward
-        # the invasion zone.
-        ref_label = "r_eff"
-        r_ref: Optional[float] = None
-        d_core: Optional[np.ndarray] = None
+        # Step 1: rasterise the REQUIRED core polygon(s). The core defines both
+        # the anchor (its centroid) and the normalising radius R_C; without a
+        # valid core the metric is undefined.
         candidate_cores: List[List[List[float]]] = []
         if request.core_polygons:
             candidate_cores = request.core_polygons
         elif request.core_polygon is not None:
             candidate_cores = [request.core_polygon]
 
-        ys_c: Optional[np.ndarray] = None
-        xs_c: Optional[np.ndarray] = None
-        if candidate_cores:
-            core_mask = np.zeros((H, W), dtype=np.uint8)
-            valid_count = 0
-            for poly in candidate_cores:
-                core_pts_arr = np.asarray(poly, dtype=np.float32)
-                if (
-                    core_pts_arr.ndim == 2
-                    and core_pts_arr.shape[1] == 2
-                    and core_pts_arr.shape[0] >= 3
-                ):
-                    cv2.fillPoly(core_mask, [core_pts_arr.astype(np.int32)], 1)
-                    valid_count += 1
-            n_core = int(core_mask.sum())
-            if valid_count > 0 and n_core > 0:
-                ys_c, xs_c = np.nonzero(core_mask)
-                r_ref = float(np.sqrt(n_core / np.pi))
-                ref_label = "core"
-            else:
-                # Surface a warning so a malformed/off-canvas/collinear core
-                # polygon doesn't silently degrade DI to the r_eff fallback.
-                logger.warning(
-                    "DI core polygons rejected: provided=%d valid_shape=%d "
-                    "rasterised_pixels=%d image=%dx%d -> r_eff fallback",
-                    len(candidate_cores), valid_count, n_core, W, H,
-                )
-                ref_label = "r_eff_fallback"
-
-        # Step 2: choose the centroid. Prefer the core's centroid (improvement A
-        # over the original mass-weighted mask centroid); fall back to the mask
-        # centroid only when no core is available.
-        if xs_c is not None and ys_c is not None and xs_c.size > 0:
-            cx = float(xs_c.mean())
-            cy = float(ys_c.mean())
-            d_core = np.hypot(xs_c - cx, ys_c - cy)
-        else:
-            cx = float(xs.mean())
-            cy = float(ys.mean())
-        d_mask = np.hypot(xs - cx, ys - cy)
-
-        if r_ref is None:
-            r_ref = float(np.sqrt(n / np.pi))
-        if r_ref <= 0:
+        core_mask = np.zeros((H, W), dtype=np.uint8)
+        valid_count = 0
+        for poly in candidate_cores:
+            core_pts_arr = np.asarray(poly, dtype=np.float32)
+            if (
+                core_pts_arr.ndim == 2
+                and core_pts_arr.shape[1] == 2
+                and core_pts_arr.shape[0] >= 3
+            ):
+                cv2.fillPoly(core_mask, [core_pts_arr.astype(np.int32)], 1)
+                valid_count += 1
+        n_core = int(core_mask.sum())
+        if valid_count == 0 or n_core == 0:
+            # DI requires a core. A malformed/off-canvas/collinear core (or no
+            # core at all) yields an explicit N/A instead of a fabricated value.
+            logger.warning(
+                "DI requires a valid core polygon; none usable "
+                "(provided=%d valid_shape=%d rasterised_pixels=%d image=%dx%d) "
+                "-> reference='no_core'",
+                len(candidate_cores), valid_count, n_core, W, H,
+            )
             return DisintegrationResponse(
-                di=0.0, w1=0.0, reference=ref_label, n_pixels=n
+                di=0.0, w1=0.0, reference="no_core", n_pixels=n
             )
 
-        if d_core is not None and d_core.size > 0:
-            # Empirical-CDF reference: compare the radial distance distribution
-            # of mask pixels against the same distribution of core pixels —
-            # both anchored on the core's centroid. Normalised by R_core to
-            # keep the metric scale-invariant.
-            w1_px = float(wasserstein_distance(d_mask, d_core))
-            w1 = w1_px / r_ref
-        else:
-            # No core: fall back to the equivalent-disk reference CDF
-            # F_ref(d̃) = d̃² in the d̃ = d / R_eff space.
-            d_tilde = np.sort(d_mask / r_ref)
-            u = (np.arange(n, dtype=np.float64) + 0.5) / n
-            w1 = float(np.mean(np.abs(d_tilde - np.sqrt(u))))
+        r_ref = float(np.sqrt(n_core / np.pi))  # R_C
+        if r_ref <= 0:
+            return DisintegrationResponse(
+                di=0.0, w1=0.0, reference="no_core", n_pixels=n
+            )
+
+        # Step 2: anchor radial distances on the CORE centroid — the metric
+        # measures how far mass spread from where the dense core sits, not the
+        # smeared mask centroid that drifts toward the invasion zone.
+        ys_c, xs_c = np.nonzero(core_mask)
+        cx = float(xs_c.mean())
+        cy = float(ys_c.mean())
+        d_mask = np.hypot(xs - cx, ys - cy)
+
+        # Step 3: 1-Wasserstein distance between the core-normalised foreground
+        # distances and the analytical uniform-disk reference F_ref(d̃)=min(d̃²,1)
+        # (inverse sqrt(u)), in inverse-cumulative form. This is exactly eq. (1).
+        d_tilde = np.sort(d_mask / r_ref)
+        u = (np.arange(n, dtype=np.float64) + 0.5) / n
+        w1 = float(np.mean(np.abs(d_tilde - np.sqrt(u))))
         di = float(np.tanh(w1))
 
         return DisintegrationResponse(
-            di=di, w1=w1, reference=ref_label, n_pixels=n
+            di=di, w1=w1, reference="core", n_pixels=n
         )
     except HTTPException:
         raise

--- a/backend/segmentation/tests/unit/test_disintegration.py
+++ b/backend/segmentation/tests/unit/test_disintegration.py
@@ -58,8 +58,12 @@ class TestDisintegrationIndex:
         assert resp.status_code == 200, resp.text
         return resp.json()
 
-    def test_perfect_disk_returns_low_di(self, client):
-        """Mask = perfect disk, no core → R_eff path → DI is small."""
+    def test_no_core_returns_na_not_a_computed_value(self, client):
+        """Mask present but no core → DI is undefined → reference='no_core'.
+
+        A core is required; there is no r_eff fallback. The DI field is a 0.0
+        N/A sentinel (callers render it as N/A), and n_pixels is still reported.
+        """
         pts = _circle(self.CX, self.CY, 60)
         body = {
             "mask_polygon": pts,
@@ -68,14 +72,13 @@ class TestDisintegrationIndex:
             "image_height": self.H,
         }
         out = self._post(client, body)
-        assert out["reference"] == "r_eff"
-        # A discretised disk has tiny rasterisation noise; DI should be near zero.
-        assert out["di"] < 0.05
-        assert out["w1"] >= 0.0
+        assert out["reference"] == "no_core"
+        assert out["di"] == 0.0
+        assert out["w1"] == 0.0
         assert out["n_pixels"] > 1000
 
     def test_disk_with_matching_core_returns_low_di(self, client):
-        """Mask polygon == core polygon → R_core ≈ R_eff → DI is small."""
+        """Mask polygon == core polygon → intact spheroid → DI is small."""
         pts = _circle(self.CX, self.CY, 60)
         body = {
             "mask_polygon": pts,
@@ -88,20 +91,29 @@ class TestDisintegrationIndex:
         assert out["di"] < 0.05
 
     def test_smaller_core_increases_di(self, client):
-        """Core ⊊ Mask → R_core < R_eff → d̃ stretched → DI larger."""
+        """Core ⊊ Mask → R_core small → d̃ = d/R_C stretched → DI larger.
+
+        Both cases carry a core (a core is required). A tight core makes the
+        same mask look far more dispersed than a core equal to the mask.
+        """
         mask_pts = _circle(self.CX, self.CY, 80)
-        core_pts = _circle(self.CX, self.CY, 30)
-        with_core = self._post(client, {
+        tight_core = _circle(self.CX, self.CY, 30)
+        full_core = _circle(self.CX, self.CY, 80)  # core == mask → intact
+        with_tight = self._post(client, {
             "mask_polygon": mask_pts,
-            "core_polygon": core_pts,
+            "core_polygon": tight_core,
             "image_width": self.W, "image_height": self.H,
         })
-        without_core = self._post(client, {
+        with_full = self._post(client, {
             "mask_polygon": mask_pts,
-            "core_polygon": None,
+            "core_polygon": full_core,
             "image_width": self.W, "image_height": self.H,
         })
-        assert with_core["di"] > without_core["di"] + 0.10
+        assert with_tight["reference"] == "core"
+        assert with_full["reference"] == "core"
+        # Intact (core == mask) → DI ≈ 0; tight core → clearly higher.
+        assert with_full["di"] < 0.05
+        assert with_tight["di"] > with_full["di"] + 0.10
 
     def test_invasion_pattern_returns_high_di(self, client):
         """Star-shape mask with a tight core → significant DI > 0."""
@@ -117,15 +129,20 @@ class TestDisintegrationIndex:
         # Heavy invasion → DI well above 0.1.
         assert out["di"] > 0.15
 
-    def test_falls_back_when_core_degenerate(self, client):
-        """Core polygon with <3 points → r_eff_fallback label."""
+    def test_degenerate_core_returns_no_core(self, client):
+        """Core polygon with <3 points → undefined DI → reference='no_core'.
+
+        A degenerate core cannot anchor the metric, so DI is N/A rather than
+        silently degrading to an equivalent-disk value.
+        """
         mask_pts = _circle(self.CX, self.CY, 60)
         out = self._post(client, {
             "mask_polygon": mask_pts,
             "core_polygon": [[10.0, 10.0], [11.0, 11.0]],  # only 2 vertices
             "image_width": self.W, "image_height": self.H,
         })
-        assert out["reference"] == "r_eff_fallback"
+        assert out["reference"] == "no_core"
+        assert out["di"] == 0.0
 
     def test_returns_zero_for_empty_polygon(self, client):
         """Mask polygon with <3 vertices → DI = 0, reference='none'."""
@@ -231,29 +248,29 @@ class TestDisintegrationIndex:
     # and the core centroid coincide and the anchor change is invisible. The
     # tests below deliberately break symmetry to exercise the new anchor.
 
-    def test_asymmetric_invasion_uses_core_anchor_not_mass(self, client):
-        """Mask extends rightward of the core. Mass centroid drifts right;
-        core centroid stays at (CX, CY). With the core-centroid anchor, all
-        rightward pixels are now far from the anchor, so DI is significantly
-        higher than when the same mask is processed without a core (which
-        falls back to the mass centroid).
+    def test_off_core_mass_raises_di_via_core_anchor(self, client):
+        """Same centred core; mass that sits off the core inflates DI.
+
+        Both cases are core-anchored on (CX, CY). A compact mask over the core
+        looks nearly intact; adding a distant rightward bulge places mass far
+        from the anchor and drives DI up. This exercises the core-centroid
+        anchor without relying on any no-core fallback.
         """
-        # Asymmetric mask: a centred blob plus a bulge to the right.
-        mask = [_circle(self.CX, self.CY, 30), _circle(self.CX + 80, self.CY, 25)]
         core = [_circle(self.CX, self.CY, 18)]
-        with_core = self._post(client, {
-            "mask_polygons": mask, "core_polygons": core,
+        compact = [_circle(self.CX, self.CY, 24)]
+        with_bulge = [_circle(self.CX, self.CY, 24), _circle(self.CX + 80, self.CY, 25)]
+        symmetric = self._post(client, {
+            "mask_polygons": compact, "core_polygons": core,
             "image_width": self.W, "image_height": self.H,
         })
-        no_core = self._post(client, {
-            "mask_polygons": mask, "core_polygons": None,
+        asymmetric = self._post(client, {
+            "mask_polygons": with_bulge, "core_polygons": core,
             "image_width": self.W, "image_height": self.H,
         })
-        assert with_core["reference"] == "core"
-        # The core anchor on (CX, CY) sees the right bulge as far away;
-        # the mass-anchor fallback sits between the blobs and sees them as
-        # roughly equidistant. Net: with_core DI must exceed no_core DI.
-        assert with_core["di"] > no_core["di"] + 0.05
+        assert symmetric["reference"] == "core"
+        assert asymmetric["reference"] == "core"
+        # Distant off-core mass (anchored on the core) must raise DI.
+        assert asymmetric["di"] > symmetric["di"] + 0.05
 
     def test_off_centre_core_changes_di_vs_centred_core(self, client):
         """Same mask, two different core positions. Old code (mass anchor)

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -585,56 +585,49 @@ edge cases where Core slightly exceeds Total due to numerical artefacts.
 
 ## Disintegration Index (DI)
 
-The DI is a scalar in \`[0, 1)\` that quantifies *how much spheroid mass has
-escaped beyond a uniform-disk reference of equivalent core area*. Reported in
-the Excel column **Disintegration Index** (4 decimal places, dimensionless).
+The DI is a scalar in \`[0, 1)\` that quantifies *how far the spheroid's radial
+mass distribution has dispersed beyond its dense core*, in a size-invariant
+way. It is **core-anchored** and **requires a core** — there is no
+equivalent-disk fallback. Reported in the Excel column **Disintegration Index**
+(4 decimal places, dimensionless); rendered as **N/A** when no core is present.
 
 Algorithm (implemented in
 \`backend/segmentation/api/metrics_endpoint.py\` — POST \`/api/disintegration-index\`):
 
 1. **Rasterise the union of every external polygon** (the whole ASPP segmentation
  mask, excluding cores) into a single binary canvas via repeated
- \`cv2.fillPoly\`. Collect the \`(x, y)\` of all \`N\` white pixels.
+ \`cv2.fillPoly\`. Collect the \`(x, y)\` of all \`M\` foreground pixels.
 
-2. **Centroid anchor**:
- - If a core polygon is present, \`(cx, cy) = (mean(xᵢ_core), mean(yᵢ_core))\` —
-   the centroid of the **core pixels**. The metric thus measures how far
-   mass spread from the dense core, not from the smeared mass centroid
-   that drifts toward the invasion zone (improvement A — biologically the
-   core is the natural reference point for "how far did things go").
- - Otherwise (no core) fallback to mask centroid
-   \`(cx, cy) = (mean(xᵢ), mean(yᵢ))\`.
+2. **Core (required)**. Rasterise the union of the \`partClass="core"\` polygon(s)
+ into \`N_C\` pixels with centroid \`c = (mean(xᵢ_core), mean(yᵢ_core))\` and
+ effective radius \`R_C = √(N_C / π)\`. If no core rasterises to ≥ 1 pixel the
+ DI is **undefined**: the endpoint returns \`reference="no_core"\` and the Excel
+ cell shows \`N/A\` (never a computed 0).
 
- Distances \`dᵢ = √((xᵢ − cx)² + (yᵢ − cy)²)\` are computed for both
- sets (\`d_mask\` over all mask pixels and \`d_core\` over core pixels)
- relative to this single anchor.
+3. **Core-anchored, core-normalised distances**. For each foreground pixel take
+ the Euclidean distance to the **core centroid** \`c\`,
+ \`rᵢ = √((xᵢ − cx)² + (yᵢ − cy)²)\`, and normalise by the core radius:
+ \`d̃ᵢ = rᵢ / R_C\`. Anchoring on the core (not the mask centroid, which drifts
+ toward the invasion zone) makes the metric measure how far mass spread *from
+ the dense core*.
 
-3. **Reference radius**:
- - If a core polygon is present, \`R_ref = √(N_core / π)\` where \`N_core\` is
-   the rasterised pixel count of the core.
- - Otherwise fallback to \`R_eff = √(N / π)\`.
+4. **Reference distribution — analytical uniform disk**. The reference is a
+ filled disk of the core's size, \`F_ref(d̃) = min(d̃², 1)\`, whose inverse
+ (quantile) is \`F_ref⁻¹(u) = √u\`. This is an *idealised* disk of radius
+ \`R_C\`, independent of the core's actual shape.
 
-4. **Reference distribution — empirical core CDF**. When a core polygon is
- present, the reference is the **empirical** distribution of distances
- \`d_core\` for every pixel inside the core, anchored on the **same
- centroid as d_mask** (the core centroid from step 2). This means the
- reference reflects the **actual radial profile of the dense core**,
- not an idealised disk. The fallback (no core) uses the analytical
- equivalent-disk CDF \`F_ref(d̃) = d̃²\` for \`d̃ ∈ [0, 1]\`.
+5. **1-Wasserstein distance** in inverse-cumulative (quantile) form, estimated
+ bin-free from the sorted normalised distances:
+ \`W₁ = ∫₀¹ |d̃(u) − √u| du ≈ (1/M) · Σᵢ |d̃₍ᵢ₎ − √((i + 0.5) / M)|\`,
+ where \`d̃₍ᵢ₎\` are the ascending \`d̃\` values. This is the paper's eq. (1).
 
-5. **1-Wasserstein distance**:
- - **Core path**: \`W₁_px = wasserstein_distance(d_mask, d_core)\` via
-   \`scipy.stats\`, computed exactly between the two empirical 1D
-   distributions. Scale-normalised: \`W₁ = W₁_px / R_core\`, where
-   \`R_core = √(N_core / π)\`.
- - **r_eff fallback**: bin-free quantile formula
-   \`W₁ ≈ (1/N) · Σᵢ |d̃₍ᵢ₎ − √((i − 0.5) / N)|\` where d̃₍ᵢ₎ are sorted
-   normalised distances \`d_mask / R_eff\`.
+6. **Saturation**: \`DI = tanh(W₁)\`. Maps \`W₁ ∈ [0, ∞) → [0, 1)\`. An intact
+ spheroid (foreground ≈ core) gives \`d̃ ≤ 1\` distributed as a filled disk and
+ \`DI ≈ 0\`; as mass disperses to \`d̃ ≫ 1\`, \`DI → 1\`.
 
-6. **Saturation**: \`DI = tanh(W₁)\`. Maps \`W₁ ∈ [0, ∞) → [0, 1)\`.
-
-**Properties**: dimensionless, scale-invariant (all distances normalised by
-\`R_ref\`), rotation-invariant, translation-invariant (centroid-relative).
+**Properties**: dimensionless, scale-invariant (distances normalised by
+\`R_C\`), rotation-invariant, translation-invariant (core-relative). Depends only
+on the core's *size* (\`R_C\`), not its shape — the reference is an ideal disk.
 
 **Calibrated thresholds** (user 12bprusek, April 2026):
 - *time_0h* (compact): DI median ≈ 0.001
@@ -645,7 +638,9 @@ Algorithm (implemented in
 
 - **No ASPP segmentation** (HRNet, CBAM-ResUNet, plain U-Net, sperm, wound):
 no core polygon is generated. \`Core Area = 0\`, \`Total Spheroid Area\` still
-reports the sum of all external polygons. Compatibility-safe for any model.
+reports the sum of all external polygons, but the **Disintegration Index is
+\`N/A\`** (\`reference="no_core"\`) — DI is core-anchored and undefined without a
+core. Area columns remain compatibility-safe for any model.
 - **Image with no polygons or no externals**: both metrics report \`0\`.
 - **Cropped spheroid touching image edge**: the centroid is biased, the
 rasterised area is truncated. Detected via bbox of mask = canvas edge —

--- a/backend/src/services/metrics/__tests__/metricsCalculator.basicMetrics.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.basicMetrics.test.ts
@@ -406,7 +406,8 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
     // 10×10 external polygon → area = 100 px²; no core, no scale
     const image = buildImage('a1', [extPolygon(square(10))]);
     const result = await calc.calculateAllImageMetrics([image]);
-    // postMock will be called for DI; area comes from local Shoelace
+    // No core → DI short-circuits to 'no_core' (no ML call); area still comes
+    // from the local Shoelace computation.
     expect(result[0]!.totalSpheroidArea).toBeCloseTo(100, 3);
   });
 
@@ -454,18 +455,45 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
     expect(result[0]!.disintegrationIndex).toBe(0);
   });
 
-  it('referenceMode="none" when image has external polygon but missing dimensions', async () => {
-    // Image has no width/height → DI endpoint skip
-    const image = buildImage('a6', [extPolygon(square(10))]);
+  it('referenceMode="none" when image has external polygon + core but missing dimensions', async () => {
+    // A core is present (so the no_core short-circuit does not fire), but the
+    // image has no width/height → DI endpoint is skipped and referenceMode
+    // stays at its initialised 'none'.
+    const corePoly = {
+      type: 'external' as const,
+      partClass: 'core' as const,
+      points: square(4),
+    };
+    const image = buildImage('a6', [extPolygon(square(10)), corePoly]);
     // No dims passed → width/height are undefined
     const result = await calc.calculateAllImageMetrics([image]);
-    // The code logs a warn and keeps di.referenceMode as initialised 'none'
     expect(result[0]!.referenceMode).toBe('none');
+  });
+
+  it('referenceMode="no_core" when externals are present but no core polygon', async () => {
+    // DI is core-anchored; without a core it is undefined → N/A, and no ML
+    // call is issued (the short-circuit fires before the network path).
+    const image = buildImage('a6b', [extPolygon(square(10))], {
+      width: 100,
+      height: 100,
+    });
+    const result = await calc.calculateAllImageMetrics([image]);
+    expect(result[0]!.referenceMode).toBe('no_core');
+    expect(result[0]!.disintegrationIndex).toBe(0);
+    expect(postMock).not.toHaveBeenCalled();
+    // Areas are still reported.
+    expect(result[0]!.totalSpheroidArea).toBeCloseTo(100, 3);
   });
 
   it('referenceMode="failed" when DI HTTP call rejects', async () => {
     postMock.mockRejectedValue(new Error('Network error'));
-    const image = buildImage('a7', [extPolygon(square(10))], {
+    // A core is required for the ML call to be issued at all.
+    const corePoly = {
+      type: 'external' as const,
+      partClass: 'core' as const,
+      points: square(4),
+    };
+    const image = buildImage('a7', [extPolygon(square(10)), corePoly], {
       width: 100,
       height: 100,
     });
@@ -477,16 +505,21 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
 
   it('propagates DI values from successful ML response', async () => {
     postMock.mockResolvedValue({
-      data: { di: 0.42, w1: 2.1, reference: 'r_eff', n_pixels: 12345 },
+      data: { di: 0.42, w1: 2.1, reference: 'core', n_pixels: 12345 },
     });
-    const image = buildImage('a8', [extPolygon(square(10))], {
+    const corePoly = {
+      type: 'external' as const,
+      partClass: 'core' as const,
+      points: square(4),
+    };
+    const image = buildImage('a8', [extPolygon(square(10)), corePoly], {
       width: 100,
       height: 100,
     });
     const result = await calc.calculateAllImageMetrics([image]);
     expect(result[0]!.disintegrationIndex).toBeCloseTo(0.42, 5);
     expect(result[0]!.wassersteinW1).toBeCloseTo(2.1, 5);
-    expect(result[0]!.referenceMode).toBe('r_eff');
+    expect(result[0]!.referenceMode).toBe('core');
     expect(result[0]!.nPixels).toBe(12345);
   });
 

--- a/backend/src/services/metrics/__tests__/metricsCalculator.gaps.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.gaps.test.ts
@@ -469,7 +469,7 @@ describe('MetricsCalculator — exportToExcel (ASPP / spheroid_invasive path)', 
       polygonCount: 2,
       disintegrationIndex: 0.15,
       wassersteinW1: 0.6,
-      referenceMode: 'r_eff',
+      referenceMode: 'no_core',
       nPixels: 30000,
       totalSpheroidArea: 800,
       coreArea: 0,
@@ -515,8 +515,21 @@ describe('MetricsCalculator — exportToExcel (ASPP / spheroid_invasive path)', 
     );
     const calls = (mockWorksheet.addRow as ReturnType<typeof vi.fn>).mock.calls;
     const firstRow = calls[0][0] as Record<string, number>;
-    // DI from first entry: 0.42 → rounded to 4 decimals = 0.42
+    // DI from first entry (referenceMode='core'): 0.42 → rounded 4dp = 0.42
     expect(firstRow.disintegrationIndex).toBeCloseTo(0.42, 4);
+  });
+
+  it("renders DI as 'N/A' for non-core reference modes (no fabricated 0)", async () => {
+    await calc.exportToExcel(
+      [],
+      '/tmp/aspp.xlsx',
+      undefined,
+      sampleImageMetrics
+    );
+    const calls = (mockWorksheet.addRow as ReturnType<typeof vi.fn>).mock.calls;
+    // Second entry has referenceMode='no_core' → DI is undefined → 'N/A'.
+    const secondRow = calls[1][0] as Record<string, unknown>;
+    expect(secondRow.disintegrationIndex).toBe('N/A');
   });
 
   it('uses px^2 units in column headers when no scale is provided', async () => {

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -24,11 +24,8 @@ import {
   calculatePerimeter,
   calculateBoundingBox,
   calculateConvexHull,
-  pointToLineDistance,
   rotatingCalipers,
-  isPointInPolygon,
   isPolygonInside,
-  calculateCentroid,
 } from './geometricPrimitives';
 
 export interface PolygonMetrics {
@@ -64,21 +61,25 @@ export interface PolygonMetrics {
 
 /** Per-image disintegration metrics. Computed on-demand at export time.
  *
- * `referenceMode` distinguishes how DI was computed (or why it wasn't):
- *   - 'core'           → empirical-CDF reference from detected core pixels
- *   - 'r_eff'          → equivalent-disk fallback (no core polygon present)
- *   - 'r_eff_fallback' → core polygon supplied but rasterised to 0 pixels
- *   - 'none'           → no externals or no image dimensions; DI not attempted
- *   - 'failed'         → DI HTTP call or polygon JSON parse threw an error
- *                        Lets exporters render `'N/A'` instead of a sentinel 0.
+ * DI is core-anchored and **requires a core**: distances are normalised by the
+ * core radius R_C and compared to the analytical uniform-disk reference
+ * (paper eq. 1). There is no equivalent-disk fallback.
+ *
+ * `referenceMode` distinguishes whether DI was computed (or why it wasn't):
+ *   - 'core'    → computed per eq. (1) from the detected core polygon
+ *   - 'no_core' → no usable core polygon; DI is undefined → N/A (not 0)
+ *   - 'none'    → no externals or no image dimensions; DI not attempted
+ *   - 'failed'  → DI HTTP call or polygon JSON parse threw an error
+ * Every non-'core' mode means the DI field is an N/A sentinel: exporters must
+ * render `'N/A'`, never the sentinel `0`.
  */
 export interface ImageMetrics {
   imageId: string;
   imageName: string;
   polygonCount: number;
-  disintegrationIndex: number; // tanh(W1) ∈ [0, 1)
+  disintegrationIndex: number; // tanh(W1) ∈ [0, 1); valid only when referenceMode==='core'
   wassersteinW1: number; // raw 1-Wasserstein distance, ≥ 0
-  referenceMode: 'core' | 'r_eff' | 'r_eff_fallback' | 'none' | 'failed';
+  referenceMode: 'core' | 'no_core' | 'none' | 'failed';
   nPixels: number;
   // Areas (px² by default, μm² when pixelToMicrometerScale is provided).
   totalSpheroidArea: number; // sum of external polygon areas, core excluded
@@ -384,8 +385,9 @@ export class MetricsCalculator {
    * `/api/disintegration-index` endpoint. Areas are computed locally via the
    * Shoelace formula and reported even if the DI HTTP call fails.
    *
-   * Falls back to R_eff (equivalent radius of the mask union) when no core
-   * polygon is present (non-ASPP segmentations).
+   * DI is core-anchored and **requires a core**. When no `partClass='core'`
+   * polygon is present the DI is undefined (`referenceMode='no_core'`, rendered
+   * as N/A) and no ML call is made — there is no equivalent-disk fallback.
    */
   async calculateAllImageMetrics(
     images: ImageWithSegmentation[],
@@ -461,7 +463,16 @@ export class MetricsCalculator {
       };
 
       const usableExternals = externals.filter(p => p.partClass !== 'core');
-      if (usableExternals.length > 0) {
+      if (usableExternals.length > 0 && cores.length === 0) {
+        // DI is core-anchored and requires a core. Without one it is undefined;
+        // report N/A explicitly rather than issuing a doomed ML call.
+        di = {
+          disintegrationIndex: 0,
+          wassersteinW1: 0,
+          referenceMode: 'no_core',
+          nPixels: 0,
+        };
+      } else if (usableExternals.length > 0) {
         try {
           // DI is computed from the UNION of every external polygon (the
           // entire ASPP segmentation mask), not just the largest spheroid.
@@ -477,7 +488,7 @@ export class MetricsCalculator {
           } else {
             di = await this.calculateImageDisintegrationIndex(
               maskPolygons,
-              corePolygonsForDi.length > 0 ? corePolygonsForDi : undefined,
+              corePolygonsForDi,
               image.width,
               image.height
             );
@@ -531,7 +542,7 @@ export class MetricsCalculator {
 
   private async calculateImageDisintegrationIndex(
     maskPolygons: Point[][],
-    corePolygons: Point[][] | undefined,
+    corePolygons: Point[][],
     imageWidth: number,
     imageHeight: number
   ): Promise<{
@@ -541,9 +552,8 @@ export class MetricsCalculator {
     nPixels: number;
   }> {
     const mask_polygons = maskPolygons.map(pts => pts.map(p => [p.x, p.y]));
-    const core_polygons = corePolygons
-      ? corePolygons.map(pts => pts.map(p => [p.x, p.y]))
-      : null;
+    // DI requires a core; callers only reach here with a non-empty core set.
+    const core_polygons = corePolygons.map(pts => pts.map(p => [p.x, p.y]));
     const response = await this.http.post<{
       di: number;
       w1: number;
@@ -1137,7 +1147,11 @@ export class MetricsCalculator {
           totalSpheroidArea: safe(m.totalSpheroidArea, 2),
           coreArea: safe(m.coreArea, 2),
           invasionArea: safe(m.invasionArea, 2),
-          disintegrationIndex: safe(m.disintegrationIndex, 4),
+          // DI is defined only when a core anchored the computation; every
+          // other reference mode (no_core / none / failed) is a genuine N/A,
+          // not a real zero.
+          disintegrationIndex:
+            m.referenceMode === 'core' ? safe(m.disintegrationIndex, 4) : 'N/A',
         });
       });
     }


### PR DESCRIPTION
## What

Reworks the Disintegration Index (DI) so the app **always requires a core** and computes it **exactly per the paper's eq (1)**.

Before, the DI had two divergent branches:
- **with a core** → an *empirical* Wasserstein `wasserstein_distance(d_mask, d_core)/R_C` (which leaked the core's *shape* into DI);
- **without a core** → an `r_eff` fallback anchored on the mask centroid.

The paper's eq (1) specifies the **analytical uniform-disk reference** `F_ref(d̃)=min(d̃²,1)` (inverse `√u`) and always has a core — so the app matched the paper only in the branch that never runs in the paper's regime.

## Now (single path, core required)

- Anchor = core centroid; normalise by `R_C = √(N_core/π)`.
- `W₁ = mean(|sort(d_mask/R_C) − √u|)`, `u=(i+0.5)/N`; `DI = tanh(W₁)`.
- Depends only on the core's **size**, not its shape.
- **No valid core → DI undefined** → `reference='no_core'`, rendered as **N/A** (never a fabricated `0`). No `r_eff` fallback.
- Reference modes collapse to `'core' | 'no_core' | 'none' | 'failed'`. The backend short-circuits to `no_core` (skips the ML call) when no core polygon is present.

## Impact

This changes the DI **definition**: ASPP DI values shift (empirical → analytical reference), and projects without a core that previously got an `r_eff` DI now get **N/A**. No DB or API-contract change beyond the `reference` enum values.

## Verification

- **ML**: 16/16 `test_disintegration.py` via the real FastAPI HTTP path (GPU container). Intact (core==mask) → DI≈0.0004; tight core → 0.80; invasion star → 0.84; no/degenerate core → `no_core`; empty mask → `none`.
- **Backend**: `tsc --noEmit` clean; ESLint 0; Prettier clean; 432 vitest (metrics + export) green.
- Also removes 3 dead geometry imports surfaced by the ESLint-0 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed Behavior**
  - Disintegration Index calculations now require a valid core region and use core-anchored distance analysis.
  - Images without a usable core return an explicit `no_core` status and a zero API value.
  - Excel exports display `N/A` instead of a numeric DI value when no valid core reference exists.

- **Documentation**
  - Updated DI documentation to describe core requirements, normalization, reference calculations, and edge-case behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->