### PR TITLE
fix(essays): report partial runs, and make the GPU signals readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,15 +194,30 @@ rebuild: down build up
 health-check:
 	@echo "🧪 Testing services..."
 	@command -v curl >/dev/null 2>&1 || { echo "❌ Error: curl is not installed. Please install curl to run health checks."; exit 1; }
+	@# Each service is checked on its dev port first, then its production port.
+	@# Before this the target only knew the dev ports, so it silently could not
+	@# check a production stack at all — which is why the essays worker's GPU
+	@# field had no reader despite being the whole point of adding it.
 	@set -e; \
-	status=$$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3001/health) && \
-	 if [ "$$status" = "200" ]; then echo "✅ Backend healthy"; else echo "❌ Backend unhealthy (HTTP $$status)"; exit 1; fi
-	@set -e; \
-	status=$$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:8000/health) && \
-	 if [ "$$status" = "200" ]; then echo "✅ ML Service healthy"; else echo "❌ ML Service unhealthy (HTTP $$status)"; exit 1; fi
-	@set -e; \
-	status=$$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3000/health) && \
-	 if [ "$$status" = "200" ]; then echo "✅ Frontend healthy"; else echo "❌ Frontend unhealthy (HTTP $$status)"; exit 1; fi
+	probe() { \
+	  name="$$1"; shift; \
+	  for port in "$$@"; do \
+	    code=$$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:$$port/health" 2>/dev/null || true); \
+	    if [ "$$code" = "200" ]; then echo "✅ $$name healthy (:$$port)"; return 0; fi; \
+	  done; \
+	  echo "❌ $$name unhealthy on ports $$*"; return 1; \
+	}; \
+	probe Backend 3001 4001; \
+	probe "ML Service" 8000 4008; \
+	probe Frontend 3000 4000; \
+	for port in 8001 4009; do \
+	  body=$$(curl -sS --max-time 5 "http://localhost:$$port/health" 2>/dev/null || true); \
+	  case "$$body" in \
+	    "") continue;; \
+	    *'"gpu":"ok"'*) echo "✅ Essays worker healthy, GPU ok (:$$port)"; break;; \
+	    *) echo "⚠️  Essays worker serving but GPU degraded (:$$port): $$body"; break;; \
+	  esac; \
+	done
 
 # Run unit tests in Docker
 test:

