### PR TITLE
fix(mt): Marika's two bug reports — untracked type labels, and per-channel window/level

### DIFF
--- a/src/lib/__tests__/playbackProxyWindow.test.ts
+++ b/src/lib/__tests__/playbackProxyWindow.test.ts
@@ -185,3 +185,54 @@ describe('anyWindowNeedsFullDepth', () => {
     ).toBe(true);
   });
 });
+
+describe('the cold registry must not lock the proxy off', () => {
+  beforeEach(() => {
+    clearProxyRanges();
+  });
+
+  it('judges an un-observed channel by its own range, not the container union', () => {
+    // The closed loop this pins: `observed` is filled ONLY from the
+    // X-Proxy-Range header, which arrives only on a response to a repr=proxy
+    // request, which this gate has to allow first. Judging a dim channel's
+    // narrow window against the container-wide figure refuses the proxy
+    // forever, and the user cannot widen past that channel's own ceiling.
+    //
+    // Marika's container: IRM spans 2941..4145 while the container figure is
+    // 65535. 1204/65535*256 = 4.7 levels -> refused. Against IRM's own 4145:
+    // 1204/4145*256 = 74 levels -> fine, and it is 74 levels in truth.
+    const windows = {
+      WD_LED_IRM: { min: 2941, max: 4145, rangeMax: 4145 },
+      TIRF_491: { min: 489, max: 53927, rangeMax: 53927 },
+    };
+    expect(
+      anyWindowNeedsFullDepth(windows, 65535, ['WD_LED_IRM', 'TIRF_491'], {
+        min: 0,
+        max: 65535,
+      })
+    ).toBe(false);
+  });
+
+  it('still demands the original once a channel is genuinely narrowed', () => {
+    const windows = {
+      // A tenth of its own range — really would band.
+      WD_LED_IRM: { min: 3000, max: 3120, rangeMax: 4145 },
+    };
+    expect(
+      anyWindowNeedsFullDepth(windows, 65535, ['WD_LED_IRM'], {
+        min: 0,
+        max: 65535,
+      })
+    ).toBe(true);
+  });
+
+  it('prefers a real observed encode range over the channel range', () => {
+    // Once a proxy has actually been fetched, its header is the truth: the
+    // encode range can sit BELOW the data max, and that is what quantises.
+    noteProxyRange('dim', 1023);
+    const windows = { dim: { min: 0, max: 1177, rangeMax: 1177 } };
+    expect(
+      anyWindowNeedsFullDepth(windows, 65535, ['dim'], { min: 0, max: 65535 })
+    ).toBe(false);
+  });
+});

--- a/src/lib/__tests__/playbackProxyWindow.test.ts
+++ b/src/lib/__tests__/playbackProxyWindow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   windowNeedsFullDepth,
+  anyWindowNeedsFullDepth,
   noteProxyRange,
   clearProxyRanges,
   observedProxyRanges,
@@ -74,12 +75,12 @@ describe('judging against the range a channel is really encoded at', () => {
     expect(windowNeedsFullDepth(0, 1177, CONTAINER, ['640_nm'])).toBe(false);
   });
 
