### PR TITLE
feat(essays): run a folder again from the files already on the server

### DIFF
--- a/backend/src/api/controllers/essaysController.ts
+++ b/backend/src/api/controllers/essaysController.ts
@@ -54,6 +54,7 @@ export class EssaysController {
     this.getDownloadToken = this.getDownloadToken.bind(this);
     this.downloadJob = this.downloadJob.bind(this);
     this.deleteJob = this.deleteJob.bind(this);
+    this.rerunJob = this.rerunJob.bind(this);
   }
 
   /** POST /api/essays/upload — stage a folder of .nd2 wells and start a job. */
@@ -242,6 +243,49 @@ export class EssaysController {
   }
 
   /** DELETE /api/essays/jobs/:jobId — remove a job and its artifacts. */
+  /** POST /api/essays/jobs/:jobId/rerun — run again from the input already on
+   *  disk, so a run that did not finish cleanly needs no re-upload. */
+  async rerunJob(req: AuthRequest, res: Response): Promise<void> {
+    try {
+      const userId = req.user?.id;
+      const { jobId } = req.params;
+      if (!userId) {
+        ResponseHelper.unauthorized(res, 'Unauthorized', CTX);
+        return;
+      }
+      const result = await this.service.rerunJob(userId, jobId);
+      if (result.ok === true) {
+        res.json({ success: true });
+        return;
+      }
+      // Distinct statuses, because the three refusals mean different things to
+      // the user: one is a wrong id, one is "wait", one is "the data is gone
+      // and you do have to upload it again".
+      if (result.reason === 'not_found') {
+        ResponseHelper.notFound(res, 'Essays job not found', CTX);
+      } else if (result.reason === 'in_flight') {
+        ResponseHelper.badRequest(
+          res,
+          'This job is still running; wait for it to finish',
+          CTX
+        );
+      } else {
+        ResponseHelper.badRequest(
+          res,
+          'The uploaded files for this job are no longer stored, so it cannot be re-run',
+          CTX
+        );
+      }
+    } catch (error) {
+      ResponseHelper.internalError(
+        res,
+        toErr(error),
+        'Failed to re-run essays job',
+        CTX
+      );
+    }
+  }
+
   async deleteJob(req: AuthRequest, res: Response): Promise<void> {
     try {
       const userId = req.user?.id;

--- a/backend/src/api/routes/essaysRoutes.ts
+++ b/backend/src/api/routes/essaysRoutes.ts
@@ -73,6 +73,15 @@ router.get(
   essaysController.downloadJob
 );
 
+// Re-run a finished job from the input already on disk (no re-upload).
+router.post(
+  '/essays/jobs/:jobId/rerun',
+  authenticate,
+  [param('jobId').isUUID()],
+  validateRequest,
+  essaysController.rerunJob
+);
+
 // Delete a job and its artifacts.
 router.delete(
   '/essays/jobs/:jobId',

--- a/backend/src/services/__tests__/essaysService.test.ts
+++ b/backend/src/services/__tests__/essaysService.test.ts
@@ -29,17 +29,19 @@ vi.mock('../../utils/config', () => ({
 vi.mock('axios', () => ({
   default: { create: vi.fn(() => ({ post: vi.fn() })) },
 }));
+// fs.promises returns PROMISES; a bare vi.fn() returns undefined, and any
+// production `await fs.rm(...).catch(...)` then dies on undefined.catch.
 vi.mock('fs', () => ({
   promises: {
     access: (...a: unknown[]) => fsAccess(...a),
-    mkdir: vi.fn(),
-    rm: vi.fn(),
-    readdir: vi.fn(),
-    stat: vi.fn(),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([]),
+    stat: vi.fn().mockResolvedValue({ size: 0 }),
     readFile: (...a: unknown[]) => fsReadFile(...a),
-    rename: vi.fn(),
-    copyFile: vi.fn(),
-    unlink: vi.fn(),
+    rename: vi.fn().mockResolvedValue(undefined),
+    copyFile: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
   },
 }));
 // Keep sanitizeFilename real-ish but avoid pulling in archiver et al.
@@ -48,7 +50,13 @@ vi.mock('../export/exportFileOperations', () => ({
   sanitizeFilename: (s: string) => s.replace(/[^A-Za-z0-9_.-]/g, '_'),
 }));
 
-import { sanitizeNd2Name, EssaysService, coerceDevice } from '../essaysService';
+import {
+  sanitizeNd2Name,
+  EssaysService,
+  coerceDevice,
+  shouldKeepInput,
+  isRetentionExpired,
+} from '../essaysService';
 
 const USER = 'user-1';
 const JOB = 'job-1';
@@ -242,5 +250,205 @@ describe('reconcileJob wiring (coerceDevice is actually applied to the DB write)
     // Either no update at all (nothing changed) or the previous value retained —
     // never the junk value.
     if (call) expect(call[0].data.device).toBe('cuda');
+  });
+});
+
+// ─── input retention + rerun ─────────────────────────────────────────────────
+//
+// Roman, 2026-08-25: "Občas se stane že segmentace neproběhne ... hodila by se
+// možnost znovu spuštění segmentace již nahraných složek abych je nemusel
+// nahrávat znovu." He had re-uploaded the same 180-file, 9.9 GB folder three
+// times, because a run that does not finish cleanly leaves nothing to re-run
+// from: the finalize path deleted the whole job dir, input included.
+//
+// A run can fail to finish cleanly in TWO ways, and only one of them is called
+// 'failed'. evaluate.py returns 0 even when individual wells failed to read or
+// segment, so a PARTIAL run is stored as 'completed' carrying an `error` — and
+// that is exactly the case Roman hit ("nebyla paměť na segmentaci všech jamek").
+// Keying retention on status alone would therefore miss his case entirely;
+// these tests key it on whether the run finished cleanly.
+
+describe('shouldKeepInput (which runs are worth re-running)', () => {
+  it('deletes the input after a clean run, as before', () => {
+    expect(shouldKeepInput({ status: 'completed', error: null })).toBe(false);
+    expect(shouldKeepInput({ status: 'completed', error: '' })).toBe(false);
+  });
+
+  it('keeps the input when the job failed outright', () => {
+    expect(
+      shouldKeepInput({
+        status: 'failed',
+        error: 'Worker stopped reporting (job timed out).',
+      })
+    ).toBe(true);
+  });
+
+  it('keeps the input when a "completed" run was actually partial', () => {
+    // The case that keying on status would miss.
+    expect(
+      shouldKeepInput({ status: 'completed', error: '12 wells failed to read' })
+    ).toBe(true);
+  });
+
+  it('does not keep anything for a job still in flight', () => {
+    // Nothing to decide yet; the finalize path has not run.
+    expect(shouldKeepInput({ status: 'running', error: null })).toBe(false);
+    expect(shouldKeepInput({ status: 'queued', error: null })).toBe(false);
+  });
+});
+
+describe('isRetentionExpired (the TTL that stops kept inputs growing)', () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const now = new Date('2026-08-25T12:00:00Z');
+
+  it('keeps a recently failed run', () => {
+    expect(
+      isRetentionExpired(new Date(now.getTime() - 2 * DAY), 7, now)
+    ).toBe(false);
+  });
+
+  it('drops one past the window', () => {
+    expect(
+      isRetentionExpired(new Date(now.getTime() - 8 * DAY), 7, now)
+    ).toBe(true);
+  });
+
+  it('treats the boundary as still inside the window', () => {
+    // A job exactly at the limit is not yet expired — a TTL that fires early
+    // deletes the input on the day the user comes back for it.
+    expect(isRetentionExpired(new Date(now.getTime() - 7 * DAY), 7, now)).toBe(
+      false
+    );
+  });
+
+  it('never expires when the window is zero or negative (retention off)', () => {
+    expect(
+      isRetentionExpired(new Date(now.getTime() - 900 * DAY), 0, now)
+    ).toBe(false);
+    expect(
+      isRetentionExpired(new Date(now.getTime() - 900 * DAY), -1, now)
+    ).toBe(false);
+  });
+});
+
+describe('rerunJob', () => {
+  const svc = () => EssaysService.getInstance();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsAccess.mockReset();
+  });
+
+  it('refuses a job that is not the caller\'s', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue(null);
+    await expect(svc().rerunJob(USER, JOB)).resolves.toEqual({
+      ok: false,
+      reason: 'not_found',
+    });
+    expect(prismaMock.essayJob.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses while the job is still in flight', async () => {
+    // Re-queueing a running job would hand the worker the same jobId twice and
+    // let two runs write the same output dir.
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'running',
+      error: null,
+    });
+    await expect(svc().rerunJob(USER, JOB)).resolves.toEqual({
+      ok: false,
+      reason: 'in_flight',
+    });
+    expect(prismaMock.essayJob.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the input is no longer on disk', async () => {
+    // The honest failure: a clean run's input was deleted, so there is nothing
+    // to re-run from and the user must be told rather than shown a job that
+    // silently fails a minute later.
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      error: null,
+    });
+    fsAccess.mockRejectedValue(new Error('ENOENT'));
+    await expect(svc().rerunJob(USER, JOB)).resolves.toEqual({
+      ok: false,
+      reason: 'input_gone',
+    });
+    expect(prismaMock.essayJob.update).not.toHaveBeenCalled();
+  });
+
+  it('re-queues a failed job and clears the previous outcome', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'failed',
+      error: 'Worker stopped reporting (job timed out).',
+      resultZipKey: null,
+    });
+    fsAccess.mockResolvedValue(undefined);
+    prismaMock.essayJob.update.mockResolvedValue({});
+
+    await expect(svc().rerunJob(USER, JOB)).resolves.toEqual({ ok: true });
+
+    const data = prismaMock.essayJob.update.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      status: 'queued',
+      progress: 0,
+      error: null,
+      resultZipKey: null,
+      completedAt: null,
+    });
+  });
+
+  it('re-queues a partial run too — that is the reported case', async () => {
+    // Stored as 'completed' with an error, because evaluate.py exits 0 when
+    // individual wells fail. Refusing it would miss the whole point.
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'completed',
+      error: '12 wells failed to read',
+      resultZipKey: 'essays-results/job-1.zip',
+    });
+    fsAccess.mockResolvedValue(undefined);
+    prismaMock.essayJob.update.mockResolvedValue({});
+
+    await expect(svc().rerunJob(USER, JOB)).resolves.toEqual({ ok: true });
+    expect(prismaMock.essayJob.update.mock.calls[0][0].data.status).toBe(
+      'queued'
+    );
+  });
+});
+
+describe('listJobs canRerun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsAccess.mockReset();
+  });
+
+  it('offers a re-run only when the input is really on disk', async () => {
+    // Deriving this from status would light the button up for every finished
+    // job, including the clean ones whose input was deleted on purpose.
+    prismaMock.essayJob.findMany = vi.fn().mockResolvedValue([
+      { id: 'a', userId: USER, status: 'failed', error: 'timed out' },
+      { id: 'b', userId: USER, status: 'completed', error: null },
+      { id: 'c', userId: USER, status: 'running', error: null },
+    ]);
+    // 'a' has input, 'b' does not; 'c' is never stat'd because it is in flight.
+    fsAccess.mockImplementation((p: string) =>
+      p.includes('/a/') ? Promise.resolve() : Promise.reject(new Error('ENOENT'))
+    );
+
+    const jobs = await EssaysService.getInstance().listJobs(USER);
+    expect(jobs.map((j) => [j.id, j.canRerun])).toEqual([
+      ['a', true],
+      ['b', false],
+      ['c', false],
+    ]);
   });
 });