--- a/backend/essays/essays_api.py
+++ b/backend/essays/essays_api.py
@@ -11,6 +11,7 @@ the backend reaches it over the docker network.
 """
 from __future__ import annotations
 
+import collections
 import json
 import os
 import queue
@@ -20,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 from pathlib import Path
 from typing import Literal, NamedTuple
 
@@ -60,6 +62,19 @@ _OK_LINE = re.compile(r"\[ok\]\s+\((\d+)/(\d+)\)\s+(\S+):\s+(\d+)\s+MT")
 # worse than the bug this file exists to surface, because the field was then
 # actively wrong rather than merely unwatched.
 _DEVICE_LINE = re.compile(r"\[info\]\s+device=(\S+)")
+# evaluate.py catches per-well read failures and per-position segmentation
+# failures, counts them, prints them as [warn], and then returns 0 REGARDLESS.
+# The worker checked only the exit code, so a run where most wells failed to read
+# was reported as `completed, 100%` with a downloadable zip — and because the
+# parse loop dropped every unmatched line, the reasons existed nowhere. For a
+# scientific pipeline that is worse than crashing: a crash demands attention,
+# this produces data someone trusts.
+_DONE_LINE = re.compile(
+    r"\[done\]\s+(\d+)\s+positions?,\s+(\d+)\s+microtubules?,\s+(\d+)\s+failures?")
+_DIAG_LINE = re.compile(r"\[(warn|error)\]")
+# Unmatched output is kept in a bounded tail so a traceback can reach the user
+# instead of only `evaluate.py exited with code 1`.
+_OUTPUT_TAIL_LINES = 100
 
 # The two values this worker ever sends (`evaluate.py` also accepts `auto` and
 # `mps`, which we never use). A CPU-with-a-reason state deliberately is NOT here:
@@ -206,7 +221,7 @@ def _await_gpu(job_id: str, out_dir: str) -> tuple[Device, "CpuReason | None"]:
             print(f"[essays] job {job_id}: GPU unreachable, running on CPU",
                   file=sys.stderr, flush=True)
             return "cpu", "fault"
-        return "cpu", None, probe.degraded
+        return "cpu", None
     need = int(GPU_MIN_FREE_GB * 1024)
     deadline = time.monotonic() + GPU_WAIT_TIMEOUT_S
     waited = False
@@ -248,6 +263,17 @@ def _build_cmd(req: ProcessRequest, device: Device) -> list[str]:
     return cmd
 
 
+def _exit_error(code: int, tail: "collections.deque[str]") -> str:
+    """Message for a non-zero exit, carrying the output that explains it.
+
+    Without the tail the operator gets only the exit code and every diagnosis
+    starts with a re-run — the module's traceback went to a pipe we parsed with
+    three regexes and then discarded.
+    """
+    msg = f"evaluate.py exited with code {code}"
+    return f"{msg}. Last output:\n" + "\n".join(tail) if tail else msg
+
+
 def _run_job(req: ProcessRequest) -> None:
     job_id, out_dir = req.jobId, req.outDir
     # Everything runs inside the try so ANY failure (a bad input dir, an mkdir on
@@ -277,6 +303,9 @@ def _run_job(req: ProcessRequest) -> None:
             env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
         wells_total = 0
+        n_fail: int | None = None
+        tail: "collections.deque[str]" = collections.deque(
+            maxlen=_OUTPUT_TAIL_LINES)
         proc = subprocess.Popen(
             _build_cmd(req, device), cwd=str(MODULE_DIR), env=env,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
@@ -318,14 +347,45 @@ def _run_job(req: ProcessRequest) -> None:
                 _set_status(job_id, out_dir, wellsDone=wells_done,
                             positionsDone=pos, mtCount=mts, progress=progress)
                 continue
+            m = _DONE_LINE.search(line)
+            if m:
+                n_fail = int(m.group(3))
+                continue
+            # Anything else: keep it, and echo the module's own diagnostics so a
+            # failed well leaves a trace an operator can actually read.
+            tail.append(line.rstrip())
+            if _DIAG_LINE.search(line):
+                print(f"[essays] job {job_id}: {line.rstrip()}",
+                      file=sys.stderr, flush=True)
         code = proc.wait()
-        if code == 0:
-            _set_status(job_id, out_dir, state="completed", progress=100)
-        else:
+        if code != 0:
             _set_status(job_id, out_dir, state="failed",
-                        error=f"evaluate.py exited with code {code}")
+                        error=_exit_error(code, tail))
+        elif n_fail:
+            # Exit 0 with failures counted is a PARTIAL result. Deliberately
+            # still `completed`: the run did finish and the zip is useful — one
+            # bad well out of 180 must not withhold the other 179. But it is not
+            # a clean success either, so the count travels in `error` and the UI
+            # renders it as a warning on a completed run. Withholding the results
+            # would be wrong in one direction; saying nothing was wrong in the
+            # other.
+            print(f"[essays] job {job_id}: module reported {n_fail} "
+                  "well/position failure(s) — results are incomplete",
+                  file=sys.stderr, flush=True)
+            _set_status(
+                job_id, out_dir, state="completed", progress=100,
+                failures=n_fail,
+                error=f"{n_fail} well/position failure(s) — some wells are "
+                      "missing from the results. See the worker log for the "
+                      "module's [warn] lines.")
+        else:
+            _set_status(job_id, out_dir, state="completed", progress=100,
+                        failures=0, error=None)
     except Exception as e:  # noqa: BLE001 — surface any failure to the backend
-        _set_status(job_id, out_dir, state="failed", error=str(e))
+        # repr, not str: str(KeyError()) and str(RuntimeError()) are empty, which
+        # would put a failed job in the UI with no reason at all.
+        traceback.print_exc()
+        _set_status(job_id, out_dir, state="failed", error=repr(e))
 
 
 def _worker() -> None:

--- a/backend/essays/tests/test_essays_api.py
+++ b/backend/essays/tests/test_essays_api.py
@@ -1,0 +1,238 @@
+"""Tests for the Automated Essays worker's decision logic.
+
+This file exists because the worker had none, while the TypeScript half of the
+same feature had five. All the state logic lives here: which device a job gets,
+whether landing on CPU was a fault or mere contention, and whether a run that
+exited 0 was actually complete.
+
+Everything below runs with plain pytest and monkeypatch — no GPU, no cloned
+module, no checkpoint. The GPU is precisely the thing being mocked, so the
+CLAUDE.md exclusion for "tests requiring infrastructure not gated on
+availability" does not reach these.
+
+Run: pytest backend/essays/tests/ (see the recipe in the module docstring of
+backend/segmentation/tests/test_microtubule_model.py for the container form).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PKG_ROOT = Path(__file__).resolve().parents[1]
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+essays_api = pytest.importorskip("essays_api")
+
+
+@pytest.fixture(autouse=True)
+def _no_status_writes(monkeypatch, tmp_path):
+    """Keep _set_status in memory — these tests are about decisions, not I/O."""
+    written: list[dict] = []
+    monkeypatch.setattr(
+        essays_api, "_set_status",
+        lambda job_id, out_dir, **f: written.append({"jobId": job_id, **f}))
+    essays_api._written = written  # type: ignore[attr-defined]
+    return written
+
+
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(essays_api.time, "sleep", lambda _s: None)
+
+
+# --- _gpu_free_mib: the four outcomes -------------------------------------
+
+def test_probe_quiet_on_a_genuinely_cpu_only_host(monkeypatch, capsys):
+    """No nvidia-smi and no NVIDIA_VISIBLE_DEVICES is expected, not a fault."""
+    monkeypatch.setattr(essays_api.shutil, "which", lambda _n: None)
+    monkeypatch.delenv("NVIDIA_VISIBLE_DEVICES", raising=False)
+
+    probe = essays_api._gpu_free_mib()
+
+    assert probe == (None, False)
+    assert capsys.readouterr().err == ""
+
+
+def test_probe_flags_a_missing_nvidia_smi_in_a_gpu_declared_container(
+        monkeypatch, capsys):
+    """nvidia-smi is hook-injected, not in the image.
+
+    So its absence inside a `runtime: nvidia` container means the hook did not
+    run — a fault, even though the same condition on a plain host is normal.
+    """
+    monkeypatch.setattr(essays_api.shutil, "which", lambda _n: None)
+    monkeypatch.setenv("NVIDIA_VISIBLE_DEVICES", "all")
+
+    probe = essays_api._gpu_free_mib()
+
+    assert probe.free_mib is None and probe.degraded is True
+    assert "hook did not inject" in capsys.readouterr().err
+
+
+def test_probe_reports_free_vram(monkeypatch):
+    monkeypatch.setattr(essays_api.shutil, "which", lambda _n: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(essays_api.subprocess, "check_output",
+                        lambda *_a, **_k: "20480\n")
+
+    assert essays_api._gpu_free_mib() == (20480, False)
+
+
+def test_probe_flags_a_failing_nvidia_smi(monkeypatch, capsys):
+    monkeypatch.setattr(essays_api.shutil, "which", lambda _n: "/usr/bin/nvidia-smi")
+
+    def _boom(*_a, **_k):
+        raise subprocess.CalledProcessError(255, "nvidia-smi")
+
+    monkeypatch.setattr(essays_api.subprocess, "check_output", _boom)
+
+    probe = essays_api._gpu_free_mib()
+
+    assert probe.free_mib is None and probe.degraded is True
+    assert "nvidia-smi is unusable" in capsys.readouterr().err
+
+
+def test_probe_can_be_silenced_for_pollers(monkeypatch, capsys):
+    """/health polls every 30 s; a broken GPU must not log 2 880 times a day."""
+    monkeypatch.setattr(essays_api.shutil, "which", lambda _n: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(essays_api.subprocess, "check_output",
+                        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("x")))
+
+    probe = essays_api._gpu_free_mib(warn=False)
+
+    assert probe.degraded is True
+    assert capsys.readouterr().err == ""
+
+
+# --- _await_gpu: device + reason, per exit --------------------------------
+
+def _probe(monkeypatch, *results):
+    """Feed _await_gpu a scripted sequence of probe outcomes."""
+    seq = list(results)
+    monkeypatch.setattr(
+        essays_api, "_gpu_free_mib",
+        lambda warn=True: seq.pop(0) if len(seq) > 1 else seq[0])
+
+
+def test_await_gpu_returns_cuda_when_there_is_room(monkeypatch):
+    _probe(monkeypatch, essays_api.GpuProbe(20480, False))
+
+    assert essays_api._await_gpu("j", "/out") == ("cuda", None)
+
+
+def test_await_gpu_is_quiet_on_a_cpu_only_host(monkeypatch, capsys):
+    _probe(monkeypatch, essays_api.GpuProbe(None, False))
+
+    assert essays_api._await_gpu("j", "/out") == ("cpu", None)
+    assert capsys.readouterr().err == ""
+
+
+def test_await_gpu_reports_an_unreachable_gpu_as_a_fault(monkeypatch, capsys):
+    _probe(monkeypatch, essays_api.GpuProbe(None, True))
+
+    assert essays_api._await_gpu("j", "/out") == ("cpu", "fault")
+    assert "GPU unreachable" in capsys.readouterr().err
+
+
+def test_await_gpu_calls_a_busy_card_busy_not_broken(monkeypatch, capsys):
+    """The distinction this whole change exists for.
+
+    A shared card that never frees 13 GiB is doing its job. Reporting it as a
+    fault put "please report this" on the most ordinary CPU exit there is, while
+    /health in the same container said the GPU was fine.
+    """
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(essays_api, "GPU_WAIT_TIMEOUT_S", 0.0)
+    _probe(monkeypatch, essays_api.GpuProbe(1024, False))
+
+    device, reason = essays_api._await_gpu("j", "/out")
+
+    assert (device, reason) == ("cpu", "busy")
+    err = capsys.readouterr().err
+    assert "still below" in err and "unreachable" not in err
+
+
+def test_await_gpu_treats_a_mid_wait_disappearance_as_a_fault(monkeypatch, capsys):
+    """It answered a moment ago, so vanishing is a fault regardless of env."""
+    _no_sleep(monkeypatch)
+    _probe(monkeypatch,
+           essays_api.GpuProbe(1024, False),      # first: busy, so we wait
+           essays_api.GpuProbe(None, True))       # then: gone
+    monkeypatch.setattr(essays_api, "GPU_WAIT_TIMEOUT_S", 3600.0)
+
+    assert essays_api._await_gpu("j", "/out") == ("cpu", "fault")
+    assert "vanished mid-wait" in capsys.readouterr().err
+
+
+# --- /health --------------------------------------------------------------
+
+@pytest.mark.parametrize("probe,expected", [
+    (essays_api.GpuProbe(20480, False), "ok"),
+    (essays_api.GpuProbe(None, False), "none"),
+    (essays_api.GpuProbe(None, True), "unreachable"),
+])
+def test_health_maps_every_probe_state(monkeypatch, probe, expected):
+    monkeypatch.setattr(essays_api, "_gpu_free_mib", lambda warn=True: probe)
+
+    body = essays_api.health()
+
+    assert body["gpu"] == expected
+    assert body["gpuFreeMib"] == probe.free_mib
+    # Deliberately still "ok" when degraded: the worker IS serving, just slowly.
+    assert body["status"] == "ok"
+
+
+def test_health_does_not_spam_the_log(monkeypatch):
+    """The poller must pass warn=False, or a broken GPU floods the log."""
+    seen: list[bool] = []
+    monkeypatch.setattr(
+        essays_api, "_gpu_free_mib",
+        lambda warn=True: seen.append(warn) or essays_api.GpuProbe(None, True))
+
+    essays_api.health()
+
+    assert seen == [False]
+
+
+# --- output parsing: the module's own accounting ---------------------------
+
+def test_device_line_matches_the_modules_real_output():
+    """Pinned against the literal line evaluate.py prints."""
+    m = essays_api._DEVICE_LINE.search(
+        "[info] device=cpu  threshold=0.5  mt_width=3 bg_gap=2 bg_width=4")
+    assert m and m.group(1) == "cpu"
+    # ...and must not swallow the well-count line the other regex needs.
+    assert not essays_api._DEVICE_LINE.search(
+        "[info] 180 well file(s) to process from /in")
+
+
+@pytest.mark.parametrize("line,n_fail", [
+    ("[done] 720 positions, 51553 microtubules, 0 failures in 12.3 min", 0),
+    ("[done] 4 positions, 12 microtubules, 2 failures in 0.4 min", 2),
+    ("[done] 1 position, 1 microtubule, 1 failure in 0.1 min", 1),
+])
+def test_done_line_extracts_the_failure_count(line, n_fail):
+    """evaluate.py returns 0 even when wells failed; this line is the only
+    machine-readable record that they did."""
+    m = essays_api._DONE_LINE.search(line)
+    assert m and int(m.group(3)) == n_fail
+
+
+def test_exit_error_carries_the_output_that_explains_it():
+    import collections
+
+    tail = collections.deque(["Traceback (most recent call last):",
+                              "ValueError: bad well"])
+    msg = essays_api._exit_error(1, tail)
+
+    assert "exited with code 1" in msg and "ValueError: bad well" in msg
+
+
+def test_exit_error_without_output_is_still_readable():
+    import collections
+
+    assert essays_api._exit_error(2, collections.deque()) == \
+        "evaluate.py exited with code 2"

--- a/backend/segmentation/api/main.py
+++ b/backend/segmentation/api/main.py
@@ -259,6 +259,24 @@ async def health():
     try:
         # Detect CUDA
         cuda_available = torch.cuda.is_available()
+        # torch.cuda.is_available() keeps returning True after a cgroup re-apply
+        # strips this container's device allowlist, because the CUDA context is
+        # already initialised in-process — that false negative is exactly how the
+        # 2026-07-27 incident hid. Probing the device node is the live check:
+        # EPERM on a mode-0666 node is the strip's signature, and it costs an
+        # open() rather than a CUDA call or a subprocess.
+        device_nodes_open = True
+        if cuda_available:
+            try:
+                os.close(os.open("/dev/nvidiactl", os.O_RDONLY))
+            except OSError:
+                device_nodes_open = False
+                logger.error(
+                    "CUDA reports available but /dev/nvidiactl is not openable — "
+                    "this container's device allowlist was stripped. Inference "
+                    "still works while the existing CUDA context lives, but any "
+                    "new process gets CPU. Recreate the container."
+                )
         
         # Detect MPS (Apple Silicon)
         mps_available = torch.backends.mps.is_available() if hasattr(torch.backends, 'mps') else False
@@ -289,7 +307,7 @@ async def health():
             status="healthy",
             timestamp=datetime.now().isoformat(),
             models_loaded=models_loaded,
-            gpu_available=gpu_available
+            gpu_available=gpu_available and device_nodes_open
         )
     except Exception as e:
         raise internal_error(logger, "Health check failed", e)

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -46,6 +46,7 @@ interface WorkerStatus {
   mtCount?: number;
   device?: string;
   deviceReason?: string;
+  failures?: number;
   error?: string | null;
 }
 
