### PR TITLE
fix(export): report progress during the microtubule stages

### DIFF
--- a/backend/src/services/export/__tests__/exportFileOperations.test.ts
+++ b/backend/src/services/export/__tests__/exportFileOperations.test.ts
@@ -28,7 +28,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sanitizeFilename, getProgressMessage } from '../exportFileOperations';
+import {
+  sanitizeFilename,
+  getProgressMessage,
+  countExportSteps,
+} from '../exportFileOperations';
 
 // ---------------------------------------------------------------------------
 // sanitizeFilename
@@ -253,5 +257,72 @@ describe('getProgressMessage', () => {
       expect(msg).toContain('1/2');
       expect(msg).toContain('55%');
     });
+  });
+});
+
+/**
+ * Regression guard for the "export is stuck" report (2026-08-25).
+ *
+ * A 300-frame microtubule export sat at 95% for ~20 minutes. It was not stuck:
+ * the four microtubule-only exporters were pushed into the same `Promise.all`
+ * as the generic ones but were neither counted in the denominator nor reported
+ * on, so the bar ran out of steps while the longest stage had not started.
+ */
+describe('countExportSteps', () => {
+  const generic = {
+    includeOriginalImages: true,
+    includeVisualizations: true,
+    annotationFormats: ['coco'],
+    metricsFormats: ['xlsx'],
+    includeDocumentation: true,
+  };
+
+  it('counts only the generic tasks for a non-microtubule project', () => {
+    expect(countExportSteps(generic, false, true)).toBe(5);
+  });
+
+  it('counts the four microtubule exporters for an MT project', () => {
+    // THE REGRESSION: this returned 5 before the fix, so the bar hit
+    // 5 + 5*(90/5) = 95% and froze for the whole kymograph stage.
+    expect(
+      countExportSteps({ ...generic, mtKymographs: { enabled: true } }, true, true)
+    ).toBe(9);
+  });
+
+  it('omits the kymograph step when kymographs are disabled', () => {
+    expect(
+      countExportSteps({ ...generic, mtKymographs: { enabled: false } }, true, true)
+    ).toBe(8);
+  });
+
+  it('omits every image-gated MT step when the project has no images', () => {
+    // mt-metrics, ImageJ RoiSet and CVAT are all gated on images.
+    expect(
+      countExportSteps({ ...generic, mtKymographs: { enabled: true } }, true, false)
+    ).toBe(6);
+  });
+
+  it('omits MT metrics when no metrics format was requested', () => {
+    const noMetrics = { ...generic, metricsFormats: [], mtKymographs: { enabled: true } };
+    // loses the generic metrics step AND the MT metrics step
+    expect(countExportSteps(noMetrics, true, true)).toBe(7);
+  });
+
+  it('never returns 0 for an MT project with images, so the divisor is safe', () => {
+    expect(countExportSteps({}, true, true)).toBeGreaterThan(0);
+  });
+});
+
+describe('getProgressMessage — microtubule stages', () => {
+  it.each([
+    ['mt-metrics', 'Measuring microtubules'],
+    ['kymographs', 'Building kymographs'],
+    ['imagej-roi', 'Writing ImageJ ROI sets'],
+    ['cvat', 'Writing CVAT annotations'],
+  ] as const)('labels the %s stage', (stage, expected) => {
+    expect(getProgressMessage(50, stage)).toContain(expected);
+    expect(getProgressMessage(50, stage, { current: 3, total: 10 })).toContain(
+      `${expected} (3/10)`
+    );
   });
 });

--- a/backend/src/services/export/exportFileOperations.ts
+++ b/backend/src/services/export/exportFileOperations.ts
@@ -72,7 +72,55 @@ export type ExportProgressStage =
   | 'visualizations'
   | 'annotations'
   | 'metrics'
+  // Microtubule-only stages. They run inside the same `Promise.all` as the
+  // generic ones above, but on an MT project they are the long pole by a wide
+  // margin — a 300-frame export spent ~20 min in `kymographs` alone while the
+  // bar sat frozen at 95%, because none of these four reported anything.
+  | 'mt-metrics'
+  | 'kymographs'
+  | 'imagej-roi'
+  | 'cvat'
   | 'compression';
