### PR TITLE
feat(metrics): disintegration metric panel in the export

### DIFF
--- a/backend/segmentation/api/metrics_endpoint.py
+++ b/backend/segmentation/api/metrics_endpoint.py
@@ -38,11 +38,41 @@ class DisintegrationRequest(BaseModel):
     image_height: int
 
 
+# Speckle guard for the fragmentation/porosity panel metrics. Exposed in the
+# response so results are reproducible; keep in sync with the metrics guide.
+_DI_CLOSING_RADIUS_PX = 2
+_DI_MIN_FRAGMENT_PX = 30
+_DI_MIN_HOLE_PX = 30
+
+
 class DisintegrationResponse(BaseModel):
     di: float
     w1: float
     reference: str  # 'core' | 'no_core' | 'none'
     n_pixels: int
+
+    # --- disintegration metric panel (populated only when reference == 'core';
+    # every field stays None for no_core / none so callers render N/A) ---
+    # Axis A (radial dispersal): 95th percentile of core-normalised distances.
+    radial_reach_q95: Optional[float] = None
+    # Axis B (mass partition): fraction of FG mass outside the core.
+    dispersed_mass_fraction: Optional[float] = None
+    # Axis C (fragmentation): connected components of FG after a speckle guard.
+    fragment_count: Optional[int] = None
+    largest_fragment_fraction: Optional[float] = None
+    # Axis D (porosity): FG solidity + enclosed-hole count (Betti-1).
+    solidity: Optional[float] = None
+    hole_count: Optional[int] = None
+    # Rasterised region sizes (px) — FG = C ∪ K, so n_fg_px = n_core_px + n_corona_px.
+    n_core_px: Optional[int] = None
+    n_corona_px: Optional[int] = None
+    n_fg_px: Optional[int] = None
+    # Axis E (absolute size): equivalent diameters 2*sqrt(N/pi) in pixels.
+    core_equiv_diameter_px: Optional[float] = None
+    whole_equiv_diameter_px: Optional[float] = None
+    # Echoed speckle-guard settings for reproducibility.
+    closing_radius_px: Optional[int] = None
+    min_fragment_px: Optional[int] = None
 
 class Point(BaseModel):
     x: float
@@ -287,8 +317,14 @@ async def disintegration_index(request: DisintegrationRequest):
         w1 = float(np.mean(np.abs(d_tilde - np.sqrt(u))))
         di = float(np.tanh(w1))
 
+        # Step 4: companion panel metrics spanning the other disintegration axes,
+        # all derived from the same rasterised masks. FG = C ∪ K (union of the
+        # foreground mask and the core) so the core is always inside FG even if
+        # its polygon slightly overhangs the mask.
+        panel = _compute_panel_metrics(mask | core_mask, cx, cy, r_ref, n_core)
+
         return DisintegrationResponse(
-            di=di, w1=w1, reference="core", n_pixels=n
+            di=di, w1=w1, reference="core", n_pixels=n, **panel
         )
     except HTTPException:
         raise
@@ -304,6 +340,89 @@ async def disintegration_index(request: DisintegrationRequest):
         raise internal_error(
             logger, "Failed to compute disintegration index", exc
         ) from exc
