### PR TITLE
fix(essays): retry a well the GPU dropped, and name the ones it keeps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -74,6 +74,11 @@ Thumbs.db
 # External / scratch model artifacts dropped at repo root
 path_c_v24c/
 microtubules_v7_pysoax/
+# Git ignores this one through its OWN nested .gitignore ("Deployment artifact,
+# not part of the cell-segmentation-hub repository"), which prettier does not
+# read — so without this line `prettier --check .` fails on vendored DINOv2
+# files and the pre-commit hook blocks every commit in the repo.
+mt-instance-seg/
 
 # Local "remember" skill scratch state (gitignored, never shipped).
 # Contains free-form notes + bare-expression timestamp files that

--- a/backend/essays/essays_api.py
+++ b/backend/essays/essays_api.py
@@ -72,6 +72,13 @@ _DEVICE_LINE = re.compile(r"\[info\]\s+device=(\S+)")
 # parse loop dropped every unmatched line, the reasons existed nowhere. For a
 # scientific pipeline that is worse than crashing: a crash demands attention,
 # this produces data someone trusts.
+#
+# The count below is still the only number we parse, but it is no longer the
+# only record: evaluate.py now writes failures.csv into the output dir (and so
+# into the download) naming every lost well and its exception. Echoing the
+# [warn] lines to stderr stays as an operator convenience, but it is no longer
+# load-bearing — that log dies with the container, which is exactly how two
+# runs' failure reasons became unrecoverable in 2026-08.
 _DONE_LINE = re.compile(
     r"\[done\]\s+(\d+)\s+positions?,\s+(\d+)\s+microtubules?,\s+(\d+)\s+failures?")
 _DIAG_LINE = re.compile(r"\[(warn|error)\]")
@@ -378,9 +385,9 @@ def _run_job(req: ProcessRequest) -> None:
             _set_status(
                 job_id, out_dir, state="completed", progress=100,
                 failures=n_fail,
-                error=f"{n_fail} well/position failure(s) — some wells are "
-                      "missing from the results. See the worker log for the "
-                      "module's [warn] lines.")
+                error=f"{n_fail} well/position failure(s) — these wells are "
+                      "missing from results.csv. failures.csv in the download "
+                      "names each one and why it failed.")
         else:
             _set_status(job_id, out_dir, state="completed", progress=100,
                         failures=0, error=None)

--- a/backend/essays/module/evaluate.py
+++ b/backend/essays/module/evaluate.py
@@ -31,11 +31,13 @@ repository's GitHub Release on first run (or pass ``--weights /path/to.pt``).
 from __future__ import annotations
 
 import argparse
