### PR TITLE
fix(mt-metrics): exact-thickness band + ImageJ background ROI = the measured region

### DIFF
--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -689,3 +689,202 @@ async def mt_metrics(req: MTMetricsRequest) -> MTMetricsResponse:
         frame_height=int(H),
         frame_width=int(W),
     )
+
+
+# ----------------------------------------------------------------------------
+#  Background-ROI endpoint (ImageJ composite ROIs for the MT export)
+# ----------------------------------------------------------------------------
+#
+# The ImageJ RoiSet export draws each microtubule's per-MT LOCAL background as a
+# ROI so a biologist can re-measure exactly what the ``median/mean_background``
+# columns were computed from. That region is the vicinity ring
+# ``dilate(band, thickness*margin) & ~signal_union`` — a band with EVERY
+# microtubule (its own core + any neighbour crossing the ring) cut out. A plain
+# stroke-width polyline cannot express those holes, so it is exported as an
+# ImageJ COMPOSITE (ShapeRoi): the outer contour plus a hole contour per cut-out,
+# rendered with the even-odd fill rule. The mask is the SAME ``_vicinity_mask``
+# the metrics endpoint samples, so the ROI and the numbers can never diverge.
+
+
+class MTBgPolylineInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance_id: str
+    points: List[List[float]]
+    # ImageJ ROI name (e.g. ``mt_3_bg``) baked into the composite bytes.
+    roi_name: str
+    # ARGB stroke colour (opaque alpha in the high byte) matching the sibling MT
+    # ROI's per-track colour. None leaves ImageJ's default.
+    stroke_color: Optional[int] = None
+    # 1-based stack slice this ROI sits on (the video frame).
+    position: Optional[int] = None
+
+
+class MTBgFrameInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frame_index: int
+    polylines: List[MTBgPolylineInput]
+
+
+class MTBackgroundRoisRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frames: List[MTBgFrameInput]
+    thickness_px: int = Field(5, ge=1, le=100)
+    margin_multiplier: float = Field(2.0, ge=0.0, le=10.0)
+    # Real frame dimensions so the ring clips at the true image border exactly as
+    # the metrics endpoint does. When omitted, a canvas bounding all polylines
+    # (padded by the margin) is used — identical except for MTs touching a border.
+    frame_height: Optional[int] = None
+    frame_width: Optional[int] = None
+
+
+class MTBackgroundRoi(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance_id: str
+    # Base64 of the ImageJ ``.roi`` composite bytes.
+    roi_b64: str
+
+
+class MTBackgroundRoisFrame(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frame_index: int
+    rois: List[MTBackgroundRoi]
+
+
+class MTBackgroundRoisResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frames: List[MTBackgroundRoisFrame]
+
+
+def _vicinity_composite_roi_bytes(
+    vicinity: np.ndarray,
+    name: str,
+    stroke_color: Optional[int],
+    position: Optional[int],
+) -> Optional[bytes]:
+    """Encode a boolean vicinity mask as ImageJ COMPOSITE ``.roi`` bytes.
+
+    Outer contours + hole contours (``RETR_CCOMP``) become one geometric path
+    (MOVETO/LINETO/CLOSE per contour); ImageJ's even-odd fill turns the hole
+    contours into cut-outs. Returns None for an empty mask (no ring — the
+    metrics side reports null background for the same case).
+    """
+    import cv2
+    import struct
+    import roifile
+
+    mask = np.ascontiguousarray(vicinity.astype(np.uint8))
+    if mask.sum() == 0:
+        return None
+    contours, _ = cv2.findContours(
+        mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE
+    )
+    contours = [c for c in contours if c.shape[0] >= 3]
+    if not contours:
+        return None
+
+    path: List[float] = []
+    for c in contours:
+        pts = c.reshape(-1, 2)
+        path.extend((0.0, float(pts[0, 0]), float(pts[0, 1])))  # MOVETO
+        for q in pts[1:]:
+            path.extend((1.0, float(q[0]), float(q[1])))  # LINETO
+        path.append(4.0)  # CLOSE
+    multi = np.asarray(path, dtype=np.float32)
+
+    ys, xs = np.nonzero(mask)
+    roi = roifile.ImagejRoi(
+        roitype=roifile.ROI_TYPE.RECT,
+        name=name,
+        left=int(xs.min()),
+        top=int(ys.min()),
+        right=int(xs.max()) + 1,
+        bottom=int(ys.max()) + 1,
+        n_coordinates=0,
+        shape_roi_size=int(multi.size),
+        multi_coordinates=multi,
+    )
+    if stroke_color is not None:
+        # ImageJ .roi is big-endian ARGB.
+        roi.stroke_color = struct.pack(">I", int(stroke_color) & 0xFFFFFFFF)
+    if position is not None and position > 0:
+        roi.position = int(position)
+    return roi.tobytes()
+
+
+@router.post("/mt-background-rois", response_model=MTBackgroundRoisResponse)
+async def mt_background_rois(
+    req: MTBackgroundRoisRequest,
+) -> MTBackgroundRoisResponse:
+    """Per-MT background composite ROIs for the ImageJ export.
+
+    Mirrors the metrics endpoint's geometry step (exact-thickness bands →
+    signal union → per-MT vicinity ring) and encodes each ring as an ImageJ
+    COMPOSITE ROI. Geometry-only (no raster read), so it is cheap.
+    """
+    import base64
+
+    margin_radius = int(round(req.thickness_px * req.margin_multiplier))
+    out_frames: List[MTBackgroundRoisFrame] = []
+
+    for fr in req.frames:
+        valid_pts = [
+            np.asarray(pl.points, dtype=np.float32)
+            for pl in fr.polylines
+            if len(pl.points) >= 2
+        ]
+        if not valid_pts:
+            out_frames.append(
+                MTBackgroundRoisFrame(frame_index=fr.frame_index, rois=[])
+            )
+            continue
+
+        if req.frame_height and req.frame_width:
+            h, w = int(req.frame_height), int(req.frame_width)
+        else:
+            stacked = np.concatenate(valid_pts, axis=0)
+            pad = margin_radius + req.thickness_px + 4
+            w = int(np.ceil(stacked[:, 0].max())) + pad
+            h = int(np.ceil(stacked[:, 1].max())) + pad
+
+        band_masks: List[np.ndarray] = []
+        for pl in fr.polylines:
+            pts = np.asarray(pl.points, dtype=np.float32)
+            if pts.ndim != 2 or pts.shape[1] != 2 or pts.shape[0] < 2:
+                band_masks.append(np.zeros((h, w), dtype=np.uint8))
+            else:
+                band_masks.append(_rasterize_band(pts, h, w, req.thickness_px))
+
+        signal_union = np.zeros((h, w), dtype=np.uint8)
+        for m in band_masks:
+            signal_union |= m
+        not_signal = signal_union == 0
+
+        rois: List[MTBackgroundRoi] = []
+        for i, pl in enumerate(fr.polylines):
+            vicinity = _vicinity_mask(band_masks[i], not_signal, margin_radius)
+            roi_bytes = _vicinity_composite_roi_bytes(
+                vicinity, pl.roi_name, pl.stroke_color, pl.position
+            )
+            if roi_bytes is not None:
+                rois.append(
+                    MTBackgroundRoi(
+                        instance_id=pl.instance_id,
+                        roi_b64=base64.b64encode(roi_bytes).decode("ascii"),
+                    )
+                )
+        out_frames.append(
+            MTBackgroundRoisFrame(frame_index=fr.frame_index, rois=rois)
+        )
+
+    logger.info(
+        "mt-background-rois: %d frames, %d composite ROIs",
+        len(out_frames),
+        sum(len(f.rois) for f in out_frames),
+    )
+    return MTBackgroundRoisResponse(frames=out_frames)

--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -182,30 +182,56 @@ def _polyline_length(points: np.ndarray) -> float:
 def _rasterize_band(
     points: np.ndarray, h: int, w: int, thickness: int
 ) -> np.ndarray:
-    """Rasterize a polyline as a thickness-wide 0/1 mask.
+    """Rasterize a polyline as an EXACT ``thickness``-wide 0/1 band.
 
-    cv2.polylines with `LINE_8` strokes whole pixels (no antialiasing),
-    so the resulting mask is binary and the pixel_count is exactly the
-    band area at the requested thickness. Rounded line caps + joins
-    follow OpenCV's default, which matches what ImageJ's "fill stroke"
-    produces for a width-N polyline.
+    A pixel is in the band iff its centre lies within ``thickness / 2`` of the
+    polyline centreline, computed via a precise Euclidean distance transform of
+    the 1-px-rasterised centreline. This makes ``pixel_count`` the band area at
+    the *requested* thickness and makes the band coincide with an ImageJ line
+    ROI of stroke width ``thickness`` (the region exported alongside the
+    metrics).
+
+    Why not ``cv2.polylines(thickness=N)``: OpenCV's thick-line renderer draws a
+    band ~``N + 2`` px wide (measured: N=3→5, N=5→7, N=7→9 px on cv2 4.8), so it
+    over-counts the area by ~40 % at N=5 and disagrees with the exported ImageJ
+    stroke. The distance-transform band removes that systematic bias (exact for
+    odd ``thickness``; even widths round to ``thickness + 1`` since an integer
+    band cannot be centred symmetrically on a 1-px line).
+
+    The transform runs only inside the polyline's bounding box padded by
+    ``ceil(thickness/2) + 2`` — a band is tiny relative to the frame, so this is
+    O(bbox) not O(H*W), and the padded window fully contains the band so the
+    windowed result is identical to a full-frame transform.
     """
     import cv2  # local import to keep module load cheap for tests
-    mask = np.zeros((h, w), dtype=np.uint8)
+    band = np.zeros((h, w), dtype=np.uint8)
     if points.shape[0] < 2:
-        return mask
+        return band
     # cv2 wants (N, 1, 2) int32. (x, y) order matches what the editor
-    # serialises; cv2 also uses (x, y) for polyline points so no swap
-    # is needed.
-    pts_int = np.rint(points).astype(np.int32).reshape(-1, 1, 2)
-    cv2.polylines(
-        mask, [pts_int],
-        isClosed=False,
-        color=1,
-        thickness=int(thickness),
-        lineType=8,  # cv2.LINE_8 numeric constant; avoids attr lookup on cold cv2 import
-    )
-    return mask
+    # serialises; cv2 also uses (x, y) for polyline points so no swap is needed.
+    pts = np.rint(points).astype(np.int32)
+    t = int(thickness)
+    if t <= 1:
+        cv2.polylines(band, [pts.reshape(-1, 1, 2)], False, 1, 1, lineType=8)
+        return band
+
+    r = t / 2.0
+    pad = int(np.ceil(r)) + 2
+    x0 = max(0, int(pts[:, 0].min()) - pad)
+    x1 = min(w, int(pts[:, 0].max()) + pad + 1)
+    y0 = max(0, int(pts[:, 1].min()) - pad)
+    y1 = min(h, int(pts[:, 1].max()) + pad + 1)
+    if x1 <= x0 or y1 <= y0:
+        return band
+    center = np.zeros((y1 - y0, x1 - x0), dtype=np.uint8)
+    local = (pts - np.array([x0, y0])).reshape(-1, 1, 2)
+    cv2.polylines(center, [local], False, 1, 1, lineType=8)
+    # distanceTransform gives, for every non-zero pixel, the distance to the
+    # nearest zero pixel — so invert (centreline → 0) and threshold at r.
+    inv = np.where(center > 0, 0, 255).astype(np.uint8)
+    dist = cv2.distanceTransform(inv, cv2.DIST_L2, cv2.DIST_MASK_PRECISE)
+    band[y0:y1, x0:x1] = (dist <= r).astype(np.uint8)
+    return band
 
 
 def _dilate(mask: np.ndarray, radius: int) -> np.ndarray:

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -31,6 +31,11 @@ Pillow==12.2.0
 numpy==1.26.4
 scipy==1.11.4
 scikit-image==0.22.0
+# roifile encodes the ImageJ .roi background ROIs for the MT export as COMPOSITE
+# (ShapeRoi) shapes — an outer band with the microtubule signal cut out, which a
+# plain stroke-width polyline cannot represent. Pure-Python, numpy-only; used by
+# the /mt-background-rois endpoint. Pinned to the validated release.
+roifile==2025.12.12
 # matplotlib renders the per-frame intensity-profile plots for the "intensity
 # profiles" export mode (/kymograph render_profiles). 3.9.x supports Python 3.10
 # + numpy 1.26. Imported lazily with the Agg backend — no runtime display needed.

--- a/backend/segmentation/tests/unit/test_mt_metrics_band.py
+++ b/backend/segmentation/tests/unit/test_mt_metrics_band.py
@@ -1,0 +1,47 @@
+"""Regression tests for the microtubule band rasteriser (`_rasterize_band`).
+
+The band must be the EXACT requested thickness so `area_px` ≈ length*thickness
+and the sampled region coincides with the ImageJ line ROI exported at the same
+stroke width. A prior implementation used ``cv2.polylines(thickness=N)``, which
+renders an ~``N+2`` px band (over-counting area by ~40 % at N=5) — these tests
+lock in the exact-width behaviour so that regression can't return.
+
+pytest / cv2 are not installed in the ML runtime container; the module-level
+importorskip makes this a no-op there and runnable in the GPU one-off image.
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip("cv2")
+
+from api.mt_metrics import _rasterize_band  # noqa: E402
+
+
+def _mid_width(points, thickness, h=80, w=220):
+    band = _rasterize_band(np.asarray(points, np.float32), h, w, thickness)
+    # width at a column safely inside the span (away from the end caps)
+    return int(band[:, 100].sum()), int(band.sum())
+
+
+def test_straight_line_width_equals_thickness_odd():
+    line = [[30, 30], [130, 30]]
+    for t in (1, 3, 5, 7):
+        width, _ = _mid_width(line, t)
+        assert width == t, f"thickness {t} -> band width {width}, expected {t}"
+
+
+def test_area_close_to_length_times_thickness():
+    # A straight 100-px line at thickness 5: area ≈ 100*5 plus a few cap pixels,
+    # NOT the ~729 the old cv2.polylines(thickness=5) produced.
+    _, area = _mid_width([[30, 30], [130, 30]], 5)
+    assert 500 <= area <= 560, f"area {area} not near length*thickness (500)"
+
+
+def test_thickness_one_is_the_centreline():
+    width, _ = _mid_width([[30, 30], [130, 30]], 1)
+    assert width == 1
+
+
+def test_degenerate_polyline_is_empty():
+    band = _rasterize_band(np.asarray([[10, 10]], np.float32), 40, 40, 5)
+    assert band.sum() == 0

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -1257,6 +1257,100 @@ describe('exportImageJRoiSets', () => {
     expect(result.warnings.some(w => /approximate/i.test(w))).toBe(true);
   });
 
+  it('drops malformed background-ROI bytes (no ImageJ magic) and emits no _bg', async () => {
+    const out = await mkTmp();
+    axiosPostMock.mockReset();
+    // A 200 whose payload is not a valid ImageJ ROI (no `Iout` magic). It must
+    // be dropped — never written into the zip as a corrupt .roi — and the
+    // authoritative-map branch then emits no `_bg` (no stroke fallback either).
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        frames: [
+          {
+            frame_index: 0,
+            rois: [
+              {
+                instance_id: '0',
+                roi_b64: Buffer.from('not-a-roi').toString('base64'),
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await exportImageJRoiSets(oneVideoFrame(), out, 'proj', {
+      thicknessPx: 5,
+      marginMultiplier: 2,
+      backgroundStrokeWidth: 13,
+    });
+
+    const zip = await fs.readFile(
+      path.join(out, 'annotations', 'imagej', 'vid_RoiSet.zip')
+    );
+    const names = zipEntryNames(zip);
+    expect(names).toContain('untyped_1__frame_0000.roi'); // signal ROI still there
+    expect(names).not.toContain('untyped_1_bg__frame_0000.roi'); // malformed → dropped
+    // Composite fetch "succeeded" (no throw) → no fallback warning.
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('excludes corrupt frames and non-polyline items from the background request', async () => {
+    const out = await mkTmp();
+    axiosPostMock.mockReset();
+    axiosPostMock.mockResolvedValueOnce({ data: { frames: [] } });
+
+    const frames: RoiFrameInput[] = [
+      { id: 'c1', name: 'vid.nd2', isVideoContainer: true, segmentation: null },
+      // Corrupt JSON — must be skipped in BOTH the request and the encoder.
+      {
+        id: 'bad',
+        name: 'vid.nd2 (frame 1)',
+        parentVideoId: 'c1',
+        frameIndex: 0,
+        segmentation: { polygons: '{not json' },
+      },
+      // A polyline + a closed polygon: only the polyline is a background target.
+      {
+        id: 'f1',
+        name: 'vid.nd2 (frame 2)',
+        parentVideoId: 'c1',
+        frameIndex: 1,
+        segmentation: {
+          polygons: JSON.stringify([
+            line('1', [
+              [10, 10],
+              [20, 25],
+            ]),
+            line(
+              '2',
+              [
+                [30, 30],
+                [40, 30],
+                [40, 40],
+              ],
+              'polygon'
+            ),
+          ]),
+        },
+      },
+    ];
+
+    await exportImageJRoiSets(frames, out, 'proj', {
+      thicknessPx: 5,
+      marginMultiplier: 2,
+    });
+
+    const body = axiosPostMock.mock.calls[0][1] as {
+      frames: Array<{ frame_index: number; polylines: unknown[] }>;
+    };
+    // Only frame 1 (the polyline), and only its single polyline — corrupt frame 0
+    // dropped, the polygon excluded.
+    expect(body.frames).toHaveLength(1);
+    expect(body.frames[0].frame_index).toBe(1);
+    expect(body.frames[0].polylines).toHaveLength(1);
+  });
+
   it('writes one <video>_RoiSet.zip per container, skipping empty frames', async () => {
     const out = await mkTmp();
     const frames: RoiFrameInput[] = [

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -32,7 +32,13 @@
  * `roifile` Python package during development.
  */
 
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, afterAll, vi } from 'vitest';
+
+// Mock only the axios default export so the ML `/mt-background-rois` fetch in
+// `exportImageJRoiSets` is controllable. Tests that don't pass `thicknessPx`
+// never call it, so the existing suites are unaffected.
+const axiosPostMock = vi.hoisted(() => vi.fn());
+vi.mock('axios', () => ({ default: { post: axiosPostMock } }));
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -1156,6 +1162,100 @@ describe('exportImageJRoiSets', () => {
     tmpDirs.push(dir);
     return dir;
   }
+
+  const oneVideoFrame = (): RoiFrameInput[] => [
+    { id: 'c1', name: 'vid.nd2', isVideoContainer: true, segmentation: null },
+    {
+      id: 'f0',
+      name: 'vid.nd2 (frame 1)',
+      parentVideoId: 'c1',
+      frameIndex: 0,
+      segmentation: {
+        polygons: JSON.stringify([
+          line('1', [
+            [10, 10],
+            [20, 25],
+          ]),
+        ]),
+      },
+    },
+  ];
+
+  it('fetches composite _bg ROIs from ML and inserts them by the aligned key', async () => {
+    const out = await mkTmp();
+    axiosPostMock.mockReset();
+    // A real ImageJ ROI buffer (starts with the `Iout` magic the fetch validates).
+    const fakeComposite = encodeImageJRoi(
+      [
+        { x: 1, y: 1 },
+        { x: 9, y: 1 },
+      ],
+      'polyline',
+      'bg'
+    );
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        frames: [
+          {
+            frame_index: 0,
+            rois: [{ instance_id: '0', roi_b64: fakeComposite.toString('base64') }],
+          },
+        ],
+      },
+    });
+
+    const result = await exportImageJRoiSets(oneVideoFrame(), out, 'proj', {
+      thicknessPx: 5,
+      marginMultiplier: 2,
+    });
+
+    // The request carries the join fields the encoder looks up: frame_index +
+    // instance_id (= itemIndex) + the `<label>_bg` name + 1-based position.
+    expect(axiosPostMock).toHaveBeenCalledTimes(1);
+    const body = axiosPostMock.mock.calls[0][1] as {
+      frames: Array<{
+        frame_index: number;
+        polylines: Array<{
+          instance_id: string;
+          roi_name: string;
+          position: number;
+        }>;
+      }>;
+    };
+    expect(body.frames[0].frame_index).toBe(0);
+    expect(body.frames[0].polylines[0].instance_id).toBe('0');
+    expect(body.frames[0].polylines[0].roi_name).toBe('untyped_1_bg');
+    expect(body.frames[0].polylines[0].position).toBe(1);
+
+    // The composite _bg entry landed in the zip → the key `0:0` matched.
+    const zip = await fs.readFile(
+      path.join(out, 'annotations', 'imagej', 'vid_RoiSet.zip')
+    );
+    const names = zipEntryNames(zip);
+    expect(names).toContain('untyped_1__frame_0000.roi');
+    expect(names).toContain('untyped_1_bg__frame_0000.roi');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('falls back to the stroke _bg band and warns the user when the ML fetch fails', async () => {
+    const out = await mkTmp();
+    axiosPostMock.mockReset();
+    axiosPostMock.mockRejectedValueOnce(new Error('ML unavailable'));
+
+    const result = await exportImageJRoiSets(oneVideoFrame(), out, 'proj', {
+      thicknessPx: 5,
+      marginMultiplier: 2,
+      backgroundStrokeWidth: 13,
+    });
+
+    // Non-fatal: the export still ships a (coarser) stroke-band _bg…
+    const zip = await fs.readFile(
+      path.join(out, 'annotations', 'imagej', 'vid_RoiSet.zip')
+    );
+    expect(zipEntryNames(zip)).toContain('untyped_1_bg__frame_0000.roi');
+    // …and the degradation is surfaced to the user, not just the server log.
+    expect(result.warnings.some(w => /approximate/i.test(w))).toBe(true);
+  });
 
   it('writes one <video>_RoiSet.zip per container, skipping empty frames', async () => {
     const out = await mkTmp();

--- a/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
+++ b/backend/src/services/export/__tests__/imagejRoiEncoder.test.ts
@@ -1001,6 +1001,63 @@ describe('buildVideoRoiEntries', () => {
     expect(bg.position).toBe(sig.position);
   });
 
+  const onePolylineFrame = () => [
+    {
+      id: 'f0',
+      name: 'v',
+      parentVideoId: 'c1',
+      frameIndex: 0,
+      segmentation: {
+        polygons: JSON.stringify([
+          {
+            trackId: 't1',
+            geometry: 'polyline',
+            mtType: 'h',
+            points: [
+              { x: 0, y: 0 },
+              { x: 10, y: 0 },
+            ],
+          },
+        ]),
+      },
+    },
+  ];
+
+  it('uses the pre-fetched composite buffer for <name>_bg when bgRoiBytes is provided', () => {
+    const palette = new Map([['h', { name: 'HeLa', color: '#ff0000' }]]);
+    const composite = Buffer.from('COMPOSITE_BG_BYTES_FROM_ML');
+    // key = `${frameIndex}:${itemIndex}` = '0:0'.
+    const bgMap = new Map<string, Buffer>([['0:0', composite]]);
+    const build = buildVideoRoiEntries(
+      onePolylineFrame(),
+      5,
+      palette,
+      13, // stroke-band fallback width — must be IGNORED when the map is present
+      bgMap
+    );
+    expect(build.entries.map(e => e.name).sort()).toEqual([
+      'HeLa_1__frame_0000.roi',
+      'HeLa_1_bg__frame_0000.roi',
+    ]);
+    const map = byName(build.entries);
+    // The _bg entry is the exact ML composite bytes, not a re-encoded stroke band.
+    expect(map.get('HeLa_1_bg__frame_0000.roi')!.buffer).toBe(composite);
+  });
+
+  it('omits <name>_bg when a present bgRoiBytes map has no key (empty vicinity ring)', () => {
+    const palette = new Map([['h', { name: 'HeLa', color: '#ff0000' }]]);
+    // Present-but-empty map is authoritative: no background ROI AND no stroke
+    // fallback (an empty ring = null background on the metrics side).
+    const build = buildVideoRoiEntries(
+      onePolylineFrame(),
+      5,
+      palette,
+      13,
+      new Map<string, Buffer>()
+    );
+    expect(build.entries.map(e => e.name)).toEqual(['HeLa_1__frame_0000.roi']);
+  });
+
   it('skips the background band when it is not wider than the signal (margin 0)', () => {
     const build = buildVideoRoiEntries(
       [

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -46,6 +46,8 @@ import {
   imageJStrokeColor,
   imageJColorFromHex,
 } from './imagejColor';
+import axios from 'axios';
+import { config } from '../../utils/config';
 
 // ---------------------------------------------------------------------------
 //  Low-level encoder
@@ -417,6 +419,48 @@ export interface VideoRoiBuild {
   droppedPolygons: number;
 }
 
+/** One planned ROI: the resolved geometry, points, `<type>_<counter>` label and
+ *  per-track/per-class stroke colour. Shared by the entry encoder and the
+ *  background-ROI request builder so both see the SAME items in the SAME order —
+ *  the list index is the join key for the per-MT background composite bytes. */
+interface PlannedRoiItem {
+  geometry: RoiGeometry;
+  points: PolygonPoint[];
+  label: string;
+  strokeColor: number;
+}
+
+/**
+ * Resolve a frame's raw polygons into ordered {@link PlannedRoiItem}s: map the
+ * geometry/label/colour, then drop degenerate geometry (polyline < 2 / polygon <
+ * 3 points, or any non-finite coordinate). Deterministic in `polygons` order, so
+ * item index `i` identifies the same polyline in both the encoder and the ML
+ * background request.
+ */
+function planFrameItems(
+  polygons: RawPolygon[],
+  mtNameByKey: Map<string, string>,
+  labelById?: Map<string, RoiTypeLabel>
+): PlannedRoiItem[] {
+  return polygons
+    .map((p, index) => {
+      const geometry: RoiGeometry =
+        p.geometry === 'polygon' ? 'polygon' : 'polyline';
+      const typeLabel = p.mtType ? labelById?.get(p.mtType) : undefined;
+      const key = p.trackId || p.instanceId || p.id;
+      const label = (key && mtNameByKey.get(key)) || roiLabel(p, index);
+      return {
+        geometry,
+        points: validPoints(p.points),
+        label,
+        strokeColor: typeLabel
+          ? imageJColorFromHex(typeLabel.color)
+          : imageJStrokeColor(colorKeyForRoi(p)),
+      };
+    })
+    .filter(it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3));
+}
+
 /**
  * Build the ImageJ ``.roi`` zip entries for ONE video's frames. Pure (no IO)
  * so the exact bytes — slice position, per-track stroke colour, geometry, and
@@ -451,8 +495,19 @@ export function buildVideoRoiEntries(
    *  the region background stats are sampled from (`thickness + 2*margin`). When
    *  set and wider than the signal thickness, each polyline also gets a
    *  `<name>_bg` polyline drawn at this width, so ImageJ shows the background
-   *  band around the (narrower) signal band. Omit to skip background ROIs. */
-  backgroundStrokeWidth?: number
+   *  band around the (narrower) signal band. Omit to skip background ROIs.
+   *
+   *  Superseded by `bgRoiBytes` when that map is supplied: the fallback only
+   *  applies when the ML background-ROI request was skipped or failed. */
+  backgroundStrokeWidth?: number,
+  /** Pre-fetched per-MT background COMPOSITE ROI bytes from the ML
+   *  `/mt-background-rois` endpoint, keyed by ``\`${frameIndex}:${itemIndex}\```
+   *  (itemIndex = position in {@link planFrameItems}). When provided, a
+   *  polyline's `<name>_bg` ROI is this exact composite (the vicinity ring with
+   *  every MT cut out) instead of the wide stroke polyline — so ImageJ shows
+   *  precisely the region the background metrics sample. A missing key means the
+   *  ring was empty (background nulled), so no `_bg` ROI is emitted. */
+  bgRoiBytes?: Map<string, Buffer>
 ): VideoRoiBuild {
   const ordered = [...frames].sort(
     (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
@@ -480,31 +535,9 @@ export function buildVideoRoiEntries(
     const position =
       typeof frame.frameIndex === 'number' ? frame.frameIndex + 1 : undefined;
 
-    // Normalise to concrete items, dropping degenerate geometry (polyline < 2 /
-    // polygon < 3) and any polygon with non-finite coordinates. Missing geometry
-    // defaults to 'polyline' — MT annotations are always open polylines.
-    const items = parsed.polygons
-      .map((p, index) => {
-        const geometry: RoiGeometry =
-          p.geometry === 'polygon' ? 'polygon' : 'polyline';
-        // Resolve the assigned tubulin type label (if any). Its COLOUR drives
-        // the stroke so the ROI reads as its class; its NAME feeds the
-        // `<type>_<counter>` scheme via buildMtNameByKey.
-        const typeLabel = p.mtType ? labelById?.get(p.mtType) : undefined;
-        // ROI name: the per-video `<type>_<counter>` (or manual rename) when a
-        // stable key resolved, else the legacy trackId/id label as a fallback.
-        const key = p.trackId || p.instanceId || p.id;
-        const label = (key && mtNameByKey.get(key)) || roiLabel(p, index);
-        return {
-          geometry,
-          points: validPoints(p.points),
-          label,
-          strokeColor: typeLabel
-            ? imageJColorFromHex(typeLabel.color)
-            : imageJStrokeColor(colorKeyForRoi(p)),
-        };
-      })
-      .filter(it => it.points.length >= (it.geometry === 'polyline' ? 2 : 3));
+    // Normalise to concrete items (shared with the ML background-ROI request so
+    // item indices align), dropping degenerate geometry.
+    const items = planFrameItems(parsed.polygons, mtNameByKey, labelById);
 
     droppedPolygons += parsed.polygons.length - items.length;
     if (items.length === 0) continue;
@@ -529,7 +562,8 @@ export function buildVideoRoiEntries(
       usedEntryNames.add(stem.toLowerCase());
       return stem;
     };
-    for (const { geometry, points, label, strokeColor } of items) {
+    for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+      const { geometry, points, label, strokeColor } = items[itemIndex];
       const entryStem = reserveEntry(sanitizeFilename(label));
       const buffer = encodeImageJRoi(points, geometry, label, {
         position,
@@ -539,23 +573,30 @@ export function buildVideoRoiEntries(
       entries.push({ name: `${entryStem}.roi`, buffer });
       frameRois++;
 
-      // Second ROI: the per-MT background band. It's the SAME polyline drawn at
-      // the vicinity width (thickness + 2*margin), so ImageJ renders the
-      // background band around the (narrower) signal band — the ring between
-      // them is where background stats come from. Only for polylines, and only
-      // when the vicinity is actually wider than the signal (margin > 0).
-      if (
-        geometry === 'polyline' &&
+      // Per-MT background ROI (polylines only). Preferred: the exact COMPOSITE
+      // fetched from ML — the vicinity ring with every microtubule cut out, i.e.
+      // precisely the pixels `median/mean_background` are computed from. When no
+      // composite map was supplied (ML skipped or failed) fall back to the wide
+      // `<name>_bg` stroke polyline (a solid band; overstates the background but
+      // keeps a visual indicator).
+      if (geometry !== 'polyline') continue;
+      const bgLabel = `${label}_bg`;
+      let bgBuffer: Buffer | undefined;
+      if (bgRoiBytes) {
+        // A present map is authoritative: a missing key = empty ring = no ROI.
+        bgBuffer = bgRoiBytes.get(`${frame.frameIndex}:${itemIndex}`);
+      } else if (
         typeof backgroundStrokeWidth === 'number' &&
         backgroundStrokeWidth > (strokeWidth ?? 0)
       ) {
-        const bgLabel = `${label}_bg`;
-        const bgStem = reserveEntry(sanitizeFilename(bgLabel));
-        const bgBuffer = encodeImageJRoi(points, 'polyline', bgLabel, {
+        bgBuffer = encodeImageJRoi(points, 'polyline', bgLabel, {
           position,
           strokeColor,
           strokeWidth: backgroundStrokeWidth,
         });
+      }
+      if (bgBuffer) {
+        const bgStem = reserveEntry(sanitizeFilename(bgLabel));
         entries.push({ name: `${bgStem}.roi`, buffer: bgBuffer });
         frameRois++;
       }
@@ -603,6 +644,90 @@ async function writeRoiSetZip(
   });
 }
 
+interface MtBgRequestPolyline {
+  instance_id: string;
+  points: Array<[number, number]>;
+  roi_name: string;
+  stroke_color?: number;
+  position?: number;
+}
+interface MtBgRequestFrame {
+  frame_index: number;
+  polylines: MtBgRequestPolyline[];
+}
+interface MtBgResponse {
+  frames?: Array<{
+    frame_index: number;
+    rois?: Array<{ instance_id: string; roi_b64: string }>;
+  }>;
+}
+
+/**
+ * Fetch per-MT background COMPOSITE ROI bytes for one video from the ML
+ * `/mt-background-rois` endpoint. The request mirrors {@link buildVideoRoiEntries}
+ * (same frame sort, same {@link planFrameItems} order, same `<name>_bg` label +
+ * per-track colour + slice position) so the returned bytes key by
+ * ``\`${frameIndex}:${itemIndex}\``` line up with the encoder. Returns an empty
+ * map when there are no polylines; the caller treats a THROWN error as
+ * "fall back to the wide stroke band".
+ */
+async function fetchMtBackgroundRois(
+  frames: RoiFrameInput[],
+  labelById: Map<string, RoiTypeLabel> | undefined,
+  thicknessPx: number,
+  marginMultiplier: number
+): Promise<Map<string, Buffer>> {
+  const ordered = [...frames].sort(
+    (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
+  );
+  const mtNameByKey = buildMtNameByKey(ordered, labelById);
+
+  const reqFrames: MtBgRequestFrame[] = [];
+  for (const frame of ordered) {
+    if (typeof frame.frameIndex !== 'number') continue;
+    const parsed = parseFramePolygons(frame.segmentation?.polygons);
+    if (parsed.corrupt) continue;
+    const items = planFrameItems(parsed.polygons, mtNameByKey, labelById);
+    const polylines: MtBgRequestPolyline[] = [];
+    items.forEach((it, itemIndex) => {
+      if (it.geometry !== 'polyline') return;
+      polylines.push({
+        instance_id: String(itemIndex),
+        points: it.points.map(p => [p.x, p.y] as [number, number]),
+        roi_name: `${it.label}_bg`,
+        stroke_color: it.strokeColor,
+        position: frame.frameIndex! + 1,
+      });
+    });
+    if (polylines.length) {
+      reqFrames.push({ frame_index: frame.frameIndex, polylines });
+    }
+  }
+
+  const map = new Map<string, Buffer>();
+  if (reqFrames.length === 0) return map;
+
+  const url = `${config.SEGMENTATION_SERVICE_URL}/api/v1/mt-background-rois`;
+  const res = await axios.post<MtBgResponse>(
+    url,
+    {
+      frames: reqFrames,
+      thickness_px: thicknessPx,
+      margin_multiplier: marginMultiplier,
+    },
+    { timeout: 5 * 60 * 1000 }
+  );
+  for (const fr of res.data.frames ?? []) {
+    for (const roi of fr.rois ?? []) {
+      map.set(
+        `${fr.frame_index}:${roi.instance_id}`,
+        Buffer.from(roi.roi_b64, 'base64')
+      );
+    }
+  }
+  return map;
+}
+
 /**
  * Export one ImageJ **RoiSet.zip per video** for a microtubule project:
  *
@@ -633,9 +758,17 @@ export async function exportImageJRoiSets(
     shouldAbort?: () => boolean;
     strokeWidth?: number;
     /** Vicinity band width (px) for the per-MT background ROI
-     *  (`thickness + 2*margin`). When wider than `strokeWidth`, each MT also
-     *  gets a `<name>_bg` band ROI. Omit to skip background ROIs. */
+     *  (`thickness + 2*margin`). Used only as the FALLBACK stroke-band `<name>_bg`
+     *  when the composite fetch is disabled or fails. Omit to skip background
+     *  ROIs entirely. */
     backgroundStrokeWidth?: number;
+    /** Signal band thickness (px). When set, each video fetches exact per-MT
+     *  background COMPOSITE ROIs from ML (`/mt-background-rois`) and uses them for
+     *  `<name>_bg` instead of the wide stroke band. */
+    thicknessPx?: number;
+    /** Vicinity margin multiplier (× thickness) for the background ring, matching
+     *  the metrics request. Defaults to 2 when `thicknessPx` is set. */
+    marginMultiplier?: number;
   } = {}
 ): Promise<ImageJRoiExportResult> {
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
@@ -681,11 +814,38 @@ export async function exportImageJRoiSets(
       throw new Error('Export cancelled by user');
     }
 
+    // Exact per-MT background composite ROIs from ML (vicinity ring with every
+    // MT cut out). On any failure, fall back to the wide stroke `<name>_bg` band
+    // so the export still ships — non-fatal.
+    let bgRoiBytes: Map<string, Buffer> | undefined;
+    if (typeof options.thicknessPx === 'number' && options.thicknessPx > 0) {
+      try {
+        bgRoiBytes = await fetchMtBackgroundRois(
+          videoFrames,
+          labelById,
+          options.thicknessPx,
+          options.marginMultiplier ?? 2
+        );
+      } catch (error) {
+        logger.warn(
+          'ImageJ ROI export: background composite fetch failed; falling back to the stroke band',
+          'imagejRoiEncoder',
+          {
+            projectId,
+            videoKey,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+        bgRoiBytes = undefined;
+      }
+    }
+
     const build = buildVideoRoiEntries(
       videoFrames,
       options.strokeWidth,
       labelById,
-      options.backgroundStrokeWidth
+      options.backgroundStrokeWidth,
+      bgRoiBytes
     );
     corruptFrames += build.corruptFrames;
     droppedPolygons += build.droppedPolygons;

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -506,7 +506,8 @@ export function buildVideoRoiEntries(
    *  polyline's `<name>_bg` ROI is this exact composite (the vicinity ring with
    *  every MT cut out) instead of the wide stroke polyline — so ImageJ shows
    *  precisely the region the background metrics sample. A missing key means the
-   *  ring was empty (background nulled), so no `_bg` ROI is emitted. */
+   *  ML endpoint returned no composite for that polyline (empty or degenerate
+   *  ring), so no `_bg` ROI is emitted. */
   bgRoiBytes?: Map<string, Buffer>
 ): VideoRoiBuild {
   const ordered = [...frames].sort(
@@ -583,7 +584,8 @@ export function buildVideoRoiEntries(
       const bgLabel = `${label}_bg`;
       let bgBuffer: Buffer | undefined;
       if (bgRoiBytes) {
-        // A present map is authoritative: a missing key = empty ring = no ROI.
+        // A present map is authoritative: a missing key = ML emitted no
+        // composite for this polyline (empty/degenerate ring) = no `_bg` ROI.
         bgBuffer = bgRoiBytes.get(`${frame.frameIndex}:${itemIndex}`);
       } else if (
         typeof backgroundStrokeWidth === 'number' &&
@@ -705,7 +707,8 @@ async function fetchMtBackgroundRois(
   }
 
   const map = new Map<string, Buffer>();
-  if (reqFrames.length === 0) return map;
+  const requested = reqFrames.reduce((n, f) => n + f.polylines.length, 0);
+  if (requested === 0) return map;
 
   const url = `${config.SEGMENTATION_SERVICE_URL}/api/v1/mt-background-rois`;
   const res = await axios.post<MtBgResponse>(
@@ -717,13 +720,48 @@ async function fetchMtBackgroundRois(
     },
     { timeout: 5 * 60 * 1000 }
   );
+
+  // Validate each entry before trusting it: a response-shape drift (renamed /
+  // missing field) or a truncated payload would otherwise embed corrupt bytes
+  // into the zip as a `.roi` ImageJ can't open — `Buffer.from(bad, 'base64')`
+  // never throws, it silently truncates. Require a string field + the ImageJ
+  // ROI magic `Iout`; drop and count anything else.
+  const IMAGEJ_ROI_MAGIC = Buffer.from('Iout', 'ascii');
+  let malformed = 0;
   for (const fr of res.data.frames ?? []) {
     for (const roi of fr.rois ?? []) {
-      map.set(
-        `${fr.frame_index}:${roi.instance_id}`,
-        Buffer.from(roi.roi_b64, 'base64')
-      );
+      if (
+        typeof roi?.roi_b64 !== 'string' ||
+        typeof roi?.instance_id !== 'string'
+      ) {
+        malformed++;
+        continue;
+      }
+      const buf = Buffer.from(roi.roi_b64, 'base64');
+      if (buf.length < 4 || !buf.subarray(0, 4).equals(IMAGEJ_ROI_MAGIC)) {
+        malformed++;
+        continue;
+      }
+      map.set(`${fr.frame_index}:${roi.instance_id}`, buf);
     }
+  }
+  if (malformed > 0) {
+    logger.warn(
+      'ImageJ ROI export: dropped malformed background-ROI bytes from the ML response',
+      'imagejRoiEncoder',
+      { malformed, requested }
+    );
+  }
+  // A 200 that yields ZERO ROIs for a video that requested many is far more
+  // likely a degradation (bad canvas / vicinity regression) than "every ring is
+  // genuinely empty" — surface it rather than silently emitting no background
+  // ROIs (which the authoritative-map branch can't distinguish from intent).
+  if (map.size === 0) {
+    logger.warn(
+      'ImageJ ROI export: ML returned no background ROIs though polylines were requested; background ROIs will be missing for this video',
+      'imagejRoiEncoder',
+      { requested }
+    );
   }
   return map;
 }
@@ -806,6 +844,7 @@ export async function exportImageJRoiSets(
   let corruptFrames = 0;
   let droppedPolygons = 0;
   let failedVideos = 0;
+  let compositeFallbackVideos = 0;
   const usedZipNames = new Set<string>();
 
   // One zip per video, written sequentially to cap concurrent write streams.
@@ -837,6 +876,7 @@ export async function exportImageJRoiSets(
           }
         );
         bgRoiBytes = undefined;
+        compositeFallbackVideos++;
       }
     }
 
@@ -892,6 +932,15 @@ export async function exportImageJRoiSets(
   if (failedVideos > 0) {
     warnings.push(
       `ImageJ ROI export: ${failedVideos} video(s) could not be packaged into a RoiSet.zip and were skipped.`
+    );
+  }
+  if (compositeFallbackVideos > 0) {
+    // Surface the degradation to the USER, not just the server log: the exact
+    // per-MT background composite ROIs (the vicinity ring with every MT cut
+    // out) couldn't be fetched, so the `_bg` ROIs are the coarser stroke band,
+    // which is NOT the region the median/mean_background columns sample.
+    warnings.push(
+      `ImageJ ROI export: exact background ROIs were unavailable for ${compositeFallbackVideos} video(s); the "_bg" ROIs are an approximate band and do not match the background metric region.`
     );
   }
   if (corruptFrames > 0) {

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -693,6 +693,11 @@ export class ExportService {
               shouldAbort: () => this.isJobCancelled(jobId),
               strokeWidth: mtThicknessPx,
               backgroundStrokeWidth: mtBackgroundStrokeWidth,
+              // Fetch exact per-MT background COMPOSITE ROIs (vicinity ring with
+              // every MT cut out) from ML; backgroundStrokeWidth stays as the
+              // fallback band if that request fails.
+              thicknessPx: mtThicknessPx,
+              marginMultiplier: mtMarginMultiplier,
             }
           )
             .then(result => {


### PR DESCRIPTION
## Problem (found via review of the MT metrics computation)

Two correctness issues, both confirmed with evidence on a real 21-microtubule frame:

1. **`area_px` was inflated ~40%.** The band was rasterised with `cv2.polylines(thickness=N)`, which renders an **N+2 px** wide band (measured: N=3→5, N=5→7, N=7→9 px), not N. So `area_px` ≈ length×(thickness+2), and the sampled MT region didn't match the exported ImageJ line ROI (strokeWidth=thickness).
2. **The ImageJ `<name>_bg` background ROI didn't match the background metric.** `median/mean_background` sample the vicinity ring `dilate(band, thickness*margin) & ~signal_union` — a ring with **every microtubule cut out**. The exported `_bg` ROI was a solid `thickness+2*margin` stroke band that overlapped the microtubules (27.4% of its pixels were signal on the test frame). Measuring it in ImageJ gave a much brighter "background" than the reported number.

## Fix

- **Exact-thickness band** (`_rasterize_band`): rasterise via a precise distance transform so the band is exactly `thickness` px. `area_px` ≈ length×thickness (verified 1968 vs 1910 = +3% caps, was +39%); MT intensity now sampled from the region the ImageJ MT ROI represents. Windowed to the polyline bbox (O(bbox)).
- **`_bg` ROI = the measured region** (`/mt-background-rois` ML endpoint + `roifile`): each microtubule's background ROI is now the exact vicinity ring — an ImageJ **COMPOSITE (ShapeRoi)** with every MT cut out — encoded from the *same* `_vicinity_mask` the metrics use (SSOT). The background metric logic is unchanged (it already excluded all MTs); it just recomputes from the exact band. The old stroke band remains as a non-fatal fallback if the ML call fails.

Scope decisions confirmed with the user: cut **all** microtubules (self + neighbours) from the background; don't measure background where any MT is.

## Verification

- ML: exact-band regression test; `/mt-background-rois` verified on 21 real polylines — **0 signal px inside the bg ROI**, decoded composite vs metric vicinity **IoU 0.997**, composite/name/colour/position round-trip via roifile.
- Backend: `buildVideoRoiEntries` composite path + fallback (41 vitest tests, incl. 2 new); `make ci` green.
- Adds `roifile==2025.12.12` (pure-Python, numpy-only) to the ML service.

_Deploy + real-export E2E verification follows on this branch; results posted below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ImageJ microtubule exports now generate precise per-microtubule background ROIs using the configured thickness and margin settings.
  - Added support for exporting background vicinity-ring ROI data per frame and per detected microtubule polyline.

- **Bug Fixes**
  - Improved band geometry to match the requested thickness exactly, including odd and 1-pixel cases.
  - When precise background ROI data can’t be retrieved, exports continue using the previous approximate stroke-band fallback and emit a warning.

- **Tests**
  - Added regression tests for exact band width, area, single-pixel lines, and degenerate polylines.
  - Added export tests for correct inclusion/omission of per-microtubule background ROIs and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->