+
+
+def _compute_panel_metrics(
+    fg_mask: np.ndarray, cx: float, cy: float, r_ref: float, n_core: int
+) -> Dict[str, Any]:
+    """Companion disintegration metrics from the rasterised foreground mask.
+
+    Spans the axes DI does not: radial reach (A), fragmentation (C) and porosity
+    (D), plus rasterised region sizes (E). All are size/resolution comparable or
+    reported with their pixel context. ``fg_mask`` is the binary FG = C ∪ K.
+    """
+    ys_fg, xs_fg = np.nonzero(fg_mask)
+    n_fg = int(xs_fg.size)
+    n_corona = max(0, n_fg - int(n_core))
+
+    # Axis A companion — 95th percentile of core-normalised FG distances (reach
+    # of the leading edge, in core radii).
+    d_fg = np.hypot(xs_fg - cx, ys_fg - cy) / r_ref
+    radial_reach_q95 = float(np.percentile(d_fg, 95)) if n_fg > 0 else 0.0
+
+    # Axis C — fragmentation. Close small gaps, drop speckle, count components.
+    ksz = 2 * _DI_CLOSING_RADIUS_PX + 1
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (ksz, ksz))
+    closed = cv2.morphologyEx(fg_mask, cv2.MORPH_CLOSE, kernel)
+    num_labels, _labels, stats, _cent = cv2.connectedComponentsWithStats(
+        closed, connectivity=8
+    )
+    if num_labels > 1:
+        areas = stats[1:, cv2.CC_STAT_AREA]  # skip background label 0
+        kept = areas[areas >= _DI_MIN_FRAGMENT_PX]
+    else:
+        kept = np.empty(0, dtype=np.int64)
+    fragment_count = int(kept.size)
+    # Fraction of the de-speckled mass in the single largest piece. Denominator
+    # is the kept-component total (not raw n_fg) so closing can't push it past 1.
+    kept_total = int(kept.sum())
+    largest_fragment_fraction = (
+        float(int(kept.max()) / kept_total) if kept_total > 0 else 0.0
+    )
+
+    # Axis D — porosity. Solidity = FG area / convex-hull area; hole count is the
+    # number of enclosed background regions (Betti-1) above the speckle floor.
+    solidity = 0.0
+    if n_fg >= 3:
+        hull = cv2.convexHull(np.column_stack([xs_fg, ys_fg]).astype(np.int32))
+        hull_area = float(cv2.contourArea(hull))
+        if hull_area > 0:
+            # Clamp to 1.0: pixel-count / hull-polygon-area can drift slightly
+            # above 1 for convex shapes due to rasterisation.
+            solidity = min(1.0, float(n_fg / hull_area))
+
+    hole_count = 0
+    contours, hierarchy = cv2.findContours(
+        (fg_mask > 0).astype(np.uint8), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE
+    )
+    if hierarchy is not None:
+        for idx, node in enumerate(hierarchy[0]):
+            # node = [next, prev, first_child, parent]; a parent means this is a
+            # hole contour nested inside a foreground component.
+            if node[3] != -1 and cv2.contourArea(contours[idx]) >= _DI_MIN_HOLE_PX:
+                hole_count += 1
+
+    # Axis B — dispersed-mass fraction f_disp = N_K / N_FG (share of mass outside
+    # the dense core). Axis E — equivalent diameters 2*sqrt(N/pi) in pixels.
+    dispersed_mass_fraction = float(n_corona / n_fg) if n_fg > 0 else 0.0
+    core_equiv_diameter_px = float(2.0 * np.sqrt(int(n_core) / np.pi))
+    whole_equiv_diameter_px = float(2.0 * np.sqrt(n_fg / np.pi)) if n_fg > 0 else 0.0
+
+    return {
+        "radial_reach_q95": radial_reach_q95,
+        "dispersed_mass_fraction": dispersed_mass_fraction,
+        "fragment_count": fragment_count,
+        "largest_fragment_fraction": largest_fragment_fraction,
+        "solidity": solidity,
+        "hole_count": hole_count,
+        "n_core_px": int(n_core),
+        "n_corona_px": n_corona,
+        "n_fg_px": n_fg,
+        "core_equiv_diameter_px": core_equiv_diameter_px,
+        "whole_equiv_diameter_px": whole_equiv_diameter_px,
+        "closing_radius_px": _DI_CLOSING_RADIUS_PX,
+        "min_fragment_px": _DI_MIN_FRAGMENT_PX,
+    }
 
 
 @router.get("/metrics-info")

--- a/backend/segmentation/tests/unit/test_disintegration.py
+++ b/backend/segmentation/tests/unit/test_disintegration.py
@@ -306,3 +306,77 @@ class TestDisintegrationIndex:
         })
         assert out["reference"] == "core"
         assert out["di"] > 0.20