+import gc
 import os
 import sys
 import time
 import traceback
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 
@@ -49,6 +51,118 @@ from _mt_package import (  # noqa: E402  (needs _HERE on sys.path)
 
 DEFAULT_WEIGHTS = default_weights()
 BUNDLED_BACKBONE_CONFIG = _HERE / "config" / "dinov3_vitl16"
+
+# A position that fails on the GPU is usually a passing squall rather than a
+# verdict on the data. Measured in production (RTX A5000, 2026-08): one
+# 2048x2048 position peaks at 13.37 GiB against a 14.13 GiB per-process cap, on
+# a 23.56 GiB card shared with the interactive `ml` service and Maptimize — so a
+# co-tenant's spike makes the next allocation raise OutOfMemoryError. The
+# failures arrived in contiguous 5-9 minute bursts, and re-running the same
+# folder a week later failed on a *disjoint* set of positions: every well that
+# was lost one time came back the next. Waiting a burst out costs minutes;
+# dropping the well costs the well, silently, from a scientific table.
+RETRY_BACKOFF_S = (30, 120, 300)
+
+# ...but a GPU that is broken rather than merely busy would otherwise turn a
+# 20 h job into a week of sleeping (720 positions x 7.5 min each). This is a
+# run-wide stop-loss: once this much has been spent waiting, the remaining
+# failures are recorded straight away and the batch finishes on time.
+RETRY_WAIT_BUDGET_S = 3600.0
+
+
+class _RetryBudget:
+    """Run-wide allowance for time spent waiting on a transient GPU failure."""
+
+    def __init__(self, total_s: float):
+        self.remaining = total_s
+
+    def take(self, seconds: float) -> bool:
+        """Consume ``seconds``; False once the run's allowance is spent.
+
+        Deliberately allows the final wait to overshoot rather than refusing a
+        retry that a nearly-exhausted budget could almost afford — the point is
+        to bound the damage, not to meter it exactly.
+        """
+        if self.remaining <= 0:
+            return False
+        self.remaining -= seconds
+        return True
+
+
+class _ErrorInfo(NamedTuple):
+    """What a failed attempt leaves behind — text only, never the exception.
+
+    A caught exception owns its ``__traceback__``, which owns every frame of the
+    failed call, which owns their locals: for an OOM inside the model that is
+    the entire forward pass, still resident on the GPU. Keeping the exception
+    alive across the backoff makes ``empty_cache()`` a no-op and the retry
+    hopeless — measured 2026-08-13, a first cut that held the exception saw all
+    three positions burn all four attempts although the 3 GiB that squeezed them
+    out had been freed 40 s earlier: the process's own usage sat at 14.2 GiB of
+    its 14.13 GiB cap the whole time.
+    """
+
+    type_name: str
+    message: str
+
+
+class _Attempt(NamedTuple):
+    """Outcome of one position: exactly one of ``result`` / ``error`` is set."""
+
+    result: dict | None
+    attempts: int
+    error: _ErrorInfo | None
+
+
+def _release_gpu_memory() -> None:
+    """Hand this process's cached-but-unused VRAM back before a retry.
+
+    ``gc.collect()`` first and not for tidiness: a traceback and its frames
+    reference each other, so the failed attempt's tensors sit in a reference
+    cycle that plain refcounting will not break, and ``empty_cache()`` can only
+    return blocks that nothing still points at.
+    """
+    gc.collect()
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception as e:  # noqa: BLE001 — cleanup must never end the run
+        print(f"[warn] could not release GPU memory before retry: {e}")
+
+
+def _predict_with_retry(model, image, threshold: float, label: str,
+                        budget: _RetryBudget) -> _Attempt:
+    """Segment one position, riding out a transient failure.
+
+    Retries on ANY exception rather than on OutOfMemoryError alone: OOM is the
+    failure mode we measured, but the cost of retrying something unrecoverable
+    is bounded by ``budget`` while the cost of not retrying is a missing well.
+    """
+    last: _ErrorInfo | None = None
+    attempt = 1
+    for attempt in range(1, len(RETRY_BACKOFF_S) + 2):
+        try:
+            return _Attempt(model.predict(image, seed_threshold=threshold),
+                            attempt, None)
+        except Exception as e:  # noqa: BLE001 — the budget decides, not the type
+            # Take the text and nothing else; see _ErrorInfo. Everything below
+            # deliberately sits OUTSIDE this block, because `e` — and with it
+            # the failed forward pass — only becomes collectable once it ends.
+            last = _ErrorInfo(type(e).__name__, str(e))
+
+        if attempt > len(RETRY_BACKOFF_S):
+            break
+        wait = RETRY_BACKOFF_S[attempt - 1]
+        if not budget.take(wait):
+            print(f"[warn] {label}: {last.type_name}: {last.message} — run's "
+                  f"retry budget is spent, giving up on this position")
+            break
+        print(f"[warn] {label}: {last.type_name}: {last.message} — retrying in "
+              f"{wait}s (attempt {attempt + 1}/{len(RETRY_BACKOFF_S) + 1})")
+        _release_gpu_memory()
+        time.sleep(wait)
+    return _Attempt(None, attempt, last)
 
 
 def resolve_device(requested: str) -> str:
@@ -134,7 +248,8 @@ def main() -> int:
         os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
     from mt_pipeline import (iter_positions, find_nd2_files, measure_frame,
-                             CsvWriter, save_overlay, save_annotation_json)
+                             CsvWriter, FailureLog, parse_well_id, save_overlay,
+                             save_annotation_json)
 
     files = find_nd2_files(args.data)
     if not files:
@@ -174,6 +289,10 @@ def main() -> int:
 
     out = Path(args.out)
     csvw = CsvWriter(out / "results.csv")
+    # Opened unconditionally: a header-only failures.csv is the run stating that
+    # nothing was lost, which a missing file cannot do.
+    failures = FailureLog(out / "failures.csv")
+    budget = _RetryBudget(RETRY_WAIT_BUDGET_S)
     sol_match = tuple(s.strip() for s in args.solution_name.split(",") if s.strip())
 
     n_pos = n_mt = n_fail = 0
@@ -185,6 +304,11 @@ def main() -> int:
                                             solution_match=sol_match))
         except Exception as e:
             n_fail += 1
+            # No position list, so no per-position identity to record — the
+            # whole well is gone, which is what a blank position column means.
+            failures.record(well_id=parse_well_id(f), position="",
+                            source_file=f.name, stage="read", attempts=1,
+                            error_type=type(e).__name__, error_message=str(e))
             print(f"[warn] ({fi}/{len(files)}) failed to read {f.name}: {e}")
             continue
 
@@ -192,16 +316,23 @@ def main() -> int:
         for pos in positions:
             ti = time.time()
             solution_median = float(np.median(pos.solution))