@@ -312,7 +313,19 @@ export class EssaysService {
     const p = path.join(this.jobDir(userId, jobId), 'status.json');
     try {
       return JSON.parse(await fs.readFile(p, 'utf8')) as WorkerStatus;
-    } catch {
+    } catch (e) {
+      // ENOENT is the normal case — the worker has not written yet. Anything
+      // else (a torn/corrupt file, an EACCES from the uid-1001 shared mount)
+      // used to be swallowed identically, and the staleness watchdog would then
+      // fail the job with "Worker stopped reporting" — a false diagnosis of a
+      // problem that was on our side of the handoff.
+      if ((e as { code?: string }).code !== 'ENOENT') {
+        logger.error(
+          `essays: cannot read status.json for ${jobId}: ${String(e)}`,
+          undefined,
+          CTX
+        );
+      }
       return null;
     }
   }
@@ -439,6 +452,10 @@ export class EssaysService {
           progress: 100,
           mtCount: ws.mtCount ?? job.mtCount,
           device: coerceDevice(ws.device, ws.deviceReason) ?? job.device,
+          // A completed run can still be partial: evaluate.py returns 0 even
+          // when wells failed to read or segment. Carrying `error` on the
+          // success path is what lets the UI say so without withholding the zip.
+          error: ws.error ?? null,
           resultZipKey,
           completedAt: new Date(),
         },