+
+/**
+ * How many parallel tasks the export will push into its `Promise.all`.
+ *
+ * This is the denominator of the progress bar, and it is a contract with
+ * `exportService.generateExport`: every `exportTasks.push(...)` there must be
+ * represented by exactly one entry here, under the same condition.
+ *
+ * It exists as a pure function because the bug it encodes was invisible inside
+ * the 1300-line method: the four microtubule exporters were pushed but never
+ * counted, so a 300-frame MT export drove the bar to 5 + 5*(90/5) = 95% as the
+ * generic tasks finished and then froze there for the ~20 minutes the
+ * kymographs actually took. Users reported it as "the export is stuck".
+ */
+export function countExportSteps(
+  options: {
+    includeOriginalImages?: boolean;
+    includeVisualizations?: boolean;
+    annotationFormats?: unknown[] | null;
+    metricsFormats?: unknown[] | null;
+    includeDocumentation?: boolean;
+    mtKymographs?: { enabled?: boolean } | null;
+  },
+  isMicrotubuleProject: boolean,
+  hasImages: boolean
+): number {
+  return [
+    options.includeOriginalImages,
+    options.includeVisualizations,
+    options.annotationFormats?.length,
+    options.metricsFormats?.length,
+    options.includeDocumentation,
+    // Microtubule-only exporters. ImageJ RoiSet and CVAT are always-on for MT
+    // projects (no toggle), so they are gated on images alone.
+    isMicrotubuleProject && options.metricsFormats?.length && hasImages,
+    isMicrotubuleProject && options.mtKymographs?.enabled,
+    isMicrotubuleProject && hasImages,
+    isMicrotubuleProject && hasImages,
+  ].filter(Boolean).length;
+}
 
 export interface ExportProgressDetail {
   current: number;
@@ -102,6 +150,14 @@ export function getProgressMessage(
         return `Creating annotation files (${current}/${total})${itemSuffix}... ${progress}%`;
       case 'metrics':
         return `Calculating metrics (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'mt-metrics':
+        return `Measuring microtubules (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'kymographs':
+        return `Building kymographs (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'imagej-roi':
+        return `Writing ImageJ ROI sets (${current}/${total})${itemSuffix}... ${progress}%`;
+      case 'cvat':
+        return `Writing CVAT annotations (${current}/${total})${itemSuffix}... ${progress}%`;
       case 'compression':
         return `Creating archive... ${progress}%`;
       default:
@@ -117,6 +173,14 @@ export function getProgressMessage(
         return `Creating annotation files... ${progress}%`;
       case 'metrics':
         return `Calculating metrics... ${progress}%`;
+      case 'mt-metrics':
+        return `Measuring microtubules... ${progress}%`;
+      case 'kymographs':
+        return `Building kymographs... ${progress}%`;
+      case 'imagej-roi':
+        return `Writing ImageJ ROI sets... ${progress}%`;
+      case 'cvat':
+        return `Writing CVAT annotations... ${progress}%`;
       case 'compression':
         return `Creating archive... ${progress}%`;
       default:

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -188,7 +188,18 @@ export async function exportMicrotubuleKymographs(
   projectId: string,
   exportDir: string,
   options: MTKymographOptions,
-  selectedImageIds?: string[] | null
+  selectedImageIds?: string[] | null,
+  /**
+   * Called once per finished (microtubule x channel) job, in completion order.
+   * Deliberately NOT part of `MTKymographOptions`: that object is deserialised
+   * straight off the wire, and a function has no business round-tripping
+   * through JSON. Kept optional so every existing caller and test is unchanged.
+   *
+   * This is the export's longest stage by far — one real 300-frame project
+   * spent ~20 min here — so it is the one place where per-item reporting is
+   * worth the plumbing rather than a single bump on completion.
+   */
+  onProgress?: (done: number, total: number) => void
 ): Promise<void> {
   // Normalise the mode: the controller casts req.body without validation, so an
   // older cached FE bundle (or a direct API caller) may omit it. Default to the
@@ -319,6 +330,11 @@ export async function exportMicrotubuleKymographs(
     // Capped per MT so a long time-lapse can't emit thousands of PNGs. --------
     if (mode === 'profiles') {
       let profileCount = 0;
+      let jobsDone = 0;
+      const reportDone = (): void => {
+        jobsDone++;
+        onProgress?.(jobsDone, jobs.length);
+      };
       await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
         try {
           const result = await buildKymograph({
@@ -368,6 +384,11 @@ export async function exportMicrotubuleKymographs(
             `Profile export failed for ${job.videoName}/${job.polylineId}/${job.sourceChannel}: ${(err as Error).message}`,
             CTX
           );
+        } finally {
+          // `finally`, not the end of `try`: a microtubule whose profile export
+          // failed is still one job the user is no longer waiting on. Counting
+          // only successes would stall the bar short of 100% on any failure.
+          reportDone();
         }
       });
 
@@ -385,6 +406,11 @@ export async function exportMicrotubuleKymographs(
     // worksheet (channel = motor/protein) in velocity_metrics.xlsx.
     const rowsByChannel = new Map<string, VelocityRow[]>();
 
+    let jobsDone = 0;
+    const reportDone = (): void => {
+      jobsDone++;
+      onProgress?.(jobsDone, jobs.length);
+    };
     await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
       try {
         const result = await buildKymograph({
@@ -449,6 +475,8 @@ export async function exportMicrotubuleKymographs(
           `Kymograph failed for ${job.videoName}/${job.polylineId}/${job.sourceChannel}: ${(err as Error).message}`,
           CTX
         );
+      } finally {
+        reportDone();
       }
     });
 

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -41,6 +41,8 @@ import {
   sanitizeFilename,
   getProgressMessage,
   createZipArchive,
+  countExportSteps,
+  type ExportProgressStage,
 } from './export/exportFileOperations';
 import {
   computeMTMetrics,
@@ -487,13 +489,21 @@ export class ExportService {
       // Parallel export processing - run independent tasks concurrently
       const exportTasks: Promise<void>[] = [];
       let progressStep = 0;
-      const totalSteps = [
-        options.includeOriginalImages,
-        options.includeVisualizations,
-        options.annotationFormats?.length,
-        options.metricsFormats?.length,
-        options.includeDocumentation,
-      ].filter(Boolean).length;
+
+      // Whether this is a microtubule project — drives which exporters run
+      // (skip standard annotations/metrics, add MT-metrics/kymograph/ImageJ/CVAT).
+      // Declared HERE, above `totalSteps`, because the step count below depends
+      // on it. Reading it from its old position further down would be a TDZ
+      // crash at runtime that the type checker does not catch.
+      const isMicrotubuleProject = isMicrotubuleProjectType(project.type);
+
+      // SSOT: the denominator lives beside `getProgressMessage` so it can be
+      // unit-tested against the push sites it mirrors.
+      const totalSteps = countExportSteps(
+        options,
+        isMicrotubuleProject,
+        Boolean(project.images?.length)
+      );
 
       // Use 90% of progress for processing tasks, leaving 5% for ZIP creation
       const progressIncrement = totalSteps > 0 ? 90 / totalSteps : 0;
@@ -526,10 +536,6 @@ export class ExportService {
           })
         );
       }
-
-      // Whether this is a microtubule project — drives which exporters run
-      // (skip standard annotations/metrics, add MT-metrics/kymograph/ImageJ/CVAT).
-      const isMicrotubuleProject = isMicrotubuleProjectType(project.type);
 
       // Generate visualizations (can run in parallel)
       if (options.includeVisualizations && project.images) {
@@ -643,7 +649,14 @@ export class ExportService {
             exportDir,
             options,
             jobId
-          )
+          ).then(() => {
+            progressStep++;
+            this.updateJobProgress(
+              jobId,
+              5 + progressStep * progressIncrement,
+              'mt-metrics'
+            );
+          })
         );
       }
 
@@ -656,8 +669,32 @@ export class ExportService {
             options.mtKymographs,
             // Scope kymographs/profiles to the selected frames, like the other
             // MT exporters (which already scope via the filtered project.images).
-            options.selectedImageIds
-          )
+            options.selectedImageIds,
+            // Per-microtubule reporting. This stage is the export's long pole,
+            // so a single bump on completion would still leave the bar frozen
+            // for its whole duration. `progressStep` is read HERE rather than
+            // captured at push time: at push time nothing has completed yet, so
+            // every task would share the same base and they would fight over
+            // one band. Reading it live keeps the bar monotonic, because
+            // `progressStep` only ever grows.
+            (done, total) => {
+              const base = 5 + progressStep * progressIncrement;
+              const within = total > 0 ? (done / total) * progressIncrement : 0;
+              this.updateJobProgress(
+                jobId,
+                Math.min(95, Math.round(base + within)),
+                'kymographs',
+                { current: done, total }
+              );
+            }
+          ).then(() => {
+            progressStep++;
+            this.updateJobProgress(
+              jobId,
+              5 + progressStep * progressIncrement,
+              'kymographs'
+            );
+          })
         );
       }
 
@@ -707,6 +744,12 @@ export class ExportService {
                   job.warnings = [...(job.warnings ?? []), ...result.warnings];
                 }
               }
+              progressStep++;
+              this.updateJobProgress(
+                jobId,
+                5 + progressStep * progressIncrement,
+                'imagej-roi'
+              );
             })
             .catch(error => {
               // A real user cancellation should still fail the job.
@@ -748,6 +791,12 @@ export class ExportService {
                   job.warnings = [...(job.warnings ?? []), ...result.warnings];
                 }
               }
+              progressStep++;
+              this.updateJobProgress(
+                jobId,
+                5 + progressStep * progressIncrement,
+                'cvat'
+              );
             })
             .catch(error => {
               if (this.isJobCancelled(jobId)) {
@@ -1756,12 +1805,10 @@ export class ExportService {
   private updateJobProgress(
     jobId: string,
     progress: number,
-    stage?:
-      | 'images'
-      | 'visualizations'
-      | 'annotations'
-      | 'metrics'
-      | 'compression',
+    // Was a second, hand-maintained copy of this union. It drifted the moment
+    // the microtubule stages were added to `getProgressMessage`, so the stages
+    // could not be passed from here at all. One definition, imported.
+    stage?: ExportProgressStage,
     stageProgress?: { current: number; total: number; currentItem?: string }
   ): void {
     const job = this.exportJobs.get(jobId);


### PR DESCRIPTION
## The report

A 300-frame microtubule export sat at 95% for ~20 minutes and was reported as stuck.

**It was not stuck.** It was writing kymographs the whole time — one per microtubule — and finished on its own with a 929 MB archive while I was debugging it. Evidence gathered live in production:

- backend up 6 h, healthy — no restart, so not the PR #318 OOM
- `heap_size_limit = 8240 MB`, RSS 1.96 GiB — the `NODE_OPTIONS` fix is live and nowhere near its ceiling
- status endpoint returned **304**, never 404 — the job existed, its payload just never changed
- the output directory grew by 4 files / 25 s the whole time it "hung"

## Root cause

`generateExport` pushes nine tasks into one `Promise.all`. Only five were wired into the progress bar:

| task | counted in `totalSteps` | reports progress |
|---|---|---|
| copyOriginalImagesWithProgress | yes | yes |
| generateVisualizations | yes | yes |
| generateAnnotations | yes | yes |
| generateMetrics | yes | yes |
| generateDocumentation | yes | yes |
| **generateMicrotubuleMetrics** | **no** | **no** |
| **exportMicrotubuleKymographs** | **no** | **no** |
| **exportImageJRoiSets** | **no** | **no** |
| **exportCvatAnnotations** | **no** | **no** |

So the bar spent its whole 90-point budget on the generic tasks — `5 + 5*(90/5) = 95` — and then froze there for the entire longest stage.

The accounting was written for the generic pipeline and never extended when the MT exporters were added. That is why this hits MT projects specifically: **the four silent tasks are exactly the expensive ones.**

## The fix

- All four counted, all four report on completion.
- Kymographs additionally report **per microtubule** via a new optional `onProgress`. A single bump on completion would still have left the bar frozen for the whole stage — that is the bug, not a smaller version of it. It fires from a `finally`, so a failed microtubule advances the bar instead of stalling it short of 100%.
- `progressStep` is read *inside* the callback, not captured at push time: at push time nothing has completed, so every task would share one base and fight over the same band. Read live it is monotonic.
- `updateJobProgress` had a second hand-maintained copy of the stage union — which is why the new stages could not have been passed even if reported. One definition now, imported.
- `isMicrotubuleProject` hoisted above `totalSteps`, which now depends on it. Left in place this was a TDZ crash the type checker does not catch (CLAUDE.md failure pattern #11).

## Testability

The step count moved into a pure `countExportSteps`. Inside the 1300-line method the bug was invisible; as a function it is a checkable contract with the push sites — every `exportTasks.push` needs exactly one entry under the same condition.

## Verification

- 6 tests for `countExportSteps`, 4 for the new stage labels — **65 pass** in that file, **114** in the neighbouring export suites.
- **Mutation-tested**: deleting the four MT entries from the count turns **5 of 6 red**, including the 9-vs-5 assertion that is the regression itself.
- Backend `tsc --noEmit` clean; pre-commit (ESLint 0 warnings, prettier) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgw18koquTQUEnKsZQmCfV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed progress tracking for microtubule project exports, including metrics, kymographs, ImageJ ROIs, and CVAT files.
  * Progress updates now show completed and total export items during kymograph processing.

* **Bug Fixes**
  * Export progress now accurately includes all applicable stages and reaches completion even when individual export jobs fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->