-            try:
-                # IRM, not TIRF: the v7 checkpoint was trained on IRM frames
-                # (see microtubule/segment_mt.py). Feeding it TIRF produced
-                # confident, wrong centerlines for every run before 2026-08.
-                seg = model.predict(pos.irm, seed_threshold=args.threshold)
-                centerlines = seg["centerlines_rc"]
-            except Exception as e:
+            # IRM, not TIRF: the v7 checkpoint was trained on IRM frames
+            # (see microtubule/segment_mt.py). Feeding it TIRF produced
+            # confident, wrong centerlines for every run before 2026-08.
+            attempt = _predict_with_retry(model, pos.irm, args.threshold,
+                                          f"{well} pos{pos.position}", budget)
+            if attempt.error is not None:
                 n_fail += 1
-                print(f"[warn] segmentation failed {well} pos{pos.position}: {e}")
+                failures.record(well_id=pos.well_id, position=pos.position,
+                                source_file=f.name, stage="segment",
+                                attempts=attempt.attempts,
+                                error_type=attempt.error.type_name,
+                                error_message=attempt.error.message)
+                print(f"[warn] segmentation failed {well} pos{pos.position} "
+                      f"after {attempt.attempts} attempt(s): "
+                      f"{attempt.error.type_name}: {attempt.error.message}")
                 continue
+            centerlines = attempt.result["centerlines_rc"]
 
             # ...and TIRF for the readout: the centerlines come from IRM, the
             # intensities integrated along them are the TIRF signal.
@@ -237,10 +368,14 @@ def main() -> int:
                   f"solution_median={solution_median:.1f}  ({time.time()-ti:.1f}s)")
 
     csvw.close()
+    failures.close()
     dt = time.time() - t_start
     print(f"\n[done] {n_pos} positions, {n_mt} microtubules, {n_fail} failures "
           f"in {dt/60:.1f} min")
     print(f"[done] results -> {csvw.path}")
+    if n_fail:
+        print(f"[done] failures -> {failures.path} (one row per lost well, "
+              f"with the reason)")
     return 0
 
 

--- a/backend/essays/module/mt_pipeline/__init__.py
+++ b/backend/essays/module/mt_pipeline/__init__.py
@@ -9,11 +9,13 @@ table plus QC overlays.
 from .nd2_io import (Position, iter_positions, find_nd2_files, parse_well_id,
                      read_acquisition_time)
 from .measure import measure_frame
-from .report import CsvWriter, save_overlay, save_annotation_json, COLUMNS
+from .report import (CsvWriter, FailureLog, save_overlay, save_annotation_json,
+                     COLUMNS, FAILURE_COLUMNS)
 
 __all__ = [
     "Position", "iter_positions", "find_nd2_files", "parse_well_id",
     "read_acquisition_time",
     "measure_frame",
-    "CsvWriter", "save_overlay", "save_annotation_json", "COLUMNS",
+    "CsvWriter", "FailureLog", "save_overlay", "save_annotation_json",
+    "COLUMNS", "FAILURE_COLUMNS",
 ]

--- a/backend/essays/module/mt_pipeline/report.py
+++ b/backend/essays/module/mt_pipeline/report.py
@@ -31,6 +31,24 @@ COLUMNS = [
 ]
 
 
+# One row per well/position the run could not produce. Ships next to results.csv
+# so it travels inside the download: before this existed the only record of a
+# failed well was a `[warn]` line on the worker's stderr, which is deleted with
+# the container — after the 2026-08-11 recreate, the reasons behind two runs'
+# 255 and 68 failures were unrecoverable, and the affected wells could only be
+# identified by diffing the two result zips.
+FAILURE_COLUMNS = [
+    "well_id", "position", "source_file",
+    # "read" = the ND2 could not be opened (the whole well is absent),
+    # "segment" = the model raised on this one position.
+    "stage",
+    # How many tries it took to give up. > 1 means the retry ran and the error
+    # outlived it, which separates a passing squall from a standing problem.
+    "attempts",
+    "error_type", "error_message",
+]
+
+
 class CsvWriter:
     """Append-as-you-go CSV writer with a fixed header."""
 
@@ -47,6 +65,55 @@ class CsvWriter:
         for r in rows:
             self._w.writerow(r)
         self.n_rows += len(rows)