+
+
+@pytest.mark.unit
+class TestDisintegrationPanel:
+    """Tests for the companion metric panel returned alongside DI."""
+
+    H, W = 256, 256
+    CX, CY = 128.0, 128.0
+
+    def _post(self, client, body):
+        resp = client.post("/api/disintegration-index", json=body)
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_intact_disk_panel(self, client):
+        """Intact disk (core == mask): one fragment, near-solid, no holes."""
+        pts = _circle(self.CX, self.CY, 60)
+        out = self._post(client, {
+            "mask_polygon": pts, "core_polygon": pts,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "core"
+        assert out["fragment_count"] == 1
+        assert out["largest_fragment_fraction"] == pytest.approx(1.0, abs=1e-6)
+        assert out["solidity"] > 0.9
+        assert out["solidity"] <= 1.0
+        assert out["hole_count"] == 0
+        # FG = C ∪ K, and here K is empty (core == mask).
+        assert out["n_fg_px"] == out["n_core_px"] + out["n_corona_px"]
+        assert out["radial_reach_q95"] == pytest.approx(0.97, abs=0.06)
+        assert out["core_equiv_diameter_px"] > 0
+        assert out["whole_equiv_diameter_px"] > 0
+        # Speckle-guard settings are echoed for reproducibility.
+        assert out["closing_radius_px"] == 2
+        assert out["min_fragment_px"] == 30
+
+    def test_two_separated_blobs_two_fragments(self, client):
+        """A main blob + a distant satellite → two fragments, split mass."""
+        out = self._post(client, {
+            "mask_polygons": [_circle(80, 128, 35), _circle(200, 128, 30)],
+            "core_polygons": [_circle(80, 128, 20)],
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["fragment_count"] == 2
+        assert out["largest_fragment_fraction"] < 0.75
+        assert 0.0 <= out["dispersed_mass_fraction"] <= 1.0
+
+    def test_no_core_panel_is_null(self, client):
+        """No core → the whole panel is null (N/A), not a fabricated 0."""
+        out = self._post(client, {
+            "mask_polygon": _circle(self.CX, self.CY, 60),
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert out["reference"] == "no_core"
+        for key in (
+            "radial_reach_q95", "dispersed_mass_fraction", "fragment_count",
+            "largest_fragment_fraction", "solidity", "hole_count",
+            "n_core_px", "n_corona_px", "n_fg_px",
+            "core_equiv_diameter_px", "whole_equiv_diameter_px",
+        ):
+            assert out[key] is None, f"{key} should be null without a core"
+
+    def test_dispersed_mass_fraction_increases_with_corona(self, client):
+        """A larger corona (bigger mask, same core) raises dispersed-mass frac."""
+        core = _circle(self.CX, self.CY, 20)
+        tight = self._post(client, {
+            "mask_polygon": _circle(self.CX, self.CY, 25), "core_polygon": core,
+            "image_width": self.W, "image_height": self.H,
+        })
+        wide = self._post(client, {
+            "mask_polygon": _circle(self.CX, self.CY, 70), "core_polygon": core,
+            "image_width": self.W, "image_height": self.H,
+        })
+        assert wide["dispersed_mass_fraction"] > tight["dispersed_mass_fraction"]

--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -634,6 +634,31 @@ on the core's *size* (\`R_C\`), not its shape — the reference is an ideal disk
 - *time_48h* (rozprsknuté): DI median ≈ 0.48
 - 320× separation between groups
 
+## Disintegration Metric Panel
+
+Alongside DI the export reports a panel of companion metrics spanning the
+*independent* ways a spheroid disintegrates, so redundancy with DI is explicit.
+All are computed in the **same endpoint** from the same rasterised masks
+(\`FG = C ∪ K\`, i.e. the foreground mask unioned with the core), and all are
+**\`N/A\` unless a core anchored the computation** (\`reference="core"\`). Notation:
+\`N_C\`/\`N_K\`/\`N_FG\` = pixel counts of core / corona / foreground; \`R_C\` = core
+radius; \`d̃ = |p − c| / R_C\`.
+
+| Metric (Excel column) | Axis | Formula | Reads as |
+| --- | --- | --- | --- |
+| **Radial Reach q95** | A — radial dispersal | 95th percentile of \`{d̃}\` | how far (in core radii) the leading 5 % of mass has travelled |
+| **Dispersed-Mass Fraction** | B — mass partition | \`N_K / N_FG\` ∈ [0,1] | fraction of mass now outside the dense core |
+| **Fragment Count** | C — fragmentation | connected components of FG after closing (\`r=2 px\`) with components \`< 30 px\` dropped | into how many pieces the spheroid has broken |
+| **Largest-Fragment Fraction** | C — fragmentation | largest component ÷ de-speckled mass ∈ (0,1] | \`1\` = one mass, \`→0\` = fully fragmented |
+| **Solidity** | D — porosity | \`N_FG / N_hull\` ∈ [0,1] | \`1\` = compact, \`→0\` = porous/dispersed |
+| **Hole Count** | D — porosity | enclosed holes in FG (Betti-1, holes \`≥ 30 px\`) | internal porosity |
+| **Core/Whole Equiv. Diameter** | E — absolute size | \`2·√(N/π)\` ×(µm/px) | absolute size context (not size-invariant) |
+
+The **speckle guard** (closing radius \`2 px\`, min component/hole \`30 px\`) is fixed
+and echoed by the endpoint (\`closing_radius_px\`, \`min_fragment_px\`) so results are
+reproducible. Axis-A **Radius of gyration** and other second-moment descriptors
+are deliberately *omitted* — their rank correlation with DI is ≈ 0.95 (same axis).
+
 ## Edge Cases & Caveats
 
 - **No ASPP segmentation** (HRNet, CBAM-ResUNet, plain U-Net, sperm, wound):
@@ -660,8 +685,10 @@ spheroids known to have necrotic centres.
 - **DI computation**: \`backend/segmentation/api/metrics_endpoint.py\`
 - **Per-image area orchestration**: \`backend/src/services/metrics/metricsCalculator.ts\`
 (\`calculateAllImageMetrics\`)
-- **Excel writer**: same file (\`exportToExcel\` — emits Image Name, Image ID,
-Total Spheroid Area, Core Area, Invasion Area, Disintegration Index)
+- **Excel writer**: same file (\`exportToExcel\` — emits Image Name, Total
+Spheroid Area, Core Area, Invasion Area, Disintegration Index, and the metric
+panel: Radial Reach q95, Dispersed-Mass Fraction, Fragment Count,
+Largest-Fragment Fraction, Solidity, Hole Count, Core/Whole Equiv. Diameter)
 `;
 }
 

--- a/backend/src/services/metrics/__tests__/metricsCalculator.basicMetrics.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.basicMetrics.test.ts
@@ -483,6 +483,12 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
     expect(postMock).not.toHaveBeenCalled();
     // Areas are still reported.
     expect(result[0]!.totalSpheroidArea).toBeCloseTo(100, 3);
+    // The whole disintegration panel is N/A (null) without a core.
+    expect(result[0]!.radialReachQ95).toBeNull();
+    expect(result[0]!.dispersedMassFraction).toBeNull();
+    expect(result[0]!.fragmentCount).toBeNull();
+    expect(result[0]!.solidity).toBeNull();
+    expect(result[0]!.coreEquivDiameter).toBeNull();
   });
 
   it('referenceMode="failed" when DI HTTP call rejects', async () => {
@@ -503,9 +509,22 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
     expect(result[0]!.totalSpheroidArea).toBeCloseTo(100, 3);
   });
 
-  it('propagates DI values from successful ML response', async () => {
+  it('propagates DI + panel values from successful ML response', async () => {
     postMock.mockResolvedValue({
-      data: { di: 0.42, w1: 2.1, reference: 'core', n_pixels: 12345 },
+      data: {
+        di: 0.42,
+        w1: 2.1,
+        reference: 'core',
+        n_pixels: 12345,
+        radial_reach_q95: 2.5,
+        dispersed_mass_fraction: 0.7,
+        fragment_count: 4,
+        largest_fragment_fraction: 0.55,
+        solidity: 0.6,
+        hole_count: 2,
+        core_equiv_diameter_px: 10,
+        whole_equiv_diameter_px: 40,
+      },
     });
     const corePoly = {
       type: 'external' as const,
@@ -521,6 +540,52 @@ describe('MetricsCalculator — calculateAllImageMetrics', () => {
     expect(result[0]!.wassersteinW1).toBeCloseTo(2.1, 5);
     expect(result[0]!.referenceMode).toBe('core');
     expect(result[0]!.nPixels).toBe(12345);
+    // Scale-free panel fields pass through unchanged.
+    expect(result[0]!.radialReachQ95).toBeCloseTo(2.5, 5);
+    expect(result[0]!.dispersedMassFraction).toBeCloseTo(0.7, 5);
+    expect(result[0]!.fragmentCount).toBe(4);
+    expect(result[0]!.largestFragmentFraction).toBeCloseTo(0.55, 5);
+    expect(result[0]!.solidity).toBeCloseTo(0.6, 5);
+    expect(result[0]!.holeCount).toBe(2);
+    // No scale passed → diameters stay in pixels (×1).
+    expect(result[0]!.coreEquivDiameter).toBeCloseTo(10, 5);
+    expect(result[0]!.wholeEquivDiameter).toBeCloseTo(40, 5);
+  });
+
+  it('scales equivalent diameters by µm/px but not the fractions', async () => {
+    postMock.mockResolvedValue({
+      data: {
+        di: 0.3,
+        w1: 1.0,
+        reference: 'core',
+        n_pixels: 9999,
+        radial_reach_q95: 3.0,
+        dispersed_mass_fraction: 0.5,
+        fragment_count: 1,
+        largest_fragment_fraction: 1.0,
+        solidity: 0.9,
+        hole_count: 0,
+        core_equiv_diameter_px: 10,
+        whole_equiv_diameter_px: 20,
+      },
+    });
+    const corePoly = {
+      type: 'external' as const,
+      partClass: 'core' as const,
+      points: square(4),
+    };
+    const image = buildImage('a8b', [extPolygon(square(10)), corePoly], {
+      width: 100,
+      height: 100,
+    });
+    const result = await calc.calculateAllImageMetrics([image], 2); // 2 µm/px
+    // Diameters are lengths → ×2.
+    expect(result[0]!.coreEquivDiameter).toBeCloseTo(20, 5);
+    expect(result[0]!.wholeEquivDiameter).toBeCloseTo(40, 5);
+    // Dimensionless panel fields are unaffected by scale.
+    expect(result[0]!.radialReachQ95).toBeCloseTo(3.0, 5);
+    expect(result[0]!.dispersedMassFraction).toBeCloseTo(0.5, 5);
+    expect(result[0]!.solidity).toBeCloseTo(0.9, 5);
   });
 
   it('polygonCount counts all closed polygons (external + internal)', async () => {

--- a/backend/src/services/metrics/__tests__/metricsCalculator.gaps.test.ts
+++ b/backend/src/services/metrics/__tests__/metricsCalculator.gaps.test.ts
@@ -462,6 +462,15 @@ describe('MetricsCalculator — exportToExcel (ASPP / spheroid_invasive path)', 
       totalSpheroidArea: 1200,
       coreArea: 300,
       invasionArea: 900,
+      // Panel populated for a core-anchored row.
+      radialReachQ95: 2.5,
+      dispersedMassFraction: 0.75,
+      fragmentCount: 3,
+      largestFragmentFraction: 0.6,
+      solidity: 0.55,
+      holeCount: 1,
+      coreEquivDiameter: 19.5,
+      wholeEquivDiameter: 39.1,
     },
     {
       imageId: 'img-b',
@@ -474,6 +483,15 @@ describe('MetricsCalculator — exportToExcel (ASPP / spheroid_invasive path)', 
       totalSpheroidArea: 800,
       coreArea: 0,
       invasionArea: 800,
+      // No core → whole panel is N/A.
+      radialReachQ95: null,
+      dispersedMassFraction: null,
+      fragmentCount: null,
+      largestFragmentFraction: null,
+      solidity: null,
+      holeCount: null,
+      coreEquivDiameter: null,
+      wholeEquivDiameter: null,
     },
   ];
 
@@ -530,6 +548,53 @@ describe('MetricsCalculator — exportToExcel (ASPP / spheroid_invasive path)', 
     // Second entry has referenceMode='no_core' → DI is undefined → 'N/A'.
     const secondRow = calls[1][0] as Record<string, unknown>;
     expect(secondRow.disintegrationIndex).toBe('N/A');
+  });
+
+  it('writes the panel metrics for a core row and N/A for a no_core row', async () => {
+    await calc.exportToExcel(
+      [],
+      '/tmp/aspp.xlsx',
+      undefined,
+      sampleImageMetrics
+    );
+    const calls = (mockWorksheet.addRow as ReturnType<typeof vi.fn>).mock.calls;
+    const coreRow = calls[0][0] as Record<string, unknown>;
+    const noCoreRow = calls[1][0] as Record<string, unknown>;
+    // Core row: every panel field carries its value.
+    expect(coreRow.radialReachQ95).toBeCloseTo(2.5, 3);
+    expect(coreRow.dispersedMassFraction).toBeCloseTo(0.75, 4);
+    expect(coreRow.fragmentCount).toBe(3);
+    expect(coreRow.largestFragmentFraction).toBeCloseTo(0.6, 4);
+    expect(coreRow.solidity).toBeCloseTo(0.55, 4);
+    expect(coreRow.holeCount).toBe(1);
+    expect(coreRow.coreEquivDiameter).toBeCloseTo(19.5, 2);
+    expect(coreRow.wholeEquivDiameter).toBeCloseTo(39.1, 2);
+    // no_core row: the entire panel is N/A, not a fabricated 0.
+    for (const key of [
+      'radialReachQ95',
+      'dispersedMassFraction',
+      'fragmentCount',
+      'largestFragmentFraction',
+      'solidity',
+      'holeCount',
+      'coreEquivDiameter',
+      'wholeEquivDiameter',
+    ]) {
+      expect(noCoreRow[key]).toBe('N/A');
+    }
+  });
+
+  it('scales equivalent diameters by µm/px but leaves fractions scale-free', async () => {
+    // Diameters are lengths → ×scale; dimensionless panel fields are unchanged.
+    // (This exercises the exporter's column layout under a scale, not the
+    // upstream ML scaling which lives in calculateAllImageMetrics.)
+    await calc.exportToExcel([], '/tmp/aspp.xlsx', 2.0, sampleImageMetrics);
+    const headers = mockWorksheetColumns.map(
+      (c: Record<string, unknown>) => c.header as string
+    );
+    expect(
+      headers.some(h => typeof h === 'string' && h.includes('Equiv. Diameter (um)'))
+    ).toBe(true);
   });
 
   it('uses px^2 units in column headers when no scale is provided', async () => {

--- a/backend/src/services/metrics/metricsCalculator.ts
+++ b/backend/src/services/metrics/metricsCalculator.ts
@@ -85,6 +85,46 @@ export interface ImageMetrics {
   totalSpheroidArea: number; // sum of external polygon areas, core excluded
   coreArea: number; // detected core polygon area (0 if no core)
   invasionArea: number; // totalSpheroidArea − coreArea, clamped at 0
+  // Disintegration metric panel — spans the axes DI does not. Every field is
+  // null when referenceMode !== 'core' (undefined without a core → N/A).
+  radialReachQ95: number | null; // A: 95th pct of core-normalised distances (core radii)
+  dispersedMassFraction: number | null; // B: N_K / N_FG ∈ [0,1]
+  fragmentCount: number | null; // C: connected components of FG (speckle-guarded)
+  largestFragmentFraction: number | null; // C: largest piece / de-speckled mass ∈ (0,1]
+  solidity: number | null; // D: N_FG / hull area ∈ [0,1]
+  holeCount: number | null; // D: enclosed holes in FG (Betti-1)
+  coreEquivDiameter: number | null; // E: 2√(N_core/π) (px, or μm with scale)
+  wholeEquivDiameter: number | null; // E: 2√(N_FG/π) (px, or μm with scale)
+}
+
+/** The DI + panel subset of ImageMetrics (everything not derived locally). */
+type DiFields = Omit<
+  ImageMetrics,
+  | 'imageId'
+  | 'imageName'
+  | 'polygonCount'
+  | 'totalSpheroidArea'
+  | 'coreArea'
+  | 'invasionArea'
+>;
+
+/** N/A DI result: DI + every panel metric absent. Used for every reference mode
+ * except 'core' (no core → the whole panel is undefined, rendered as N/A). */
+function naDiFields(referenceMode: ImageMetrics['referenceMode']): DiFields {
+  return {
+    disintegrationIndex: 0,
+    wassersteinW1: 0,
+    referenceMode,
+    nPixels: 0,
+    radialReachQ95: null,
+    dispersedMassFraction: null,
+    fragmentCount: null,
+    largestFragmentFraction: null,
+    solidity: null,
+    holeCount: null,
+    coreEquivDiameter: null,
+    wholeEquivDiameter: null,
+  };
 }
 
 // Local Point alias kept so the many call sites in this file stay terse.
@@ -448,30 +488,15 @@ export class MetricsCalculator {
         continue;
       }
 
-      // Step 2: optional DI computation. Network call to ML; failures must
-      // NOT void the area metrics already computed in step 1.
-      let di: {
-        disintegrationIndex: number;
-        wassersteinW1: number;
-        referenceMode: ImageMetrics['referenceMode'];
-        nPixels: number;
-      } = {
-        disintegrationIndex: 0,
-        wassersteinW1: 0,
-        referenceMode: 'none',
-        nPixels: 0,
-      };
+      // Step 2: optional DI + panel computation. Network call to ML; failures
+      // must NOT void the area metrics already computed in step 1.
+      let di: DiFields = naDiFields('none');
 
       const usableExternals = externals.filter(p => p.partClass !== 'core');
       if (usableExternals.length > 0 && cores.length === 0) {
         // DI is core-anchored and requires a core. Without one it is undefined;
         // report N/A explicitly rather than issuing a doomed ML call.
-        di = {
-          disintegrationIndex: 0,
-          wassersteinW1: 0,
-          referenceMode: 'no_core',
-          nPixels: 0,
-        };
+        di = naDiFields('no_core');
       } else if (usableExternals.length > 0) {
         try {
           // DI is computed from the UNION of every external polygon (the
@@ -490,7 +515,8 @@ export class MetricsCalculator {
               maskPolygons,
               corePolygonsForDi,
               image.width,
-              image.height
+              image.height,
+              pixelToMicrometerScale
             );
           }
         } catch (err) {
@@ -501,12 +527,7 @@ export class MetricsCalculator {
             'MetricsCalculator',
             { imageId: image.id }
           );
-          di = {
-            disintegrationIndex: 0,
-            wassersteinW1: 0,
-            referenceMode: 'failed',
-            nPixels: 0,
-          };
+          di = naDiFields('failed');
         }
       }
 
@@ -530,10 +551,7 @@ export class MetricsCalculator {
       imageId: image?.id ?? '',
       imageName: image?.name ?? '',
       polygonCount: 0,
-      disintegrationIndex: 0,
-      wassersteinW1: 0,
-      referenceMode: 'none',
-      nPixels: 0,
+      ...naDiFields('none'),
       totalSpheroidArea: 0,
       coreArea: 0,
       invasionArea: 0,
@@ -544,13 +562,9 @@ export class MetricsCalculator {
     maskPolygons: Point[][],
     corePolygons: Point[][],
     imageWidth: number,
-    imageHeight: number
-  ): Promise<{
-    disintegrationIndex: number;
-    wassersteinW1: number;
-    referenceMode: ImageMetrics['referenceMode'];
-    nPixels: number;
-  }> {
+    imageHeight: number,
+    pixelToMicrometerScale?: number
+  ): Promise<DiFields> {
     const mask_polygons = maskPolygons.map(pts => pts.map(p => [p.x, p.y]));
     // DI requires a core; callers only reach here with a non-empty core set.
     const core_polygons = corePolygons.map(pts => pts.map(p => [p.x, p.y]));
@@ -559,17 +573,42 @@ export class MetricsCalculator {
       w1: number;
       reference: ImageMetrics['referenceMode'];
       n_pixels: number;
+      radial_reach_q95: number | null;
+      dispersed_mass_fraction: number | null;
+      fragment_count: number | null;
+      largest_fragment_fraction: number | null;
+      solidity: number | null;
+      hole_count: number | null;
+      core_equiv_diameter_px: number | null;
+      whole_equiv_diameter_px: number | null;
     }>('/api/disintegration-index', {
       mask_polygons,
       core_polygons,
       image_width: imageWidth,
       image_height: imageHeight,
     });
+    const d = response.data;
+    // Diameters are lengths → ×scale (μm/px). Fractions/counts/reach are
+    // scale-free. Panel fields are null unless the endpoint returned 'core'.
+    const lengthScale =
+      pixelToMicrometerScale && pixelToMicrometerScale > 0
+        ? pixelToMicrometerScale
+        : 1;
+    const scaleLen = (v: number | null): number | null =>
+      v === null || v === undefined ? null : v * lengthScale;
     return {
-      disintegrationIndex: response.data.di,
-      wassersteinW1: response.data.w1,
-      referenceMode: response.data.reference,
-      nPixels: response.data.n_pixels,
+      disintegrationIndex: d.di,
+      wassersteinW1: d.w1,
+      referenceMode: d.reference,
+      nPixels: d.n_pixels,
+      radialReachQ95: d.radial_reach_q95 ?? null,
+      dispersedMassFraction: d.dispersed_mass_fraction ?? null,
+      fragmentCount: d.fragment_count ?? null,
+      largestFragmentFraction: d.largest_fragment_fraction ?? null,
+      solidity: d.solidity ?? null,
+      holeCount: d.hole_count ?? null,
+      coreEquivDiameter: scaleLen(d.core_equiv_diameter_px),
+      wholeEquivDiameter: scaleLen(d.whole_equiv_diameter_px),
     };
   }
 
@@ -1115,6 +1154,7 @@ export class MetricsCalculator {
 
     const isScaled = pixelToMicrometerScale && pixelToMicrometerScale > 0;
     const areaUnit = isScaled ? 'um^2' : 'px^2';
+    const lengthUnit = isScaled ? 'um' : 'px';
 
     const sheet = workbook.addWorksheet('Image Metrics');
     sheet.columns = [
@@ -1135,10 +1175,41 @@ export class MetricsCalculator {
         key: 'disintegrationIndex',
         width: 22,
       },
+      // Disintegration metric panel — the axes DI does not cover. All N/A when
+      // no core anchored the computation.
+      { header: 'Radial Reach q95 (R_core)', key: 'radialReachQ95', width: 24 },
+      {
+        header: 'Dispersed-Mass Fraction',
+        key: 'dispersedMassFraction',
+        width: 24,
+      },
+      { header: 'Fragment Count', key: 'fragmentCount', width: 16 },
+      {
+        header: 'Largest-Fragment Fraction',
+        key: 'largestFragmentFraction',
+        width: 26,
+      },
+      { header: 'Solidity', key: 'solidity', width: 14 },
+      { header: 'Hole Count', key: 'holeCount', width: 14 },
+      {
+        header: `Core Equiv. Diameter (${lengthUnit})`,
+        key: 'coreEquivDiameter',
+        width: 26,
+      },
+      {
+        header: `Whole Equiv. Diameter (${lengthUnit})`,
+        key: 'wholeEquivDiameter',
+        width: 26,
+      },
     ];
 
     const safe = (v: number, decimals = 2): number =>
       isFinite(v) ? parseFloat(v.toFixed(decimals)) : 0;
+    // Panel fields are null exactly when DI wasn't core-anchored → render N/A.
+    const naNum = (v: number | null, decimals: number): number | 'N/A' =>
+      v === null || v === undefined || !isFinite(v)
+        ? 'N/A'
+        : parseFloat(v.toFixed(decimals));
 
     if (imageMetrics) {
       imageMetrics.forEach(m => {
@@ -1152,6 +1223,14 @@ export class MetricsCalculator {
           // not a real zero.
           disintegrationIndex:
             m.referenceMode === 'core' ? safe(m.disintegrationIndex, 4) : 'N/A',
+          radialReachQ95: naNum(m.radialReachQ95, 3),
+          dispersedMassFraction: naNum(m.dispersedMassFraction, 4),
+          fragmentCount: naNum(m.fragmentCount, 0),
+          largestFragmentFraction: naNum(m.largestFragmentFraction, 4),
+          solidity: naNum(m.solidity, 4),
+          holeCount: naNum(m.holeCount, 0),
+          coreEquivDiameter: naNum(m.coreEquivDiameter, 2),
+          wholeEquivDiameter: naNum(m.wholeEquivDiameter, 2),
         });
       });
     }


### PR DESCRIPTION
## What

Adds a panel of companion metrics next to the Disintegration Index for disintegrating-spheroid (`spheroid_invasive`) exports, spanning the axes DI does **not** cover, so redundancy is explicit.

All are computed in the **same** `/api/disintegration-index` endpoint from the same rasterised masks (`FG = C ∪ K`) — one source of truth with DI — and are **N/A whenever no core anchored the computation**.

| Column | Axis | Formula |
| --- | --- | --- |
| Radial Reach q95 | A radial dispersal | 95th pct of `{d̃}` |
| Dispersed-Mass Fraction | B mass partition | `N_K / N_FG` |
| Fragment Count | C fragmentation | CCs of FG after closing (r=2 px), min 30 px |
| Largest-Fragment Fraction | C fragmentation | largest ÷ de-speckled mass |
| Solidity | D porosity | `N_FG / N_hull` |
| Hole Count | D porosity | enclosed holes (Betti-1) |
| Core / Whole Equiv. Diameter | E absolute size | `2√(N/π)` ×(µm/px) |

`Solidity` and `Largest-Fragment Fraction` are clamped to their proper ranges (rasterisation can otherwise nudge them past 1). Speckle-guard thresholds are echoed by the endpoint (`closing_radius_px`, `min_fragment_px`) for reproducibility. Radius-of-gyration / second-moment descriptors are deliberately omitted (rank-correlation with DI ≈ 0.95).

## Verification

- **ML**: 20/20 `test_disintegration.py` via the real FastAPI HTTP path (GPU container), incl. a new panel test class (intact disk → 1 fragment/solid/no holes; two blobs → 2 fragments; no-core → whole panel null).
- **Backend**: `tsc` clean; ESLint 0; Prettier clean; 435 vitest (metrics + export) incl. panel propagation + µm scaling + N/A rendering.

Follows #293 (core-required DI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)