--- a/src/pages/AutomatedEssays.tsx
+++ b/src/pages/AutomatedEssays.tsx
@@ -226,6 +226,17 @@ const AutomatedEssays: React.FC = () => {
                     {(job.status === 'running' || job.status === 'queued') && (
                       <Progress value={job.progress} className="mt-2" />
                     )}
+                    {job.status === 'completed' && job.error && (
+                      // A completed run can still be partial — evaluate.py
+                      // returns 0 even when wells failed. Amber, not red: the
+                      // results are there and downloadable, just incomplete.
+                      <div className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500 mt-2">
+                        <AlertCircle className="h-3 w-3 shrink-0" />
+                        <span className="truncate" title={job.error}>
+                          {job.error}
+                        </span>
+                      </div>
+                    )}
                     {job.status === 'failed' && job.error && (
                       <div className="flex items-center gap-1 text-xs text-red-500 mt-2">
                         <AlertCircle className="h-3 w-3 shrink-0" />


### PR DESCRIPTION
Closes the backlog the second five-agent review of #306 left open.

## A partial run was reported as a clean success

`evaluate.py` catches per-well read failures and per-position segmentation failures, counts them into `n_fail`, prints them as `[warn]`, and then **returns 0 regardless**. The worker checked only the exit code:

```python
code = proc.wait()
if code == 0:
    _set_status(job_id, out_dir, state="completed", progress=100)
```

So a run where wells failed became `completed, 100%` with a downloadable zip. And because the parse loop matched three regexes and dropped every other line, the reasons existed nowhere:

```
docker logs spheroseg-essays | grep -cE '\[ok\]|\[warn\]|\[done\]|Traceback'  ->  0
```

Across three finished jobs, not one line of module output had ever reached the container log. For a scientific pipeline that is worse than crashing — a crash demands attention; this produces data someone trusts.

**The run now stays `completed`.** One bad well out of 180 must not withhold the other 179. But it carries the failure count in `error`, and the UI renders that as an amber warning on a completed job. Withholding the results would be wrong in one direction; saying nothing was wrong in the other. A non-zero exit now carries a bounded 100-line tail of the module's output instead of just the exit code, and `[warn]`/`[error]` lines are echoed to stderr as they stream.

Also `repr(e)` rather than `str(e)` in the catch-all — `str(KeyError())` is empty, which put failed jobs in the UI with no reason at all.

## The worker had no tests

The TypeScript half of this feature had five; the Python half, which holds *all* the state logic, had none. Added 20: `_gpu_free_mib`'s four outcomes, `_await_gpu`'s five exits, `/health`'s three-way mapping plus its `warn=False` contract, and both output regexes pinned against the literal lines `evaluate.py` prints.

No GPU, no cloned module, no checkpoint — the GPU is precisely the thing being mocked, so CLAUDE.md's exclusion for *unavailable* infrastructure does not reach them. 0.56 s.

**They earned their place on the first run.** `_await_gpu` was returning a 3-tuple on the CPU-only-host path — `return "cpu", None, probe.degraded`, a leftover from an earlier edit — which would have raised on unpacking. Not reachable under the production compose (it always sets `NVIDIA_VISIBLE_DEVICES`), but a real bug, found in seconds by the first test that called the function.

## ml's GPU check could not observe the failure it cites

`torch.cuda.is_available()` keeps returning True after a cgroup re-apply strips the allowlist, because the CUDA context is already initialised in-process — that false negative is exactly how the incident hid for weeks. The check was also startup-only.

`/health` now additionally probes `open('/dev/nvidiactl')`, whose `EPERM` on a mode-0666 node is the strip's signature, and folds it into `gpu_available`. Verified both ways: openable → True; unopenable → False (both `EPERM` and `ENOENT` are `OSError`).

## `make health` could not check production at all

It only knew the dev ports (3001/8000/3000) while production runs on 4001/4008/4000 — which is the real reason the essays worker's new `gpu` field had no reader. It now tries dev then production for every service, and reads the `gpu` field explicitly, since a degraded GPU deliberately keeps HTTP 200:

```
✅ Backend healthy (:4001)
✅ ML Service healthy (:4008)
✅ Frontend healthy (:4000)
✅ Essays worker healthy, GPU ok (:4009)
```

## `readWorkerStatus`'s empty catch

`catch { return null }` made a corrupt `status.json` and an `EACCES` from the uid-1001 shared mount indistinguishable from "not written yet". The staleness watchdog then failed the job with *"Worker stopped reporting"* — a false diagnosis of a problem on our side of the handoff. `ENOENT` stays quiet; everything else logs at error.

## Not closed

Sanitising the checkpoint to drop the two dead `PosixPath` values. That would fix Windows *without* the pickle shim and remove the `weights_only=False` arbitrary-pickle fallback on every platform — the strongest available fix — but it means re-publishing 1.2 GB of weights. That is a distribution decision, not a code fix.

## Verification

20 essays tests, 20 essaysService, 13 microtubule, 205 in the ML suite. `make ci` green. The 2 microtubule failures and 3 `tests/unit` collection errors are pre-existing and unrelated — `pysoax` is not importable in the test env, and `services.model_loader` / `services.inference` moved to `ml/` in #227 (last touched there, not here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzEHMc3B8JxGFwWtTZhwQw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Health checks now verify development and production service endpoints, including the essays worker.
  - Automated Essays reports GPU availability and degraded device states more accurately.
  - Completed jobs with partial failures now retain downloadable results and display a warning with details.

- **Bug Fixes**
  - Improved detection of GPU access problems and worker failures.
  - Job errors now include relevant output when available.
  - Service status file errors are reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->