+        self._fh.flush()
+
+    def close(self) -> None:
+        self._fh.close()
+
+
+class FailureLog:
+    """Names every well the run failed to produce, and why.
+
+    Written even when nothing fails: a header-only file states "no well was
+    lost", whereas a missing file cannot be told apart from a writer that never
+    ran. A run's results are only trustworthy if its gaps are enumerable.
+    """
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "w", newline="")
+        self._w = csv.DictWriter(self._fh, fieldnames=FAILURE_COLUMNS,
+                                 extrasaction="ignore")
+        self._w.writeheader()
+        self._fh.flush()
+        self.n_rows = 0
+
+    def record(self, *, well_id: str, position: int | str, source_file: str,
+               stage: str, attempts: int, error_type: str,
+               error_message: str) -> None:
+        """Name one lost well.
+
+        Takes the error as *text*, never as an exception object: on the
+        segmentation path the caller must already have dropped the exception,
+        because its traceback pins the failed forward pass on the GPU (see
+        ``_ErrorInfo`` in evaluate.py). Accepting an exception here would invite
+        callers to keep one alive just to reach this line.
+        """
+        self._w.writerow({
+            "well_id": well_id,
+            "position": position,
+            "source_file": source_file,
+            "stage": stage,
+            "attempts": attempts,
+            "error_type": error_type,
+            # Newlines would break the row apart in a naive CSV reader, and a
+            # torch OOM message is multi-line.
+            "error_message": " ".join(error_message.split()),
+        })
+        self.n_rows += 1
+        # Flush per row: a batch that dies mid-run must still hand over the
+        # failures it already knew about.
         self._fh.flush()
 
     def close(self) -> None:

