### PR TITLE
fix(export): give the heap room for a large export, and stop polling a job that is gone

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -50,6 +50,26 @@ services:
       - PORT=3001
       - UPLOAD_DIR=/app/uploads
       - ENABLE_TRACING=false
+      # V8 old-space ceiling. NOT the same limit as `deploy.resources.limits.
+      # memory` below: the cgroup bounds RSS (native buffers, Cairo canvases,
+      # sharp), while this bounds the JavaScript heap. Node's default is ~2 GB
+      # regardless of how much the cgroup allows, so raising the cgroup to 12G
+      # (2026-08-19) did nothing for a heap OOM.
+      #
+      # A 300-frame microtubule export went from 60 MB to the 2 GB ceiling in
+      # ~16 s and killed the process (2026-08-20): every export task — image
+      # copies, visualizations, COCO/YOLO/JSON, MT metrics, kymographs, ImageJ
+      # RoiSets, CVAT — runs concurrently and each holds the whole image array.
+      # Smaller exports the same morning (70 frames) peaked at 150 MB, so this
+      # is not a leak; it is the concurrent fan-out over a large frame count.
+      # The same export re-run under this ceiling peaked at 1925 MB — i.e. it
+      # had been missing the old ceiling by under 200 MB — and completed.
+      #
+      # This is HEADROOM, not the fix — the same caveat as the cgroup limit
+      # below. The export is supposed to process frames in batches rather than
+      # hold all of them; until it does, this only decides how many frames it
+      # takes before the same crash returns.
+      - NODE_OPTIONS=--max-old-space-size=8192
       # Database password from shell environment
       - DB_PASSWORD=${DB_PASSWORD}
       # Queue processing — default 1 to prevent concurrent multipart request errors