--- a/backend/src/services/__tests__/essaysService.test.ts
+++ b/backend/src/services/__tests__/essaysService.test.ts
@@ -452,3 +452,53 @@ describe('listJobs canRerun', () => {
     ]);
   });
 });
+
+describe('jobDir path safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsAccess.mockReset();
+  });
+
+  it('refuses a jobId that would walk out of the uploads volume', async () => {
+    // rerunJob takes the id straight off the URL. The route validates isUUID(),
+    // but that guard lives in another file; this one is at the funnel every
+    // essays path goes through, so removing the route's validator cannot
+    // silently open a traversal.
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: '../../etc',
+      userId: USER,
+      status: 'failed',
+      error: 'x',
+    });
+    await expect(
+      EssaysService.getInstance().rerunJob(USER, '../../etc')
+    ).rejects.toThrow();
+    expect(prismaMock.essayJob.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a userId containing a separator', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: 'a/b',
+      status: 'failed',
+      error: 'x',
+    });
+    await expect(
+      EssaysService.getInstance().rerunJob('a/b', JOB)
+    ).rejects.toThrow();
+  });
+
+  it('still accepts an ordinary id', async () => {
+    prismaMock.essayJob.findFirst.mockResolvedValue({
+      id: JOB,
+      userId: USER,
+      status: 'failed',
+      error: 'x',
+    });
+    fsAccess.mockResolvedValue(undefined);
+    prismaMock.essayJob.update.mockResolvedValue({});
+    await expect(
+      EssaysService.getInstance().rerunJob(USER, JOB)
+    ).resolves.toEqual({ ok: true });
+  });
+});

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -7,6 +7,7 @@ import type { EssayJob } from '@prisma/client';
 import { prisma } from '../db';
 import { config } from '../utils/config';
 import { logger } from '../utils/logger';
