### PR TITLE
feat(nginx): proxy maptimize's remote mcp connector and oauth server

### DIFF
--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -471,6 +471,11 @@ upstream maptimize_api {
     keepalive 32;
 }
 
+upstream maptimize_mcp {
+    server maptimize-mcp:8080;
+    keepalive 8;
+}
+
 # Maptimize HTTP server
 server {
     listen 80;
@@ -538,6 +543,50 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+    }
+
+    # Remote MCP connector (Streamable HTTP) for Claude Desktop / Cowork / Code.
+    # Public; each caller authenticates with their own OAuth bearer token,
+    # which the MCP service validates against the backend. Preserve Authorization
+    # (do NOT clear it) and stream SSE (no buffering).
+    location = /mcp {
+        return 307 /mcp/;
+    }
+    location /mcp/ {
+        proxy_pass http://maptimize_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # OAuth 2.0 authorization server (for Claude Desktop's remote MCP connector).
+    # Served by the backend at the domain root; /oauth/ carries authorize/token/
+    # register, the .well-known paths carry discovery metadata.
+    location /oauth/ {
+        proxy_pass http://maptimize_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /.well-known/oauth-authorization-server {
+        proxy_pass http://maptimize_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://maptimize_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # API endpoints


### PR DESCRIPTION
This commit has been sitting unpushed on local `main` since 2026-07-23 and is **already live in production** — it just never reached `origin/main`. Opening it on its own so it stops getting dragged into unrelated PRs.

## Why now

It kept reappearing in #306. I rebased it out once; the next `merge main` pulled it straight back, because from git's point of view it is legitimate history that `origin/main` is missing. A rebase only fixes the symptom until the next merge — the actual fix is getting the commit onto `origin/main`, which is what this PR does.

## What it does

Maptimize's document database is reachable by Claude Desktop / Cowork / Code over a remote MCP connector. This container terminates TLS for `maptimize.utia.cas.cz`, so it has to route `/mcp/` (Streamable HTTP, Authorization preserved, SSE streamed unbuffered with long timeouts) and the OAuth endpoints to `maptimize-mcp:8080`.

One file, +49 lines, no deletions.

## Verified live

The running container already serves it:

```
docker exec spheroseg-nginx grep -c maptimize-mcp /etc/nginx/conf.d/nginx.active.conf  -> 1
curl -o /dev/null -w '%{http_code}' https://maptimize.utia.cas.cz/mcp/               -> 401
```

401 is the expected response — the connector authenticates per caller, so an unauthenticated probe reaching the auth layer proves the proxy route works end to end.

Merging this changes nothing about the running system; it makes the repo agree with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzEHMc3B8JxGFwWtTZhwQw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MCP connector endpoints, including streaming requests.
  * Added OAuth2 discovery and authorization routes for remote MCP connections.
  * Added automatic redirection from `/mcp` to `/mcp/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->