--- a/src/pages/export/hooks/__tests__/useSharedAdvancedExport.polling.test.ts
+++ b/src/pages/export/hooks/__tests__/useSharedAdvancedExport.polling.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Regression tests for the export-status polling loop.
+ *
+ * Export jobs live only in the backend's in-memory Map, so a backend restart
+ * makes a running job vanish and every later `GET .../status` returns 404. On
+ * 2026-08-20 a 300-frame microtubule export OOM-crashed the backend; the poll
+ * swallowed the resulting 404s and the UI sat at "Processing…" for over twenty
+ * minutes, because the catch block only logged:
+ *
+ *     } catch (error) {
+ *       logger.error('Failed to poll export status', error);
+ *       // Continue polling unless we get consecutive errors
+ *     }
+ *
+ * — a comment describing a counter that did not exist. These tests pin the
+ * counter that now does, in both directions: a lost job must end the export,
+ * and a transient error must not.
+ *
+ * Unlike the sibling suite, the socket here is mocked DISCONNECTED on purpose:
+ * that is what puts the hook into the `startPolling()` branch this file is
+ * about. The interval is driven with fake timers and every render is unmounted,
+ * so it cannot outlive its test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+// ---- mocks (must precede all imports) -------------------------------------
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(),
+  Socket: class {},
+}));
+
+vi.mock('@/services/webSocketManager', () => ({
+  default: class {
+    static getInstance = vi.fn();
+    connect = vi.fn();
+    disconnect = vi.fn();
+    on = vi.fn();
+    off = vi.fn();
+    emit = vi.fn();
+  },
+}));
+
+// Disconnected socket => wsConnected=false => the hook polls immediately.
+const mockSocket = {
+  connected: false,
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+};
+vi.mock('@/contexts/useWebSocket', () => ({
+  useWebSocket: () => ({
+    socket: mockSocket,
+    manager: null,
+    isConnected: false,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(() => 'tid'),
+    dismiss: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+// `vi.mock` factories are hoisted above every top-level binding, so the spy
+// has to be created by `vi.hoisted` to exist by the time the factory runs.
+const { clearExportState } = vi.hoisted(() => ({
+  clearExportState: vi.fn(),
+}));
+vi.mock('@/lib/exportStateManager', () => ({
+  default: class {
+    static getExportState = vi.fn(() => null);
+    static saveExportState = vi.fn();
+    static saveExportStateThrottled = vi.fn();
+    static clearExportState = clearExportState;
+    static deduplicateRequest = vi.fn(
+      async (_: string, fn: () => Promise<unknown>) => fn()
+    );
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    getExportDownloadToken: vi.fn(),
+    buildExportDownloadUrl: vi.fn(() => 'http://download-url'),
+  },
+}));
+
+// ---- imports after mocks --------------------------------------------------
+
+import { ExportProvider } from '@/contexts/ExportContext';
+import { useSharedAdvancedExport } from '../useSharedAdvancedExport';
+import apiClient from '@/lib/api';
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+  React.createElement(ExportProvider, null, children);
+
+const PROJECT = 'proj-poll-404';
+const POLL_MS = 2000;
+
+/** An axios-shaped rejection carrying an HTTP status. */
+const httpError = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+
+/** A full AxiosResponse, so the mocks type-check against the real client. */
+const axiosOk = (data: unknown): AxiosResponse<unknown> => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: { headers: {} } as InternalAxiosRequestConfig,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.mocked(localStorage.getItem).mockReturnValue(null);
+  vi.mocked(localStorage.setItem).mockImplementation(() => {});
+  vi.mocked(localStorage.removeItem).mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Start an export so the hook has a job to poll for. */
+async function startExporting() {
+  vi.mocked(apiClient.post).mockResolvedValueOnce(
+    axiosOk({ jobId: 'job-lost' })
+  );
+  const rendered = renderHook(() => useSharedAdvancedExport(PROJECT), {
+    wrapper,
+  });
+  await act(async () => {
+    await rendered.result.current.startExport();
+  });
+  expect(rendered.result.current.isExporting).toBe(true);
+  return rendered;
+}
+
+/** Let the interval fire `times` times. */
+async function tick(times: number) {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_MS);
+    });
+  }
+}
+
+describe('useSharedAdvancedExport – polling a job the server has forgotten', () => {
+  it('gives up and reports failure after three consecutive 404s', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockRejectedValue(httpError(404));
+
+    await tick(3);
+
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.exportStatus).toMatch(/Export failed/i);
+    unmount();
+  });
+
+  it('clears the persisted state so a reload does not resurrect the job', async () => {
+    const { unmount } = await startExporting();
+    clearExportState.mockClear();
+    vi.mocked(apiClient.get).mockRejectedValue(httpError(404));
+
+    await tick(3);
+
+    expect(clearExportState).toHaveBeenCalledWith(PROJECT);
+    unmount();
+  });
+
+  it('stops polling once it has given up', async () => {
+    const { unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockRejectedValue(httpError(404));
+
+    await tick(3);
+    const callsAtGiveUp = vi.mocked(apiClient.get).mock.calls.length;
+    await tick(5);
+
+    expect(vi.mocked(apiClient.get).mock.calls.length).toBe(callsAtGiveUp);
+    unmount();
+  });
+
+  it('is still exporting after only two 404s', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockRejectedValue(httpError(404));
+
+    await tick(2);
+
+    expect(result.current.isExporting).toBe(true);
+    unmount();
+  });
+
+  it('keeps polling through repeated 500s — those are transient', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockRejectedValue(httpError(500));
+
+    await tick(6);
+
+    expect(result.current.isExporting).toBe(true);
+    unmount();
+  });
+
+  it('keeps polling through a network error with no response at all', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('Network Error'));
+
+    await tick(6);
+
+    expect(result.current.isExporting).toBe(true);
+    unmount();
+  });
+
+  it('finishes the export when the poll reports completion', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockResolvedValue(
+      axiosOk({ status: 'completed', progress: 100 })
+    );
+
+    await tick(1);
+
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.exportStatus).toMatch(/completed/i);
+    unmount();
+  });
+
+  it('stops polling once the job has completed', async () => {
+    const { unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockResolvedValue(
+      axiosOk({ status: 'completed', progress: 100 })
+    );
+
+    await tick(1);
+    const callsAtCompletion = vi.mocked(apiClient.get).mock.calls.length;
+    await tick(5);
+
+    expect(vi.mocked(apiClient.get).mock.calls.length).toBe(callsAtCompletion);
+    unmount();
+  });
+
+  it('surfaces a server-reported failure with its message', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockResolvedValue(
+      axiosOk({ status: 'failed', progress: 40, message: 'disk full' })
+    );
+
+    await tick(1);
+
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.exportStatus).toContain('disk full');
+    unmount();
+  });
+
+  it('reports progress while the job is still running', async () => {
+    const { result, unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockResolvedValue(
+      axiosOk({ status: 'processing', progress: 42 })
+    );
+
+    await tick(1);
+
+    expect(result.current.isExporting).toBe(true);
+    expect(result.current.exportProgress).toBe(42);
+    unmount();
+  });
+
+  it('runs exactly one poller — the effect must not stack intervals', async () => {
+    const { unmount } = await startExporting();
+    vi.mocked(apiClient.get).mockResolvedValue(
+      axiosOk({ status: 'processing', progress: 10 })
+    );
+
+    await tick(4);
+
+    // Four interval periods, one poller: four requests. Before the handle
+    // moved out of render state the effect re-armed itself on every commit
+    // and production saw two pollers 200 ms apart.
+    expect(vi.mocked(apiClient.get).mock.calls.length).toBe(4);
+    unmount();
+  });
+
+  it('a successful poll resets the counter, so scattered 404s never add up', async () => {
+    const { result, unmount } = await startExporting();
+    const ok = axiosOk({ status: 'processing', progress: 40 });
+    vi.mocked(apiClient.get)
+      .mockRejectedValueOnce(httpError(404))
+      .mockRejectedValueOnce(httpError(404))
+      .mockResolvedValueOnce(ok)
+      .mockRejectedValueOnce(httpError(404))
+      .mockRejectedValueOnce(httpError(404))
+      .mockResolvedValueOnce(ok);
+
+    await tick(6);
+
+    expect(result.current.isExporting).toBe(true);
+    unmount();
+  });
+});

