### PR TITLE
test(ml): defer the net import so it cannot break suite collection

### DIFF
--- a/backend/segmentation/tests/test_net_head_width_errors.py
+++ b/backend/segmentation/tests/test_net_head_width_errors.py
@@ -15,11 +15,25 @@ import torch
 
 sys.path.insert(0, "/app/models/microtubule")
 
-from net import head_width  # noqa: E402
+
+def _head_width():
+    """Import inside the test, never at module scope.
+
+    At module scope this breaks COLLECTION of the whole suite — pytest imports
+    every test module up front, and importing `net` then drags in the model
+    package, whose import chain reaches mamba_ssm/Triton and dies before any
+    test runs. The file passes in isolation and takes the suite down with it,
+    which is the worst of both. `test_microtubule_small_frames.py` defers its
+    `from net import TILE` for the same reason.
+    """
+    from net import head_width
+
+    return head_width
 
 
 def test_a_valid_checkpoint_reports_its_head_width():
     state = {"decoder.seg_layers.0.weight": torch.zeros(1, 32, 1, 1)}
+    head_width = _head_width()
     assert head_width(state) == 1
     state = {"decoder.seg_layers.0.weight": torch.zeros(7, 32, 1, 1)}
     assert head_width(state) == 7
@@ -33,7 +47,7 @@ def test_a_checkpoint_without_seg_layers_raises_a_catchable_error():
     of a 500 naming the checkpoint.
     """
     with pytest.raises(Exception) as excinfo:
-        head_width({"encoder.stages.0.weight": torch.zeros(8, 3, 3, 3)})
+        _head_width()({"encoder.stages.0.weight": torch.zeros(8, 3, 3, 3)})
 
     assert not isinstance(excinfo.value, SystemExit), (
         "SystemExit is a BaseException and bypasses every service error handler"
@@ -45,7 +59,7 @@ def test_a_checkpoint_without_seg_layers_raises_a_catchable_error():
 def test_the_error_survives_a_plain_except_exception():
     """Exactly the shape model_loader.load_model uses."""
     try:
-        head_width({})
+        _head_width()({})
     except Exception as exc:  # noqa: BLE001 — mirrors the production handler
         assert "ResEnc" in str(exc) or "seg_layers" in str(exc)
     else:


### PR DESCRIPTION
Found while verifying the day's work by running `pytest tests/` rather than only the files I had touched.

`test_net_head_width_errors.py` (added earlier today) imported `head_width` at module scope. pytest imports every test module up front, so that import ran during collection, dragged in the model package, and its chain reached mamba_ssm/Triton and died before a single test executed.

Green in isolation, and it took the whole suite's collection down with it — the worst combination, because the file that looks fine is the one causing the breakage.

Deferred into a helper, which is what the sibling `test_microtubule_small_frames.py` already does with its `from net import TILE`.

| | before | after |
|---|---|---|
| collection errors | 8 | **7** |
| tests collected | 409 | **412** |

The remaining seven are pre-existing, in files this branch never touched (`test_cancel_api`, `test_parallel_processing`, `test_performance_benchmarks`, `test_error_scenarios`, `test_inference_service`, `test_model_manager`, `test_threshold_bounds`) — the missing-module state CLAUDE.md already records for the ML suite.

The four ML test files added today still pass, 29 of them, run with `--gpus all` per the documented recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgw18koquTQUEnKsZQmCfV
MD
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for malformed model checkpoints, ensuring failures can be caught as runtime errors instead of terminating the application.
  * Prevented unrelated model-package dependencies from causing the test suite to fail during test collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->