--- a/backend/essays/module/tests/test_failure_resilience.py
+++ b/backend/essays/module/tests/test_failure_resilience.py
@@ -1,0 +1,262 @@
+"""A transient GPU failure must not silently delete a well from the results.
+
+Reported from the field 2026-08-12: the same folder, re-run a week apart,
+produced 255 failed wells one time and 68 the other. Diffing the two result
+zips showed the failure sets were *disjoint* — every position that failed in one
+run succeeded in the other, and both runs attempted all 720 positions. So the
+input was never the problem.
+
+Measured cause (production container, RTX A5000): one 2048x2048 position peaks
+at 13.37 GiB reserved against a 14.13 GiB per-process cap
+(``ESSAYS_GPU_MEM_FRACTION=0.6`` of a 23.56 GiB card, applied by
+``sitecustomize.py``). The card is shared with the interactive ``ml`` service and
+with Maptimize, so when a co-tenant spikes, ``model.predict`` raises
+``torch.OutOfMemoryError`` — and ``evaluate.main()`` caught it, counted it and
+moved on. Failures arrived in contiguous 5-9 minute bursts, which is how a
+single co-tenant job cost ~85 wells in one go.
+
+Two things were wrong and both are asserted here:
+
+  * a *recoverable* error permanently dropped a well (no retry), and
+  * the reason existed only as a ``[warn]`` line on the worker's stderr, which
+    dies with the container — after the 2026-08-11 recreate neither run's
+    reasons could be recovered at all.
+
+These tests drive ``evaluate.main()`` rather than the retry helper in isolation:
+a helper test would pass while the call site still swallowed the exception.
+
+Run with: pytest tests/ (no GPU, no checkpoint, no ND2 file needed).
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import sys
+import types
+import weakref
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PKG_ROOT = Path(__file__).resolve().parents[1]
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+import mt_pipeline  # noqa: E402
+from mt_pipeline.nd2_io import Position  # noqa: E402
+
+WELL_ID = "K06"
+N_POSITIONS = 3
+
+
+class _Boom(RuntimeError):
+    """Stands in for torch.OutOfMemoryError, which needs no torch to model."""
+
+
+# evaluate.main() materialises every Position of a file before predicting any of
+# them, so a call-order counter cannot identify which position a predict() call
+# is for. The index rides on the pixel values instead.
+_IRM_BASE = 100
+
+
+def _position(index: int) -> Position:
+    irm = np.full((8, 8), _IRM_BASE + index, dtype=np.uint16)
+    other = np.full((8, 8), 11, dtype=np.uint16)
+    return Position(well_id=WELL_ID, position=index, irm=irm, tirf=other,
+                    solution=other, px_um=0.0722,
+                    acquired_at="2026-06-01T20:14:53Z")
+
+
+@pytest.fixture
+def run_evaluate(tmp_path, monkeypatch):
+    """Drive ``evaluate.main()`` with a model whose failures the test scripts.
+
+    ``fail_plan`` maps a position index to the number of consecutive attempts
+    that must raise before it succeeds; ``inf`` never succeeds. The CSV writers
+    are the real ones — what the user receives is the thing under test.
+    """
+    import evaluate
+
+    slept: list[float] = []
+    monkeypatch.setattr(evaluate.time, "sleep", slept.append)
+
+    fail_plan: dict[int, float] = {}
+    attempts: dict[int, int] = {}
+    read_fails: set[str] = set()
+    # Whether the previous attempt's exception was still reachable when the next
+    # attempt began — see test_previous_failure_is_released_before_the_retry.
+    prev_alive: list[bool] = []
+    last_raised: list[object] = []
+
+    class _FakeModel:
+        def load_weights(self, weights, device):
+            return self
+
+        def predict(self, frame, seed_threshold=0.5):
+            idx = int(np.asarray(frame).flat[0]) - _IRM_BASE
+            attempts[idx] = attempts.get(idx, 0) + 1
+            if last_raised:
+                gc.collect()  # tracebacks cycle; refcounting alone won't do
+                prev_alive.append(last_raised.pop()() is not None)
+            if attempts[idx] <= fail_plan.get(idx, 0):
+                exc = _Boom(f"CUDA out of memory. Tried to allocate 3.00 GiB "
+                            f"(pos {idx}, attempt {attempts[idx]})")
+                last_raised.append(weakref.ref(exc))
+                raise exc
+            return {"centerlines_rc": [np.array([[1.0, 1.0], [1.0, 4.0]])]}
+
+    monkeypatch.setitem(sys.modules, "microtubule",
+                        types.SimpleNamespace(MicrotubuleModel=_FakeModel))
+    monkeypatch.setattr(evaluate, "resolve_device", lambda requested: "cpu")
+    monkeypatch.setattr(evaluate, "ensure_weights", lambda w: Path(w))
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    nd2 = data_dir / f"Well{WELL_ID}_ChannelIRM_TIRF_488_Seq0141.nd2"
+    nd2.touch()
+
+    def _fake_iter_positions(path, **kwargs):
+        if Path(path).name in read_fails:
+            raise OSError("ND2 header unreadable")
+        for i in range(N_POSITIONS):
+            yield _position(i)
+
+    monkeypatch.setattr(mt_pipeline, "find_nd2_files", lambda p: [nd2])
+    monkeypatch.setattr(mt_pipeline, "iter_positions", _fake_iter_positions)
+    monkeypatch.setattr(mt_pipeline, "measure_frame",
+                        lambda frame, centerlines, **kw: [
+                            {"mt_id": 1, "length_px": 5.0, "n_px_mt": 10}])
+    monkeypatch.setattr(mt_pipeline, "save_overlay", lambda *a, **k: None)
+
+    out_dir = tmp_path / "out"
+
+    def _run(plan=None, fail_read=False, *extra_args, capsys=None):
+        if plan:
+            fail_plan.update(plan)
+        if fail_read:
+            read_fails.add(nd2.name)
+        monkeypatch.setattr(sys, "argv",
+                            ["evaluate.py", "--data", str(data_dir),
+                             "--out", str(out_dir), "--weights",
+                             str(tmp_path / "fake.pt"), "--device", "cpu",
+                             "--no-json", *extra_args])
+        assert evaluate.main() == 0
+        return types.SimpleNamespace(out_dir=out_dir, attempts=attempts,
+                                     slept=slept, prev_alive=prev_alive)
+
+    return _run
+
+
+def _backoff() -> tuple:
+    import evaluate
+    return evaluate.RETRY_BACKOFF_S
+
+
+def _rows(path: Path) -> list[dict]:
+    with open(path, newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+# --------------------------------------------------------------------------
+# The headline defect: a transient error must cost a retry, not the well.
+# --------------------------------------------------------------------------
+
+def test_transient_failure_is_retried_and_the_well_is_kept(run_evaluate):
+    """Position 1 fails twice then succeeds — it must still reach results.csv."""
+    result = run_evaluate({1: 2})
+
+    positions = {int(r["position"]) for r in _rows(result.out_dir / "results.csv")}
+    assert positions == {0, 1, 2}, "a recoverable position was dropped"
+    assert result.attempts[1] == 3, "the failing position was not retried"
+
+
+def test_a_retried_well_is_not_counted_as_a_failure(run_evaluate, capsys):
+    """The [done] count the worker parses must report *final* failures only."""
+    run_evaluate({1: 2})
+    assert "0 failures" in capsys.readouterr().out
+
+
+def test_retry_waits_between_attempts(run_evaluate):
+    """Backoff, not a tight loop: a co-tenant spike lasts minutes, not ms."""
+    result = run_evaluate({1: 2})
+    assert result.slept[:2] == list(_backoff()[:2])
+
+
+def test_previous_failure_is_released_before_the_retry(run_evaluate):
+    """Holding the exception across the backoff makes the retry pointless.
+
+    A caught exception owns its ``__traceback__``, which owns every frame of the
+    failed call, which owns their locals — for an OOM inside the model that is
+    the whole forward pass still resident on the GPU. Keeping a reference to it
+    while waiting turns ``empty_cache()`` into a no-op, so the retry meets the
+    same wall it was supposed to outlast.
+
+    Measured against the real model on 2026-08-13: a first cut of this retry
+    held ``last = e``, and all three positions burned all four attempts even
+    though the co-tenant's 3 GiB had been released 40 s earlier — the process's
+    own usage never dropped below 14.2 GiB of its 14.13 GiB cap. Only the text
+    of the error may outlive the ``except`` block.
+    """
+    result = run_evaluate({0: 2})
+
+    assert result.attempts[0] == 3
+    assert result.prev_alive == [False, False], (
+        "a previous attempt's exception was still reachable when the next "
+        "attempt started — its traceback pins the GPU tensors the retry needs"
+    )
+
+
+# --------------------------------------------------------------------------
+# The reason must survive the run — it used to live only on the worker's stderr.
+# --------------------------------------------------------------------------
+
+def test_exhausted_position_is_recorded_in_failures_csv(run_evaluate):
+    """A position that never recovers is named, with the reason, in the zip."""
+    result = run_evaluate({1: float("inf")})
+
+    rows = _rows(result.out_dir / "failures.csv")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["well_id"] == WELL_ID
+    assert row["position"] == "1"
+    assert row["stage"] == "segment"
+    assert row["error_type"] == "_Boom"
+    assert "out of memory" in row["error_message"]
+    assert int(row["attempts"]) == len(_backoff()) + 1
+    assert row["source_file"].endswith(".nd2")
+
+
+def test_unreadable_file_is_recorded_too(run_evaluate):
+    """The other failure site: a well whose ND2 cannot be opened at all."""
+    result = run_evaluate(fail_read=True)
+
+    rows = _rows(result.out_dir / "failures.csv")
+    assert len(rows) == 1
+    assert rows[0]["stage"] == "read"
+    assert rows[0]["error_type"] == "OSError"
+    assert "unreadable" in rows[0]["error_message"]
+
+
+def test_failures_csv_exists_and_is_empty_on_a_clean_run(run_evaluate):
+    """Absence of the file would be ambiguous; a header-only file is a claim."""
+    result = run_evaluate()
+    assert _rows(result.out_dir / "failures.csv") == []
+
+
+# --------------------------------------------------------------------------
+# A permanently broken GPU must not turn a 20 h job into a week of sleeping.
+# --------------------------------------------------------------------------
+
+def test_retry_waiting_is_bounded_across_the_run(run_evaluate, monkeypatch):
+    """Once the budget is spent, failures are recorded without further waiting."""
+    import evaluate
+    monkeypatch.setattr(evaluate, "RETRY_WAIT_BUDGET_S", 1.0)
+
+    result = run_evaluate({i: float("inf") for i in range(N_POSITIONS)})
+
+    assert sum(result.slept) <= evaluate.RETRY_BACKOFF_S[0] + 1.0
+    assert len(_rows(result.out_dir / "failures.csv")) == N_POSITIONS
+    # The later positions gave up immediately rather than re-paying the backoff.
+    assert result.attempts[N_POSITIONS - 1] == 1

--- a/src/pages/AutomatedEssays.tsx
+++ b/src/pages/AutomatedEssays.tsx
@@ -219,23 +219,35 @@ const AutomatedEssays: React.FC = () => {
                     {(job.status === 'running' || job.status === 'queued') && (
                       <Progress value={job.progress} className="mt-2" />
                     )}
-                    {job.status === 'completed' && job.error && (
-                      // A completed run can still be partial — evaluate.py
-                      // returns 0 even when wells failed. Amber, not red: the
-                      // results are there and downloadable, just incomplete.
-                      <div className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500 mt-2">
-                        <AlertCircle className="h-3 w-3 shrink-0" />
-                        <span className="truncate" title={job.error}>
-                          {job.error}
-                        </span>
-                      </div>
-                    )}
-                    {job.status === 'failed' && job.error && (
-                      <div className="flex items-center gap-1 text-xs text-red-500 mt-2">
-                        <AlertCircle className="h-3 w-3 shrink-0" />
-                        <span className="truncate">{job.error}</span>
-                      </div>
-                    )}
+                    {job.error &&
+                      (job.status === 'completed' ||
+                        job.status === 'failed') && (
+                        // A completed run can still be partial — evaluate.py
+                        // returns 0 even when wells failed. Amber, not red: the
+                        // results are there and downloadable, just incomplete.
+                        // Red is for a run that produced nothing at all.
+                        <div
+                          data-testid="essay-job-error"
+                          className={`flex items-start gap-1 text-xs mt-2 ${
+                            job.status === 'completed'
+                              ? 'text-amber-600 dark:text-amber-500'
+                              : 'text-red-500'
+                          }`}
+                        >
+                          <AlertCircle className="h-3 w-3 shrink-0 mt-0.5" />
+                          {/* Wrapped and scrollable, never clamped to one line.
+                              Reported 2026-08-12: a `truncate` hid everything
+                              past the first sentence, and the rest was reachable
+                              only through a native title tooltip the reporter
+                              never found — on the `failed` branch not even that.
+                              A failed run's message carries the module's output
+                              tail, so it is capped by height, not by characters:
+                              long errors scroll, they do not disappear. */}
+                          <span className="whitespace-pre-wrap break-words max-h-32 overflow-y-auto">
+                            {job.error}
+                          </span>
+                        </div>
+                      )}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     {job.status === 'completed' && (

--- a/src/pages/__tests__/AutomatedEssays.test.tsx
+++ b/src/pages/__tests__/AutomatedEssays.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * AutomatedEssays page — the run-error surface.
+ *
+ * Reported 2026-08-12: "web už zobrazuje že některé jamky nebyly přečteny
+ * nicméně vidím jen první větu hlášení ale nemůžu ji nahlédnout celou a buď
+ * nevím kde nebo není možné ji otevřít."
+ *
+ * The message was rendered in a `truncate` span — one line, ellipsis — so a
+ * partial run's explanation was clipped after roughly its first sentence. The
+ * remainder existed only as a native `title` tooltip on the completed branch,
+ * and on the `failed` branch not even that: that span carried no title at all,
+ * making a failed run's reason unreadable by any means.
+ *
+ * These tests assert what the user can actually read, not which class names the
+ * component happens to use, except where the class IS the behaviour (`truncate`
+ * clamps in a real browser but not in jsdom, so it has to be asserted directly —
+ * jsdom does no layout, and a text assertion alone would pass on the bug).
+ *
+ * NOT tested here: upload/dropzone, download token flow, delete — unrelated to
+ * the report.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import type { EssayJob } from '@/types/essays';
+
+const { mockListEssayJobs } = vi.hoisted(() => ({
+  mockListEssayJobs: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    listEssayJobs: mockListEssayJobs,
+    uploadEssays: vi.fn(),
+    deleteEssayJob: vi.fn(),
+    getEssayDownloadToken: vi.fn(),
+    buildEssayDownloadUrl: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/DashboardHeader', () => ({
+  default: () => <div data-testid="dashboard-header" />,
+}));
+vi.mock('@/components/essays/EssaysDropzone', () => ({
+  default: () => <div data-testid="essays-dropzone" />,
+}));
+vi.mock('@/contexts/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+import AutomatedEssays from '../AutomatedEssays';
+
+// The exact string the worker now puts on a partial run (essays_api.py). Two
+// sentences: the bug was that only the first one survived the clamp.
+const PARTIAL_ERROR =
+  '68 well/position failure(s) — these wells are missing from results.csv. ' +
+  'failures.csv in the download names each one and why it failed.';
+
+const job = (over: Partial<EssayJob> = {}): EssayJob => ({
+  id: 'job-1',
+  name: '20260601_201313_389',
+  status: 'completed',
+  progress: 100,
+  fileCount: 180,
+  mtCount: 182333,
+  device: 'cuda',
+  resultZipKey: 'essays-results/job-1.zip',
+  error: null,
+  createdAt: '2026-08-10T13:49:31.176Z',
+  updatedAt: '2026-08-11T10:15:32.089Z',
+  completedAt: '2026-08-11T10:15:32.089Z',
+  ...over,
+});
+
+const renderPage = async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AutomatedEssays />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return screen.findByTestId('essay-job-error');
+};
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+describe('AutomatedEssays run error', () => {
+  it('shows a partial run’s whole message, not just its first sentence', async () => {
+    mockListEssayJobs.mockResolvedValue([job({ error: PARTIAL_ERROR })]);
+
+    const el = await renderPage();
+
+    expect(el).toHaveTextContent(PARTIAL_ERROR);
+    // The sentence that names failures.csv is the one the clamp used to eat,
+    // and it is the only pointer the user has to the per-well reasons.
+    expect(el.textContent).toContain('failures.csv in the download');
+  });
+
+  it('does not clamp the message to a single line', async () => {
+    mockListEssayJobs.mockResolvedValue([job({ error: PARTIAL_ERROR })]);
+
+    const text = (await renderPage()).querySelector('span');
+
+    expect(text).not.toBeNull();
+    // `truncate` is white-space:nowrap + ellipsis — the reported bug itself.
+    expect(text!.className).not.toMatch(/\btruncate\b/);
+    expect(text!.className).toMatch(/whitespace-pre-wrap/);
+  });
+
+  it('renders a failed run’s reason, which previously had no tooltip either', async () => {
+    const failure =
+      'evaluate.py exited with code 1. Last output:\n' +
+      'Traceback (most recent call last):\n' +
+      '  File "evaluate.py", line 199, in main\n' +
+      'torch.OutOfMemoryError: CUDA out of memory.';
+    mockListEssayJobs.mockResolvedValue([
+      job({ status: 'failed', error: failure, resultZipKey: null }),
+    ]);
+
+    const el = await renderPage();
+
+    expect(el.textContent).toContain('torch.OutOfMemoryError');
+    expect(el.textContent).toContain('line 199');
+  });
+
+  it('keeps a long message readable by scrolling it, not by hiding it', async () => {
+    mockListEssayJobs.mockResolvedValue([
+      job({ status: 'failed', error: Array(60).fill('line').join('\n') }),
+    ]);
+
+    const text = (await renderPage()).querySelector('span')!;
+
+    // Capped by height with a scrollbar: the tail stays reachable instead of
+    // being dropped, and one bad run cannot push the rest of the list offscreen.
+    expect(text.className).toMatch(/overflow-y-auto/);
+    expect(text.className).toMatch(/max-h-/);
+  });
+
+  it('says nothing when a completed run lost no wells', async () => {
+    mockListEssayJobs.mockResolvedValue([job({ error: null })]);
+
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter>
+          <AutomatedEssays />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText('20260601_201313_389')).toBeInTheDocument();
+    expect(screen.queryByTestId('essay-job-error')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes the field report of 2026-08-12 (podhajeckyr@ibt.cas.cz), which had two halves:

> web už zobrazuje že některé jamky nebyly přečteny nicméně vidím jen první větu hlášení ale nemůžu ji nahlédnout celou (…) K tomu se ještě pojí že stejný run (složku z jednoho dne) to segmentuje různě úspěšně. Minulý týden run z 20260601 ukazoval 255 chybných jamek a tento týden 68.

## What was actually happening

The input dirs are deleted after a run and the worker's stderr died with the 2026-08-11 container recreate, so the only surviving evidence was the two result zips. Diffing them settled it:

| | positions in results | failures | reported |
|---|---|---|---|
| run of 2026-08-05 | 465 | 255 | 146 892 MT |
| run of 2026-08-10 | 652 | 68 | 182 333 MT |

Both sum to **720** = 180 files × 4 positions, so every position was attempted both times, and the failure sets were **disjoint** — every well lost in one run came back in the other. The input was never at fault.

Measured in the production container (RTX A5000): one 2048×2048 position peaks at **13.37 GiB reserved against a 14.13 GiB per-process cap** (`ESSAYS_GPU_MEM_FRACTION=0.6`, applied by `sitecustomize.py`), steady state 12.7 GiB with no creep. The card is shared with the interactive `ml` service and with Maptimize, so a co-tenant's spike makes the next allocation raise `OutOfMemoryError` — which `evaluate.py` counted and moved past. Failures arrived in contiguous 5–9 minute bursts, so one neighbouring job cost ~85 wells at a stroke.

## Changes

- **Retry** a failed position with backoff 30/120/300 s (outlasts a burst of the observed length), under a run-wide 1 h stop-loss so a GPU that is *broken* rather than *busy* cannot turn a 20 h job into a week of sleeping.
- **Keep only the error's text across the wait.** A caught exception owns its traceback → the frames of the failed forward pass → their GPU tensors. A first cut held the exception and every retry failed anyway, with the process pinned at 14.2 GiB of its 14.13 GiB cap 40 s after contention cleared. `gc.collect()` before `empty_cache()` breaks the traceback cycle.
- **`failures.csv`** beside `results.csv` (well, position, source file, stage, attempts, exception type and message) so it travels inside the download. Written even when empty — a header-only file states that nothing was lost, which a missing file cannot.
- **UI**: the run's message wraps and scrolls instead of being clamped to one line; the `failed` branch previously had no tooltip at all, so its reason was unreadable by any means.

## Verification

Real 3-position ND2 on the production GPU, squeezed by a real 3 GiB co-tenant allocation:

- squeeze lifted mid-backoff → OOM on three attempts, **recovered on the fourth**; the recovered `results.csv` is **byte-identical** to the uncontended run (73 MT, same MD5)
- squeeze held → exits 0 with three `OutOfMemoryError` rows in `failures.csv`
- full stack after deploy: upload → worker → completed with the new message → the downloaded zip contains `failures.csv` naming the lost well

60 tests (28 module incl. 8 new, 32 worker, 5 frontend), `make ci` clean, 0 console errors in production.

Both fixes are **deployed** (essays + frontend recreated, nginx restarted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCNHLci5dcnoDU8NdEi4Z3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed per-well failure reports to essay job downloads through `failures.csv`.
  * Added automatic retries for temporary segmentation failures.
  * Improved error messages with affected wells and guidance for finding failure details.

* **Bug Fixes**
  * Prevented unreadable wells and exhausted retries from stopping failure details from being recorded.
  * Improved display of completed and failed job errors, including wrapping and scrolling for long messages.

* **Tests**
  * Added coverage for retry behavior, failure reporting, clean runs, and readable error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->