--- a/src/pages/export/hooks/useSharedAdvancedExport.ts
+++ b/src/pages/export/hooks/useSharedAdvancedExport.ts
@@ -21,6 +21,20 @@ const sanitizeFilename = (filename: string): string => {
 };
 
 /**
+ * How many consecutive 404s from the export-status poll prove the job is
+ * really gone rather than momentarily unreachable. Export jobs live only in
+ * the backend's memory, so a restart — including the process being killed
+ * mid-export — makes the job vanish and every later poll 404s forever. Three
+ * in a row is proof, not a race: the backend registers the job before it
+ * returns the id the client polls with.
+ */
+const EXPORT_STATUS_NOT_FOUND_LIMIT = 3;
+
+/** Shown when the backend has forgotten a job the UI is still waiting on. */
+const EXPORT_LOST_MESSAGE =
+  'The server no longer knows about this export — it was most likely interrupted by a restart. Please start it again.';
+
+/**
  * Trigger a native browser download by creating a hidden anchor and
  * clicking it. The browser streams the response straight to disk —
  * no Blob, no axios timeout, and (crucially) the download cannot
@@ -134,9 +148,25 @@ export const useSharedAdvancedExport = (
   const [createdBlobUrls, _setCreatedBlobUrls] = useState<string[]>([]);
   const downloadedJobIds = useRef<Set<string>>(new Set());
   const downloadInProgress = useRef<boolean>(false);
-  const [pollingInterval, setPollingInterval] = useState<NodeJS.Timeout | null>(
-    null
-  );
+  const consecutiveStatusNotFound = useRef<number>(0);
+  /** The live status-poll interval.
+   *
+   *  A ref, not state, and deliberately so: this used to be `useState` AND a
+   *  dependency of the effect that assigns it, so every `setPollingInterval`
+   *  re-ran the effect, which cleared the timer and started another one, which
+   *  set state again. Production logs from 2026-08-20 show the result — two
+   *  independent pollers hitting `/status` 200 ms apart instead of one every
+   *  two seconds. Keeping the handle out of the render cycle breaks the loop.
+   */
+  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  /** Clear the live poll, if any. Safe to call when nothing is running. */
+  const stopPolling = useCallback(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+  }, []);
   const [wsConnected, setWsConnected] = useState(false);
   const [currentProjectName, setCurrentProjectName] = useState<
     string | undefined
