### PR TITLE
fix(essays): segment IRM not TIRF, and keep the uploaded folder's name

### DIFF
--- a/backend/essays/essays_api.py
+++ b/backend/essays/essays_api.py
@@ -46,6 +46,8 @@ _VALUE_FLAGS = {
     "mtWidth": "--mt-width",
     "bgGap": "--bg-gap",
     "bgWidth": "--bg-width",
+    # Two channel roles, two flags: the module segments IRM and measures TIRF.
+    "irmName": "--irm-name",
     "tirfName": "--tirf-name",
     "solutionName": "--solution-name",
     "limitWells": "--limit-wells",

--- a/backend/essays/tests/test_essays_api.py
+++ b/backend/essays/tests/test_essays_api.py
@@ -207,6 +207,16 @@ def test_device_line_matches_the_modules_real_output():
     # ...and must not swallow the well-count line the other regex needs.
     assert not essays_api._DEVICE_LINE.search(
         "[info] 180 well file(s) to process from /in")
+    # ...nor the channel-roles line added alongside the IRM segmentation fix.
+    # Three [info] lines now share this stream; only one carries the device, and
+    # a device parsed out of the wrong one would put a false value in the UI.
+    # Literal copied from a real run.
+    channels = ("[info] segmenting channel ~'irm', measuring intensity on "
+                "channel ~'tirf', solution channel ~'insol,in sol,solution'")
+    assert not essays_api._DEVICE_LINE.search(channels)
+    assert not essays_api._INFO_TOTAL.search(channels)
+    assert not essays_api._OK_LINE.search(channels)
+    assert not essays_api._DIAG_LINE.search(channels)
 
 
 @pytest.mark.parametrize("line,n_fail", [

--- a/backend/essays/tests/test_essays_api.py
+++ b/backend/essays/tests/test_essays_api.py
@@ -236,3 +236,65 @@ def test_exit_error_without_output_is_still_readable():
 
     assert essays_api._exit_error(2, collections.deque()) == \
         "evaluate.py exited with code 2"
+
+
+# --- _build_cmd: the option pass-through ----------------------------------
+#
+# These flags are the ONLY way a caller can reach evaluate.py, so a missing
+# entry in _VALUE_FLAGS is not a broken option — it is an option that silently
+# runs on the module's default. `irmName` is the one that matters most: without
+# it a user could not point segmentation at their IRM channel, which is the
+# whole subject of the 2026-08 channel-role fix.
+
+def _req(**options):
+    return essays_api.ProcessRequest(
+        jobId="job-1", inputDir="/in", outDir="/out", options=options or None)
+
+
+def test_build_cmd_has_the_invariant_head():
+    cmd = essays_api._build_cmd(_req(), "cuda")
+
+    assert cmd[:2] == ["python", "evaluate.py"]
+    assert cmd[cmd.index("--data") + 1] == "/in"
+    assert cmd[cmd.index("--out") + 1] == "/out"
+    assert cmd[cmd.index("--device") + 1] == "cuda"
+    assert cmd[cmd.index("--weights") + 1] == essays_api.WEIGHTS
+
+
+def test_build_cmd_passes_both_channel_roles_separately():
+    cmd = essays_api._build_cmd(_req(irmName="reflect", tirfName="epi"), "cpu")
+
+    assert cmd[cmd.index("--irm-name") + 1] == "reflect"
+    assert cmd[cmd.index("--tirf-name") + 1] == "epi"
+
+
+@pytest.mark.parametrize("key,flag,value,expected", [
+    ("threshold", "--threshold", 0.6, "0.6"),
+    ("mtWidth", "--mt-width", 7, "7"),
+    ("bgGap", "--bg-gap", 2, "2"),
+    ("bgWidth", "--bg-width", 4, "4"),
+    ("irmName", "--irm-name", "irm", "irm"),
+    ("tirfName", "--tirf-name", "tirf", "tirf"),
+    ("solutionName", "--solution-name", "insol", "insol"),
+    ("limitWells", "--limit-wells", 3, "3"),
+])
+def test_build_cmd_maps_every_value_option(key, flag, value, expected):
+    cmd = essays_api._build_cmd(_req(**{key: value}), "cpu")
+
+    assert cmd[cmd.index(flag) + 1] == expected
+
+
+def test_build_cmd_omits_unset_options():
+    """An absent option must not become an empty-string argument."""
+    cmd = essays_api._build_cmd(_req(), "cpu")
+
+    for flag in essays_api._VALUE_FLAGS.values():
+        assert flag not in cmd
+    for flag in essays_api._BOOL_FLAGS.values():
+        assert flag not in cmd
+
+
+def test_build_cmd_treats_bool_flags_as_presence_only():
+    on = essays_api._build_cmd(_req(noOverlays=True, noJson=False), "cpu")
+
+    assert "--no-overlays" in on and "--no-json" not in on

--- a/backend/src/api/controllers/__tests__/essaysController.test.ts
+++ b/backend/src/api/controllers/__tests__/essaysController.test.ts
@@ -79,6 +79,7 @@ describe('parseOptions (evaluate.py option whitelist)', () => {
         bgGap: 1,
         bgWidth: 5,
         limitWells: 2,
+        irmName: 'irm',
         tirfName: 'tirf',
         solutionName: 'insol',
         noOverlays: true,
@@ -92,11 +93,22 @@ describe('parseOptions (evaluate.py option whitelist)', () => {
       bgGap: 1,
       bgWidth: 5,
       limitWells: 2,
+      irmName: 'irm',
       tirfName: 'tirf',
       solutionName: 'insol',
       noOverlays: true,
       noJson: false,
     });
+  });
+
+  it('carries irmName independently of tirfName', () => {
+    // The two channel roles are separate on purpose: the module segments IRM
+    // and measures TIRF. A whitelist that let only one through would silently
+    // pin the other to its default.
+    expect(parseOptions('{"irmName":"reflect"}')).toEqual({
+      irmName: 'reflect',
+    });
+    expect(parseOptions('{"irmName":42}')).toEqual({});
   });
 });
 

--- a/backend/src/api/controllers/essaysController.ts
+++ b/backend/src/api/controllers/essaysController.ts
@@ -36,6 +36,7 @@ export function parseOptions(raw: unknown): EssayJobOptions {
   if (num(parsed.bgGap) !== undefined) out.bgGap = num(parsed.bgGap);
   if (num(parsed.bgWidth) !== undefined) out.bgWidth = num(parsed.bgWidth);
   if (num(parsed.limitWells) !== undefined) out.limitWells = num(parsed.limitWells);
+  if (typeof parsed.irmName === 'string') out.irmName = parsed.irmName;
   if (typeof parsed.tirfName === 'string') out.tirfName = parsed.tirfName;
   if (typeof parsed.solutionName === 'string') out.solutionName = parsed.solutionName;
   if (typeof parsed.noOverlays === 'boolean') out.noOverlays = parsed.noOverlays;

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -29,6 +29,12 @@ export interface EssayJobOptions {
   mtWidth?: number;
   bgGap?: number;
   bgWidth?: number;
+  /**
+   * Substring naming the channel each role uses. They are separate because the
+   * module segments IRM (what the v7 checkpoint was trained on) and reads the
+   * intensities off TIRF — conflating them is the defect fixed 2026-08.
+   */
+  irmName?: string;
   tirfName?: string;
   solutionName?: string;
   limitWells?: number;

--- a/src/components/essays/__tests__/folderName.test.ts
+++ b/src/components/essays/__tests__/folderName.test.ts
@@ -69,13 +69,14 @@ describe('folderNameFromFiles', () => {
   });
 
   it('prefers webkitRelativePath when both are present', () => {
-    // The picker path goes through file-selector too, which then copies
-    // webkitRelativePath into `path`; either would do, but the preference must
-    // be deterministic.
+    // In production both properties agree (file-selector copies
+    // webkitRelativePath into `path` for picker-sourced files), so the two are
+    // given DIFFERENT folders here on purpose — otherwise the assertion holds
+    // whichever property is read and pins nothing.
     const files = [
       fileWith('WellA01.nd2', {
         webkitRelativePath: 'run_from_picker/WellA01.nd2',
-        path: 'run_from_picker/WellA01.nd2',
+        path: '/run_from_drop/WellA01.nd2',
       }),
     ];
     expect(folderNameFromFiles(files)).toBe('run_from_picker');

--- a/src/components/essays/__tests__/folderName.test.ts
+++ b/src/components/essays/__tests__/folderName.test.ts
@@ -1,0 +1,97 @@
+/**
+ * folderNameFromFiles — the run's name must survive BOTH ways of choosing a
+ * folder.
+ *
+ * Reported 2026-07-31: every Automated Essays run was named `essays_<date>`
+ * instead of the uploaded folder, losing the acquisition identifier the user
+ * encodes there. The helper read only `webkitRelativePath`, which the native
+ * folder picker sets and a dragged folder does not — react-dropzone's
+ * file-selector puts the entry's `fullPath` on `path` instead. Both real shapes
+ * are pinned below, taken from the library's own `toFileWithPath()`
+ * (node_modules/file-selector/dist/es5/file.js).
+ *
+ * Not tested here: that the name reaches the request body. That path
+ * (`folderName: folderNameFromFiles(staged)` -> FormData -> essay_jobs.name)
+ * was never broken — the whole defect lived inside this function.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { folderNameFromFiles } from '../folderName';
+
+type PathedFile = File & { webkitRelativePath?: string; path?: string };
+
+/** A File as the browser/file-selector hands it over, per source. */
+const fileWith = (
+  name: string,
+  props: { webkitRelativePath?: string; path?: string }
+): PathedFile => {
+  const f = new File(['x'], name) as PathedFile;
+  // Both are read-only accessors on a real File; define them the way
+  // file-selector does rather than assigning.
+  Object.defineProperty(f, 'webkitRelativePath', {
+    value: props.webkitRelativePath ?? '',
+    enumerable: true,
+  });
+  if (props.path !== undefined) {
+    Object.defineProperty(f, 'path', { value: props.path, enumerable: true });
+  }
+  return f;
+};
+
+describe('folderNameFromFiles', () => {
+  it('reads the folder from a native folder picker (webkitRelativePath)', () => {
+    const files = [
+      fileWith('WellA01.nd2', {
+        webkitRelativePath: '20260731_1423_acquisition/WellA01.nd2',
+      }),
+    ];
+    expect(folderNameFromFiles(files)).toBe('20260731_1423_acquisition');
+  });
+
+  it('reads the folder from a dragged folder (path, with leading slash)', () => {
+    // file-selector sets `path` to the FileSystemEntry fullPath and leaves
+    // webkitRelativePath empty. This is the case that regressed.
+    const files = [
+      fileWith('WellA01.nd2', {
+        path: '/20260731_1423_acquisition/WellA01.nd2',
+      }),
+    ];
+    expect(folderNameFromFiles(files)).toBe('20260731_1423_acquisition');
+  });
+
+  it('takes the top-level folder when the drop was nested', () => {
+    const files = [
+      fileWith('WellA01.nd2', {
+        path: '/20260731_1423_acquisition/plate1/WellA01.nd2',
+      }),
+    ];
+    expect(folderNameFromFiles(files)).toBe('20260731_1423_acquisition');
+  });
+
+  it('prefers webkitRelativePath when both are present', () => {
+    // The picker path goes through file-selector too, which then copies
+    // webkitRelativePath into `path`; either would do, but the preference must
+    // be deterministic.
+    const files = [
+      fileWith('WellA01.nd2', {
+        webkitRelativePath: 'run_from_picker/WellA01.nd2',
+        path: 'run_from_picker/WellA01.nd2',
+      }),
+    ];
+    expect(folderNameFromFiles(files)).toBe('run_from_picker');
+  });
+
+  it('returns undefined for loose files, so the caller keeps its fallback', () => {
+    // Dragging bare files (no folder): file-selector degrades `path` to the
+    // file name. Returning "WellA01.nd2" as the run name would be worse than
+    // the essays_<date> fallback.
+    expect(
+      folderNameFromFiles([fileWith('WellA01.nd2', { path: 'WellA01.nd2' })])
+    ).toBeUndefined();
+    expect(folderNameFromFiles([fileWith('WellA01.nd2', {})])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty selection', () => {
+    expect(folderNameFromFiles([])).toBeUndefined();
+  });
+});

--- a/src/components/essays/folderName.ts
+++ b/src/components/essays/folderName.ts
@@ -1,0 +1,34 @@
+/**
+ * Recovering the uploaded folder's name from the files the dropzone yielded.
+ *
+ * Lives beside EssaysDropzone because it is entirely about that component's two
+ * input paths: the same folder arrives with its relative path on a DIFFERENT
+ * property depending on how the user chose it, and reading only one of them
+ * silently dropped every dragged folder's name (all three of the reporting
+ * user's runs fell back to `essays_<date>`, 2026-07).
+ */
+
+/** A File as the browser and react-dropzone's file-selector hand it over. */
+type FileWithPath = File & {
+  /** Set by a `webkitdirectory` input: `"Run/A01.nd2"`. */
+  webkitRelativePath?: string;
+  /**
+   * Set by file-selector on every dropped file (see its `toFileWithPath`):
+   * the FileSystemEntry `fullPath` for a dragged folder (`"/Run/A01.nd2"`,
+   * leading slash included), otherwise a copy of `webkitRelativePath`, and for
+   * a loose dropped file it degrades to the bare file name.
+   */
+  path?: string;
+};
+
+/**
+ * Top-level folder the selection came from, or `undefined` when there isn't
+ * one — so the caller can fall back rather than name a run after a single file.
+ */
+export const folderNameFromFiles = (files: File[]): string | undefined => {
+  const first = files[0] as FileWithPath | undefined;
+  const rel = first?.webkitRelativePath || first?.path;
+  if (!rel) return undefined;
+  const segments = rel.split('/').filter(Boolean);
+  return segments.length > 1 ? segments[0] : undefined;
+};

--- a/src/pages/AutomatedEssays.tsx
+++ b/src/pages/AutomatedEssays.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import EssaysDropzone from '@/components/essays/EssaysDropzone';
+import { folderNameFromFiles } from '@/components/essays/folderName';
 import { useLanguage } from '@/contexts/useLanguage';
 import apiClient from '@/lib/api';
 import type { EssayJob } from '@/types/essays';
@@ -23,14 +24,6 @@ const humanSize = (bytes: number): string => {
     i++;
   }
   return `${v.toFixed(1)} ${units[i]}`;
-};
-
-// Best-effort folder name from a picked/dragged file's relative path.
-const folderNameFromFiles = (files: File[]): string | undefined => {
-  const rel = (files[0] as File & { webkitRelativePath?: string })
-    ?.webkitRelativePath;
-  if (rel && rel.includes('/')) return rel.split('/')[0];
-  return undefined;
 };
 
 const statusVariant = (

--- a/src/types/essays.ts
+++ b/src/types/essays.ts
@@ -26,6 +26,12 @@ export interface EssayJobOptions {
   mtWidth?: number;
   bgGap?: number;
   bgWidth?: number;
+  /**
+   * Substring naming the channel each role uses. Separate flags because the
+   * module segments IRM and measures intensities on TIRF; see EssayJobOptions
+   * in backend/src/services/essaysService.ts.
+   */
+  irmName?: string;
   tirfName?: string;
   solutionName?: string;
   limitWells?: number;


### PR DESCRIPTION
Two field reports against Automated Essays, both from the same user on
2026-07-31, filed through the in-app feedback button.

---

## 1. Bug — inference ran on the TIRF channel instead of IRM

> *"vypadá to že inference pochází z TIRF kanálu místo IRM … tam je to vyslovně
> napsané že skript inferuje a dělá readout přímo z TIRF kanálu a IRM plně
> ignoruje"*

He is right, and it had been true of every run the tool ever produced.

**The science lives in the module repo**, not here: `/automated-essays` is a thin
FastAPI runner (`backend/essays/essays_api.py`) over
[`michalprusek/AutomatedEssaysModule`](https://github.com/michalprusek/AutomatedEssaysModule),
cloned at image-build time. The actual fix is
[AutomatedEssaysModule#3](https://github.com/michalprusek/AutomatedEssaysModule/pull/3)
(merged):

- `evaluate.py` now passes `pos.irm` to `model.predict()` — the v7 checkpoint is
  trained on IRM (`microtubule/segment_mt.py`: *"End-to-end IRM → list of MT
  centerlines"*, validating `expected (H, W) IRM`) — and keeps `pos.tirf` for
  `measure_frame()`, which is what the user asked for.
- `mt_pipeline/nd2_io.py` previously did not read the IRM channel **at all**.
- A well with no IRM channel now fails loudly instead of being segmented on
  whatever else is present.
- QC overlays are written per channel (`_irm.png` / `_tirf.png`). Drawing only
  the TIRF one is why this hid for so long: a centerline traced from the wrong
  image still landed on something filament-shaped.

Verified end-to-end on the user's own ND2 (`WellD03_ChannelIRM_TIRF_488`,
3 positions, CUDA, real v7 weights): **87 MTs from TIRF → 73 from IRM**, median
`net_mean_intensity` 683 → 574. The numbers genuinely move.

**This PR** carries the app-side half: `irmName` → `--irm-name` in the worker's
`_VALUE_FLAGS`, through `parseOptions`' whitelist and both `EssayJobOptions`
copies. No UI — the defaults are right for this assay, and the flag is there for
recordings whose channels are named differently.

---

## 2. Feature — keep the uploaded folder's name

> *"Bylo by možné udržet název nahrávané složky? Já mám unikátní identifikátor v
> názvu složky … Případně by se pak dalo to přihodit do results.csv jako nový
> sloupec Date."*

This turned out to be **a bug, not a missing feature** — the plumbing was
already there and already broken. All three of his jobs are named
`essays_2026-07-08 / -07-27 / -07-29`, i.e. the fallback. The wire path
(FormData `folderName` → `essay_jobs.name`) was fine; the derivation was not.
The two ways of choosing a folder expose its path on different properties:

| how the folder was chosen | `webkitRelativePath` | `path` (react-dropzone) |
|---|---|---|
| "Select folder" button | `Run/A01.nd2` | — |
| **dragged onto the drop area** | *empty* | `/Run/A01.nd2` (leading slash) |
| dragged loose files | *empty* | `A01.nd2` |

Only the first was read, so every dragged folder lost its name. Now both are,
normalised to path segments, with a bare file name rejected so it can never
become a run's name. The helper moves into `components/essays/folderName.ts` —
a component module exporting a non-component defeats Vite HMR, which this repo's
ESLint config enforces as an error.

Both approaches he offered are now implemented, because they fail differently:
the folder name is what he recognises, and `acquired_at` (new `results.csv`
column, module side) survives renaming or re-uploading the folder. It is read
from the ND2's own `absoluteJulianDayNumber` — `text_info['date']` is the
acquisition PC's locale-formatted local time, so `5/19/2026` is only unambiguous
by luck and is never parsed.

---

## Tests

- 6 for `folderNameFromFiles`, covering all three real `File` shapes taken from
  `file-selector`'s own `toFileWithPath()`.
- `parseOptions` gains `irmName` (kept, and rejected when ill-typed).
- The worker's `_build_cmd` gets its first tests at all: every value flag, the
  bool flags' presence-only semantics, and unset options producing no empty
  arguments — a missing `_VALUE_FLAGS` entry is not a broken option, it is an
  option that silently runs on the module's default.

**Mutation-checked both fixes.** Dropping `|| first?.path` reddens the two
drag-and-drop cases; removing the `irmName` entry reddens two worker tests.
On the module side, reverting `pos.irm` to `pos.tirf` reddens
`test_segmentation_receives_the_irm_channel`.

`make ci` green (TS ×2, ESLint 0 warnings, i18n 6/6).

---

## Note for the reporter

Results produced **before** this change were measured along centerlines traced
from the wrong image and should be re-run. His three completed jobs' inputs have
already been cleaned up, so he will need to re-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163XTPPc7QSCXfZPzrP8AmN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the IRM channel name when running automated essay processing.
  * Improved folder detection for uploaded and dragged folders, including nested folder paths.

* **Bug Fixes**
  * Folder names are now derived consistently across supported file-selection methods.
  * IRM channel options are validated and handled independently from TIRF settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->