-  it('takes the coarsest of the visible channels, since one window serves all', () => {
+  it('takes the coarsest of the channels it is given', () => {
     noteProxyRange('640_nm', 1023);
     noteProxyRange('irm', 32767);
 
-    // 1177 wide is fine for 640 nm and hopeless for irm; drawing both means
-    // the answer has to be the worse one.
+    // 1177 wide is fine for 640 nm and hopeless for irm; asked about both, the
+    // answer has to be the worse one.
     expect(windowNeedsFullDepth(0, 1177, CONTAINER, ['640_nm', 'irm'])).toBe(
       true
     );
@@ -117,5 +118,70 @@ describe('judging against the range a channel is really encoded at', () => {
 
     expect(observedProxyRanges()).toEqual({});
     expect(windowNeedsFullDepth(0, 1177, CONTAINER, ['640_nm'])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// anyWindowNeedsFullDepth — one frame, per-channel windows
+// ---------------------------------------------------------------------------
+
+describe('anyWindowNeedsFullDepth', () => {
+  beforeEach(() => {
+    clearProxyRanges();
+  });
+
+  /** Same measured container as above: brightest channel encoded at 32767. */
+  const CONTAINER = 32767;
+  const FALLBACK = { min: 0, max: CONTAINER };
+
+  it('judges each channel by its OWN window and its OWN proxy range', () => {
+    noteProxyRange('640_nm', 1023);
+    noteProxyRange('irm', 32767);
+
+    // The exact case the shared window got wrong: 640 nm is narrowed to its
+    // own faint data (plenty of levels at range 1023) while irm stays wide
+    // open. Neither channel needs the original.
+    expect(
+      anyWindowNeedsFullDepth(
+        { '640_nm': { min: 0, max: 1177 }, irm: { min: 0, max: 32767 } },
+        CONTAINER,
+        ['640_nm', 'irm'],
+        FALLBACK
+      )
+    ).toBe(false);
+  });
+
+  it('demands the original as soon as ONE channel is narrowed too far', () => {
+    noteProxyRange('640_nm', 1023);
+    noteProxyRange('irm', 32767);
+
+    expect(
+      anyWindowNeedsFullDepth(
+        // irm narrowed to 1177 of its 32767 — under an eighth, so it bands.
+        { '640_nm': { min: 0, max: 1177 }, irm: { min: 0, max: 1177 } },
+        CONTAINER,
+        ['640_nm', 'irm'],
+        FALLBACK
+      )
+    ).toBe(true);
+  });
+
+  it('errs toward the original for a channel with no window yet', () => {
+    noteProxyRange('irm', 32767);
+    expect(
+      anyWindowNeedsFullDepth(
+        { irm: { min: 0, max: 32767 } },
+        CONTAINER,
+        ['irm', 'not_reported_yet'],
+        FALLBACK
+      )
+    ).toBe(true);
+  });
+
+  it('measures the fallback window when there are no channels at all', () => {
+    expect(anyWindowNeedsFullDepth({}, CONTAINER, [], FALLBACK)).toBe(false);
+    expect(
+      anyWindowNeedsFullDepth({}, CONTAINER, [], { min: 0, max: 10 })
+    ).toBe(true);
   });
 });

--- a/src/lib/__tests__/webglCompositor.test.ts
+++ b/src/lib/__tests__/webglCompositor.test.ts
@@ -71,6 +71,7 @@ function makeChannel(
     height: 3,
     color: [255, 255, 255],
     opacity: 1,
+    window: { min: 0, max: 65535, rangeMax: 65535 },
     ...overrides,
   };
 }
@@ -577,19 +578,47 @@ describe('createCompositor — initialisation', () => {
 });
 
 describe('createCompositor — draw', () => {
+  it('gives each channel ITS OWN window uniforms in a single draw', () => {
+    // The bug this pins: one window shared by every channel. An IRM channel
+    // spanning 2941..4145 composited with a fluorescence channel spanning
+    // 489..53927 was drawn through the union, 489..53927, so the IRM content
+    // occupied ~2 % of the display range and read as a flat grey field.
+    const gl = createFakeGl();
+    const compositor = createCompositor(attachContext(gl))!;
+    gl.calls.length = 0;
+
+    compositor.draw([
+      makeChannel({
+        channel: 'WD_LED_IRM',
+        window: { min: 2941, max: 4145, rangeMax: 4145 },
+      }),
+      makeChannel({
+        channel: 'TIRF_491',
+        window: { min: 489, max: 53927, rangeMax: 53927 },
+      }),
+    ]);
+
+    // uniform1f writes arrive in draw order: 4 window uniforms per channel.
+    const los = named(gl, 'uniform1f')
+      .filter(c => (c.args[0] as { name: string }).name === 'uLo')
+      .map(c => c.args[1]);
+    const his = named(gl, 'uniform1f')
+      .filter(c => (c.args[0] as { name: string }).name === 'uHi')
+      .map(c => c.args[1]);
+    expect(los).toEqual([2941, 489]);
+    expect(his).toEqual([4145, 53927]);
+  });
+
   it('clears once, then issues exactly one draw call per channel', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
     gl.calls.length = 0;
 
-    compositor.draw(
-      [
-        makeChannel({ channel: 'DAPI' }),
-        makeChannel({ channel: 'GFP' }),
-        makeChannel({ channel: 'RFP' }),
-      ],
-      WINDOW
-    );
+    compositor.draw([
+      makeChannel({ channel: 'DAPI' }),
+      makeChannel({ channel: 'GFP' }),
+      makeChannel({ channel: 'RFP' }),
+    ]);
 
     expect(countOf(gl, 'clear')).toBe(1);
     expect(countOf(gl, 'drawArrays')).toBe(3);
@@ -605,7 +634,7 @@ describe('createCompositor — draw', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
     gl.calls.length = 0;
-    compositor.draw([makeChannel()], WINDOW);
+    compositor.draw([makeChannel()]);
 
     expect(named(gl, 'enable')[0].args).toEqual([GL_ENUMS.BLEND]);
     // ONE/ONE for RGB accumulates ('lighter'); ONE/ZERO for alpha keeps it at
@@ -626,11 +655,13 @@ describe('createCompositor — draw', () => {
     const compositor = createCompositor(attachContext(gl))!;
     gl.calls.length = 0;
 
-    compositor.draw([makeChannel({ color: [255, 0, 128], opacity: 0.5 })], {
-      min: 900,
-      max: 100,
-      rangeMax: 100000,
-    });
+    compositor.draw([
+      makeChannel({
+        color: [255, 0, 128],
+        opacity: 0.5,
+        window: { min: 900, max: 100, rangeMax: 100000 },
+      }),
+    ]);
 
     expect(floatUniforms(gl)).toEqual({
       uLo: 100,
@@ -652,12 +683,12 @@ describe('createCompositor — draw', () => {
     const compositor = createCompositor(attachContext(gl))!;
     const channel = makeChannel();
 
-    compositor.draw([channel], WINDOW);
+    compositor.draw([channel]);
     expect(countOf(gl, 'createTexture')).toBe(1);
     expect(countOf(gl, 'texImage2D')).toBe(1);
     expect(countOf(gl, 'texSubImage2D')).toBe(0);
 
-    compositor.draw([channel], WINDOW);
+    compositor.draw([channel]);
     expect(countOf(gl, 'createTexture')).toBe(1);
     expect(countOf(gl, 'texImage2D')).toBe(1);
     expect(countOf(gl, 'texSubImage2D')).toBe(0);
@@ -670,9 +701,9 @@ describe('createCompositor — draw', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
 
-    compositor.draw([makeChannel()], WINDOW);
+    compositor.draw([makeChannel()]);
     const nextFrame = makeChannel();
-    compositor.draw([nextFrame], WINDOW);
+    compositor.draw([nextFrame]);
 
     // makeChannel() builds a fresh array each call, so the second draw uploads
     // into the SAME texture rather than allocating another.
@@ -696,17 +727,14 @@ describe('createCompositor — draw', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
 
-    compositor.draw([makeChannel({ width: 4, height: 3 })], WINDOW);
-    compositor.draw(
-      [
-        makeChannel({
-          width: 8,
-          height: 6,
-          data: new Uint16Array(8 * 6),
-        }),
-      ],
-      WINDOW
-    );
+    compositor.draw([makeChannel({ width: 4, height: 3 })]);
+    compositor.draw([
+      makeChannel({
+        width: 8,
+        height: 6,
+        data: new Uint16Array(8 * 6),
+      }),
+    ]);
 
     expect(countOf(gl, 'texImage2D')).toBe(2);
     expect(countOf(gl, 'createTexture')).toBe(2);
@@ -720,9 +748,9 @@ describe('createCompositor — draw', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
 
-    compositor.draw([makeChannel({ data: new Uint16Array(4 * 3) })], WINDOW);
+    compositor.draw([makeChannel({ data: new Uint16Array(4 * 3) })]);
     gl.calls.length = 0;
-    compositor.draw([makeChannel({ data: new Uint8Array(4 * 3) })], WINDOW);
+    compositor.draw([makeChannel({ data: new Uint8Array(4 * 3) })]);
 
     expect(countOf(gl, 'deleteTexture')).toBe(1);
     expect(countOf(gl, 'texImage2D')).toBe(1);
@@ -736,10 +764,7 @@ describe('createCompositor — draw', () => {
     (_bits, makeData, internalFormat, type) => {
       const gl = createFakeGl();
       const compositor = createCompositor(attachContext(gl))!;
-      compositor.draw(
-        [makeChannel({ data: makeData() as Uint16Array })],
-        WINDOW
-      );
+      compositor.draw([makeChannel({ data: makeData() as Uint16Array })]);
       const args = named(gl, 'texImage2D')[0].args;
       expect(args[2]).toBe(internalFormat);
       expect(args[6]).toBe(GL_ENUMS.RED_INTEGER);
@@ -750,7 +775,7 @@ describe('createCompositor — draw', () => {
   it('sets NEAREST/CLAMP_TO_EDGE (integer textures are not filterable)', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
-    compositor.draw([makeChannel()], WINDOW);
+    compositor.draw([makeChannel()]);
     const params = named(gl, 'texParameteri').map(c => c.args.slice(1));
     expect(params).toEqual([
       [GL_ENUMS.TEXTURE_MIN_FILTER, GL_ENUMS.NEAREST],
@@ -768,7 +793,7 @@ describe('createCompositor — draw', () => {
       makeChannel({ channel: 'GFP' }),
     ];
 
-    for (let frame = 0; frame < 5; frame++) compositor.draw(channels, WINDOW);
+    for (let frame = 0; frame < 5; frame++) compositor.draw(channels);
 
     // Program/buffer/VAO built once; two textures total; 5 frames x 2 draws.
     expect(countOf(gl, 'createProgram')).toBe(1);
@@ -790,7 +815,7 @@ describe('createCompositor — draw', () => {
     compositor.setSize(100, 100);
     gl.calls.length = 0;
 
-    compositor.draw([makeChannel({ width: 4, height: 3 })], WINDOW);
+    compositor.draw([makeChannel({ width: 4, height: 3 })]);
 
     // The quad always maps the whole texture to the whole canvas; a mismatch
     // is a scale, not a crash.
@@ -802,7 +827,7 @@ describe('createCompositor — draw', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
     gl.calls.length = 0;
-    expect(() => compositor.draw([], WINDOW)).not.toThrow();
+    expect(() => compositor.draw([])).not.toThrow();
     expect(countOf(gl, 'clear')).toBe(1);
     expect(countOf(gl, 'drawArrays')).toBe(0);
   });
@@ -814,7 +839,7 @@ describe('createCompositor — draw', () => {
     gl.state.textureOk = false;
     gl.calls.length = 0;
 
-    expect(() => compositor.draw([makeChannel()], WINDOW)).not.toThrow();
+    expect(() => compositor.draw([makeChannel()])).not.toThrow();
     expect(countOf(gl, 'drawArrays')).toBe(0);
     expect(logger.error).toHaveBeenCalled();
   });
@@ -896,7 +921,7 @@ describe('createCompositor — context loss', () => {
     expect(compositor.isAlive()).toBe(false);
 
     gl.calls.length = 0;
-    expect(() => compositor.draw([makeChannel()], WINDOW)).not.toThrow();
+    expect(() => compositor.draw([makeChannel()])).not.toThrow();
     expect(gl.calls).toHaveLength(0);
   });
 
@@ -942,10 +967,10 @@ describe('createCompositor — dispose', () => {
     const canvas = attachContext(gl);
     const onContextLost = vi.fn();
     const compositor = createCompositor(canvas, onContextLost)!;
-    compositor.draw(
-      [makeChannel({ channel: 'DAPI' }), makeChannel({ channel: 'GFP' })],
-      WINDOW
-    );
+    compositor.draw([
+      makeChannel({ channel: 'DAPI' }),
+      makeChannel({ channel: 'GFP' }),
+    ]);
 
     compositor.dispose();
 
@@ -964,7 +989,7 @@ describe('createCompositor — dispose', () => {
   it('is safe to call twice and deletes nothing a second time', () => {
     const gl = createFakeGl();
     const compositor = createCompositor(attachContext(gl))!;
-    compositor.draw([makeChannel()], WINDOW);
+    compositor.draw([makeChannel()]);
 
     compositor.dispose();
     const after = {
@@ -988,7 +1013,7 @@ describe('createCompositor — dispose', () => {
     compositor.dispose();
     gl.calls.length = 0;
 
-    expect(() => compositor.draw([makeChannel()], WINDOW)).not.toThrow();
+    expect(() => compositor.draw([makeChannel()])).not.toThrow();
     expect(() => compositor.setSize(800, 600)).not.toThrow();
     expect(gl.calls).toHaveLength(0);
     expect(canvas.width).not.toBe(800);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1901,13 +1901,22 @@ class ApiClient {
     videoId: string,
     trackIds: string[],
     mtType: string | null
-  ): Promise<{ framesAffected: number }> {
+  ): Promise<{ framesAffected: number | null }> {
     const response = await this.instance.patch(
       `/segmentation/videos/${videoId}/tracks/type`,
       { trackIds, mtType }
     );
     const data = this.extractData(response);
-    return { framesAffected: Number(data?.framesAffected ?? 0) };
+    // NULL, not 0, when the response carries no usable count. The caller reads
+    // 0 as "the backend wrote nothing", which is a real and diagnosable state;
+    // coercing an absent field to 0 would report that for every write the
+    // moment the response shape changed, and a non-numeric value coerced to NaN
+    // would silently disable the check instead (NaN === 0 is false).
+    const raw = (data as { framesAffected?: unknown } | null)?.framesAffected;
+    return {
+      framesAffected:
+        typeof raw === 'number' && Number.isFinite(raw) ? raw : null,
+    };
   }
 
   /** Read the project's microtubule type-label palette. */

--- a/src/lib/playbackProxyWindow.ts
+++ b/src/lib/playbackProxyWindow.ts
@@ -111,15 +111,30 @@ export function windowNeedsFullDepth(
  * One frame carries every channel, so the strictest channel decides: if the
  * user has narrowed the IRM window to bring up faint filaments, the frame must
  * arrive at full depth even though the fluorescence channels are still wide
- * open. Each channel is judged against ITS OWN window and ITS OWN proxy range —
- * the two things that determine how many levels it actually has.
+ * open. Each channel is judged against ITS OWN window and ITS OWN range.
+ *
+ * WHICH range, and why it matters. `observed` is the truth once a proxy has
+ * been fetched, because a proxy's encode range can sit BELOW the channel's data
+ * max and that is what quantises. But `observed` is filled ONLY from the
+ * `X-Proxy-Range` header, which arrives only on a response to a `repr=proxy`
+ * request — which this gate has to allow first. So on a cold registry the
+ * fallback has to be something a dim channel can actually pass, or the loop
+ * never closes. The container-wide figure is not: it is the BRIGHTEST channel's
+ * number, and judged against it any channel dimmer than an eighth of the
+ * container can never clear MIN_LEVELS_IN_WINDOW, no matter what the user does
+ * — the slider ceiling is that channel's own rangeMax. So the channel's own
+ * range is the fallback, and the container figure only stands in for a channel
+ * that has reported no range at all. (The backend describes the same handshake
+ * from its side in playbackProxyService.ts.)
  *
  * With no visible channels there is nothing per-channel to judge, so the
- * caller's fallback window (the one `reportDataRange` maintains for images that
- * have no channel set) is measured against the container figure instead.
+ * caller's fallback window — the one kept for images with no channel set — is
+ * measured against the container figure instead.
  */
 export function anyWindowNeedsFullDepth(
-  windows: Readonly<Record<string, { min: number; max: number }>>,
+  windows: Readonly<
+    Partial<Record<string, { min: number; max: number; rangeMax?: number }>>
+  >,
   containerRangeMax: number | null,
   visibleChannels: readonly string[],
   fallbackWindow: { min: number; max: number }
@@ -136,6 +151,11 @@ export function anyWindowNeedsFullDepth(
     // A channel whose window has not been reported yet cannot be reasoned
     // about; err toward the original, as every other edge case here does.
     if (!win) return true;
-    return windowNeedsFullDepth(win.min, win.max, containerRangeMax, [channel]);
+    return windowNeedsFullDepth(
+      win.min,
+      win.max,
+      win.rangeMax ?? containerRangeMax,
+      [channel]
+    );
   });
 }

--- a/src/lib/playbackProxyWindow.ts
+++ b/src/lib/playbackProxyWindow.ts
@@ -123,9 +123,11 @@ export function windowNeedsFullDepth(
  * number, and judged against it any channel dimmer than an eighth of the
  * container can never clear MIN_LEVELS_IN_WINDOW, no matter what the user does
  * — the slider ceiling is that channel's own rangeMax. So the channel's own
- * range is the fallback, and the container figure only stands in for a channel
- * that has reported no range at all. (The backend describes the same handshake
- * from its side in playbackProxyService.ts.)
+ * range is the fallback. (`rangeMax` is optional in the signature for tests
+ * only; a real `ChannelWindow` always carries one, and a channel that has
+ * reported nothing has no entry and is caught above.) The backend hits the same
+ * failure one granularity up — its container-wide `proxyRangeMax` bootstraps
+ * off the same request — and describes it in playbackProxyService.ts.
  *
  * With no visible channels there is nothing per-channel to judge, so the
  * caller's fallback window — the one kept for images with no channel set — is

--- a/src/lib/playbackProxyWindow.ts
+++ b/src/lib/playbackProxyWindow.ts
@@ -68,10 +68,13 @@ export function observedProxyRanges(): Readonly<Record<string, number>> {
  * user narrowed the window to SEE into bands — exactly the detail a microtubule
  * measurement is looking for.
  *
- * Judged against the widest range among the VISIBLE channels, since one window
- * is applied to all of them and the coarsest decides. Only used once every
- * visible channel's real range is known; until then the container figure
- * stands in, which errs toward full depth.
+ * Judged against the widest range among the channels named in `channels`. Since
+ * windows are per channel now, production always names exactly one (or none, for
+ * an image with no channel set); the reduction stays because the answer for a
+ * SET still has to be its coarsest member — that is what
+ * {@link anyWindowNeedsFullDepth} composes. Only used once every named channel's
+ * real range is known; until then the container figure stands in, which errs
+ * toward full depth.
  *
  * Deliberately conservative at the edges: a zero-width window, and a container
  * with no range at all, both answer "use the original", because neither can be
@@ -100,4 +103,39 @@ export function windowNeedsFullDepth(
   const width = hi - lo;
   if (width <= 0) return true;
   return (width / rangeMax) * PROXY_LEVELS < MIN_LEVELS_IN_WINDOW;
+}
+
+/**
+ * Whether ANY visible channel's own window forces the original 16-bit PNG.
+ *
+ * One frame carries every channel, so the strictest channel decides: if the
+ * user has narrowed the IRM window to bring up faint filaments, the frame must
+ * arrive at full depth even though the fluorescence channels are still wide
+ * open. Each channel is judged against ITS OWN window and ITS OWN proxy range —
+ * the two things that determine how many levels it actually has.
+ *
+ * With no visible channels there is nothing per-channel to judge, so the
+ * caller's fallback window (the one `reportDataRange` maintains for images that
+ * have no channel set) is measured against the container figure instead.
+ */
+export function anyWindowNeedsFullDepth(
+  windows: Readonly<Record<string, { min: number; max: number }>>,
+  containerRangeMax: number | null,
+  visibleChannels: readonly string[],
+  fallbackWindow: { min: number; max: number }
+): boolean {
+  if (visibleChannels.length === 0) {
+    return windowNeedsFullDepth(
+      fallbackWindow.min,
+      fallbackWindow.max,
+      containerRangeMax
+    );
+  }
+  return visibleChannels.some(channel => {
+    const win = windows[channel];
+    // A channel whose window has not been reported yet cannot be reasoned
+    // about; err toward the original, as every other edge case here does.
+    if (!win) return true;
+    return windowNeedsFullDepth(win.min, win.max, containerRangeMax, [channel]);
+  });
 }

--- a/src/lib/webglCompositor.ts
+++ b/src/lib/webglCompositor.ts
@@ -63,6 +63,13 @@ export interface CompositorChannel {
   color: [number, number, number];
   /** 0-1. Multiplies the tinted result, matching the CPU path's `scale`. */
   opacity: number;
+  /** THIS channel's window/level. Per channel, not per draw: channels in one
+   *  composite differ in dynamic range by more than an order of magnitude (an
+   *  IRM channel spanning ~1200 counts beside a fluorescence channel spanning
+   *  53000), and a single shared window renders the narrow one as a flat field.
+   *  The loop in draw() already derived uniforms per channel; only the window
+   *  it read them from was global. */
+  window: CompositorWindow;
 }
 
 /** Window/level, in RAW SAMPLE UNITS (not normalised). Identical meaning to
@@ -87,7 +94,7 @@ export interface Compositor {
    * path's `globalCompositeOperation = 'lighter'`, so their order is
    * irrelevant. Safe to call on every frame and on every slider tick.
    */
-  draw(channels: CompositorChannel[], window: CompositorWindow): void;
+  draw(channels: CompositorChannel[]): void;
 
   /** Release textures, buffers, programs and the GL context. */
   dispose(): void;
@@ -582,7 +589,7 @@ export const createCompositor: CreateCompositor = (
       if (!contextLost) gl.viewport(0, 0, w, h);
     },
 
-    draw(channels: CompositorChannel[], win: CompositorWindow): void {
+    draw(channels: CompositorChannel[]): void {
       if (disposed || contextLost) return;
 
       gl.viewport(0, 0, canvas.width, canvas.height);
@@ -601,7 +608,7 @@ export const createCompositor: CreateCompositor = (
         const channel = channels[i];
         const texture = uploadChannel(channel);
         if (!texture) continue;
-        computeChannelUniforms(win, channel, scratch);
+        computeChannelUniforms(channel.window, channel, scratch);
         gl.uniform1f(uLo, scratch.lo);
         gl.uniform1f(uHi, scratch.hi);
         gl.uniform1f(uRange, scratch.range);

--- a/src/lib/windowLevel.ts
+++ b/src/lib/windowLevel.ts
@@ -16,7 +16,8 @@
 export const MAX_LUT_INDEX = 65535;
 
 /** Window/level LUT over the sample domain [0, rangeMax] → 8-bit display.
- *  Sized to the current channel set's brightest value, so a 16-bit frame
+ *  Sized to ONE channel's brightest value — the caller builds a table per
+ *  channel, because channels are windowed independently — so a 16-bit channel
  *  gets up to a 65536-entry table. Values ≤ windowMin map to black,
  *  ≥ windowMax to white; an inverted window is swapped, and a zero-width one
  *  divides by 1 rather than by 0. */

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1066,11 +1066,13 @@ const SegmentationEditor = () => {
   //     save wiped the label back out of the DB.
   //
   // An UNTRACKED, hand-drawn polyline has no trackId, and on a one-frame
-  // "snapshot" container it can never acquire one: the cross-frame tracker only
-  // births ids for polylines that existed at segmentation time, and the other
-  // source — forward propagation — has no later frame to write to. It is a valid
-  // target: its label lives on this frame and persists through the normal save,
-  // so drawing an MT by hand and typing it must NOT error with "no track".
+  // "snapshot" container no flow the UI triggers gives it one: the cross-frame
+  // tracker only births ids for polylines that existed at segmentation time,
+  // and the other source — forward propagation — has no later frame to write
+  // to. It is a valid target: its label lives on this frame and persists
+  // through the normal save (`mtType` survives every stage of the polygon
+  // validator), so drawing an MT by hand and typing it must NOT error with
+  // "no track".
   const handleChangeMtType = useCallback(
     async (polygonId: string, mtType: string | null) => {
       // Snapshot the target selection ONCE, before the await. A frame scrub or
@@ -1091,9 +1093,10 @@ const SegmentationEditor = () => {
       if (trackIds.length > 0) {
         // A tracked target needs the container id to reach its other frames.
         // `video.container` is null for a beat during a container switch —
-        // useVideoFrames keeps the PREVIOUS container's data until the new id
-        // matches — and the context menu is gated on `isPolyline` alone, so
-        // this is reachable. Stamping only the current frame and then reporting
+        // useVideoFrames derives it as `data.id === videoContainerId ? data
+        // : null`, and the query cache serves the previous container's data
+        // until the new id lands — and the context menu is gated on
+        // `isPolyline` alone, so this is reachable. Stamping only the current frame and then reporting
         // success would leave the rest of the track quietly unlabelled.
         if (!videoId) {
           logger.error(
@@ -1134,19 +1137,31 @@ const SegmentationEditor = () => {
         mtType
       );
       if (changed > 0) {
-        // A TRACKED target is already durable — setTrackType wrote every frame
-        // above — so its stamp must not enter the undo stack: undoing would
-        // revert this frame alone and the next autosave would persist a frame
-        // whose label disagrees with the rest of its own track. An UNTRACKED
-        // target's stamp IS the whole change, so it stays undoable.
-        editorRef.current.updatePolygons(updated, trackIds.length === 0);
+        // Always into the history — no `addToHistory: false` here, on either
+        // path. The editor has TWO save paths reading TWO different sources:
+        // the manual save sends `polygons`, but the image-switch autosave sends
+        // `history[historyIndex]`. A stamp kept out of the history therefore
+        // survives Save and is destroyed by the next frame scrub, which
+        // autosaves the pre-stamp snapshot over a row `setTrackType` has
+        // already labelled — every frame of the track ends up labelled except
+        // the one the user was looking at.
+        //
+        // The cost is on the tracked path: an Undo reverts this frame's copy
+        // while the backend's cross-frame write stands, so the frame disagrees
+        // with its own track until re-applied. That is a worse trade to take
+        // the other way round — it needs a deliberate Undo, whereas the
+        // autosave hazard fires on ordinary navigation. Undoing the backend
+        // write properly means re-issuing the inverse setTrackType, which the
+        // generic undo stack has no way to express.
+        editorRef.current.updatePolygons(updated);
       }
 
       // Nothing was written anywhere: no track to write across, and the
       // right-clicked polygon is not on this frame. That happens when the
-      // polygons are replaced while the type submenu is open (a resegment, a
-      // background reload) or across the await in "New label…", which creates
-      // the label and then assigns it. Reporting success there would be a lie.
+      // polygons are replaced while the type submenu is open — a resegment or a
+      // background reload — including across the await in "New label…", which
+      // persists the palette entry before assigning it and so widens the window
+      // for one. Reporting success there would be a lie.
       if (trackIds.length === 0 && matched === 0) {
         logger.warn(
           `Microtubule type change hit no target: polygon ${polygonId} is not on the current frame`
@@ -1161,8 +1176,9 @@ const SegmentationEditor = () => {
       // or they already carried the requested label while this frame's copy had
       // been undone. The two are not separable from here — the response carries
       // no "matched" count — so this stays a log line rather than something
-      // shown to the user. If it ever needs to be actionable, the backend has
-      // both numbers already and should return the second one too.
+      // shown to the user. Making it actionable means teaching the backend to
+      // count matches as well as writes — `setPolygonsTrackType` returns only
+      // `changed` today, so the FE and BE twins have diverged on exactly this.
       if (framesAffected === 0 && changed > 0) {
         logger.warn(
           `setTrackType wrote no frames for track(s) ${trackIds.join(', ')} on video ${videoId} — either the other frames already carried this label, or they are now stale`

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -1123,24 +1123,49 @@ const SegmentationEditor = () => {
       // updates. Commit only when something actually changed — a no-op
       // reassignment (or a mid-await frame scrub that leaves no matching polygon)
       // must not dirty the frame or push an empty undo entry.
-      const { polygons: updated, changed } = applyMtTypeToPolygons(
+      const {
+        polygons: updated,
+        changed,
+        matched,
+      } = applyMtTypeToPolygons(
         editorRef.current.getPolygons(),
         targetPolygonIds,
         new Set(trackIds),
         mtType
       );
       if (changed > 0) {
-        editorRef.current.updatePolygons(updated);
+        // A TRACKED target is already durable — setTrackType wrote every frame
+        // above — so its stamp must not enter the undo stack: undoing would
+        // revert this frame alone and the next autosave would persist a frame
+        // whose label disagrees with the rest of its own track. An UNTRACKED
+        // target's stamp IS the whole change, so it stays undoable.
+        editorRef.current.updatePolygons(updated, trackIds.length === 0);
       }
 
-      // Genuine cross-frame desync: the current frame carries the track (we just
-      // changed it) yet the whole-track write matched 0 frames — the track's
-      // other frames are now stale. `framesAffected === 0` with `changed === 0`
-      // is only a no-op re-assignment, not a desync, so it is intentionally not
-      // warned.
+      // Nothing was written anywhere: no track to write across, and the
+      // right-clicked polygon is not on this frame. That happens when the
+      // polygons are replaced while the type submenu is open (a resegment, a
+      // background reload) or across the await in "New label…", which creates
+      // the label and then assigns it. Reporting success there would be a lie.
+      if (trackIds.length === 0 && matched === 0) {
+        logger.warn(
+          `Microtubule type change hit no target: polygon ${polygonId} is not on the current frame`
+        );
+        toast.error(t('microtubule.type.updateFailed'));
+        return;
+      }
+
+      // The backend counts a frame only when its polygons actually CHANGED, so
+      // `framesAffected === 0` alongside a local change means one of two very
+      // different things: the track's other frames are stale (a real desync),
+      // or they already carried the requested label while this frame's copy had
+      // been undone. The two are not separable from here — the response carries
+      // no "matched" count — so this stays a log line rather than something
+      // shown to the user. If it ever needs to be actionable, the backend has
+      // both numbers already and should return the second one too.
       if (framesAffected === 0 && changed > 0) {
         logger.warn(
-          `setTrackType matched no frames for track(s) ${trackIds.join(', ')} on video ${videoId}`
+          `setTrackType wrote no frames for track(s) ${trackIds.join(', ')} on video ${videoId} — either the other frames already carried this label, or they are now stale`
         );
       }
 

--- a/src/pages/segmentation/SegmentationEditor.tsx
+++ b/src/pages/segmentation/SegmentationEditor.tsx
@@ -22,7 +22,11 @@ import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { handleCancelledError } from '@/lib/errorUtils';
 import { transformSegmentationPolygons } from './utils/transformSegmentationPolygons';
-import { resolveTargetTrackIds } from './utils/mtTypeTargets';
+import {
+  resolveTargetTrackIds,
+  resolveTargetPolygonIds,
+  applyMtTypeToPolygons,
+} from './utils/mtTypeTargets';
 import { usePolygonHandlers } from './hooks/usePolygonHandlers';
 import { useSegmentationLoader } from './hooks/useSegmentationLoader';
 import { useResegment } from './hooks/useResegment';
@@ -1046,37 +1050,103 @@ const SegmentationEditor = () => {
     [toggleMultiSelect, clearMultiSelect]
   );
 
-  // Assign (or clear) a microtubule type label. Whole-track semantics: resolves
-  // the target polygons' trackIds and sets `mtType` on every frame via the
-  // backend, then reloads so the current frame recolours. When ≥2 MTs are
-  // multi-selected the label applies to all of them; otherwise just the
-  // right-clicked polyline's track. Reads the selection through the ref so this
-  // callback stays identity-stable for the CanvasPolygon memo comparator.
+  // Assign (or clear) a microtubule type label. When ≥2 MTs are multi-selected
+  // the label applies to all of them; otherwise just the right-clicked polyline.
+  // Reads the selection through the ref so this callback stays identity-stable
+  // for the CanvasPolygon memo comparator.
+  //
+  // Two-part write:
+  //  1. Tracked MTs (have a `trackId`) → whole-track, cross-frame persistence via
+  //     the backend, so every frame of the track carries the label.
+  //  2. The current frame's polygons are stamped OPTIMISTICALLY in the editor
+  //     state. This is what makes the panel/canvas recolour immediately AND keeps
+  //     `mtType` in the polygons a later save serialises. The old code relied on a
+  //     network reload for this — but that reload is abortable (a race cancels the
+  //     GET), so the canvas kept the stale, type-less polygons and a subsequent
+  //     save wiped the label back out of the DB.
+  //
+  // An UNTRACKED, hand-drawn polyline has no trackId, and on a one-frame
+  // "snapshot" container it can never acquire one: the cross-frame tracker only
+  // births ids for polylines that existed at segmentation time, and the other
+  // source — forward propagation — has no later frame to write to. It is a valid
+  // target: its label lives on this frame and persists through the normal save,
+  // so drawing an MT by hand and typing it must NOT error with "no track".
   const handleChangeMtType = useCallback(
     async (polygonId: string, mtType: string | null) => {
-      const videoId = video.container?.id;
-      if (!videoId) return;
-      const polys = editorRef.current.getPolygons();
+      // Snapshot the target selection ONCE, before the await. A frame scrub or
+      // selection change during setTrackType must not skew which polygons we
+      // stamp — the cross-frame trackIds and the current-frame ids have to come
+      // from the same instant.
+      const selection = new Set(selectedPolygonIdsRef.current);
       const trackIds = resolveTargetTrackIds(
         polygonId,
-        selectedPolygonIdsRef.current,
-        polys
+        selection,
+        editorRef.current.getPolygons()
       );
-      if (trackIds.length === 0) {
-        toast.error(t('microtubule.type.noTrack'));
-        return;
+      const targetPolygonIds = resolveTargetPolygonIds(polygonId, selection);
+      const videoId = video.container?.id;
+
+      // Cross-frame whole-track persistence — only for tracked targets.
+      let framesAffected: number | null = null;
+      if (trackIds.length > 0) {
+        // A tracked target needs the container id to reach its other frames.
+        // `video.container` is null for a beat during a container switch —
+        // useVideoFrames keeps the PREVIOUS container's data until the new id
+        // matches — and the context menu is gated on `isPolyline` alone, so
+        // this is reachable. Stamping only the current frame and then reporting
+        // success would leave the rest of the track quietly unlabelled.
+        if (!videoId) {
+          logger.error(
+            'Cannot set microtubule type: no video container for a tracked polyline'
+          );
+          toast.error(t('microtubule.type.updateFailed'));
+          return;
+        }
+        try {
+          ({ framesAffected } = await apiClient.setTrackType(
+            videoId,
+            trackIds,
+            mtType
+          ));
+          evictVideoFrameSegmentationCaches();
+        } catch (error) {
+          logger.error('Failed to set microtubule type', error);
+          toast.error(t('microtubule.type.updateFailed'));
+          return;
+        }
       }
-      try {
-        await apiClient.setTrackType(videoId, trackIds, mtType);
-        evictVideoFrameSegmentationCaches();
-        await reloadSegmentation();
-        toast.success(t('microtubule.type.updated'));
-      } catch (error) {
-        logger.error('Failed to set microtubule type', error);
-        toast.error(t('microtubule.type.updateFailed'));
+
+      // Optimistically stamp the current frame's target polygons (re-read for the
+      // latest geometry, but with the pre-await target sets). Match by polygon id
+      // OR trackId, so a tracked MT's current-frame polyline recolours in
+      // lock-step with the cross-frame write above and an untracked one still
+      // updates. Commit only when something actually changed — a no-op
+      // reassignment (or a mid-await frame scrub that leaves no matching polygon)
+      // must not dirty the frame or push an empty undo entry.
+      const { polygons: updated, changed } = applyMtTypeToPolygons(
+        editorRef.current.getPolygons(),
+        targetPolygonIds,
+        new Set(trackIds),
+        mtType
+      );
+      if (changed > 0) {
+        editorRef.current.updatePolygons(updated);
       }
+
+      // Genuine cross-frame desync: the current frame carries the track (we just
+      // changed it) yet the whole-track write matched 0 frames — the track's
+      // other frames are now stale. `framesAffected === 0` with `changed === 0`
+      // is only a no-op re-assignment, not a desync, so it is intentionally not
+      // warned.
+      if (framesAffected === 0 && changed > 0) {
+        logger.warn(
+          `setTrackType matched no frames for track(s) ${trackIds.join(', ')} on video ${videoId}`
+        );
+      }
+
+      toast.success(t('microtubule.type.updated'));
     },
-    [video.container, reloadSegmentation, evictVideoFrameSegmentationCaches, t]
+    [video.container, evictVideoFrameSegmentationCaches, t]
   );
 
   // Delete a label: the backend nulls every `mtType` reference to it, so evict

--- a/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
+++ b/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
@@ -12,7 +12,13 @@
  * be ≥4096 MB when running this file directly.
  */
 import React from 'react';
-import { render, screen, act, cleanup } from '@testing-library/react';
+import {
+  render,
+  screen,
+  act,
+  cleanup,
+  fireEvent,
+} from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -280,8 +286,26 @@ vi.mock('../components/canvas/FrameLoadingGate', () => ({
   default: () => null,
 }));
 
+// Stubbed to a button rather than null so the microtubule type-label callback
+// is reachable. `onChangeMtType` is the ONLY route from the orchestrator to a
+// user gesture (SegmentationEditorLayout -> CanvasPolygon -> PolygonContextMenu),
+// and with a null stub a full revert of the untracked-label fix passes the
+// whole suite. The layout's real `polylineKind === 'microtubule'` gate still
+// runs — this only replaces the leaf.
 vi.mock('../components/canvas/CanvasPolygon', () => ({
-  default: () => null,
+  default: ({
+    polygon,
+    onChangeMtType,
+  }: {
+    polygon: { id: string };
+    onChangeMtType?: (id: string, mtType: string | null) => void;
+  }) =>
+    onChangeMtType ? (
+      <button
+        data-testid={`mt-type-${polygon.id}`}
+        onClick={() => onChangeMtType(polygon.id, 'mt_type_brain')}
+      />
+    ) : null,
 }));
 
 vi.mock('../components/canvas/CanvasSvgFilters', () => ({
@@ -633,7 +657,7 @@ describe('effectiveResegmentModel — project-type gating', () => {
 
     const btn = screen.getByTestId('resegment-btn');
     await act(async () => {
-      btn.click();
+      fireEvent.click(btn);
     });
 
     await act(async () => {
@@ -655,7 +679,7 @@ describe('effectiveResegmentModel — project-type gating', () => {
 
     const btn = screen.getByTestId('resegment-btn');
     await act(async () => {
-      btn.click();
+      fireEvent.click(btn);
     });
 
     await act(async () => {
@@ -677,7 +701,7 @@ describe('effectiveResegmentModel — project-type gating', () => {
 
     const btn = screen.getByTestId('resegment-btn');
     await act(async () => {
-      btn.click();
+      fireEvent.click(btn);
     });
 
     await act(async () => {
@@ -699,7 +723,7 @@ describe('effectiveResegmentModel — project-type gating', () => {
 
     const btn = screen.getByTestId('resegment-btn');
     await act(async () => {
-      btn.click();
+      fireEvent.click(btn);
     });
 
     await act(async () => {
@@ -885,5 +909,163 @@ describe('Image name normalization', () => {
     renderEditor();
     const hdr = screen.getByTestId('editor-header');
     expect(hdr.getAttribute('data-name')).toBe('');
+  });
+});
+
+// ─── microtubule type labels ─────────────────────────────────────────────────
+//
+// The two halves of the fix — an untracked polyline must be a valid target, and
+// the label must be stamped into editor state rather than fetched back by an
+// abortable reload — live in handleChangeMtType, not in the pure helpers. Both
+// were reverted here to check: with CanvasPolygon stubbed to null, a full revert
+// of either passed the entire suite. These tests are the ones that fail.
+
+describe('microtubule type labels', () => {
+  const polyline = (over: Record<string, unknown> = {}) => ({
+    id: 'poly-1',
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    geometry: 'polyline',
+    type: 'external',
+    class: 'spheroid',
+    ...over,
+  });
+
+  beforeEach(() => {
+    mockProjectData.projectType = 'microtubules';
+    mockProjectData.images = [{ id: 'img-1', name: 'f.tif' }];
+    mockVideo.container = { id: 'vid-1', channels: [] };
+  });
+
+  const setPolygons = (polys: unknown[]) => {
+    mockEditor.polygons = polys as never[];
+    mockEditor.getPolygons.mockReturnValue(polys as never[]);
+  };
+
+  it('types an UNTRACKED polyline without any cross-frame write', async () => {
+    setPolygons([polyline()]);
+    renderEditor();
+    const btn = await screen.findByTestId('mt-type-poly-1');
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    const { toast } = await import('sonner');
+    // The whole bug: this used to abort with "no track yet" before doing
+    // anything, because the polyline has no trackId.
+    expect(mockApiClient.setTrackType).not.toHaveBeenCalled();
+    expect(mockEditor.updatePolygons).toHaveBeenCalledTimes(1);
+    const [stamped] = mockEditor.updatePolygons.mock.calls[0] as [
+      Array<{ id: string; mtType?: string }>,
+    ];
+    expect(stamped.find(p => p.id === 'poly-1')?.mtType).toBe('mt_type_brain');
+    expect(toast.success).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps an untracked stamp undoable, since it is the whole change', async () => {
+    setPolygons([polyline()]);
+    renderEditor();
+    const target = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(target);
+    });
+
+    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBe(true);
+  });
+
+  it('writes across frames for a TRACKED polyline and stamps this frame too', async () => {
+    setPolygons([polyline({ trackId: 'track-9' })]);
+    mockApiClient.setTrackType.mockResolvedValue({ framesAffected: 7 });
+    renderEditor();
+
+    const target = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(target);
+    });
+
+    expect(mockApiClient.setTrackType).toHaveBeenCalledWith(
+      'vid-1',
+      ['track-9'],
+      'mt_type_brain'
+    );
+    // …and the local stamp must NOT be undoable: the backend write already
+    // landed on every frame, so an undo would desync this frame from its track.
+    expect(mockEditor.updatePolygons).toHaveBeenCalledTimes(1);
+    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBe(false);
+  });
+
+  it('does not dirty the frame when the label is already the one asked for', async () => {
+    setPolygons([polyline({ mtType: 'mt_type_brain' })]);
+    renderEditor();
+
+    const target = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(target);
+    });
+
+    const { toast } = await import('sonner');
+    // No write, no undo entry — but the user still gets a success, because the
+    // MT does carry the label they asked for.
+    expect(mockEditor.updatePolygons).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('reports failure when the polygon is no longer on the frame', async () => {
+    // The context menu holds the id it was opened with; a resegment or a
+    // background reload can replace the frame's polygons underneath it.
+    setPolygons([polyline()]);
+    renderEditor();
+    const btn = await screen.findByTestId('mt-type-poly-1');
+    setPolygons([polyline({ id: 'poly-fresh' })]);
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    const { toast } = await import('sonner');
+    expect(mockApiClient.setTrackType).not.toHaveBeenCalled();
+    expect(mockEditor.updatePolygons).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed cross-frame write and stamps nothing', async () => {
+    setPolygons([polyline({ trackId: 'track-9' })]);
+    mockApiClient.setTrackType.mockRejectedValue(new Error('boom'));
+    renderEditor();
+
+    const target = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(target);
+    });
+
+    const { toast } = await import('sonner');
+    expect(mockEditor.updatePolygons).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('refuses a tracked target when the container is not resolved yet', async () => {
+    setPolygons([polyline({ trackId: 'track-9' })]);
+    mockVideo.container = null;
+    renderEditor();
+
+    const target = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(target);
+    });
+
+    const { toast } = await import('sonner');
+    // Stamping only this frame and calling it success would leave the rest of
+    // the track quietly unlabelled.
+    expect(mockApiClient.setTrackType).not.toHaveBeenCalled();
+    expect(mockEditor.updatePolygons).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
+++ b/src/pages/segmentation/__tests__/SegmentationEditor.orchestration.test.tsx
@@ -966,15 +966,32 @@ describe('microtubule type labels', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('keeps an untracked stamp undoable, since it is the whole change', async () => {
+  it('puts the stamp in the undo history on BOTH paths', async () => {
+    // Not a style choice. The image-switch autosave saves
+    // `history[historyIndex]`, NOT `polygons` (useEnhancedSegmentationEditor
+    // ~line 293), while the manual save uses `polygons`. A stamp kept out of
+    // history therefore survives Save but is wiped by the very next frame
+    // scrub, which autosaves the pre-stamp snapshot over a row the backend had
+    // just labelled. Passing no second argument takes the default, which is
+    // what puts it in history.
     setPolygons([polyline()]);
     renderEditor();
-    const target = await screen.findByTestId('mt-type-poly-1');
+    const untracked = await screen.findByTestId('mt-type-poly-1');
     await act(async () => {
-      fireEvent.click(target);
+      fireEvent.click(untracked);
     });
+    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBeUndefined();
 
-    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBe(true);
+    mockEditor.updatePolygons.mockClear();
+    setPolygons([polyline({ trackId: 'track-9' })]);
+    mockApiClient.setTrackType.mockResolvedValue({ framesAffected: 7 });
+    cleanup();
+    renderEditor();
+    const tracked = await screen.findByTestId('mt-type-poly-1');
+    await act(async () => {
+      fireEvent.click(tracked);
+    });
+    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBeUndefined();
   });
 
   it('writes across frames for a TRACKED polyline and stamps this frame too', async () => {
@@ -992,10 +1009,7 @@ describe('microtubule type labels', () => {
       ['track-9'],
       'mt_type_brain'
     );
-    // …and the local stamp must NOT be undoable: the backend write already
-    // landed on every frame, so an undo would desync this frame from its track.
     expect(mockEditor.updatePolygons).toHaveBeenCalledTimes(1);
-    expect(mockEditor.updatePolygons.mock.calls[0][1]).toBe(false);
   });
 
   it('does not dirty the frame when the label is already the one asked for', async () => {

--- a/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
+++ b/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
@@ -35,8 +35,7 @@ export default function FrameWindowPrefetcher({
     channel,
     channelCoverage,
     channelWindows,
-    windowMin,
-    windowMax,
+    fallbackWindow,
     proxyRangeMax,
   } = useImageDisplay();
   // The same decision the canvas makes. Warming the representation the canvas
@@ -44,10 +43,12 @@ export default function FrameWindowPrefetcher({
   // budget and the HTTP cache on bytes nothing reads.
   const repr =
     canDecodeWebpGray() &&
-    !anyWindowNeedsFullDepth(channelWindows, proxyRangeMax, visibleChannels, {
-      min: windowMin,
-      max: windowMax,
-    })
+    !anyWindowNeedsFullDepth(
+      channelWindows,
+      proxyRangeMax,
+      visibleChannels,
+      fallbackWindow
+    )
       ? ('proxy' as const)
       : undefined;
 

--- a/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
+++ b/src/pages/segmentation/components/canvas/FrameWindowPrefetcher.tsx
@@ -16,7 +16,7 @@ import {
   type FrameMinimal,
 } from '../../hooks/useFrameWindowPrefetch';
 import { useDecodeAhead } from '../../hooks/useDecodeAhead';
-import { windowNeedsFullDepth } from '@/lib/playbackProxyWindow';
+import { anyWindowNeedsFullDepth } from '@/lib/playbackProxyWindow';
 import { canDecodeWebpGray } from '@/lib/webpGray';
 
 interface FrameWindowPrefetcherProps {
@@ -34,6 +34,7 @@ export default function FrameWindowPrefetcher({
     visibleChannels,
     channel,
     channelCoverage,
+    channelWindows,
     windowMin,
     windowMax,
     proxyRangeMax,
@@ -43,7 +44,10 @@ export default function FrameWindowPrefetcher({
   // budget and the HTTP cache on bytes nothing reads.
   const repr =
     canDecodeWebpGray() &&
-    !windowNeedsFullDepth(windowMin, windowMax, proxyRangeMax, visibleChannels)
+    !anyWindowNeedsFullDepth(channelWindows, proxyRangeMax, visibleChannels, {
+      min: windowMin,
+      max: windowMax,
+    })
       ? ('proxy' as const)
       : undefined;
 

--- a/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
+++ b/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
@@ -232,7 +232,7 @@ export default function MultiChannelCanvas({
   // and depending on it directly would recomposite the canvas for changes that
   // cannot affect the tone curve.
   const windowsKey = Object.entries(channelWindows)
-    .map(([c, w]) => `${c}:${w.min}:${w.max}:${w.rangeMax}`)
+    .map(([c, w]) => (w ? `${c}:${w.min}:${w.max}:${w.rangeMax}` : `${c}:-`))
     .join('|');
   const windowFor = useCallback(
     (channel: string): CompositorWindow => {
@@ -568,16 +568,27 @@ export default function MultiChannelCanvas({
       // from the parent-supplied reportChannelRanges/onLoad can't leave the
       // canvas blank. The key is the CONTAINER, not the channel set: ticking a
       // channel on must auto-fit that channel alone and leave the windows the
-      // user has already tuned on the others exactly where they are.
+      // user has already tuned on the others exactly where they are. An absent
+      // containerId stays NULL rather than being folded to '': two different
+      // id-less videos are not the same container, and treating them as one
+      // hands the second the first's window.
       setDecodeVersion(v => v + 1);
+      // Two try/catches, not one: a throw from reportChannelRanges leaves the
+      // decode committed but the windows not, so the frame paints through the
+      // 8-bit identity — worth naming separately from an onLoad failure, which
+      // costs only the parent's size bookkeeping.
       try {
-        reportChannelRanges(ranges, containerId ?? '');
-        onLoad?.(loaded[0].width, loaded[0].height, channelsKey);
+        reportChannelRanges(ranges, containerId ?? null);
       } catch (err) {
         logger.error(
-          'MultiChannelCanvas: onLoad/reportChannelRanges callback threw',
+          'MultiChannelCanvas: reportChannelRanges threw — this frame will paint through the default window',
           err
         );
+      }
+      try {
+        onLoad?.(loaded[0].width, loaded[0].height, channelsKey);
+      } catch (err) {
+        logger.error('MultiChannelCanvas: onLoad callback threw', err);
       }
     })().catch(err => {
       if (!controller.signal.aborted) {

--- a/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
+++ b/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
@@ -11,9 +11,10 @@
  *      createImageBitmap path would silently crush them to 8-bit). Non-
  *      grayscale PNGs fall back to an 8-bit createImageBitmap decode.
  *   3. Apply the user's min/max window-level LUT remap on the true sample
- *      values — ImageJ-style. The window range auto-scales to each channel
- *      set's real min/max (reported to ImageDisplayContext) so a 16-bit
- *      frame opens with a sensible contrast and the sliders span the data.
+ *      values — ImageJ-style. Each channel carries its OWN window, auto-scaled
+ *      to that channel's real min/max (reported to ImageDisplayContext), so a
+ *      dim channel stays legible beside a bright one instead of collapsing
+ *      into a few grey levels of the brighter one's range.
  *   4. Tint the grayscale by the channel's display colour and additively
  *      composite (canvas `globalCompositeOperation = 'lighter'`), mimicking
  *      multi-channel fluorescence emission.
@@ -212,8 +213,7 @@ export default function MultiChannelCanvas({
 }: MultiChannelCanvasProps) {
   const {
     channelWindows,
-    windowMin,
-    windowMax,
+    fallbackWindow,
     proxyRangeMax,
     brightness,
     contrast,
@@ -222,27 +222,33 @@ export default function MultiChannelCanvas({
   } = useImageDisplay();
   const { t } = useLanguage();
 
-  // Per-channel window/level. Declared here — above every effect that reads it
-  // — because a hook placed before the `const` it captures throws
-  // "Cannot access before initialization" at runtime, which the type checker
-  // does not catch and the minified bundle reports as a single letter.
+  // Per-channel window/level. Must sit AFTER `channelWindows` above and before
+  // the composite effect that reads it — a hook placed before a `const` it
+  // captures throws "Cannot access before initialization" at runtime, which the
+  // type checker does not catch and the minified bundle reports as a single
+  // letter (CLAUDE.md failure pattern #11). Anywhere in between is fine.
   //
-  // `windowsKey` is what the composite effect depends on: the windows object is
-  // a fresh reference on every context write (opacity, colour, frame index),
-  // and depending on it directly would recomposite the canvas for changes that
-  // cannot affect the tone curve.
+  // `windowsKey` is a VALUE fingerprint, so the composite effect re-runs only
+  // when a window's numbers actually move. The object's identity is stable
+  // across unrelated context writes (every setter spreads `...s`), but the
+  // reducers do hand back a new map whenever any channel's bounds widen — which
+  // happens on frame scrubs, where the tone curve has not changed.
   const windowsKey = Object.entries(channelWindows)
     .map(([c, w]) => (w ? `${c}:${w.min}:${w.max}:${w.rangeMax}` : `${c}:-`))
     .join('|');
   const windowFor = useCallback(
-    (channel: string): CompositorWindow => {
+    (channel: string): CompositorWindow | null => {
       const w = channelWindows[channel];
-      // A channel decoded before its range has been folded into state draws
-      // once through the 8-bit identity window; the next commit has its real
-      // one. Better than skipping the channel, which would flash a gap.
-      return w
-        ? { min: w.min, max: w.max, rangeMax: w.rangeMax }
-        : { min: 0, max: 255, rangeMax: 255 };
+      // NULL, not an 8-bit identity window. React batches the decode's
+      // `setDecodeVersion` and `reportChannelRanges` into one commit, so in the
+      // normal path every composited channel already has a window and this
+      // never fires. If it ever does, drawing is the wrong answer: a 16-bit
+      // channel through a 0..255 window is not mis-toned, it is FULL WHITE —
+      // buildLut caps at index 255 and the shader clamps to the same maxIndex,
+      // and under `lighter` blending that saturated channel wipes out the
+      // others too. A missing channel is honest; a white field looks like
+      // signal, which is the exact confusion this whole change exists to end.
+      return w ? { min: w.min, max: w.max, rangeMax: w.rangeMax } : null;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [windowsKey]
@@ -309,10 +315,12 @@ export default function MultiChannelCanvas({
   // then cannot turn into samples, and draw those channels blank.
   const useProxy =
     canDecodeWebpGray() &&
-    !anyWindowNeedsFullDepth(channelWindows, proxyRangeMax, visibleChannels, {
-      min: windowMin,
-      max: windowMax,
-    });
+    !anyWindowNeedsFullDepth(
+      channelWindows,
+      proxyRangeMax,
+      visibleChannels,
+      fallbackWindow
+    );
   const repr = useProxy ? ('proxy' as const) : undefined;
 
   // --- Render-path selection: ask the CURRENT canvas element for WebGL2 once.
@@ -549,11 +557,9 @@ export default function MultiChannelCanvas({
       // auto-scale + slider bounds in ImageDisplayContext. These scalars are
       // carried out of the decoders, NOT rescanned from the samples.
       //
-      // This used to be reduced to a single min/max pair across all channels,
-      // which is the bug Marika reported as "model segments MTs where there is
-      // nothing": an IRM channel spanning 2941..4145 shared a window with TIRF
-      // channels reaching 53927, so it was drawn through 2 % of the display
-      // range and its filaments vanished under their own polylines.
+      // Reducing these to a single min/max pair across all channels is what
+      // made a narrow channel unreadable beside a wide one; the full account is
+      // on `channelWindows` in ImageDisplayContext.
       const ranges: Record<string, { min: number; max: number }> = {};
       for (const cs of loaded) {
         ranges[cs.channel] = {
@@ -581,7 +587,7 @@ export default function MultiChannelCanvas({
         reportChannelRanges(ranges, containerId ?? null);
       } catch (err) {
         logger.error(
-          'MultiChannelCanvas: reportChannelRanges threw — this frame will paint through the default window',
+          'MultiChannelCanvas: reportChannelRanges threw — channels with no window yet will be skipped this pass',
           err
         );
       }
@@ -645,16 +651,26 @@ export default function MultiChannelCanvas({
         setRenderPath('2d');
         return;
       }
-      const channels: CompositorChannel[] = loaded.map(cs => ({
-        channel: cs.channel,
-        data: cs.data,
-        width: cs.width,
-        height: cs.height,
-        color: hexToRgb(channelColors[cs.channel] ?? '#FFFFFF'),
-        opacity: (channelOpacities[cs.channel] ?? 100) / 100,
+      const channels: CompositorChannel[] = [];
+      for (const cs of loaded) {
         // Raw sample units — the same three numbers buildLut() takes below.
-        window: windowFor(cs.channel),
-      }));
+        const window = windowFor(cs.channel);
+        if (!window) {
+          logger.warn(
+            `MultiChannelCanvas: no window for channel ${cs.channel}; skipping it this pass rather than drawing it white`
+          );
+          continue;
+        }
+        channels.push({
+          channel: cs.channel,
+          data: cs.data,
+          width: cs.width,
+          height: cs.height,
+          color: hexToRgb(channelColors[cs.channel] ?? '#FFFFFF'),
+          opacity: (channelOpacities[cs.channel] ?? 100) / 100,
+          window,
+        });
+      }
       compositor.setSize(w, h);
       compositor.draw(channels);
       return;
@@ -705,9 +721,17 @@ export default function MultiChannelCanvas({
       const opacity = (channelOpacities[cs.channel] ?? 100) / 100;
       const scale = opacity >= 1 ? 1 : opacity;
       // One table per channel: they are windowed independently, so they cannot
-      // share one. Built inside the loop, which runs once per channel per
-      // composite — the same cadence the single table was built at.
+      // share one. This does move the build inside the loop — N tables per
+      // composite where there was one — but `buildLut` is O(rangeMax) against a
+      // per-pixel loop that already ran per channel in this same body, so it is
+      // a few percent of a pass that only runs when WebGL2 is unavailable.
       const cw = windowFor(cs.channel);
+      if (!cw) {
+        logger.warn(
+          `MultiChannelCanvas: no window for channel ${cs.channel}; skipping it this pass rather than drawing it white`
+        );
+        continue;
+      }
       const lut = buildLut(cw.min, cw.max, cw.rangeMax);
       const maxIdx = lut.length - 1;
       const src = cs.data;

--- a/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
+++ b/src/pages/segmentation/components/canvas/MultiChannelCanvas.tsx
@@ -39,7 +39,13 @@
  * the visible-channel list is non-empty.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { decodeGrayPngPooled } from '@/lib/png16Client';
@@ -53,7 +59,7 @@ import { FRAME_PREFETCH_WINDOW } from '../../hooks/useFrameWindowPrefetch';
 import { DECODE_AHEAD_FRAMES } from '../../hooks/useDecodeAhead';
 import { buildFrameImageUrl } from '../../hooks/segmentationPolygonCache';
 import {
-  windowNeedsFullDepth,
+  anyWindowNeedsFullDepth,
   noteProxyRange,
 } from '@/lib/playbackProxyWindow';
 import { speculativeFrameRequests } from '@/lib/requestThrottle';
@@ -205,16 +211,42 @@ export default function MultiChannelCanvas({
   onLoad,
 }: MultiChannelCanvasProps) {
   const {
+    channelWindows,
     windowMin,
     windowMax,
-    windowRangeMax,
     proxyRangeMax,
     brightness,
     contrast,
     channelOpacities,
-    reportDataRange,
+    reportChannelRanges,
   } = useImageDisplay();
   const { t } = useLanguage();
+
+  // Per-channel window/level. Declared here — above every effect that reads it
+  // — because a hook placed before the `const` it captures throws
+  // "Cannot access before initialization" at runtime, which the type checker
+  // does not catch and the minified bundle reports as a single letter.
+  //
+  // `windowsKey` is what the composite effect depends on: the windows object is
+  // a fresh reference on every context write (opacity, colour, frame index),
+  // and depending on it directly would recomposite the canvas for changes that
+  // cannot affect the tone curve.
+  const windowsKey = Object.entries(channelWindows)
+    .map(([c, w]) => `${c}:${w.min}:${w.max}:${w.rangeMax}`)
+    .join('|');
+  const windowFor = useCallback(
+    (channel: string): CompositorWindow => {
+      const w = channelWindows[channel];
+      // A channel decoded before its range has been folded into state draws
+      // once through the 8-bit identity window; the next commit has its real
+      // one. Better than skipping the channel, which would flash a gap.
+      return w
+        ? { min: w.min, max: w.max, rangeMax: w.rangeMax }
+        : { min: 0, max: 255, rangeMax: 255 };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [windowsKey]
+  );
   const canvasRef = useRef<HTMLCanvasElement>(null);
   // Decoded samples for the current frame/channel set, reused across
   // window-slider re-renders so dragging never refetches.
@@ -277,7 +309,10 @@ export default function MultiChannelCanvas({
   // then cannot turn into samples, and draw those channels blank.
   const useProxy =
     canDecodeWebpGray() &&
-    !windowNeedsFullDepth(windowMin, windowMax, proxyRangeMax, visibleChannels);
+    !anyWindowNeedsFullDepth(channelWindows, proxyRangeMax, visibleChannels, {
+      min: windowMin,
+      max: windowMax,
+    });
   const repr = useProxy ? ('proxy' as const) : undefined;
 
   // --- Render-path selection: ask the CURRENT canvas element for WebGL2 once.
@@ -510,34 +545,37 @@ export default function MultiChannelCanvas({
         lastPartialFailKeyRef.current = null;
       }
 
-      // Combined sample range across visible channels → drives the ImageJ-
-      // style auto-scale + slider bounds in ImageDisplayContext. Reduces over
-      // N per-channel scalars the decoders already produced, NOT over the
-      // samples themselves.
-      let cmin = Infinity;
-      let cmax = -Infinity;
+      // Each channel's OWN sample range → drives the per-channel ImageJ-style
+      // auto-scale + slider bounds in ImageDisplayContext. These scalars are
+      // carried out of the decoders, NOT rescanned from the samples.
+      //
+      // This used to be reduced to a single min/max pair across all channels,
+      // which is the bug Marika reported as "model segments MTs where there is
+      // nothing": an IRM channel spanning 2941..4145 shared a window with TIRF
+      // channels reaching 53927, so it was drawn through 2 % of the display
+      // range and its filaments vanished under their own polylines.
+      const ranges: Record<string, { min: number; max: number }> = {};
       for (const cs of loaded) {
-        if (cs.min < cmin) cmin = cs.min;
-        if (cs.max > cmax) cmax = cs.max;
+        ranges[cs.channel] = {
+          min: Number.isFinite(cs.min) ? cs.min : 0,
+          max: Number.isFinite(cs.max) ? cs.max : 255,
+        };
       }
 
       decodedRef.current = loaded;
       dimsRef.current = { w: loaded[0].width, h: loaded[0].height };
       // Trigger the composite BEFORE invoking external callbacks, so a throw
-      // from the parent-supplied reportDataRange/onLoad can't leave the canvas
-      // blank. The range key is scoped to the container so navigating to a
-      // different video with the same channel names still re-fits the window.
+      // from the parent-supplied reportChannelRanges/onLoad can't leave the
+      // canvas blank. The key is the CONTAINER, not the channel set: ticking a
+      // channel on must auto-fit that channel alone and leave the windows the
+      // user has already tuned on the others exactly where they are.
       setDecodeVersion(v => v + 1);
       try {
-        reportDataRange(
-          Number.isFinite(cmin) ? cmin : 0,
-          Number.isFinite(cmax) ? cmax : 255,
-          `${containerId ?? ''}::${channelsKey}`
-        );
+        reportChannelRanges(ranges, containerId ?? '');
         onLoad?.(loaded[0].width, loaded[0].height, channelsKey);
       } catch (err) {
         logger.error(
-          'MultiChannelCanvas: onLoad/reportDataRange callback threw',
+          'MultiChannelCanvas: onLoad/reportChannelRanges callback threw',
           err
         );
       }
@@ -561,7 +599,7 @@ export default function MultiChannelCanvas({
     repr,
     fetchChannels,
     fetchChannelsKey,
-    reportDataRange,
+    reportChannelRanges,
     onLoad,
     t,
     visibleChannels,
@@ -603,15 +641,11 @@ export default function MultiChannelCanvas({
         height: cs.height,
         color: hexToRgb(channelColors[cs.channel] ?? '#FFFFFF'),
         opacity: (channelOpacities[cs.channel] ?? 100) / 100,
+        // Raw sample units — the same three numbers buildLut() takes below.
+        window: windowFor(cs.channel),
       }));
-      // Raw sample units — the same three numbers buildLut() takes below.
-      const compositorWindow: CompositorWindow = {
-        min: windowMin,
-        max: windowMax,
-        rangeMax: windowRangeMax,
-      };
       compositor.setSize(w, h);
-      compositor.draw(channels, compositorWindow);
+      compositor.draw(channels);
       return;
     }
 
@@ -628,9 +662,6 @@ export default function MultiChannelCanvas({
     // frame (clearRect below handles the per-pass clear).
     if (canvas.width !== w) canvas.width = w;
     if (canvas.height !== h) canvas.height = h;
-
-    const lut = buildLut(windowMin, windowMax, windowRangeMax);
-    const maxIdx = lut.length - 1;
 
     ctx.clearRect(0, 0, w, h);
     ctx.globalCompositeOperation = 'lighter';
@@ -662,6 +693,12 @@ export default function MultiChannelCanvas({
       const [cR, cG, cB] = hexToRgb(channelColors[cs.channel] ?? '#FFFFFF');
       const opacity = (channelOpacities[cs.channel] ?? 100) / 100;
       const scale = opacity >= 1 ? 1 : opacity;
+      // One table per channel: they are windowed independently, so they cannot
+      // share one. Built inside the loop, which runs once per channel per
+      // composite — the same cadence the single table was built at.
+      const cw = windowFor(cs.channel);
+      const lut = buildLut(cw.min, cw.max, cw.rangeMax);
+      const maxIdx = lut.length - 1;
       const src = cs.data;
       for (let i = 0, p = 0; i < src.length; i++, p += 4) {
         const s = src[i];
@@ -676,9 +713,8 @@ export default function MultiChannelCanvas({
     }
   }, [
     decodeVersion,
-    windowMin,
-    windowMax,
-    windowRangeMax,
+    windowsKey,
+    windowFor,
     colorsKey,
     opacitiesKey,
     channelColors,

--- a/src/pages/segmentation/components/canvas/__tests__/FrameWindowPrefetcher.test.tsx
+++ b/src/pages/segmentation/components/canvas/__tests__/FrameWindowPrefetcher.test.tsx
@@ -33,15 +33,33 @@ vi.mock('../../../hooks/useFrameWindowPrefetch', () => ({
   ) => mockUseFrameWindowPrefetch(...args),
 }));
 
-// Control visibleChannels / channel from the test.
+// Control visibleChannels / channel / windows from the test.
 let mockVisibleChannels: string[] = [];
 let mockChannel: string | null = null;
+let mockChannelWindows: Record<
+  string,
+  { min: number; max: number; rangeMax: number; dataMin: number }
+> = {};
+let mockProxyRangeMax: number | null = null;
 
 vi.mock('../../../contexts/ImageDisplayContext', () => ({
   useImageDisplay: () => ({
     visibleChannels: mockVisibleChannels,
     channel: mockChannel,
+    channelWindows: mockChannelWindows,
+    fallbackWindow: { min: 0, max: 255, rangeMax: 255, dataMin: 0 },
+    proxyRangeMax: mockProxyRangeMax,
+    channelCoverage: {},
   }),
+}));
+
+// Not mocked before, so `canDecodeWebpGray()` returned false in jsdom and the
+// `&&` short-circuited: the proxy decision — the whole reason this component
+// reads the display context — was never reached by any test, and the context
+// mock could stay incomplete without anything noticing.
+let mockCanDecode = true;
+vi.mock('@/lib/webpGray', () => ({
+  canDecodeWebpGray: () => mockCanDecode,
 }));
 
 // -----------------------------------------------------------------------
@@ -169,5 +187,55 @@ describe('FrameWindowPrefetcher', () => {
         expect.objectContaining({ channels: [] })
       );
     });
+  });
+});
+
+// -----------------------------------------------------------------------
+// Representation choice — must match the canvas, or the prefetcher warms
+// bytes the canvas will not ask for.
+// -----------------------------------------------------------------------
+
+describe('FrameWindowPrefetcher — proxy vs original', () => {
+  beforeEach(() => {
+    mockCanDecode = true;
+    mockVisibleChannels = ['irm'];
+    mockChannel = null;
+    mockProxyRangeMax = 65535;
+    mockChannelWindows = {};
+  });
+
+  it('asks for the proxy when a channel is windowed to its own full range', () => {
+    // The regression this pins: judged against the container-wide 65535 this
+    // narrow channel can never clear the threshold, so the prefetcher would
+    // warm full-depth PNGs for ever — and because the same gate drives the
+    // canvas, no proxy would ever be fetched to teach the gate otherwise.
+    mockChannelWindows = {
+      irm: { min: 2941, max: 4145, rangeMax: 4145, dataMin: 2941 },
+    };
+    renderPrefetcher();
+    expect(mockUseFrameWindowPrefetch).toHaveBeenCalledWith(
+      expect.objectContaining({ repr: 'proxy' })
+    );
+  });
+
+  it('asks for the original once that channel is genuinely narrowed', () => {
+    mockChannelWindows = {
+      irm: { min: 3000, max: 3120, rangeMax: 4145, dataMin: 2941 },
+    };
+    renderPrefetcher();
+    expect(mockUseFrameWindowPrefetch).toHaveBeenCalledWith(
+      expect.objectContaining({ repr: undefined })
+    );
+  });
+
+  it('asks for the original when the browser cannot decode a proxy', () => {
+    mockCanDecode = false;
+    mockChannelWindows = {
+      irm: { min: 2941, max: 4145, rangeMax: 4145, dataMin: 2941 },
+    };
+    renderPrefetcher();
+    expect(mockUseFrameWindowPrefetch).toHaveBeenCalledWith(
+      expect.objectContaining({ repr: undefined })
+    );
   });
 });

--- a/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
+++ b/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
@@ -78,17 +78,22 @@ let mockChannelOpacities: Record<string, number> = {};
 // Must be a STABLE reference: it sits in the decode effect's dependency
 // array, so a fresh fn each render would re-trigger the fetch effect forever.
 const mockReportChannelRanges = vi.fn();
-// Per-channel windows, keyed by channel name. Empty by default: the component
-// falls back to the 8-bit identity window for a channel it has no entry for,
-// which is what these fixtures' all-zero samples want.
+// Per-channel windows, keyed by channel name. Defaulted for both fixture
+// channels because that is the production invariant: the decode's
+// `setDecodeVersion` and `reportChannelRanges` land in ONE React commit, so a
+// channel being composited always has a window. A channel WITHOUT one is now
+// skipped rather than drawn, so an empty default would mean the fixtures paint
+// nothing at all.
+const EIGHT_BIT = { min: 0, max: 255, rangeMax: 255, dataMin: 0 };
 let mockChannelWindows: Record<
   string,
   { min: number; max: number; rangeMax: number; dataMin: number }
-> = {};
+> = { ch1: EIGHT_BIT, ch2: EIGHT_BIT };
 
 vi.mock('@/pages/segmentation/contexts/ImageDisplayContext', () => ({
   useImageDisplay: () => ({
     channelWindows: mockChannelWindows,
+    fallbackWindow: { min: 0, max: 255, rangeMax: 255, dataMin: 0 },
     windowMin: mockWindowMin,
     windowMax: mockWindowMax,
     windowRangeMax: mockWindowRangeMax,
@@ -247,7 +252,7 @@ describe('MultiChannelCanvas', () => {
     mockBrightness = 100;
     mockContrast = 100;
     mockChannelOpacities = {};
-    mockChannelWindows = {};
+    mockChannelWindows = { ch1: EIGHT_BIT, ch2: EIGHT_BIT };
     originalFetch = global.fetch;
     originalCreateImageBitmap = global.createImageBitmap;
     // clearAllMocks wipes calls, not implementations — without this a fake
@@ -858,13 +863,10 @@ describe('MultiChannelCanvas', () => {
         max: 200,
         rangeMax: 255,
       });
-      // ch2 has no window yet, so it draws through the 8-bit identity rather
-      // than borrowing ch1's — the borrowing IS the bug.
-      expect(channels.find(c => c.channel === 'ch2')?.window).toEqual({
-        min: 0,
-        max: 255,
-        rangeMax: 255,
-      });
+      // ch2 has no window, so it is not drawn at all — it must never borrow
+      // ch1's (the borrowing IS the bug), and drawing it through an 8-bit
+      // identity would blow a 16-bit channel to white under `lighter`.
+      expect(channels.find(c => c.channel === 'ch2')).toBeUndefined();
       // No refetch (decode cache reused) and no new canvas element, so no new
       // GL context: a drag is a uniform update, nothing more.
       expect(fetchImpl).toHaveBeenCalledTimes(2);

--- a/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
+++ b/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
@@ -39,7 +39,6 @@ import {
   createCompositor,
   type Compositor,
   type CompositorChannel,
-  type CompositorWindow,
 } from '@/lib/webglCompositor';
 import { createMockCanvasContext } from '@/test-utils/canvasTestUtils';
 import MultiChannelCanvas from '../MultiChannelCanvas';
@@ -77,10 +76,18 @@ let mockContrast = 100;
 let mockChannelOpacities: Record<string, number> = {};
 // Must be a STABLE reference: it sits in the decode effect's dependency
 // array, so a fresh fn each render would re-trigger the fetch effect forever.
-const mockReportDataRange = vi.fn();
+const mockReportChannelRanges = vi.fn();
+// Per-channel windows, keyed by channel name. Empty by default: the component
+// falls back to the 8-bit identity window for a channel it has no entry for,
+// which is what these fixtures' all-zero samples want.
+let mockChannelWindows: Record<
+  string,
+  { min: number; max: number; rangeMax: number; dataMin: number }
+> = {};
 
 vi.mock('@/pages/segmentation/contexts/ImageDisplayContext', () => ({
   useImageDisplay: () => ({
+    channelWindows: mockChannelWindows,
     windowMin: mockWindowMin,
     windowMax: mockWindowMax,
     windowRangeMax: mockWindowRangeMax,
@@ -88,7 +95,7 @@ vi.mock('@/pages/segmentation/contexts/ImageDisplayContext', () => ({
     brightness: mockBrightness,
     contrast: mockContrast,
     channelOpacities: mockChannelOpacities,
-    reportDataRange: mockReportDataRange,
+    reportChannelRanges: mockReportChannelRanges,
   }),
 }));
 
@@ -228,6 +235,7 @@ describe('MultiChannelCanvas', () => {
     mockBrightness = 100;
     mockContrast = 100;
     mockChannelOpacities = {};
+    mockChannelWindows = {};
     originalFetch = global.fetch;
     originalCreateImageBitmap = global.createImageBitmap;
     // clearAllMocks wipes calls, not implementations — without this a fake
@@ -611,10 +619,10 @@ describe('MultiChannelCanvas', () => {
     });
   });
 
-  // ── reportDataRange is scoped to containerId::channelsKey ─────────────────
+  // ── reportChannelRanges: one range PER CHANNEL, keyed by container ────────
 
-  describe('reportDataRange container-scoped key', () => {
-    it('reports the combined sample range with an empty containerId prefix by default', async () => {
+  describe('reportChannelRanges', () => {
+    it('reports every channel separately, not one combined range', async () => {
       const { fetchImpl } = makeSuccessfulFetch();
       global.fetch = fetchImpl;
 
@@ -624,15 +632,19 @@ describe('MultiChannelCanvas', () => {
       });
 
       // The fake-blob 8-bit decode path produces all-zero samples (jsdom's
-      // mocked getImageData returns a zeroed Uint8ClampedArray), so both
-      // cmin and cmax collapse to 0. `containerId` is undefined in
-      // DEFAULT_PROPS, so the key's prefix is the empty string.
+      // mocked getImageData returns a zeroed Uint8ClampedArray), so every
+      // channel's min and max collapse to 0 — but each still arrives under its
+      // OWN key, which is what lets the context window them independently.
+      // `containerId` is undefined in DEFAULT_PROPS, so the key is ''.
       await waitFor(() => {
-        expect(mockReportDataRange).toHaveBeenCalledWith(0, 0, '::ch1|ch2');
+        expect(mockReportChannelRanges).toHaveBeenCalledWith(
+          { ch1: { min: 0, max: 0 }, ch2: { min: 0, max: 0 } },
+          ''
+        );
       });
     });
 
-    it('scopes the range key to containerId when the prop is provided', async () => {
+    it('keys the report on containerId when the prop is provided', async () => {
       const { fetchImpl } = makeSuccessfulFetch();
       global.fetch = fetchImpl;
 
@@ -642,7 +654,10 @@ describe('MultiChannelCanvas', () => {
       });
 
       await waitFor(() => {
-        expect(mockReportDataRange).toHaveBeenCalledWith(0, 0, 'vidA::ch1|ch2');
+        expect(mockReportChannelRanges).toHaveBeenCalledWith(
+          { ch1: { min: 0, max: 0 }, ch2: { min: 0, max: 0 } },
+          'vidA'
+        );
       });
     });
   });
@@ -728,12 +743,18 @@ describe('MultiChannelCanvas', () => {
       expect(onLoad).toHaveBeenCalledWith(400, 300, 'ch1|ch2');
     });
 
-    it('draws via the compositor with mapped channels + window, skipping the CPU loop', async () => {
+    it('draws via the compositor with each channel carrying its OWN window', async () => {
       const ctx = installSharedCanvasContext();
       const fake = makeFakeCompositor();
       const { fetchImpl } = makeSuccessfulFetch();
       global.fetch = fetchImpl;
       mockChannelOpacities = { ch2: 40 };
+      // The shape of Marika's data: a narrow channel beside a wide one. Sharing
+      // one window is what made the narrow channel render as a flat field.
+      mockChannelWindows = {
+        ch1: { min: 2941, max: 4145, rangeMax: 4145, dataMin: 2941 },
+        ch2: { min: 489, max: 53927, rangeMax: 53927, dataMin: 489 },
+      };
 
       const onLoad = vi.fn();
 
@@ -745,13 +766,20 @@ describe('MultiChannelCanvas', () => {
       expect(fake.setSize).toHaveBeenCalledWith(400, 300);
       expect(fake.draw).toHaveBeenCalledTimes(1);
 
-      const [channels, win] = fake.draw.mock.calls[0] as [
-        CompositorChannel[],
-        CompositorWindow,
-      ];
-      // Window is passed in RAW SAMPLE UNITS, exactly as buildLut took it.
-      expect(win).toEqual({ min: 0, max: 255, rangeMax: 255 });
+      const [channels] = fake.draw.mock.calls[0] as [CompositorChannel[]];
       expect(channels.map(c => c.channel).sort()).toEqual(['ch1', 'ch2']);
+      // Windows are per channel, in RAW SAMPLE UNITS, exactly as buildLut took
+      // them — and each channel gets its own, not the union of the two.
+      expect(channels.find(c => c.channel === 'ch1')?.window).toEqual({
+        min: 2941,
+        max: 4145,
+        rangeMax: 4145,
+      });
+      expect(channels.find(c => c.channel === 'ch2')?.window).toEqual({
+        min: 489,
+        max: 53927,
+        rangeMax: 53927,
+      });
 
       const ch1 = channels.find(c => c.channel === 'ch1');
       expect(ch1?.color).toEqual([255, 0, 0]); // '#FF0000' via hexToRgb
@@ -786,20 +814,30 @@ describe('MultiChannelCanvas', () => {
       expect(fetchImpl).toHaveBeenCalledTimes(2);
       expect(fake.draw).toHaveBeenCalledTimes(1);
 
-      // Simulate a Min/Max slider drag: context state changes, props don't.
-      mockWindowMin = 10;
-      mockWindowMax = 200;
+      // Simulate a Min/Max slider drag on ONE channel: context state changes,
+      // props don't. Only that channel's window moves.
+      mockChannelWindows = {
+        ch1: { min: 10, max: 200, rangeMax: 255, dataMin: 0 },
+      };
       rerender(<MultiChannelCanvas {...DEFAULT_PROPS} />);
       await act(async () => {
         await new Promise(r => setTimeout(r, 50));
       });
 
       expect(fake.draw).toHaveBeenCalledTimes(2);
-      const [, win] = fake.draw.mock.calls[1] as [
-        CompositorChannel[],
-        CompositorWindow,
-      ];
-      expect(win).toEqual({ min: 10, max: 200, rangeMax: 255 });
+      const [channels] = fake.draw.mock.calls[1] as [CompositorChannel[]];
+      expect(channels.find(c => c.channel === 'ch1')?.window).toEqual({
+        min: 10,
+        max: 200,
+        rangeMax: 255,
+      });
+      // ch2 has no window yet, so it draws through the 8-bit identity rather
+      // than borrowing ch1's — the borrowing IS the bug.
+      expect(channels.find(c => c.channel === 'ch2')?.window).toEqual({
+        min: 0,
+        max: 255,
+        rangeMax: 255,
+      });
       // No refetch (decode cache reused) and no new canvas element, so no new
       // GL context: a drag is a uniform update, nothing more.
       expect(fetchImpl).toHaveBeenCalledTimes(2);

--- a/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
+++ b/src/pages/segmentation/components/canvas/__tests__/MultiChannelCanvas.test.tsx
@@ -41,6 +41,7 @@ import {
   type CompositorChannel,
 } from '@/lib/webglCompositor';
 import { createMockCanvasContext } from '@/test-utils/canvasTestUtils';
+import { buildLut } from '@/lib/windowLevel';
 import MultiChannelCanvas from '../MultiChannelCanvas';
 import {
   MAX_SPECULATIVE_REQUESTS,
@@ -98,6 +99,17 @@ vi.mock('@/pages/segmentation/contexts/ImageDisplayContext', () => ({
     reportChannelRanges: mockReportChannelRanges,
   }),
 }));
+
+// Real implementation, but observable: the CPU composite path builds one LUT
+// per channel and the only other markers it leaves are putImageData call
+// counts, so without this a regression to a single shared table is invisible.
+vi.mock('@/lib/windowLevel', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/windowLevel')>(
+      '@/lib/windowLevel'
+    );
+  return { ...actual, buildLut: vi.fn(actual.buildLut) };
+});
 
 vi.mock('@/lib/logger', () => ({
   logger: {
@@ -603,7 +615,7 @@ describe('MultiChannelCanvas', () => {
       // Mutate the context mock's window state directly (module-level var)
       // and force a re-render — this is the perf-critical guarantee: the
       // decode effect's deps are
-      // [frameId, containerId, channelsKey, reportDataRange, onLoad, t,
+      // [frameId, containerId, channelsKey, reportChannelRanges, onLoad, t,
       // visibleChannels]. windowMin/windowMax are NOT in that list, so a
       // slider drag re-runs only the (cheap) windowing/composite effect.
       // A regression that re-adds windowMin/windowMax to the decode deps
@@ -623,6 +635,18 @@ describe('MultiChannelCanvas', () => {
 
   describe('reportChannelRanges', () => {
     it('reports every channel separately, not one combined range', async () => {
+      // The channels MUST decode to different values here. With the default
+      // all-zero fixture this assertion pins only the argument shape, and a
+      // regression that computes the union and writes that one pair under every
+      // channel key passes it — i.e. the original bug wearing the new API.
+      const ctx = installSharedCanvasContext();
+      let call = 0;
+      ctx.getImageData = vi.fn((_x, _y, w: number, h: number) => {
+        const data = new Uint8ClampedArray(w * h * 4);
+        data.fill(call++ === 0 ? 10 : 200);
+        return { data, width: w, height: h };
+      }) as unknown as typeof ctx.getImageData;
+
       const { fetchImpl } = makeSuccessfulFetch();
       global.fetch = fetchImpl;
 
@@ -631,15 +655,13 @@ describe('MultiChannelCanvas', () => {
         await new Promise(r => setTimeout(r, 50));
       });
 
-      // The fake-blob 8-bit decode path produces all-zero samples (jsdom's
-      // mocked getImageData returns a zeroed Uint8ClampedArray), so every
-      // channel's min and max collapse to 0 — but each still arrives under its
-      // OWN key, which is what lets the context window them independently.
-      // `containerId` is undefined in DEFAULT_PROPS, so the key is ''.
+      // Decode order follows the fetchChannels array, so ch1 sees 10 and ch2
+      // sees 200. `containerId` is undefined in DEFAULT_PROPS, so the key is
+      // null — which the context reads as "always a new container".
       await waitFor(() => {
         expect(mockReportChannelRanges).toHaveBeenCalledWith(
-          { ch1: { min: 0, max: 0 }, ch2: { min: 0, max: 0 } },
-          ''
+          { ch1: { min: 10, max: 10 }, ch2: { min: 200, max: 200 } },
+          null
         );
       });
     });
@@ -815,7 +837,12 @@ describe('MultiChannelCanvas', () => {
       expect(fake.draw).toHaveBeenCalledTimes(1);
 
       // Simulate a Min/Max slider drag on ONE channel: context state changes,
-      // props don't. Only that channel's window moves.
+      // props don't. Only that channel's window moves. The scalar fallback is
+      // moved OFF 0/255 so the ch2 assertion below cannot pass by coincidence —
+      // with the defaults, "identity window" and "borrowed shared window" are
+      // numerically the same thing and a regression to borrowing survives.
+      mockWindowMin = 7;
+      mockWindowMax = 199;
       mockChannelWindows = {
         ch1: { min: 10, max: 200, rangeMax: 255, dataMin: 0 },
       };
@@ -914,5 +941,40 @@ describe('MultiChannelCanvas', () => {
       expect(screen.getByTestId('multi-channel-canvas')).toBeInTheDocument();
       expect(onLoad).toHaveBeenCalledWith(400, 300, 'ch1|ch2');
     });
+  });
+});
+
+// ── CPU composite path: one LUT per channel ─────────────────────────────────
+//
+// This path runs whenever WebGL2 is unavailable or the context is lost. It is
+// the half of the per-channel window fix that no pixel assertion covers, so a
+// regression to a single shared table here would silently restore the exact
+// bug — a narrow channel drawn through a wide channel's window — on every
+// machine without WebGL2.
+
+describe('MultiChannelCanvas — CPU composite windows', () => {
+  it("builds one LUT per channel, each from that channel's own window", async () => {
+    installSharedCanvasContext();
+    // No compositor => the component falls back to the 2-D path.
+    vi.mocked(createCompositor).mockReturnValue(null);
+    mockChannelWindows = {
+      ch1: { min: 2941, max: 4145, rangeMax: 4145, dataMin: 2941 },
+      ch2: { min: 489, max: 53927, rangeMax: 53927, dataMin: 489 },
+    };
+    const { fetchImpl } = makeSuccessfulFetch();
+    global.fetch = fetchImpl;
+    vi.mocked(buildLut).mockClear();
+
+    await act(async () => {
+      render(<MultiChannelCanvas {...DEFAULT_PROPS} />);
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(buildLut).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    const calls = vi.mocked(buildLut).mock.calls;
+    expect(calls).toContainEqual([2941, 4145, 4145]);
+    expect(calls).toContainEqual([489, 53927, 53927]);
   });
 });

--- a/src/pages/segmentation/components/sidebar/DisplaySection.tsx
+++ b/src/pages/segmentation/components/sidebar/DisplaySection.tsx
@@ -2,14 +2,20 @@
  * Sidebar card with four image-display sliders: Min, Max, Brightness,
  * Contrast. Each row is a Radix Slider paired with a numeric Input
  * (Input ↔ Slider sync follows the FrameSlider pattern). Brightness/
- * Contrast persist across frame and channel changes; Min/Max persist
- * across frame scrubs (fixing the old min/max-resets-per-frame annoyance)
- * but auto-refit to the new data range when the channel set changes.
+ * Contrast are global and persist across frame and channel changes.
  *
- * Min/Max are the ImageJ-style window/level cutoffs: MultiChannelCanvas
- * remaps the true (16-bit-aware) sample values through a LUT, and the
- * slider range auto-scales to each channel set's data range. Brightness/
- * Contrast apply via CSS `filter`. The two compose at draw time.
+ * Min/Max are the ImageJ-style window/level cutoffs and belong to ONE CHANNEL
+ * at a time — the tabs above them pick which. Channels in a composite differ in
+ * dynamic range by more than an order of magnitude, and a shared window makes
+ * the narrow one unreadable: an IRM channel spanning 2941..4145 shown through
+ * the 489..53927 its TIRF siblings need is a flat grey field, which is how a
+ * correct segmentation came to look like "MTs drawn where there is nothing".
+ * The tabs default to the segmentation source, so the channel the model ran on
+ * is the one the user is adjusting unless they say otherwise.
+ *
+ * MultiChannelCanvas remaps each channel's true (16-bit-aware) samples through
+ * its own LUT; Brightness/Contrast apply once, via CSS `filter`, on the
+ * composite. The two compose at draw time.
  */
 
 import { RotateCcw } from 'lucide-react';
@@ -80,14 +86,22 @@ export default function DisplaySection() {
     windowMin,
     windowMax,
     windowRangeMax,
+    windowChannel,
+    visibleChannels,
+    channelColors,
     brightness,
     contrast,
     setWindowMin,
     setWindowMax,
+    setActiveWindowChannel,
     setBrightness,
     setContrast,
     resetDisplay,
   } = useImageDisplay();
+
+  // Only worth the row when there is a choice to make. One channel (or none,
+  // for a plain image) means the sliders can only mean that channel anyway.
+  const showChannelTabs = visibleChannels.length > 1;
 
   return (
     <div className="w-full shrink-0 bg-white dark:bg-gray-800 border-l border-b border-gray-200 dark:border-gray-700">
@@ -107,6 +121,47 @@ export default function DisplaySection() {
         </Button>
       </div>
       <div className="p-4 space-y-3">
+        {showChannelTabs && (
+          <div className="space-y-1">
+            <span className="text-xs text-gray-700 dark:text-gray-300">
+              {t('editor.windowLevel.channel')}
+            </span>
+            <div
+              role="tablist"
+              aria-label={String(t('editor.windowLevel.channel'))}
+              className="flex flex-wrap gap-1"
+            >
+              {visibleChannels.map(ch => {
+                const active = ch === windowChannel;
+                return (
+                  <button
+                    key={ch}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setActiveWindowChannel(ch)}
+                    title={ch}
+                    className={
+                      'flex items-center gap-1 rounded px-2 py-1 text-xs max-w-full ' +
+                      (active
+                        ? 'bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-100'
+                        : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700')
+                    }
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="h-2 w-2 shrink-0 rounded-full border border-gray-400"
+                      style={{
+                        backgroundColor: channelColors[ch] ?? '#FFFFFF',
+                      }}
+                    />
+                    <span className="truncate">{ch}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
         <DisplaySliderRow
           label={t('editor.windowLevel.min')}
           value={windowMin}

--- a/src/pages/segmentation/components/sidebar/DisplaySection.tsx
+++ b/src/pages/segmentation/components/sidebar/DisplaySection.tsx
@@ -6,12 +6,11 @@
  *
  * Min/Max are the ImageJ-style window/level cutoffs and belong to ONE CHANNEL
  * at a time — the tabs above them pick which. Channels in a composite differ in
- * dynamic range by more than an order of magnitude, and a shared window makes
- * the narrow one unreadable: an IRM channel spanning 2941..4145 shown through
- * the 489..53927 its TIRF siblings need is a flat grey field, which is how a
- * correct segmentation came to look like "MTs drawn where there is nothing".
- * The tabs default to the segmentation source, so the channel the model ran on
- * is the one the user is adjusting unless they say otherwise.
+ * dynamic range by more than an order of magnitude, and one shared window makes
+ * the narrow one an unreadable flat field; `ImageDisplayContext`'s
+ * `channelWindows` records what that cost. The tabs default to the segmentation
+ * source, so the channel the model ran on is the one being adjusted unless the
+ * user says otherwise.
  *
  * MultiChannelCanvas remaps each channel's true (16-bit-aware) samples through
  * its own LUT; Brightness/Contrast apply once, via CSS `filter`, on the

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -23,6 +23,32 @@ import {
 } from 'react';
 import { logger } from '@/lib/logger';
 
+/** One channel's window/level, in raw sample units.
+ *
+ *  `min`/`max` are the user-facing cutoffs; `rangeMax`/`dataMin` are the
+ *  brightest/dimmest samples the channel has actually shown, which bound the
+ *  sliders and are what "Reset" re-fits to. Keeping the bounds per channel is
+ *  what lets a 12-bit IRM channel and a 16-bit fluorescence channel each be
+ *  legible in the same composite. */
+export interface ChannelWindow {
+  min: number;
+  max: number;
+  rangeMax: number;
+  dataMin: number;
+}
+
+/** Window for images with no channel set (standalone frames, single-channel
+ *  videos). The empty string can never collide with a real channel name. */
+export const FALLBACK_CHANNEL = '';
+
+/** 8-bit defaults, used until a frame reports its true range. */
+const DEFAULT_CHANNEL_WINDOW: ChannelWindow = {
+  min: 0,
+  max: 255,
+  rangeMax: 255,
+  dataMin: 0,
+};
+
 interface ImageDisplayState {
   /** Active video frame (0-based). Undefined for non-video images. */
   frameIndex: number | undefined;
@@ -52,21 +78,21 @@ interface ImageDisplayState {
    *  arrives in `X-Proxy-Range`. It is the starting point for the banding
    *  guard, which switches to each channel's real range as frames arrive. */
   proxyRangeMax: number | null;
-  /** Lower window cutoff (0..windowRangeMax) — pixels at/below this map to
-   *  black. Same units as the source samples: 0..255 for 8-bit, 0..65535
-   *  for 16-bit microscopy frames. */
-  windowMin: number;
-  /** Upper window cutoff (0..windowRangeMax) — pixels at/above this map to
-   *  white. */
-  windowMax: number;
-  /** Slider/clamp upper bound = the brightest sample value of the current
-   *  channel set. 255 until a frame reports its true range (8-bit default,
-   *  and standalone <img> images that never decode). ImageJ-style: opening
-   *  a 16-bit frame rescales this to the data's max. */
-  windowRangeMax: number;
-  /** Dimmest sample value of the current channel set — the auto-scaled
-   *  window floor and the Reset target. */
-  dataMin: number;
+  /** Window/level PER CHANNEL, keyed by channel name; {@link FALLBACK_CHANNEL}
+   *  ('') holds the window for images that have no channel set at all.
+   *
+   *  One shared window was the bug Marika reported on 2026-08-24 as "model
+   *  segments MTs where there is nothing": it auto-fitted to the UNION of every
+   *  visible channel's range, so an IRM channel spanning 2941..4145 was drawn
+   *  through the 489..53927 window its TIRF siblings opened — 2 % of the range,
+   *  i.e. a flat grey field. The microtubules the model had correctly traced
+   *  were invisible underneath their own polylines. Channels differ in dynamic
+   *  range by more than an order of magnitude, so each needs its own window;
+   *  this is also what ImageJ does for a composite stack. */
+  channelWindows: Record<string, ChannelWindow>;
+  /** Which channel the Display panel's Min/Max sliders edit, and which one the
+   *  scalar `window*` fields below project. Null = {@link FALLBACK_CHANNEL}. */
+  activeWindowChannel: string | null;
   /** Brightness as a percentage (0..200, 100 = unchanged). Applied via
    *  CSS `filter: brightness(b/100)` on the rendered image. */
   brightness: number;
@@ -76,6 +102,16 @@ interface ImageDisplayState {
 }
 
 interface ImageDisplayContextValue extends ImageDisplayState {
+  /** The active channel's window, flattened for the four consumers that only
+   *  ever need one at a time (the Display panel's sliders, and the proxy gate's
+   *  no-channel fallback). A VIEW of `channelWindows[windowChannel]`, never a
+   *  second copy: every write goes through `channelWindows`. */
+  windowMin: number;
+  windowMax: number;
+  /** Slider ceiling for the active channel = its brightest sample so far. */
+  windowRangeMax: number;
+  /** Slider floor for the active channel = its dimmest sample so far. */
+  dataMin: number;
   setFrameIndex: (frameIndex: number) => void;
   setChannel: (channel: string | null) => void;
   /** Toggle whether `channel` is composited onto the canvas. The order
@@ -101,12 +137,23 @@ interface ImageDisplayContextValue extends ImageDisplayState {
   setWindow: (min: number, max: number) => void;
   setWindowMin: (min: number) => void;
   setWindowMax: (max: number) => void;
-  /** Called by the canvas once it has decoded a frame's true sample range.
-   *  `key` fingerprints the video container + channel set; a new key auto-fits
-   *  the window to [min, max] (ImageJ default), while frame scrubs within the
-   *  same key keep the user's window but still widen the clamp ceiling/floor so
-   *  a brighter/dimmer later frame stays reachable. */
-  reportDataRange: (min: number, max: number, key: string) => void;
+  /** Called by the multi-channel canvas with EVERY decoded channel's own sample
+   *  range. `containerKey` fingerprints the video container: a new container
+   *  drops the old windows entirely, while within one container a channel seen
+   *  for the first time auto-fits and an already-fitted one keeps the user's
+   *  window (its bounds still widen so a brighter/dimmer later frame stays
+   *  reachable). Toggling a channel on therefore fits just that channel and
+   *  leaves the others exactly where the user put them. */
+  reportChannelRanges: (
+    ranges: Record<string, { min: number; max: number }>,
+    containerKey: string
+  ) => void;
+  /** Choose which channel the Min/Max sliders edit. Null restores the default
+   *  pick (the segmentation source). */
+  setActiveWindowChannel: (channel: string | null) => void;
+  /** The channel the scalar `window*` fields above actually describe, after
+   *  defaulting. `''` means the no-channel fallback window. */
+  windowChannel: string;
   setBrightness: (brightness: number) => void;
   setContrast: (contrast: number) => void;
   /** Reset window/level back to the auto-scaled data range (ImageJ-style
@@ -126,13 +173,109 @@ const DEFAULT_STATE: ImageDisplayState = {
   channelOpacities: {},
   channelCoverage: {},
   proxyRangeMax: null,
-  windowMin: 0,
-  windowMax: 255,
-  windowRangeMax: 255,
-  dataMin: 0,
+  channelWindows: { [FALLBACK_CHANNEL]: DEFAULT_CHANNEL_WINDOW },
+  activeWindowChannel: null,
   brightness: 100,
   contrast: 100,
 };
+
+/**
+ * Which channel's window the Min/Max sliders read and write.
+ *
+ * An explicit pick wins for as long as that channel still has a window. With no
+ * pick we default to the SEGMENTATION SOURCE (`state.channel`, seeded from the
+ * container's `isSegmentationSource`): it is the channel the model actually ran
+ * on, so it is the one whose window decides whether the user can see what was
+ * segmented. Falling back further: the first visible channel, then the
+ * no-channel pseudo-window.
+ */
+function resolveWindowChannel(s: ImageDisplayState): string {
+  const { activeWindowChannel, channelWindows, visibleChannels, channel } = s;
+  if (activeWindowChannel && activeWindowChannel in channelWindows) {
+    return activeWindowChannel;
+  }
+  if (
+    channel &&
+    visibleChannels.includes(channel) &&
+    channel in channelWindows
+  ) {
+    return channel;
+  }
+  return visibleChannels.find(c => c in channelWindows) ?? FALLBACK_CHANNEL;
+}
+
+/** Every window back to its channel's own [dataMin, rangeMax]. */
+function refitAllWindows(
+  windows: Record<string, ChannelWindow>
+): Record<string, ChannelWindow> {
+  const out: Record<string, ChannelWindow> = {};
+  for (const [channel, w] of Object.entries(windows)) {
+    out[channel] = { ...w, min: w.dataMin, max: w.rangeMax };
+  }
+  return out;
+}
+
+/**
+ * Fold decoded sample ranges into the per-channel windows.
+ *
+ * A channel seen for the first time (or every channel, when `refitAll` is set
+ * because the container changed) AUTO-FITS to its own data — ImageJ's behaviour
+ * on opening a 16-bit image. A channel already carrying a window keeps the
+ * user's cutoffs and only widens its bounds, so scrubbing to a brighter or
+ * dimmer frame never yanks the view but also never leaves the new extremes
+ * unreachable by the sliders.
+ *
+ * `dropUnlisted` removes windows for channels not in `ranges`; it is set only
+ * on a container switch, where a same-named channel of a different video would
+ * otherwise inherit a stale window.
+ */
+function applyRanges(
+  s: ImageDisplayState,
+  ranges: Record<string, { min: number; max: number }>,
+  refitAll: boolean,
+  dropUnlisted: boolean
+): ImageDisplayState {
+  const next: Record<string, ChannelWindow> = dropUnlisted
+    ? {}
+    : { ...s.channelWindows };
+  let changed = dropUnlisted
+    ? Object.keys(s.channelWindows).some(k => !(k in ranges))
+    : false;
+
+  for (const [channel, raw] of Object.entries(ranges)) {
+    const hi = Math.max(1, Math.round(raw.max));
+    const lo = Math.max(0, Math.min(Math.round(raw.min), hi));
+    const current = dropUnlisted ? undefined : s.channelWindows[channel];
+    if (!current || refitAll) {
+      const fitted = { min: lo, max: hi, rangeMax: hi, dataMin: lo };
+      if (
+        !current ||
+        current.min !== lo ||
+        current.max !== hi ||
+        current.rangeMax !== hi ||
+        current.dataMin !== lo
+      ) {
+        changed = true;
+      }
+      next[channel] = fitted;
+      continue;
+    }
+    const rangeMax = Math.max(current.rangeMax, hi);
+    const dataMin = Math.min(current.dataMin, lo);
+    if (rangeMax === current.rangeMax && dataMin === current.dataMin) continue;
+    next[channel] = { ...current, rangeMax, dataMin };
+    changed = true;
+  }
+
+  // The fallback window belongs to no channel, so a container switch must not
+  // sweep it away with the rest.
+  if (dropUnlisted && !(FALLBACK_CHANNEL in next)) {
+    next[FALLBACK_CHANNEL] =
+      s.channelWindows[FALLBACK_CHANNEL] ?? DEFAULT_CHANNEL_WINDOW;
+  }
+
+  return changed ? { ...s, channelWindows: next } : s;
+}
 
 /**
  * Exported so callers that want to *optionally* read the context (e.g.
@@ -351,27 +494,57 @@ export function ImageDisplayProvider({
     }));
   }, []);
 
-  const setWindow = useCallback((min: number, max: number) => {
-    setState(s => ({
-      ...s,
-      windowMin: clampWindow(min, s.windowRangeMax),
-      windowMax: clampWindow(max, s.windowRangeMax),
-    }));
+  const setActiveWindowChannel = useCallback((channel: string | null) => {
+    setState(s => ({ ...s, activeWindowChannel: channel }));
   }, []);
 
-  const setWindowMin = useCallback((min: number) => {
-    setState(s => ({
-      ...s,
-      windowMin: clampWindow(Math.min(min, s.windowMax), s.windowRangeMax),
-    }));
-  }, []);
+  /** Rewrite the active channel's window. `edit` receives the channel's CURRENT
+   *  window (never undefined — an unseen channel starts at the 8-bit default),
+   *  so every setter below clamps against that channel's own bounds instead of
+   *  a global ceiling that may belong to a much brighter sibling. */
+  const editActiveWindow = useCallback(
+    (edit: (w: ChannelWindow) => ChannelWindow) => {
+      setState(s => {
+        const key = resolveWindowChannel(s);
+        const current = s.channelWindows[key] ?? DEFAULT_CHANNEL_WINDOW;
+        const next = edit(current);
+        if (next.min === current.min && next.max === current.max) return s;
+        return { ...s, channelWindows: { ...s.channelWindows, [key]: next } };
+      });
+    },
+    []
+  );
 
-  const setWindowMax = useCallback((max: number) => {
-    setState(s => ({
-      ...s,
-      windowMax: clampWindow(Math.max(max, s.windowMin), s.windowRangeMax),
-    }));
-  }, []);
+  const setWindow = useCallback(
+    (min: number, max: number) => {
+      editActiveWindow(w => ({
+        ...w,
+        min: clampWindow(min, w.rangeMax),
+        max: clampWindow(max, w.rangeMax),
+      }));
+    },
+    [editActiveWindow]
+  );
+
+  const setWindowMin = useCallback(
+    (min: number) => {
+      editActiveWindow(w => ({
+        ...w,
+        min: clampWindow(Math.min(min, w.max), w.rangeMax),
+      }));
+    },
+    [editActiveWindow]
+  );
+
+  const setWindowMax = useCallback(
+    (max: number) => {
+      editActiveWindow(w => ({
+        ...w,
+        max: clampWindow(Math.max(max, w.min), w.rangeMax),
+      }));
+    },
+    [editActiveWindow]
+  );
 
   // Called by the multi-channel canvas after it decodes a frame's true
   // 16-bit samples. `key` fingerprints the video container + channel set
@@ -383,30 +556,18 @@ export function ImageDisplayProvider({
   //     to encompass a brighter/dimmer later frame — otherwise a stale LUT
   //     would clip a later frame's bright signal to white and the Max slider
   //     couldn't reach it.
-  const lastRangeKeyRef = useRef<string | null>(null);
-  const reportDataRange = useCallback(
-    (min: number, max: number, key: string) => {
-      const hi = Math.max(1, Math.round(max));
-      const lo = Math.max(0, Math.min(Math.round(min), hi));
-      const isNewKey = lastRangeKeyRef.current !== key;
-      lastRangeKeyRef.current = key;
-      setState(s => {
-        if (isNewKey) {
-          return {
-            ...s,
-            dataMin: lo,
-            windowRangeMax: hi,
-            windowMin: lo,
-            windowMax: hi,
-          };
-        }
-        const nextRangeMax = Math.max(s.windowRangeMax, hi);
-        const nextDataMin = Math.min(s.dataMin, lo);
-        if (nextRangeMax === s.windowRangeMax && nextDataMin === s.dataMin) {
-          return s;
-        }
-        return { ...s, dataMin: nextDataMin, windowRangeMax: nextRangeMax };
-      });
+  // Keyed on the CONTAINER, not on the channel set: toggling a channel must fit
+  // only the newcomer, not re-fit (and so discard) the windows the user has
+  // already tuned on the channels that were already showing.
+  const lastContainerKeyRef = useRef<string | null>(null);
+  const reportChannelRanges = useCallback(
+    (
+      ranges: Record<string, { min: number; max: number }>,
+      containerKey: string
+    ) => {
+      const isNewContainer = lastContainerKeyRef.current !== containerKey;
+      lastContainerKeyRef.current = containerKey;
+      setState(s => applyRanges(s, ranges, isNewContainer, isNewContainer));
     },
     []
   );
@@ -419,11 +580,13 @@ export function ImageDisplayProvider({
     setState(s => ({ ...s, contrast: clampPercent(contrast) }));
   }, []);
 
+  /** Re-fit EVERY channel to its own data range. Per-channel windows mean a
+   *  reset that only touched the selected channel would leave the composite
+   *  half-adjusted, which is not what "Reset" reads as. */
   const resetWindow = useCallback(() => {
     setState(s => ({
       ...s,
-      windowMin: s.dataMin,
-      windowMax: s.windowRangeMax,
+      channelWindows: refitAllWindows(s.channelWindows),
     }));
   }, []);
 
@@ -434,16 +597,27 @@ export function ImageDisplayProvider({
   const resetDisplay = useCallback(() => {
     setState(s => ({
       ...s,
-      windowMin: s.dataMin,
-      windowMax: s.windowRangeMax,
+      channelWindows: refitAllWindows(s.channelWindows),
       brightness: 100,
       contrast: 100,
     }));
   }, []);
 
+  // The scalar window fields are a VIEW of one entry of channelWindows, never a
+  // second copy: everything that writes goes through channelWindows, so the
+  // panel and the canvas can never disagree about what the window is.
+  const windowChannel = resolveWindowChannel(state);
+  const activeWindow =
+    state.channelWindows[windowChannel] ?? DEFAULT_CHANNEL_WINDOW;
+
   const value = useMemo<ImageDisplayContextValue>(
     () => ({
       ...state,
+      windowMin: activeWindow.min,
+      windowMax: activeWindow.max,
+      windowRangeMax: activeWindow.rangeMax,
+      dataMin: activeWindow.dataMin,
+      windowChannel,
       setFrameIndex,
       setChannel,
       toggleChannelVisibility,
@@ -456,7 +630,8 @@ export function ImageDisplayProvider({
       setWindow,
       setWindowMin,
       setWindowMax,
-      reportDataRange,
+      reportChannelRanges,
+      setActiveWindowChannel,
       setBrightness,
       setContrast,
       resetWindow,
@@ -465,6 +640,8 @@ export function ImageDisplayProvider({
     }),
     [
       state,
+      activeWindow,
+      windowChannel,
       setFrameIndex,
       setChannel,
       toggleChannelVisibility,
@@ -477,7 +654,8 @@ export function ImageDisplayProvider({
       setWindow,
       setWindowMin,
       setWindowMax,
-      reportDataRange,
+      reportChannelRanges,
+      setActiveWindowChannel,
       setBrightness,
       setContrast,
       resetWindow,

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -89,7 +89,7 @@ interface ImageDisplayState {
    *  were invisible underneath their own polylines. Channels differ in dynamic
    *  range by more than an order of magnitude, so each needs its own window;
    *  this is also what ImageJ does for a composite stack. */
-  channelWindows: Record<string, ChannelWindow>;
+  channelWindows: Readonly<Partial<Record<string, ChannelWindow>>>;
   /** Which channel the Display panel's Min/Max sliders edit, and which one the
    *  scalar `window*` fields below project. Null = {@link FALLBACK_CHANNEL}. */
   activeWindowChannel: string | null;
@@ -106,12 +106,10 @@ interface ImageDisplayContextValue extends ImageDisplayState {
    *  ever need one at a time (the Display panel's sliders, and the proxy gate's
    *  no-channel fallback). A VIEW of `channelWindows[windowChannel]`, never a
    *  second copy: every write goes through `channelWindows`. */
-  windowMin: number;
-  windowMax: number;
+  readonly windowMin: number;
+  readonly windowMax: number;
   /** Slider ceiling for the active channel = its brightest sample so far. */
-  windowRangeMax: number;
-  /** Slider floor for the active channel = its dimmest sample so far. */
-  dataMin: number;
+  readonly windowRangeMax: number;
   setFrameIndex: (frameIndex: number) => void;
   setChannel: (channel: string | null) => void;
   /** Toggle whether `channel` is composited onto the canvas. The order
@@ -146,7 +144,7 @@ interface ImageDisplayContextValue extends ImageDisplayState {
    *  leaves the others exactly where the user put them. */
   reportChannelRanges: (
     ranges: Record<string, { min: number; max: number }>,
-    containerKey: string
+    containerKey: string | null
   ) => void;
   /** Choose which channel the Min/Max sliders edit. Null restores the default
    *  pick (the segmentation source). */
@@ -191,7 +189,16 @@ const DEFAULT_STATE: ImageDisplayState = {
  */
 function resolveWindowChannel(s: ImageDisplayState): string {
   const { activeWindowChannel, channelWindows, visibleChannels, channel } = s;
-  if (activeWindowChannel && activeWindowChannel in channelWindows) {
+  // The pick must still be VISIBLE, not merely still have a window. Hiding a
+  // channel leaves its window in the map (only a container switch sweeps
+  // those), so without this test the sliders stayed bound to a channel nothing
+  // draws: no tab read as selected, and once one channel was left the tab row
+  // disappeared entirely while the sliders went on editing the hidden one.
+  if (
+    activeWindowChannel &&
+    visibleChannels.includes(activeWindowChannel) &&
+    activeWindowChannel in channelWindows
+  ) {
     return activeWindowChannel;
   }
   if (
@@ -206,11 +213,11 @@ function resolveWindowChannel(s: ImageDisplayState): string {
 
 /** Every window back to its channel's own [dataMin, rangeMax]. */
 function refitAllWindows(
-  windows: Record<string, ChannelWindow>
-): Record<string, ChannelWindow> {
-  const out: Record<string, ChannelWindow> = {};
+  windows: Readonly<Partial<Record<string, ChannelWindow>>>
+): Partial<Record<string, ChannelWindow>> {
+  const out: Partial<Record<string, ChannelWindow>> = {};
   for (const [channel, w] of Object.entries(windows)) {
-    out[channel] = { ...w, min: w.dataMin, max: w.rangeMax };
+    if (w) out[channel] = { ...w, min: w.dataMin, max: w.rangeMax };
   }
   return out;
 }
@@ -235,7 +242,7 @@ function applyRanges(
   refitAll: boolean,
   dropUnlisted: boolean
 ): ImageDisplayState {
-  const next: Record<string, ChannelWindow> = dropUnlisted
+  const next: Partial<Record<string, ChannelWindow>> = dropUnlisted
     ? {}
     : { ...s.channelWindows };
   let changed = dropUnlisted
@@ -262,6 +269,21 @@ function applyRanges(
     }
     const rangeMax = Math.max(current.rangeMax, hi);
     const dataMin = Math.min(current.dataMin, lo);
+    // A first frame that decoded flat (an unilluminated channel of a
+    // multi-channel stack reports min === max) fits to the sanitisation floor,
+    // 0..1. The widening branch below only moves the BOUNDS, so that window
+    // would stand for the rest of the container and clamp every later frame to
+    // white. Re-fit it once a frame arrives with real range — but only while it
+    // is still the untouched full extent, so a window the user deliberately
+    // collapsed on real data is never overwritten.
+    const untouched =
+      current.min === current.dataMin && current.max === current.rangeMax;
+    const noRealRangeYet = current.rangeMax - current.dataMin <= 1;
+    if (untouched && noRealRangeYet && hi > lo) {
+      next[channel] = { min: lo, max: hi, rangeMax, dataMin };
+      changed = true;
+      continue;
+    }
     if (rangeMax === current.rangeMax && dataMin === current.dataMin) continue;
     next[channel] = { ...current, rangeMax, dataMin };
     changed = true;
@@ -563,9 +585,15 @@ export function ImageDisplayProvider({
   const reportChannelRanges = useCallback(
     (
       ranges: Record<string, { min: number; max: number }>,
-      containerKey: string
+      containerKey: string | null
     ) => {
-      const isNewContainer = lastContainerKeyRef.current !== containerKey;
+      // A null key means "no container id to compare", which has to read as a
+      // NEW container every time. Folding it to '' instead made two different
+      // id-less videos share one key, so the second inherited the first's
+      // window over data it does not describe — the same flat-field failure
+      // this per-channel work exists to remove.
+      const isNewContainer =
+        containerKey === null || lastContainerKeyRef.current !== containerKey;
       lastContainerKeyRef.current = containerKey;
       setState(s => applyRanges(s, ranges, isNewContainer, isNewContainer));
     },
@@ -616,7 +644,6 @@ export function ImageDisplayProvider({
       windowMin: activeWindow.min,
       windowMax: activeWindow.max,
       windowRangeMax: activeWindow.rangeMax,
-      dataMin: activeWindow.dataMin,
       windowChannel,
       setFrameIndex,
       setChannel,

--- a/src/pages/segmentation/contexts/ImageDisplayContext.tsx
+++ b/src/pages/segmentation/contexts/ImageDisplayContext.tsx
@@ -6,9 +6,10 @@
  * brightness/contrast values applied via a CSS filter on the rendered
  * canvas. None of it is persisted across reloads. Brightness/Contrast
  * persist across both frame and channel changes; the Min/Max window
- * persists across frame scrubs (so scrubbing a 300-frame video keeps the
- * user's adjustment) but auto-refits to the new data range whenever the
- * visible-channel set or video changes, ImageJ-style.
+ * is held PER CHANNEL: it persists across frame scrubs (so scrubbing a
+ * 300-frame video keeps the user's adjustment) and each channel auto-refits to
+ * its own data the first time that channel is seen, or whenever the video
+ * changes, ImageJ-style.
  */
 
 import {
@@ -110,6 +111,12 @@ interface ImageDisplayContextValue extends ImageDisplayState {
   readonly windowMax: number;
   /** Slider ceiling for the active channel = its brightest sample so far. */
   readonly windowRangeMax: number;
+  /** The window for images with no channel set. Exposed so the playback-proxy
+   *  gate can ask for it directly instead of reaching into `channelWindows`
+   *  with the pseudo-key, or — worse — reading it off the scalar projection,
+   *  which only happens to be the fallback because of how the slider-focus
+   *  resolver orders its last branch. */
+  readonly fallbackWindow: ChannelWindow;
   setFrameIndex: (frameIndex: number) => void;
   setChannel: (channel: string | null) => void;
   /** Toggle whether `channel` is composited onto the canvas. The order
@@ -180,8 +187,8 @@ const DEFAULT_STATE: ImageDisplayState = {
 /**
  * Which channel's window the Min/Max sliders read and write.
  *
- * An explicit pick wins for as long as that channel still has a window. With no
- * pick we default to the SEGMENTATION SOURCE (`state.channel`, seeded from the
+ * An explicit pick wins for as long as that channel is still VISIBLE and still
+ * has a window. With no pick we default to the SEGMENTATION SOURCE (`state.channel`, seeded from the
  * container's `isSegmentationSource`): it is the channel the model actually ran
  * on, so it is the one whose window decides whether the user can see what was
  * segmented. Falling back further: the first visible channel, then the
@@ -230,7 +237,13 @@ function refitAllWindows(
  * on opening a 16-bit image. A channel already carrying a window keeps the
  * user's cutoffs and only widens its bounds, so scrubbing to a brighter or
  * dimmer frame never yanks the view but also never leaves the new extremes
- * unreachable by the sliders.
+ * unreachable by the sliders. The one exception is a channel that has never had
+ * a usable range to fit to; see the re-fit branch below.
+ *
+ * `refitAll` and `dropUnlisted` are not independent in practice: `dropUnlisted`
+ * clears `current`, which already forces the fit, and the sole caller passes
+ * the same flag to both. They are separate parameters only so the two effects
+ * are named where they happen.
  *
  * `dropUnlisted` removes windows for channels not in `ranges`; it is set only
  * on a container switch, where a same-named channel of a different video would
@@ -269,13 +282,19 @@ function applyRanges(
     }
     const rangeMax = Math.max(current.rangeMax, hi);
     const dataMin = Math.min(current.dataMin, lo);
-    // A first frame that decoded flat (an unilluminated channel of a
-    // multi-channel stack reports min === max) fits to the sanitisation floor,
-    // 0..1. The widening branch below only moves the BOUNDS, so that window
+    // A frame that decoded flat (an unilluminated channel reports min === max,
+    // at 0 or at whatever baseline offset the camera adds) fits to a zero-width
+    // window. The widening branch below moves only the BOUNDS, so that window
     // would stand for the rest of the container and clamp every later frame to
-    // white. Re-fit it once a frame arrives with real range — but only while it
-    // is still the untouched full extent, so a window the user deliberately
-    // collapsed on real data is never overwritten.
+    // white. Re-fit it once a frame arrives with real range.
+    //
+    // `noRealRangeYet` is what identifies that state — a window collapsed on
+    // REAL data has wide bounds and never reaches here. `untouched` does
+    // something else, and is the deliberate part: if the user moved the sliders
+    // while the channel was still flat, they own the window from then on and it
+    // is never auto-recovered, even though that leaves the channel white until
+    // they widen it themselves. Silently overruling an explicit adjustment is
+    // the worse surprise.
     const untouched =
       current.min === current.dataMin && current.max === current.rangeMax;
     const noRealRangeYet = current.rangeMax - current.dataMin <= 1;
@@ -644,6 +663,8 @@ export function ImageDisplayProvider({
       windowMin: activeWindow.min,
       windowMax: activeWindow.max,
       windowRangeMax: activeWindow.rangeMax,
+      fallbackWindow:
+        state.channelWindows[FALLBACK_CHANNEL] ?? DEFAULT_CHANNEL_WINDOW,
       windowChannel,
       setFrameIndex,
       setChannel,

--- a/src/pages/segmentation/contexts/__tests__/ImageDisplayContext.test.tsx
+++ b/src/pages/segmentation/contexts/__tests__/ImageDisplayContext.test.tsx
@@ -76,7 +76,7 @@ describe('ImageDisplayProvider + useImageDisplay', () => {
       expect(result.current.windowMin).toBe(0);
       expect(result.current.windowMax).toBe(255);
       expect(result.current.windowRangeMax).toBe(255);
-      expect(result.current.dataMin).toBe(0);
+      expect(result.current.channelWindows['']?.dataMin).toBe(0);
       expect(result.current.brightness).toBe(100);
       expect(result.current.contrast).toBe(100);
     });
@@ -763,6 +763,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
     });
     act(() => {
@@ -788,6 +789,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
       result.current.setActiveWindowChannel('WD_LED_IRM');
     });
@@ -795,11 +797,11 @@ describe('per-channel window/level', () => {
       result.current.setWindow(3000, 3800);
     });
 
-    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
-    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
+    expect(result.current.channelWindows.WD_LED_IRM?.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(3800);
     // Untouched — this is the whole point.
-    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
-    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
+    expect(result.current.channelWindows.TIRF_491?.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491?.max).toBe(53927);
   });
 
   it('clamps an edit to the ACTIVE channel bound, not to some global one', () => {
@@ -808,6 +810,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
       result.current.setActiveWindowChannel('WD_LED_IRM');
     });
@@ -815,7 +818,7 @@ describe('per-channel window/level', () => {
       result.current.setWindowMax(99999); // far past IRM's own ceiling
     });
 
-    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(4145);
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(4145);
   });
 
   it('keeps a user window on a same-container scrub but widens that channel bound', () => {
@@ -824,6 +827,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
       result.current.setActiveWindowChannel('WD_LED_IRM');
     });
@@ -838,10 +842,10 @@ describe('per-channel window/level', () => {
       );
     });
 
-    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
-    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
-    expect(result.current.channelWindows.WD_LED_IRM.rangeMax).toBe(4400);
-    expect(result.current.channelWindows.WD_LED_IRM.dataMin).toBe(2900);
+    expect(result.current.channelWindows.WD_LED_IRM?.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(3800);
+    expect(result.current.channelWindows.WD_LED_IRM?.rangeMax).toBe(4400);
+    expect(result.current.channelWindows.WD_LED_IRM?.dataMin).toBe(2900);
   });
 
   it('auto-fits a channel switched on mid-session without disturbing the others', () => {
@@ -850,6 +854,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(
         { WD_LED_IRM: ranges.WD_LED_IRM },
         'container-1'
@@ -864,10 +869,10 @@ describe('per-channel window/level', () => {
       result.current.reportChannelRanges(ranges, 'container-1');
     });
 
-    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
-    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
-    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
-    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
+    expect(result.current.channelWindows.TIRF_491?.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491?.max).toBe(53927);
+    expect(result.current.channelWindows.WD_LED_IRM?.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(3800);
   });
 
   it('re-fits everything when the container changes', () => {
@@ -876,6 +881,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
       result.current.setActiveWindowChannel('WD_LED_IRM');
     });
@@ -905,6 +911,7 @@ describe('per-channel window/level', () => {
     });
 
     act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
       result.current.reportChannelRanges(ranges, 'container-1');
       result.current.setActiveWindowChannel('WD_LED_IRM');
     });
@@ -919,10 +926,10 @@ describe('per-channel window/level', () => {
       result.current.resetWindow();
     });
 
-    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(2941);
-    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(4145);
-    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
-    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
+    expect(result.current.channelWindows.WD_LED_IRM?.min).toBe(2941);
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(4145);
+    expect(result.current.channelWindows.TIRF_491?.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491?.max).toBe(53927);
   });
 
   it('falls back to the pseudo-channel window when there are no channels', () => {
@@ -1030,5 +1037,204 @@ describe('which channel the sliders act on', () => {
 
     expect(result.current.windowChannel).toBe('DIC');
     expect(result.current.windowMax).toBe(900);
+  });
+});
+
+describe('a pick that stops being visible', () => {
+  const ranges = {
+    WD_LED_IRM: { min: 2941, max: 4145 },
+    TIRF_491: { min: 489, max: 53927 },
+  };
+
+  it('stops editing a channel the user has hidden', () => {
+    // Reported by review: the explicit-pick branch checked only that the
+    // channel still had a window, so hiding it left the Min/Max sliders bound
+    // to a channel nothing draws — with no tab highlighted, and with the tab
+    // row gone entirely once only one channel was left.
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
+      result.current.setChannel('WD_LED_IRM');
+      result.current.reportChannelRanges(ranges, 'container-1');
+    });
+    act(() => {
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+    expect(result.current.windowChannel).toBe('TIRF_491');
+
+    act(() => {
+      result.current.toggleChannelVisibility('TIRF_491');
+    });
+
+    // Falls back to the segmentation source, which IS visible.
+    expect(result.current.windowChannel).toBe('WD_LED_IRM');
+    expect(result.current.windowMax).toBe(4145);
+  });
+
+  it('writes to the visible channel after the pick is dropped', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
+      result.current.setChannel('WD_LED_IRM');
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+    act(() => {
+      result.current.toggleChannelVisibility('TIRF_491');
+    });
+    act(() => {
+      result.current.setWindowMax(3500);
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM?.max).toBe(3500);
+    // The hidden channel must not absorb the edit.
+    expect(result.current.channelWindows.TIRF_491?.max).toBe(53927);
+  });
+
+  it('restores the pick when the channel comes back', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['WD_LED_IRM', 'TIRF_491']);
+      result.current.setChannel('WD_LED_IRM');
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+    act(() => {
+      result.current.toggleChannelVisibility('TIRF_491');
+    });
+    act(() => {
+      result.current.toggleChannelVisibility('TIRF_491');
+    });
+
+    expect(result.current.windowChannel).toBe('TIRF_491');
+  });
+});
+
+describe('a container that reports no id', () => {
+  it('never treats two id-less containers as the same one', () => {
+    // `containerId` is optional on the canvas, and keying an absent id as ''
+    // made two different videos share one key — so the second inherited the
+    // first's window over data it does not describe, which is the very failure
+    // this per-channel work exists to remove.
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['ch1']);
+      result.current.reportChannelRanges({ ch1: { min: 200, max: 400 } }, null);
+    });
+    act(() => {
+      result.current.setWindow(250, 300);
+    });
+    act(() => {
+      // A different video, also without an id.
+      result.current.reportChannelRanges(
+        { ch1: { min: 5000, max: 60000 } },
+        null
+      );
+    });
+
+    expect(result.current.channelWindows.ch1).toEqual({
+      min: 5000,
+      max: 60000,
+      rangeMax: 60000,
+      dataMin: 5000,
+    });
+  });
+});
+
+describe('bounds only ever widen', () => {
+  it('does not shrink a channel ceiling or floor on a dimmer later frame', () => {
+    // Lost when the reportDataRange block was deleted; the behaviour survived
+    // in the code with nothing pinning it. Without this, scrubbing a long video
+    // to a dim frame collapses that channel's slider ceiling to the dim frame's
+    // max, so the next Max drag clamps against the collapsed value and Reset
+    // refits the composite to the dimmest frame ever seen.
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['irm']);
+      result.current.reportChannelRanges(
+        { irm: { min: 2900, max: 4400 } },
+        'c'
+      );
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800); // user takes control
+    });
+    act(() => {
+      // A dimmer, narrower frame of the same video.
+      result.current.reportChannelRanges(
+        { irm: { min: 3200, max: 3900 } },
+        'c'
+      );
+    });
+
+    expect(result.current.channelWindows.irm?.rangeMax).toBe(4400);
+    expect(result.current.channelWindows.irm?.dataMin).toBe(2900);
+  });
+});
+
+describe('a channel whose first frame decodes flat', () => {
+  it('re-fits it once a frame with real range arrives', () => {
+    // An unilluminated channel of a multi-channel stack reports min === max on
+    // its first frame. The widening branch moves only the bounds, so that
+    // zero-width window would stand for the whole container and clamp every
+    // later frame to white.
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['dark']);
+      result.current.reportChannelRanges({ dark: { min: 0, max: 0 } }, 'c');
+    });
+    expect(result.current.channelWindows.dark?.max).toBe(1);
+
+    act(() => {
+      result.current.reportChannelRanges({ dark: { min: 40, max: 9000 } }, 'c');
+    });
+
+    expect(result.current.channelWindows.dark).toEqual({
+      min: 40,
+      max: 9000,
+      rangeMax: 9000,
+      dataMin: 0,
+    });
+  });
+
+  it('leaves a window the user deliberately collapsed alone', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['irm']);
+      result.current.reportChannelRanges({ irm: { min: 0, max: 9000 } }, 'c');
+    });
+    act(() => {
+      result.current.setWindow(500, 500); // deliberate, and non-degenerate data
+    });
+    act(() => {
+      result.current.reportChannelRanges({ irm: { min: 0, max: 9500 } }, 'c');
+    });
+
+    // Re-fitting is only for a channel that never had a usable window; a user
+    // who collapsed one on real data keeps it.
+    expect(result.current.channelWindows.irm?.min).toBe(500);
+    expect(result.current.channelWindows.irm?.max).toBe(500);
+    expect(result.current.channelWindows.irm?.rangeMax).toBe(9500);
   });
 });

--- a/src/pages/segmentation/contexts/__tests__/ImageDisplayContext.test.tsx
+++ b/src/pages/segmentation/contexts/__tests__/ImageDisplayContext.test.tsx
@@ -8,7 +8,8 @@
  *   to an in-memory store so persistence tests work reliably.
  * - Pixel-level window/level remapping lives in MultiChannelCanvas (which
  *   needs a real 2-D pipeline jsdom lacks); here we only cover the state
- *   machine, including reportDataRange's ImageJ-style auto-scale.
+ *   machine, including reportChannelRanges's ImageJ-style per-channel
+ *   auto-scale.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -644,120 +645,6 @@ describe('ImageDisplayProvider + useImageDisplay', () => {
     });
   });
 
-  // ---- reportDataRange (ImageJ-style 16-bit auto-scale) --------------------
-
-  describe('reportDataRange', () => {
-    it('rescales the slider bound and auto-fits the window to the data', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(640, 23480, 'irm|tirf');
-      });
-
-      expect(result.current.windowRangeMax).toBe(23480);
-      expect(result.current.dataMin).toBe(640);
-      expect(result.current.windowMin).toBe(640);
-      expect(result.current.windowMax).toBe(23480);
-    });
-
-    it('lets the window reach 16-bit values after a range report', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(0, 23480, 'tirf');
-      });
-      act(() => {
-        // Would clamp to 255 under the old 8-bit cap; must survive now.
-        result.current.setWindowMax(12000);
-      });
-
-      expect(result.current.windowMax).toBe(12000);
-    });
-
-    it('keeps the window on a same-key frame scrub but widens the clamp ceiling/floor', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(640, 23480, 'tirf');
-      });
-      act(() => {
-        result.current.setWindow(1000, 5000); // user narrows the window
-      });
-      act(() => {
-        // Next frame, same set, but brighter (max 24000) and dimmer floor (600).
-        result.current.reportDataRange(600, 24000, 'tirf');
-      });
-
-      // Window position preserved (not re-auto-fitted)...
-      expect(result.current.windowMin).toBe(1000);
-      expect(result.current.windowMax).toBe(5000);
-      // ...but the clamp ceiling/floor widen so the brighter/dimmer frame
-      // stays reachable and isn't clipped to white by a stale LUT.
-      expect(result.current.windowRangeMax).toBe(24000);
-      expect(result.current.dataMin).toBe(600);
-    });
-
-    it('does not shrink the clamp ceiling/floor when a same-key frame is dimmer', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(640, 23480, 'tirf');
-      });
-      act(() => {
-        result.current.reportDataRange(700, 10000, 'tirf'); // dimmer frame, same set
-      });
-
-      // Ceiling/floor are monotonic within a key — a dimmer frame must not
-      // narrow the reachable range the user already had.
-      expect(result.current.windowRangeMax).toBe(23480);
-      expect(result.current.dataMin).toBe(640);
-    });
-
-    it('re-auto-scales when the channel set changes', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(640, 23480, 'tirf');
-      });
-      act(() => {
-        result.current.reportDataRange(1826, 6017, 'irm');
-      });
-
-      expect(result.current.windowRangeMax).toBe(6017);
-      expect(result.current.windowMin).toBe(1826);
-      expect(result.current.windowMax).toBe(6017);
-    });
-
-    it('resetWindow returns to the auto-scaled data range', () => {
-      const { result } = renderHook(() => useImageDisplay(), {
-        wrapper: makeWrapper(),
-      });
-
-      act(() => {
-        result.current.reportDataRange(640, 23480, 'tirf');
-      });
-      act(() => {
-        result.current.setWindow(2000, 9000);
-      });
-      act(() => {
-        result.current.resetWindow();
-      });
-
-      expect(result.current.windowMin).toBe(640);
-      expect(result.current.windowMax).toBe(23480);
-    });
-  });
-
   // ---- localStorage persistence -------------------------------------------
 
   describe('localStorage persistence', () => {
@@ -827,5 +714,321 @@ describe('ImageDisplayProvider + useImageDisplay', () => {
         expect.anything()
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-channel window/level (ImageJ composite semantics)
+//
+// Marika, 2026-08-24: "Model segments MTs where there is nothing". The model was
+// right; the DISPLAY was wrong. One window fitted to the UNION of every visible
+// channel's range meant an IRM channel spanning 2941..4145 was shown through a
+// 489..53927 window opened by the TIRF channels — 2 % of the range — so the
+// microtubules under the polylines were invisible. Each channel must be windowed
+// by its OWN data.
+// ---------------------------------------------------------------------------
+
+describe('per-channel window/level', () => {
+  const ranges = {
+    WD_LED_IRM: { min: 2941, max: 4145 },
+    TIRF_491: { min: 489, max: 53927 },
+  };
+
+  it('auto-fits every channel to its own range, not to the union', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM).toEqual({
+      min: 2941,
+      max: 4145,
+      rangeMax: 4145,
+      dataMin: 2941,
+    });
+    expect(result.current.channelWindows.TIRF_491).toEqual({
+      min: 489,
+      max: 53927,
+      rangeMax: 53927,
+      dataMin: 489,
+    });
+  });
+
+  it('exposes the ACTIVE channel through the scalar window fields', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+    });
+    act(() => {
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+
+    expect(result.current.windowMin).toBe(2941);
+    expect(result.current.windowMax).toBe(4145);
+    expect(result.current.windowRangeMax).toBe(4145);
+
+    act(() => {
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+
+    expect(result.current.windowMin).toBe(489);
+    expect(result.current.windowMax).toBe(53927);
+    expect(result.current.windowRangeMax).toBe(53927);
+  });
+
+  it('edits only the active channel; the others keep their own window', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800);
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
+    // Untouched — this is the whole point.
+    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
+  });
+
+  it('clamps an edit to the ACTIVE channel bound, not to some global one', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindowMax(99999); // far past IRM's own ceiling
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(4145);
+  });
+
+  it('keeps a user window on a same-container scrub but widens that channel bound', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800);
+    });
+    act(() => {
+      // Next frame of the same video: IRM a touch brighter and dimmer.
+      result.current.reportChannelRanges(
+        { WD_LED_IRM: { min: 2900, max: 4400 }, TIRF_491: ranges.TIRF_491 },
+        'container-1'
+      );
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
+    expect(result.current.channelWindows.WD_LED_IRM.rangeMax).toBe(4400);
+    expect(result.current.channelWindows.WD_LED_IRM.dataMin).toBe(2900);
+  });
+
+  it('auto-fits a channel switched on mid-session without disturbing the others', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(
+        { WD_LED_IRM: ranges.WD_LED_IRM },
+        'container-1'
+      );
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800);
+    });
+    act(() => {
+      // User ticks TIRF_491 on. It is new, so it auto-fits; IRM must not move.
+      result.current.reportChannelRanges(ranges, 'container-1');
+    });
+
+    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
+    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(3000);
+    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(3800);
+  });
+
+  it('re-fits everything when the container changes', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800);
+    });
+    act(() => {
+      result.current.reportChannelRanges(
+        { WD_LED_IRM: { min: 100, max: 900 } },
+        'container-2'
+      );
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM).toEqual({
+      min: 100,
+      max: 900,
+      rangeMax: 900,
+      dataMin: 100,
+    });
+    // The old container's other channel is gone, not stale.
+    expect(result.current.channelWindows.TIRF_491).toBeUndefined();
+  });
+
+  it('resetWindow re-fits EVERY channel to its own data range', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.reportChannelRanges(ranges, 'container-1');
+      result.current.setActiveWindowChannel('WD_LED_IRM');
+    });
+    act(() => {
+      result.current.setWindow(3000, 3800);
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+    act(() => {
+      result.current.setWindow(1000, 2000);
+    });
+    act(() => {
+      result.current.resetWindow();
+    });
+
+    expect(result.current.channelWindows.WD_LED_IRM.min).toBe(2941);
+    expect(result.current.channelWindows.WD_LED_IRM.max).toBe(4145);
+    expect(result.current.channelWindows.TIRF_491.min).toBe(489);
+    expect(result.current.channelWindows.TIRF_491.max).toBe(53927);
+  });
+
+  it('falls back to the pseudo-channel window when there are no channels', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    // A standalone (non-multi-channel) image reports nothing and shows no
+    // channels, so the scalar fields describe the 8-bit fallback window.
+    expect(result.current.activeWindowChannel).toBeNull();
+    expect(result.current.windowChannel).toBe('');
+    expect(result.current.windowMin).toBe(0);
+    expect(result.current.windowMax).toBe(255);
+  });
+});
+
+describe('which channel the sliders act on', () => {
+  it('defaults to the segmentation source, not to the first channel', () => {
+    // Marika's container lists IRM first, but the rule has to hold when it does
+    // not: the segmentation source is the channel the model ran on, so it is the
+    // one whose window decides whether the user can see what was segmented.
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['TIRF_491', 'WD_LED_IRM']);
+      result.current.setChannel('WD_LED_IRM'); // isSegmentationSource
+      result.current.reportChannelRanges(
+        {
+          TIRF_491: { min: 489, max: 53927 },
+          WD_LED_IRM: { min: 2941, max: 4145 },
+        },
+        'container-1'
+      );
+    });
+
+    expect(result.current.windowChannel).toBe('WD_LED_IRM');
+    expect(result.current.windowMax).toBe(4145);
+  });
+
+  it('an explicit pick overrides the default', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['TIRF_491', 'WD_LED_IRM']);
+      result.current.setChannel('WD_LED_IRM');
+      result.current.reportChannelRanges(
+        {
+          TIRF_491: { min: 489, max: 53927 },
+          WD_LED_IRM: { min: 2941, max: 4145 },
+        },
+        'container-1'
+      );
+    });
+    act(() => {
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+
+    expect(result.current.windowChannel).toBe('TIRF_491');
+    expect(result.current.windowMax).toBe(53927);
+  });
+
+  it('falls back to the first visible channel with no segmentation source', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['TIRF_491', 'WD_LED_IRM']);
+      result.current.reportChannelRanges(
+        {
+          TIRF_491: { min: 489, max: 53927 },
+          WD_LED_IRM: { min: 2941, max: 4145 },
+        },
+        'container-1'
+      );
+    });
+
+    expect(result.current.windowChannel).toBe('TIRF_491');
+  });
+
+  it('drops a pick that the new container has no window for', () => {
+    const { result } = renderHook(() => useImageDisplay(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setVisibleChannels(['TIRF_491', 'WD_LED_IRM']);
+      result.current.reportChannelRanges(
+        {
+          TIRF_491: { min: 489, max: 53927 },
+          WD_LED_IRM: { min: 2941, max: 4145 },
+        },
+        'container-1'
+      );
+      result.current.setActiveWindowChannel('TIRF_491');
+    });
+    act(() => {
+      result.current.setVisibleChannels(['DIC']);
+      result.current.reportChannelRanges({ DIC: { min: 10, max: 900 } }, 'c2');
+    });
+
+    expect(result.current.windowChannel).toBe('DIC');
+    expect(result.current.windowMax).toBe(900);
   });
 });

--- a/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
+++ b/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTargetTrackIds } from '../mtTypeTargets';
+import {
+  resolveTargetTrackIds,
+  resolveTargetPolygonIds,
+  applyMtTypeToPolygons,
+  type TypeablePolygon,
+} from '../mtTypeTargets';
 
-const polys = [
+// Typed as TypeablePolygon so `mtType` is a readable property on the results,
+// not an excess-property error on the untyped literal.
+const polys: TypeablePolygon[] = [
   { id: 'a', trackId: 't1' },
   { id: 'b', trackId: 't2' },
   { id: 'c', trackId: 't1' }, // same track as 'a'
@@ -30,7 +37,7 @@ describe('resolveTargetTrackIds', () => {
     ]);
   });
 
-  it('returns [] for an untracked polygon (caller aborts with a toast)', () => {
+  it('returns [] for an untracked polygon (no cross-frame write; typed by id)', () => {
     expect(resolveTargetTrackIds('d', new Set(), polys)).toEqual([]);
     expect(resolveTargetTrackIds('e', new Set(), polys)).toEqual([]);
   });
@@ -42,5 +49,96 @@ describe('resolveTargetTrackIds', () => {
 
   it('returns [] when the clicked id is not among the polygons', () => {
     expect(resolveTargetTrackIds('ghost', new Set(), polys)).toEqual([]);
+  });
+});
+
+describe('resolveTargetPolygonIds', () => {
+  it('uses the clicked polygon for a lone / empty selection', () => {
+    expect([...resolveTargetPolygonIds('b', new Set())]).toEqual(['b']);
+    expect([...resolveTargetPolygonIds('b', new Set(['a']))]).toEqual(['b']);
+  });
+
+  it('uses the whole selection once it has ≥2 members', () => {
+    const out = resolveTargetPolygonIds('a', new Set(['a', 'd']));
+    expect([...out].sort()).toEqual(['a', 'd']);
+  });
+});
+
+describe('applyMtTypeToPolygons', () => {
+  const set = (...ids: string[]) => new Set(ids);
+
+  it('types an untracked, hand-drawn polyline by its id (no trackId needed)', () => {
+    const { polygons: out, changed } = applyMtTypeToPolygons(
+      polys,
+      set('e'),
+      set(),
+      'brain'
+    );
+    expect(out.find(p => p.id === 'e')?.mtType).toBe('brain');
+    expect(changed).toBe(1);
+    // Everything else is untouched (same reference).
+    expect(out.find(p => p.id === 'a')).toBe(polys[0]);
+  });
+
+  it('types a tracked MT and its same-track siblings by trackId', () => {
+    // Target only polygon 'a', but its trackId t1 also covers sibling 'c'.
+    const { polygons: out, changed } = applyMtTypeToPolygons(
+      polys,
+      set('a'),
+      set('t1'),
+      'hela'
+    );
+    expect(out.find(p => p.id === 'a')?.mtType).toBe('hela');
+    expect(out.find(p => p.id === 'c')?.mtType).toBe('hela');
+    expect(out.find(p => p.id === 'b')?.mtType).toBeUndefined();
+    expect(changed).toBe(2);
+  });
+
+  it('clears mtType when passed null', () => {
+    const typed = [{ id: 'x', trackId: 't9', mtType: 'brain' }];
+    const { polygons: out, changed } = applyMtTypeToPolygons(
+      typed,
+      set('x'),
+      set('t9'),
+      null
+    );
+    expect('mtType' in out[0]).toBe(false);
+    expect(changed).toBe(1);
+  });
+
+  it('clears mtType across a whole track (all same-track siblings)', () => {
+    const typed = [
+      { id: 'a', trackId: 't1', mtType: 'brain' },
+      { id: 'c', trackId: 't1', mtType: 'brain' },
+      { id: 'b', trackId: 't2', mtType: 'hela' },
+    ];
+    const { polygons: out, changed } = applyMtTypeToPolygons(
+      typed,
+      set('a'),
+      set('t1'),
+      null
+    );
+    expect('mtType' in out.find(p => p.id === 'a')!).toBe(false);
+    expect('mtType' in out.find(p => p.id === 'c')!).toBe(false);
+    expect(out.find(p => p.id === 'b')?.mtType).toBe('hela'); // other track kept
+    expect(changed).toBe(2);
+  });
+
+  it('is a no-op (changed=0, references preserved) when the value is unchanged', () => {
+    const typed = [{ id: 'x', trackId: 't9', mtType: 'brain' }];
+    const { polygons: out, changed } = applyMtTypeToPolygons(
+      typed,
+      set('x'),
+      set('t9'),
+      'brain' // already brain
+    );
+    expect(changed).toBe(0);
+    expect(out[0]).toBe(typed[0]); // same reference — caller can skip updatePolygons
+  });
+
+  it('does not mutate the input polygons', () => {
+    const input = [{ id: 'x', mtType: 'brain' }];
+    applyMtTypeToPolygons(input, set('x'), set(), 'hela');
+    expect(input[0].mtType).toBe('brain');
   });
 });

--- a/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
+++ b/src/pages/segmentation/utils/__tests__/mtTypeTargets.test.ts
@@ -142,3 +142,39 @@ describe('applyMtTypeToPolygons', () => {
     expect(input[0].mtType).toBe('brain');
   });
 });
+
+describe('applyMtTypeToPolygons — matched vs changed', () => {
+  const set = (...ids: string[]) => new Set(ids);
+
+  it('reports matched=0 when the target is not on this frame', () => {
+    // The right-clicked id goes stale when a resegment or a background reload
+    // replaces the frame's polygons while the type submenu is open. Without a
+    // separate `matched`, that is indistinguishable from a no-op re-assign and
+    // the caller reports success for a write that reached nothing.
+    const { changed, matched } = applyMtTypeToPolygons(
+      polys,
+      set('ghost'),
+      set(),
+      'brain'
+    );
+    expect(matched).toBe(0);
+    expect(changed).toBe(0);
+  });
+
+  it('reports matched>0 with changed=0 for a benign no-op re-assign', () => {
+    const typed: TypeablePolygon[] = [{ id: 'x', mtType: 'brain' }];
+    const { changed, matched } = applyMtTypeToPolygons(
+      typed,
+      set('x'),
+      set(),
+      'brain'
+    );
+    expect(matched).toBe(1);
+    expect(changed).toBe(0);
+  });
+
+  it('counts every same-track sibling as matched', () => {
+    const { matched } = applyMtTypeToPolygons(polys, set('a'), set('t1'), 'x');
+    expect(matched).toBe(2); // 'a' and 'c' share t1
+  });
+});

--- a/src/pages/segmentation/utils/mtTypeTargets.ts
+++ b/src/pages/segmentation/utils/mtTypeTargets.ts
@@ -2,15 +2,33 @@
  * Pure resolution of which microtubule *tracks* a "change type" action targets.
  *
  * The context-menu action can fire on a single polygon (right-clicked) or on a
- * multi-selection. Type is a whole-track property, so we map the affected
- * polygons to their `trackId`s and dedupe. Polylines without a `trackId` (never
- * tracked, or a stray un-tracked draw) contribute nothing — an empty result is
- * the caller's signal to abort with a "no track" toast rather than PATCH with an
- * empty id list.
+ * multi-selection. For a *tracked* MT the type is a whole-track property, so we
+ * map the affected polygons to their `trackId`s and dedupe. Polylines without a
+ * `trackId` (never tracked, or a hand-drawn draw) contribute nothing — an empty
+ * result just means there is no cross-frame write to do; the caller still stamps
+ * the label onto the current frame's polygon(s) by id (see
+ * {@link resolveTargetPolygonIds} + {@link applyMtTypeToPolygons}).
  */
 export interface TrackedPolygon {
   id: string;
   trackId?: string | null;
+}
+
+/**
+ * Resolve which of the current frame's polygons a "change type" action targets:
+ * a real multi-selection (≥2) acts on the whole selection; otherwise just the
+ * right-clicked polygon. This is the single home of the single-vs-multi rule —
+ * {@link resolveTargetTrackIds} builds on it — so the ≥2 threshold lives in one
+ * place. Returns POLYGON ids, so an untracked (hand-drawn) polyline, which
+ * contributes no trackId, is still a valid target.
+ */
+export function resolveTargetPolygonIds(
+  polygonId: string,
+  selectedIds: ReadonlySet<string>
+): Set<string> {
+  // A 1-element selection is treated as the single case so right-clicking an
+  // unselected MT still acts on the clicked polygon, not the lone selection.
+  return selectedIds.size >= 2 ? new Set(selectedIds) : new Set([polygonId]);
 }
 
 export function resolveTargetTrackIds(
@@ -18,17 +36,61 @@ export function resolveTargetTrackIds(
   selectedIds: ReadonlySet<string>,
   polygons: ReadonlyArray<TrackedPolygon>
 ): string[] {
-  // A lone right-click acts on that polygon; a real multi-selection (≥2) acts
-  // on the whole selection. A 1-element selection is treated as the single
-  // case so right-clicking an unselected MT still works.
-  const targetIds = selectedIds.size >= 2 ? [...selectedIds] : [polygonId];
+  const targetIds = resolveTargetPolygonIds(polygonId, selectedIds);
   return Array.from(
     new Set(
-      targetIds
+      [...targetIds]
         .map(id => polygons.find(p => p.id === id)?.trackId)
         .filter(
           (tid): tid is string => typeof tid === 'string' && tid.length > 0
         )
     )
   );
+}
+
+export interface TypeablePolygon extends TrackedPolygon {
+  mtType?: string;
+}
+
+/**
+ * Stamp `mtType` (or clear it, when `mtType` is null) onto every polygon the
+ * action targets — matched by its own id (covers untracked, hand-drawn
+ * polylines) OR by belonging to one of the target tracks (keeps a tracked MT's
+ * current-frame polyline in lock-step with the cross-frame backend write).
+ *
+ * Returns the new array plus how many polygons actually changed, mirroring the
+ * backend twin `setPolygonsTrackType`: a target already carrying the requested
+ * value is a no-op (`changed` not incremented, reference preserved), so the
+ * caller can skip `updatePolygons` and avoid dirtying the frame / pushing an
+ * empty undo entry / tripping the CanvasPolygon memo. Pure — never mutates its
+ * input; only genuinely changed polygons are shallow-copied.
+ *
+ * This optimistic stamp is what recolours the canvas + panel immediately and —
+ * crucially — keeps `mtType` in the polygons a later save serialises, instead of
+ * depending on an abortable network reload.
+ */
+export function applyMtTypeToPolygons<T extends TypeablePolygon>(
+  polygons: ReadonlyArray<T>,
+  targetPolygonIds: ReadonlySet<string>,
+  targetTrackIds: ReadonlySet<string>,
+  mtType: string | null
+): { polygons: T[]; changed: number } {
+  const next = mtType ?? undefined;
+  let changed = 0;
+  const updated = polygons.map(p => {
+    const isTarget =
+      targetPolygonIds.has(p.id) ||
+      (typeof p.trackId === 'string' &&
+        p.trackId.length > 0 &&
+        targetTrackIds.has(p.trackId));
+    if (!isTarget) return p;
+    const current = typeof p.mtType === 'string' ? p.mtType : undefined;
+    if (current === next) return p; // already that value — no-op
+    changed++;
+    const copy = { ...p };
+    if (next === undefined) delete copy.mtType;
+    else copy.mtType = next;
+    return copy;
+  });
+  return { polygons: updated, changed };
 }

--- a/src/pages/segmentation/utils/mtTypeTargets.ts
+++ b/src/pages/segmentation/utils/mtTypeTargets.ts
@@ -1,17 +1,28 @@
 /**
- * Pure resolution of which microtubule *tracks* a "change type" action targets.
+ * The pure half of assigning a microtubule type label: who the action targets,
+ * and what the frame looks like afterwards.
  *
- * The context-menu action can fire on a single polygon (right-clicked) or on a
- * multi-selection. For a *tracked* MT the type is a whole-track property, so we
- * map the affected polygons to their `trackId`s and dedupe. Polylines without a
- * `trackId` (never tracked, or a hand-drawn draw) contribute nothing — an empty
- * result just means there is no cross-frame write to do; the caller still stamps
- * the label onto the current frame's polygon(s) by id (see
- * {@link resolveTargetPolygonIds} + {@link applyMtTypeToPolygons}).
+ * Three exports, in the order the caller uses them:
+ *  - {@link resolveTargetPolygonIds} — the single-vs-multi-selection rule, and
+ *    the only place the "a selection counts from 2" threshold lives.
+ *  - {@link resolveTargetTrackIds} — those polygons' `trackId`s, deduped. For a
+ *    *tracked* MT the type is a whole-track property, so this is what the
+ *    cross-frame backend write is given. Polylines without a `trackId` (never
+ *    tracked, or hand-drawn) contribute nothing, and an empty result simply
+ *    means there is no cross-frame write to do.
+ *  - {@link applyMtTypeToPolygons} — the current frame's polygons with the
+ *    label stamped on, which is what makes an untracked polyline typeable at
+ *    all and what keeps the label in the array a save serialises.
  */
-export interface TrackedPolygon {
-  id: string;
-  trackId?: string | null;
+import type { Polygon } from '@/lib/segmentation';
+
+export interface TrackedPolygon extends Pick<Polygon, 'id'> {
+  /** Bound to the model, then widened by `| null`: these polygons arrive from
+   *  parsed JSON, and the guards below test for a non-empty string rather than
+   *  trusting the declaration. Binding to `Polygon` rather than re-declaring
+   *  `string` is what keeps this from drifting — it is one of several
+   *  structural re-declarations of the polygon shape in this codebase. */
+  trackId?: Polygon['trackId'] | null;
 }
 
 /**
@@ -49,7 +60,7 @@ export function resolveTargetTrackIds(
 }
 
 export interface TypeablePolygon extends TrackedPolygon {
-  mtType?: string;
+  mtType?: Polygon['mtType'];
 }
 
 /**
@@ -62,8 +73,9 @@ export interface TypeablePolygon extends TrackedPolygon {
  * `setPolygonsTrackType`: a target already carrying the requested value is a
  * no-op (not counted, reference preserved), so the caller can skip
  * `updatePolygons` and avoid dirtying the frame / pushing an empty undo entry /
- * tripping the CanvasPolygon memo. `matched` counts targets that were FOUND at
- * all, which is what separates "already had that label" (matched, unchanged —
+ * tripping the CanvasPolygon memo. `matched` counts target POLYGONS that were
+ * found at all (a track with two polylines on this frame counts twice), which
+ * is what separates "already had that label" (matched, unchanged —
  * benign) from "the target is not on this frame" (nothing matched — the caller
  * must not report success). The right-clicked id can go stale across an await:
  * a resegment or a background reload replaces the frame's polygons while the

--- a/src/pages/segmentation/utils/mtTypeTargets.ts
+++ b/src/pages/segmentation/utils/mtTypeTargets.ts
@@ -58,12 +58,17 @@ export interface TypeablePolygon extends TrackedPolygon {
  * polylines) OR by belonging to one of the target tracks (keeps a tracked MT's
  * current-frame polyline in lock-step with the cross-frame backend write).
  *
- * Returns the new array plus how many polygons actually changed, mirroring the
- * backend twin `setPolygonsTrackType`: a target already carrying the requested
- * value is a no-op (`changed` not incremented, reference preserved), so the
- * caller can skip `updatePolygons` and avoid dirtying the frame / pushing an
- * empty undo entry / tripping the CanvasPolygon memo. Pure — never mutates its
- * input; only genuinely changed polygons are shallow-copied.
+ * Returns the new array plus two counts. `changed` mirrors the backend twin
+ * `setPolygonsTrackType`: a target already carrying the requested value is a
+ * no-op (not counted, reference preserved), so the caller can skip
+ * `updatePolygons` and avoid dirtying the frame / pushing an empty undo entry /
+ * tripping the CanvasPolygon memo. `matched` counts targets that were FOUND at
+ * all, which is what separates "already had that label" (matched, unchanged —
+ * benign) from "the target is not on this frame" (nothing matched — the caller
+ * must not report success). The right-clicked id can go stale across an await:
+ * a resegment or a background reload replaces the frame's polygons while the
+ * type submenu is open. Pure — never mutates its input; only genuinely changed
+ * polygons are shallow-copied.
  *
  * This optimistic stamp is what recolours the canvas + panel immediately and —
  * crucially — keeps `mtType` in the polygons a later save serialises, instead of
@@ -74,9 +79,10 @@ export function applyMtTypeToPolygons<T extends TypeablePolygon>(
   targetPolygonIds: ReadonlySet<string>,
   targetTrackIds: ReadonlySet<string>,
   mtType: string | null
-): { polygons: T[]; changed: number } {
+): { polygons: T[]; changed: number; matched: number } {
   const next = mtType ?? undefined;
   let changed = 0;
+  let matched = 0;
   const updated = polygons.map(p => {
     const isTarget =
       targetPolygonIds.has(p.id) ||
@@ -84,6 +90,7 @@ export function applyMtTypeToPolygons<T extends TypeablePolygon>(
         p.trackId.length > 0 &&
         targetTrackIds.has(p.trackId));
     if (!isTarget) return p;
+    matched++;
     const current = typeof p.mtType === 'string' ? p.mtType : undefined;
     if (current === next) return p; // already that value — no-op
     changed++;
@@ -92,5 +99,5 @@ export function applyMtTypeToPolygons<T extends TypeablePolygon>(
     else copy.mtType = next;
     return copy;
   });
-  return { polygons: updated, changed };
+  return { polygons: updated, changed, matched };
 }

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2194,8 +2194,6 @@ export default {
       deleteFailed: 'Nepodařilo se smazat label',
       loadFailed: 'Nepodařilo se načíst typové labely',
       duplicateName: 'Label s tímto názvem už existuje',
-      noTrack:
-        'Tento mikrotubulus zatím nemá track — nejprve spusťte trackování.',
     },
     color: {
       label: 'Barva:',
@@ -2320,6 +2318,7 @@ export default {
     },
     windowLevel: {
       title: 'Zobrazení',
+      channel: 'Kanál',
       min: 'Min',
       max: 'Max',
       brightness: 'Jas',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2190,8 +2190,6 @@ export default {
       deleteFailed: 'Label konnte nicht gelöscht werden',
       loadFailed: 'Typ-Labels konnten nicht geladen werden',
       duplicateName: 'Ein Label mit diesem Namen existiert bereits',
-      noTrack:
-        'Dieser Mikrotubulus hat noch keinen Track — führen Sie zuerst das Tracking aus.',
     },
     color: {
       label: 'Farbe:',
@@ -2316,6 +2314,7 @@ export default {
     },
     windowLevel: {
       title: 'Anzeige',
+      channel: 'Kanal',
       min: 'Min',
       max: 'Max',
       brightness: 'Helligkeit',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2261,7 +2261,6 @@ export default {
       deleteFailed: 'Failed to delete label',
       loadFailed: 'Failed to load type labels',
       duplicateName: 'A label with this name already exists',
-      noTrack: 'This microtubule has no track yet — run tracking first.',
     },
     color: {
       label: 'Colour:',
@@ -2384,6 +2383,7 @@ export default {
     },
     windowLevel: {
       title: 'Display',
+      channel: 'Channel',
       min: 'Min',
       max: 'Max',
       brightness: 'Brightness',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2230,8 +2230,6 @@ export default {
       deleteFailed: 'No se pudo eliminar la etiqueta',
       loadFailed: 'No se pudieron cargar las etiquetas de tipo',
       duplicateName: 'Ya existe una etiqueta con este nombre',
-      noTrack:
-        'Este microtúbulo aún no tiene seguimiento — ejecute primero el seguimiento.',
     },
     color: {
       label: 'Color:',
@@ -2356,6 +2354,7 @@ export default {
     },
     windowLevel: {
       title: 'Visualización',
+      channel: 'Canal',
       min: 'Mín',
       max: 'Máx',
       brightness: 'Brillo',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2180,8 +2180,6 @@ export default {
       deleteFailed: 'Échec de la suppression du label',
       loadFailed: 'Échec du chargement des labels de type',
       duplicateName: 'Un label portant ce nom existe déjà',
-      noTrack:
-        'Ce microtubule n’a pas encore de piste — lancez d’abord le suivi.',
     },
     color: {
       label: 'Couleur :',
@@ -2306,6 +2304,7 @@ export default {
     },
     windowLevel: {
       title: 'Affichage',
+      channel: 'Canal',
       min: 'Min',
       max: 'Max',
       brightness: 'Luminosité',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -2047,7 +2047,6 @@ export default {
       deleteFailed: '删除标签失败',
       loadFailed: '加载类型标签失败',
       duplicateName: '已存在同名标签',
-      noTrack: '该微管尚无轨迹 — 请先运行追踪。',
     },
     color: {
       label: '颜色：',
@@ -2162,6 +2161,7 @@ export default {
     },
     windowLevel: {
       title: '显示',
+      channel: '通道',
       min: '最小值',
       max: '最大值',
       brightness: '亮度',


### PR DESCRIPTION
Two bug reports from Marika (in-app feedback, 2026-08-24), both root-caused and
verified in production on the test account with her own file.

Based on `feat/frap-targets` **because that is the branch production is actually
running** — `staticChannelProjectionService.ts` is in the live backend container
and does not exist on `main`. A main-based build would have reverted 73 live
commits.

## 1. "MT label assiging gives error"

> This microtubule has no track yet — run tracking first.
> Trying to assign labels (brain, HeLa) to MTs in snapshots (just 1 frame)

`handleChangeMtType` treats the label as a whole-track property and aborts when
the target has no `trackId`. A hand-drawn polyline never has one, and on a
one-frame container it can never get one: the tracker only births ids for the
polylines that existed at segmentation time, and forward propagation has no
later frame to write into. Every MT she draws by hand is unlabelable.

Confirmed in her data — on all seven containers every `polyline_<ts>_a` /
`polygon_<ts>_…` carries no trackId while the model's `polyline_N` do.

**This is the content of PR #299**, which fixed the same report on 2026-07-15,
was deployed from its branch, and was never merged. Every later build silently
reverted it. #299 is superseded by this.

## 2. "Model segments MTs where there is nothing"

The model is right; the display was wrong. Her frame is a 4-channel TIFF whose
IRM channel — the segmented one — spans 2941..4145, while its TIRF siblings
reach 53927. The editor fitted **one** window to the union and ran every channel
through **one** LUT, so IRM occupied 2.25 % of the display range: a flat grey
field under a green TIRF overlay, with polylines apparently on nothing.

Measured, not inferred: re-running v5H on her frame gives 19 polylines, 17 of
them 5–15 SD darker than a shifted control along the same curve.

Window/level is now per channel (ImageJ composite semantics): each auto-fits to
its own data, the canvas builds one LUT per channel (CPU) / passes per-channel
uniforms (GPU — the draw loop already derived them per channel, only the window
was global), and the Display panel gains a channel tab row defaulting to the
segmentation source.

Also: the range report is keyed on the container rather than the channel set, so
ticking a channel on fits just that channel; and the playback-proxy gate is per
channel (`anyWindowNeedsFullDepth`). `reportDataRange` lost its last caller and
is removed rather than left as a second way to set a window.

## Verification

- `make ci` green; 673 tests across the touched suites, 52 new.
- The per-channel compositor test is mutation-verified: reverting `draw()` to a
  shared window turns it red.
- Production, test account, her file: label on an untracked polyline → success
  toast + chip + red polyline + `mtType` in the DB with `trackId` still null,
  surviving a reload; tracked polyline still takes the cross-frame path.
  Display panel reads 2941/4145 on IRM and 1318/53927 on TIRF_491. 0 console
  errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgw18koquTQUEnKsZQmCfV