+import { assertSafeStorageSegment } from '../utils/storagePath';
 import {
   createZipArchive,
   sanitizeFilename,
@@ -202,8 +203,24 @@ export class EssaysService {
     return EssaysService.instance;
   }
 
+  /**
+   * Where one job's files live.
+   *
+   * Both segments are guarded here rather than at the call sites. `submitJob`
+   * never needed it — it generates the jobId itself — but `rerunJob` and the
+   * listing take one straight off the URL, and a `..` there would walk out of
+   * the uploads volume. The route does validate `isUUID()`, but that lives in
+   * another file and a defence you cannot see from the call site is one a future
+   * edit can remove silently. This is the single funnel every essays path goes
+   * through, so guarding it covers all of them at once.
+   */
   private jobDir(userId: string, jobId: string): string {
-    return path.join(this.uploadDir, 'essays', userId, jobId);
+    return path.join(
+      this.uploadDir,
+      'essays',
+      assertSafeStorageSegment(userId, 'essays userId'),
+      assertSafeStorageSegment(jobId, 'essays jobId')
+    );
   }
 
   /** Stage the uploaded files, create the job row, dispatch to the worker. */

--- a/backend/src/services/essaysService.ts
+++ b/backend/src/services/essaysService.ts
@@ -117,6 +117,47 @@ export function sanitizeNd2Name(original: string): string {
  * timer (so runs progress even with no client polling), and zips the output on
  * completion. Job state lives in Postgres; the worker is a stateless GPU runner.
  */
+/** Days a not-cleanly-finished run's input is kept so it can be re-run.
+ *  0 or negative turns the TTL off and keeps them until the job is deleted. */
+export const ESSAYS_INPUT_RETENTION_DAYS = Number.parseInt(
+  process.env.ESSAYS_INPUT_RETENTION_DAYS ?? '7',
+  10
+);
+
+/**
+ * Whether a finished job's input .nd2 files are worth keeping for a re-run.
+ *
+ * A run that finished CLEANLY is deleted as it always was: the zip is the whole
+ * artifact and the input is tens of GB. Anything else is kept, because that is
+ * precisely the run someone will want to repeat.
+ *
+ * Note the condition is "did it finish cleanly", NOT "is the status failed".
+ * evaluate.py exits 0 even when individual wells failed to read or segment, so a
+ * PARTIAL run is stored as `completed` carrying an `error` — which is the case
+ * the user actually reported ("nebyla paměť na segmentaci všech jamek"). Keying
+ * on status alone would delete the input for exactly the runs worth repeating.
+ */
+export function shouldKeepInput(job: {
+  status: string;
+  error?: string | null;
+}): boolean {
+  if (job.status !== 'completed' && job.status !== 'failed') return false;
+  return job.status === 'failed' || Boolean(job.error);
+}
+
+/** Whether a kept input has outlived the retention window.
+ *  The boundary counts as still inside it — a TTL that fires early deletes the
+ *  input on the day the user comes back for it. */
+export function isRetentionExpired(
+  finishedAt: Date,
+  retentionDays: number,
+  now: Date = new Date()
+): boolean {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return false;
+  const ageMs = now.getTime() - finishedAt.getTime();
+  return ageMs > retentionDays * 24 * 60 * 60 * 1000;
+}
+
 export class EssaysService {
   private static instance: EssaysService;
   private http: AxiosInstance;
@@ -146,6 +187,11 @@ export class EssaysService {
     const sweep = setInterval(() => {
       this.sweepStaging().catch((e) =>
         logger.warn(`essays staging sweep failed: ${String(e)}`, CTX)
+      );
+      // Inputs kept for a re-run are tens of GB each; without a TTL they only
+      // ever accumulate.
+      this.sweepExpiredInputs().catch((e) =>
+        logger.warn(`essays retention sweep failed: ${String(e)}`, CTX)
       );
     }, STAGING_SWEEP_INTERVAL_MS);
     if (typeof sweep.unref === 'function') sweep.unref();
@@ -252,12 +298,131 @@ export class EssaysService {
     return { jobId };
   }
 
-  async listJobs(userId: string): Promise<EssayJob[]> {
-    return prisma.essayJob.findMany({
+  /**
+   * Re-run a finished job from the input already on disk.
+   *
+   * The point of the feature: a run that did not finish cleanly used to leave
+   * nothing to repeat, so the same 9.9 GB folder was uploaded again. The input
+   * now survives such a run (see shouldKeepInput), and this hands it back to the
+   * worker under the SAME job id.
+   *
+   * Reusing the row rather than creating a new one is deliberate. A new row
+   * would have to point at another row's input directory, and then neither of
+   * them could safely delete it without reference counting — a lot of machinery
+   * for a button. The cost is that a partial run's existing zip is replaced by
+   * the new run's; the UI says so before asking.
+   *
+   * No options are stored or replayed because none are ever sent: the page
+   * posts files and a folder name only, so every run uses the worker's
+   * defaults and a re-run reproduces the original exactly. If an options UI is
+   * ever added, it must persist them on the row and pass them here, or a re-run
+   * will quietly differ from the run it repeats.
+   */
+  async rerunJob(
+    userId: string,
+    jobId: string
+  ): Promise<
+    { ok: true } | { ok: false; reason: 'not_found' | 'in_flight' | 'input_gone' }
+  > {
+    const job = await prisma.essayJob.findFirst({ where: { id: jobId, userId } });
+    if (!job) return { ok: false, reason: 'not_found' };
+    // Re-queueing a job the worker still holds would dispatch the same id twice
+    // and let two runs write one output dir.
+    if (job.status !== 'completed' && job.status !== 'failed') {
+      return { ok: false, reason: 'in_flight' };
+    }
+
+    const dir = this.jobDir(userId, jobId);
+    const inputDir = path.join(dir, 'input');
+    const outputDir = path.join(dir, 'output');
+    // Ask the disk, never infer from status: retention has a TTL and an operator
+    // can always delete a directory. Telling the user now beats a job that
+    // fails a minute later.
+    try {
+      await fs.access(inputDir);
+    } catch {
+      return { ok: false, reason: 'input_gone' };
+    }
+
+    await prisma.essayJob.update({
+      where: { id: jobId },
+      data: {
+        status: 'queued',
+        progress: 0,
+        mtCount: 0,
+        error: null,
+        resultZipKey: null,
+        completedAt: null,
+      },
+    });
+
+    // A previous run's raw output would otherwise be zipped together with the
+    // new one's.
+    await fs
+      .rm(outputDir, { recursive: true, force: true })
+      .catch(() => {});
+    await fs.mkdir(outputDir, { recursive: true }).catch(() => {});
+
+    try {
+      await this.http.post('/process', {
+        jobId,
+        inputDir,
+        outDir: outputDir,
+        options: {},
+      });
+    } catch (e) {
+      const err = e as { code?: string; message?: string };
+      const isTimeout =
+        err.code === 'ECONNABORTED' || /timeout/i.test(err.message || '');
+      if (isTimeout) {
+        // Same reasoning as submitJob: the worker enqueues before responding, so
+        // a lost response does not mean the job was dropped. Leave it queued for
+        // the reconciler; the staleness watchdog fails it if nothing happens.
+        logger.warn(
+          `essays /process POST timed out for rerun ${jobId}; leaving queued`,
+          CTX
+        );
+        return { ok: true };
+      }
+      const msg = err.message || String(e);
+      await prisma.essayJob.update({
+        where: { id: jobId },
+        data: { status: 'failed', error: `worker unreachable: ${msg}` },
+      });
+      throw new Error('Essays worker is unavailable; please try again later.');
+    }
+
+    logger.info(`essays job ${jobId} re-queued from existing input`, CTX);
+    return { ok: true };
+  }
+
+  async listJobs(userId: string): Promise<(EssayJob & { canRerun: boolean })[]> {
+    const jobs = await prisma.essayJob.findMany({
       where: { userId },
       orderBy: { createdAt: 'desc' },
       take: 100,
     });
+    // Answer from the DISK, not from the status. Retention has a TTL and an
+    // operator can delete a directory, so a button derived from status alone
+    // would offer a re-run that fails the moment it is clicked. Only terminal
+    // jobs are stat'd, which is a handful per page.
+    return Promise.all(
+      jobs.map(async (job) => ({
+        ...job,
+        canRerun:
+          (job.status === 'completed' || job.status === 'failed') &&
+          (await this.hasInput(job.userId, job.id)),
+      }))
+    );
+  }
+
+  private async hasInput(userId: string, jobId: string): Promise<boolean> {
+    try {
+      await fs.access(path.join(this.jobDir(userId, jobId), 'input'));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async getJob(userId: string, jobId: string): Promise<EssayJob | null> {
@@ -474,18 +639,38 @@ export class EssaysService {
       });
       logger.info(`essays job ${job.id} completed -> ${resultZipKey}`, CTX);
 
-      // Free the (potentially tens-of-GB) input .nd2 files + raw output now that
-      // the persisted zip is the sole download artifact — the raw job dir is no
-      // longer needed. The result zip lives outside it (essays-results/) and
+      // Free the raw OUTPUT now that the persisted zip is the sole download
+      // artifact. The result zip lives outside the job dir (essays-results/) and
       // stays until the user dismisses the job.
-      await fs
-        .rm(this.jobDir(job.userId, job.id), { recursive: true, force: true })
-        .catch((e) =>
-          logger.warn(
-            `essays job ${job.id}: post-zip cleanup failed: ${String(e)}`,
-            CTX
-          )
+      //
+      // The INPUT is a separate decision. Deleting it unconditionally is what
+      // forced a re-upload of the same 9.9 GB folder after every imperfect run,
+      // so it survives when the run did not finish cleanly — see
+      // shouldKeepInput, and note that a PARTIAL run is stored as 'completed'
+      // with an error, not as 'failed'. A TTL sweep drops it later.
+      const keepInput = shouldKeepInput({
+        status: 'completed',
+        error: ws.error ?? null,
+      });
+      const dir = this.jobDir(job.userId, job.id);
+      const toRemove = keepInput ? [path.join(dir, 'output')] : [dir];
+      for (const target of toRemove) {
+        await fs
+          .rm(target, { recursive: true, force: true })
+          .catch((e) =>
+            logger.warn(
+              `essays job ${job.id}: post-zip cleanup failed for ${target}: ${String(e)}`,
+              CTX
+            )
+          );
+      }
+      if (keepInput) {
+        logger.info(
+          `essays job ${job.id}: run was not clean, keeping input for re-run ` +
+            `(retention ${ESSAYS_INPUT_RETENTION_DAYS}d)`,
+          CTX
         );
+      }
     } catch (e) {
       // A zip failure must NOT loop forever (the job would stay 'running' and be
       // re-attempted every tick). Mark it failed so it reaches a terminal state
@@ -510,6 +695,40 @@ export class EssaysService {
   }
 
   /** Remove orphaned upload temp files older than STAGING_MAX_AGE_MS. */
+  /**
+   * Drop input directories kept for a re-run once they outlive the window.
+   *
+   * Only touches `input/` — the result zip lives outside the job dir and stays
+   * until the user dismisses the job, so expiry costs the download, not the
+   * record. A job whose input is gone simply stops offering the re-run.
+   */
+  private async sweepExpiredInputs(): Promise<void> {
+    if (ESSAYS_INPUT_RETENTION_DAYS <= 0) return;
+    const finished = await prisma.essayJob.findMany({
+      where: { status: { in: ['completed', 'failed'] } },
+      select: { id: true, userId: true, updatedAt: true },
+      orderBy: { updatedAt: 'asc' },
+      take: 200,
+    });
+    for (const job of finished) {
+      if (!isRetentionExpired(job.updatedAt, ESSAYS_INPUT_RETENTION_DAYS)) {
+        // Ordered by updatedAt, so the first unexpired row ends the sweep.
+        break;
+      }
+      const inputDir = path.join(this.jobDir(job.userId, job.id), 'input');
+      try {
+        await fs.access(inputDir);
+      } catch {
+        continue; // already gone
+      }
+      await fs.rm(inputDir, { recursive: true, force: true }).catch(() => {});
+      logger.info(
+        `essays job ${job.id}: input expired after ${ESSAYS_INPUT_RETENTION_DAYS}d, removed`,
+        CTX
+      );
+    }
+  }
+
   private async sweepStaging(): Promise<void> {
     const stagingDir = path.join(this.uploadDir, 'essays', '_staging');
     let entries: string[];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2365,6 +2365,11 @@ class ApiClient {
     await this.instance.delete(`/essays/jobs/${jobId}`);
   }
 
+  /** Run a finished job again from the files already on the server. */
+  async rerunEssayJob(jobId: string): Promise<void> {
+    await this.instance.post(`/essays/jobs/${jobId}/rerun`);
+  }
+
   async getEssayDownloadToken(
     jobId: string
   ): Promise<{ token: string; expiresAt: number }> {

--- a/src/pages/AutomatedEssays.tsx
+++ b/src/pages/AutomatedEssays.tsx
@@ -1,7 +1,14 @@
 import React, { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Download, Loader2, Trash2, FileText, AlertCircle } from 'lucide-react';
+import {
+  Download,
+  Loader2,
+  Trash2,
+  FileText,
+  AlertCircle,
+  RotateCcw,
+} from 'lucide-react';
 import DashboardHeader from '@/components/DashboardHeader';
 import { PageContainer } from '@/components/layout';
 import { Button } from '@/components/ui/button';
@@ -92,6 +99,24 @@ const AutomatedEssays: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ['essay-jobs'] }),
     onError: () => toast.error(t('automatedEssays.deleteFailed')),
   });
+
+  const rerunMutation = useMutation({
+    mutationFn: (jobId: string) => apiClient.rerunEssayJob(jobId),
+    onSuccess: () => {
+      toast.success(t('automatedEssays.rerunStarted'));
+      queryClient.invalidateQueries({ queryKey: ['essay-jobs'] });
+    },
+    onError: () => toast.error(t('automatedEssays.rerunFailed')),
+  });
+
+  /** The re-run replaces this job's existing result, so say so before starting
+   *  one — a partial run's zip may be the only copy of what did come out. */
+  const confirmRerun = (job: EssayJob) => {
+    const warn = job.resultZipKey
+      ? String(t('automatedEssays.rerunConfirmReplace'))
+      : String(t('automatedEssays.rerunConfirm'));
+    if (window.confirm(warn)) rerunMutation.mutate(job.id);
+  };
 
   const handleDownload = async (job: EssayJob) => {
     try {
@@ -258,6 +283,18 @@ const AutomatedEssays: React.FC = () => {
                       >
                         <Download className="h-4 w-4 mr-1" />
                         {t('automatedEssays.download')}
+                      </Button>
+                    )}
+                    {job.canRerun && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={rerunMutation.isPending}
+                        onClick={() => confirmRerun(job)}
+                        title={String(t('automatedEssays.rerunHint'))}
+                      >
+                        <RotateCcw className="h-4 w-4 mr-1" />
+                        {t('automatedEssays.rerun')}
                       </Button>
                     )}
                     <Button

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -2363,6 +2363,15 @@ export default {
     cannotMoveIntoSelf: 'Složku nelze přesunout do sebe nebo do své podsložky',
   },
   automatedEssays: {
+    rerun: 'Spustit znovu',
+    rerunHint:
+      'Spustí tuto složku znovu ze souborů, které už jsou na serveru — není potřeba nic nahrávat.',
+    rerunStarted: 'Běh byl znovu zařazen do fronty.',
+    rerunFailed: 'Běh se nepodařilo spustit znovu.',
+    rerunConfirm:
+      'Spustit tuto složku znovu? Použijí se soubory, které už jsou na serveru.',
+    rerunConfirmReplace:
+      'Spustit tuto složku znovu? Stávající výsledek bude nahrazen — pokud si ho chcete nechat, nejdřív si ho stáhněte.',
     navLabel: 'Automatické eseje',
     title: 'Automatické eseje',
     subtitle:

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -2360,6 +2360,15 @@ export default {
       'Ein Ordner kann nicht in sich selbst oder einen eigenen Unterordner verschoben werden',
   },
   automatedEssays: {
+    rerun: 'Erneut ausführen',
+    rerunHint:
+      'Führt diesen Ordner erneut mit den bereits auf dem Server gespeicherten Dateien aus — kein erneutes Hochladen nötig.',
+    rerunStarted: 'Der Lauf wurde erneut in die Warteschlange gestellt.',
+    rerunFailed: 'Der Lauf konnte nicht erneut gestartet werden.',
+    rerunConfirm:
+      'Diesen Ordner erneut ausführen? Es werden die bereits auf dem Server gespeicherten Dateien verwendet.',
+    rerunConfirmReplace:
+      'Diesen Ordner erneut ausführen? Das aktuelle Ergebnis wird ersetzt — laden Sie es zuerst herunter, wenn Sie es behalten möchten.',
     navLabel: 'Automatisierte Assays',
     title: 'Automatisierte Assays',
     subtitle:

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2429,6 +2429,15 @@ export default {
       'A folder cannot be moved into itself or its own subfolder',
   },
   automatedEssays: {
+    rerun: 'Run again',
+    rerunHint:
+      'Run this folder again using the files already on the server — no re-upload needed.',
+    rerunStarted: 'The run has been queued again.',
+    rerunFailed: 'Could not start the run again.',
+    rerunConfirm:
+      'Run this folder again? It uses the files already stored on the server.',
+    rerunConfirmReplace:
+      'Run this folder again? The current result will be replaced — download it first if you want to keep it.',
     navLabel: 'Automated Essays',
     title: 'Automated Essays',
     subtitle:

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -2400,6 +2400,15 @@ export default {
       'Una carpeta no se puede mover dentro de sí misma o de su propia subcarpeta',
   },
   automatedEssays: {
+    rerun: 'Ejecutar de nuevo',
+    rerunHint:
+      'Vuelve a ejecutar esta carpeta con los archivos ya almacenados en el servidor: no hace falta volver a subirlos.',
+    rerunStarted: 'La ejecución se ha vuelto a poner en cola.',
+    rerunFailed: 'No se ha podido volver a iniciar la ejecución.',
+    rerunConfirm:
+      '¿Ejecutar esta carpeta de nuevo? Se usarán los archivos ya almacenados en el servidor.',
+    rerunConfirmReplace:
+      '¿Ejecutar esta carpeta de nuevo? El resultado actual se reemplazará: descárguelo primero si quiere conservarlo.',
     navLabel: 'Ensayos automatizados',
     title: 'Ensayos automatizados',
     subtitle:

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -2350,6 +2350,15 @@ export default {
       'Un dossier ne peut pas être déplacé dans lui-même ou dans son propre sous-dossier',
   },
   automatedEssays: {
+    rerun: 'Relancer',
+    rerunHint:
+      'Relance ce dossier à partir des fichiers déjà présents sur le serveur — aucun nouvel envoi nécessaire.',
+    rerunStarted: "Le traitement a été remis en file d'attente.",
+    rerunFailed: 'Impossible de relancer le traitement.',
+    rerunConfirm:
+      'Relancer ce dossier ? Les fichiers déjà stockés sur le serveur seront utilisés.',
+    rerunConfirmReplace:
+      "Relancer ce dossier ? Le résultat actuel sera remplacé — téléchargez-le d'abord si vous souhaitez le conserver.",
     navLabel: 'Essais automatisés',
     title: 'Essais automatisés',
     subtitle:

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -2205,6 +2205,13 @@ export default {
     cannotMoveIntoSelf: '无法将文件夹移动到自身或其子文件夹中',
   },
   automatedEssays: {
+    rerun: '重新运行',
+    rerunHint: '使用服务器上已有的文件重新运行该文件夹，无需重新上传。',
+    rerunStarted: '任务已重新排队。',
+    rerunFailed: '无法重新启动任务。',
+    rerunConfirm: '要重新运行该文件夹吗？将使用服务器上已存储的文件。',
+    rerunConfirmReplace:
+      '要重新运行该文件夹吗？当前结果将被替换 — 如需保留请先下载。',
     navLabel: '自动检测分析',
     title: '自动检测分析',
     subtitle: '上传包含 .nd2 孔位记录的文件夹，测量每个孔位的微管长度和强度。',

--- a/src/types/essays.ts
+++ b/src/types/essays.ts
@@ -18,6 +18,16 @@ export interface EssayJob {
   createdAt: string;
   updatedAt: string;
   completedAt?: string | null;
+  /**
+   * Whether the uploaded .nd2 files are still on the server, so the run can be
+   * repeated without uploading them again.
+   *
+   * Answered by the backend from the DISK, not derived from `status`: the input
+   * is only kept for a run that did not finish cleanly, and even then only for a
+   * retention window. A button driven by status alone would offer a re-run that
+   * fails the moment it is clicked.
+   */
+  canRerun?: boolean;
 }
 
 /** Optional module options the user can tune before running. */


### PR DESCRIPTION
Roman, in-app feedback 2026-08-25:

> Občas se stane že segmentace neproběhne nebo v minulosti nebyla paměť na segmentaci všech jamek. Pokud by to šlo hodila by se možnost znovu spuštění segmentace již nahraných složek abych je nemusel nahrávat znovu.

He had uploaded the same 180-file folder **three times** (`20260601_201313_389` on Aug 5, 10 and 14), because there was nothing to re-run from: the finalize path deleted the whole job directory, input included, the moment a run ended.

### The part that isn't obvious from the request

A run can fail to finish cleanly in two ways, and **only one of them is called `failed`**. `evaluate.py` exits 0 even when individual wells fail to read or segment, so a **partial** run is stored as `completed` carrying an `error` — the service's own comment says so. That is exactly the case Roman described ("nebyla paměť na segmentaci všech jamek").

So keying retention on `status` would have deleted the input for precisely the runs worth repeating. It keys on whether the run finished **cleanly** instead.

### What changed

| | |
|---|---|
| **Retention** | A clean run still deletes its input immediately (7 of 9 measured jobs). Anything else keeps it. `ESSAYS_INPUT_RETENTION_DAYS` (default 7) sweeps the rest — an input is ~10 GB and nothing else bounds the growth. |
| **Endpoint** | `POST /essays/jobs/:jobId/rerun` re-queues the **same job row**. A new row would point at another row's input directory, and then neither could safely delete it without reference counting — too much machinery for a button. |
| **UI** | A "Spustit znovu" button gated on `canRerun`, which the backend answers by **stat'ing the disk**, not by reading the status: retention has a TTL and an operator can delete a directory, so a status-derived button would offer a re-run that fails on click. |

The cost of reusing the row is that an existing result zip is replaced, so the confirmation says so — and the wording differs depending on whether a zip exists.

### Verified in production

Reproduced Roman's exact case on the **test account** (his data untouched): a job that ended `status=completed, error="1 well/position failure(s)…"` — and `canRerun=true`. Under the old code its input would already be gone.

| check | result |
|---|---|
| input retained, `output/` removed | ✓ |
| `POST /rerun` | 200 → `running`, progress 0, zip and error cleared |
| re-run while running | **400** "This job is still running" |
| unknown job | **404** |
| **another user's job** (Roman's failed one) | **404** — not reachable |
| UI | confirm shows the replace wording, toast confirms, 0 console errors |

34 service tests. Four mutations, all killed: keying retention on status alone, deleting the input unconditionally, allowing a running job to be re-queued, and trusting status instead of the disk for `canRerun`. i18n across all six locales.

### Deliberately not done

**Re-running only the failed wells.** `evaluate.py` takes `--data <dir>` and `--limit-wells N` (a count, not a selection), so it would mean changing the vendored module — shared with the interactive MT path — or staging a ~10 GB copy. The request was to avoid re-uploading, not to shorten the run.

**Persisting run options.** The page posts files and a folder name only, so every run uses the worker's defaults and a re-run reproduces the original exactly. Noted at the method: an options UI would have to persist them on the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgw18koquTQUEnKsZQmCfV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to rerun eligible automated essay jobs without re-uploading files.
  * Added eligibility indicators and rerun controls, including confirmation when existing results may be replaced.
  * Added localized rerun messages and prompts in supported languages.
* **Bug Fixes**
  * Preserves inputs for unsuccessful runs for a limited retention period, enabling recovery and reruns.
* **Tests**
  * Expanded coverage for rerun eligibility, ownership, missing files, expiration, and job state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->