@@ -426,11 +456,9 @@ export const useSharedAdvancedExport = (
       createdBlobUrls.forEach(url => {
         window.URL.revokeObjectURL(url);
       });
-      if (pollingInterval) {
-        clearInterval(pollingInterval);
-      }
+      stopPolling();
     };
-  }, [createdBlobUrls, pollingInterval]);
+  }, [createdBlobUrls, stopPolling]);
 
   // Monitor WebSocket connection
   useEffect(() => {
@@ -551,13 +579,15 @@ export const useSharedAdvancedExport = (
 
     // Only start polling if WebSocket is not connected or after a timeout
     const startPolling = () => {
-      if (pollingInterval) clearInterval(pollingInterval);
+      stopPolling();
+      consecutiveStatusNotFound.current = 0;
 
       const interval = setInterval(async () => {
         try {
           const response = await apiClient.get(
             `/projects/${projectId}/export/${currentJob.id}/status`
           );
+          consecutiveStatusNotFound.current = 0;
           const status = response.data;
           if (status) {
             updateState({
@@ -574,8 +604,7 @@ export const useSharedAdvancedExport = (
                 isExporting: false,
                 completedJobId: currentJob.id,
               });
-              clearInterval(interval);
-              setPollingInterval(null);
+              stopPolling();
             } else if (status.status === 'failed') {
               updateState({
                 currentJob: currentJob
@@ -584,17 +613,43 @@ export const useSharedAdvancedExport = (
                 exportStatus: `Export failed: ${status.message || 'Unknown error'}`,
                 isExporting: false,
               });
-              clearInterval(interval);
-              setPollingInterval(null);
+              stopPolling();
             }
           }
         } catch (error) {
           logger.error('Failed to poll export status', error);
-          // Continue polling unless we get consecutive errors
+          const httpStatus = (error as { response?: { status?: number } })
+            ?.response?.status;
+          if (httpStatus !== 404) {
+            // Network blips and 5xx are transient — the job is still there.
+            return;
+          }
+          consecutiveStatusNotFound.current += 1;
+          if (
+            consecutiveStatusNotFound.current < EXPORT_STATUS_NOT_FOUND_LIMIT
+          ) {
+            return;
+          }
+          // The job is gone and no completion event is ever coming. Surface a
+          // failure instead of spinning forever on a progress bar that will
+          // never move.
+          updateState({
+            currentJob: currentJob
+              ? {
+                  ...currentJob,
+                  status: 'failed',
+                  message: EXPORT_LOST_MESSAGE,
+                }
+              : null,
+            exportStatus: `Export failed: ${EXPORT_LOST_MESSAGE}`,
+            isExporting: false,
+          });
+          stopPolling();
+          ExportStateManager.clearExportState(projectId);
         }
       }, 2000); // Poll every 2 seconds
 
-      setPollingInterval(interval);
+      pollingIntervalRef.current = interval;
     };
 
     // Start polling immediately if WebSocket is not connected
@@ -612,19 +667,15 @@ export const useSharedAdvancedExport = (
     }
 
     return () => {
-      if (pollingInterval) {
-        clearInterval(pollingInterval);
-        // Don't set state during cleanup to prevent infinite loop
-        // The state will be cleaned up when component unmounts
-      }
+      stopPolling();
     };
   }, [
     currentJob,
     isExporting,
     wsConnected,
-    pollingInterval,
     projectId,
     updateState,
+    stopPolling,
   ]);
 
   // Auto-download when export completes - FIXED VERSION with persistent tracking


### PR DESCRIPTION
A 300-frame microtubule export killed the production backend this morning, and the browser then sat on a progress bar for twenty minutes against a job that no longer existed. Two separate defects, plus a third found while testing.

## The crash

Node's old-space ceiling is ~2 GB by default and nothing had raised it, so the 12G cgroup limit added the day before was never the binding constraint — it bounds RSS, not the JS heap. Prometheus has the whole story:

```
11:06:00   57.4 MB
11:06:45   60.7 MB     ← the export's parallel phase begins
11:07:00   (scrape missing — the process is dying)
11:07:30   42.5 MB     ← a fresh process
```

Sixty megabytes to the 2 GB ceiling in about sixteen seconds. Every export task — image copies, visualizations, COCO/YOLO/JSON, MT metrics, kymographs, ImageJ RoiSets, CVAT — runs concurrently and each holds the whole image array, so demand scales with frames times consumers. Smaller exports the same morning (70 frames) peaked at 150 MB.

`NODE_OPTIONS=--max-old-space-size=8192` lets it through. Re-run against production, the same export peaked at **1925 MB** — it had been missing the old ceiling by under 200 MB — and produced a complete 2.2 GB archive: 302 originals, 300 visualizations, metrics, annotations. That is headroom, not a cure; batching the frames is, and the compose comment says so.

## The spinner

Export jobs live only in the backend's in-memory `Map`, so the restart erased the job and every later status poll 404'd. The poll swallowed it:

```js
} catch (error) {
  logger.error('Failed to poll export status', error);
  // Continue polling unless we get consecutive errors
}
```

There was no such counter. Three consecutive 404s now end the export with a message that says what happened. Transient 5xx and network errors still keep polling, and any successful poll resets the count, so scattered 404s cannot add up to a false verdict.

## The duplicate poller

Writing the test turned up why this branch had never been covered — the sibling suite skips it as "doesn't add much value". The polling effect listed `pollingInterval` in its own dependency array while assigning it, so each render cleared the timer and started another. Under fake timers it exhausted a 4 GB heap. In production it looked like this:

```
11:23:45.109  /status 404
11:23:45.312  /status 404   ← 203 ms later
11:23:47.084  /status 404
11:23:47.311  /status 404   ← 227 ms later
```

Two pollers, not one. The handle is a ref now, out of the render cycle.

## Tests

12 new tests over the polling branch the old suite declined to cover. Each was checked by mutation — seven mutants, all killed:

| mutant | tests that went red |
|---|---|
| restore the original swallow-and-continue | 3 |
| threshold 3 → 1 | 2 |
| drop the 404 guard (any error ends the export) | 2 |
| never reset the counter on a good poll | 1 |
| `stopPolling` becomes a no-op | 2 |
| poll stops reporting progress | 1 |
| completion no longer ends the export | 2 |

One test asserts **exactly four** requests over four interval periods, which is the duplicate-poller regression pinned directly.

## Verified

- The 8 GB ceiling is live on production and the crashed export was re-run to completion against it.
- `make ci` green; 99 export-related tests pass.
- The deployed minified bundle carries the new failure message (checked in the container, not the dev server).

## Not in this PR

Testing this surfaced a third, independent defect: the axios interceptor in `src/lib/api.ts` retries 429/502/503/504 by re-issuing through the same instance, so each retry's error re-enters the interceptor and starts its own retry tree. One click on Start Export while another export was running produced **~1250 requests**. The 401 branch guards with `originalRequest._retry`; the retryable branch has no equivalent. It touches every endpoint in the app, so it belongs in its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export status monitoring when the connection to the export service is interrupted.
  * Export jobs now fail with a clear user-facing message after repeated missing status responses, instead of polling indefinitely.
  * Export polling now stops correctly when jobs complete or fail.
  * Temporary server or network errors are handled more reliably, and progress updates continue after successful status checks.
  * Prevented duplicate polling activity and cleaned up saved export state after confirmed failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->