### PR TITLE
perf(ml): re-add polyline simplification to the microtubule output

### DIFF
--- a/backend/segmentation/models/microtubule/params_v5h.json
+++ b/backend/segmentation/models/microtubule/params_v5h.json
@@ -16,5 +16,6 @@
  "bridge_thr": 0.07121686958579185,
  "min_arc_len": 3,
  "ds": 2.0,
- "half_width": 1.0
+ "half_width": 1.0,
+ "polyline_eps_px": 0.30
 }

--- a/backend/segmentation/models/microtubule/wrapper.py
+++ b/backend/segmentation/models/microtubule/wrapper.py
@@ -78,6 +78,48 @@ def _normalize(a: np.ndarray, p: tuple[float, float] = (1.0, 99.0)) -> np.ndarra
     return np.clip((a - lo) / (hi - lo + 1e-6), 0.0, 1.0)
 
 
+def _simplify_polyline(cl: np.ndarray, eps_px: float) -> np.ndarray:
+    """Ramer-Douglas-Peucker simplification of one centerline, INPUT-px space.
+
+    This is output formatting, not instancing: it runs after the instancer's
+    ``ds``-spaced grid has already been traced and junction-matched, so it
+    changes only how densely the accepted geometry is stored, never which
+    filaments are found. ``cv2.approxPolyDP(..., closed=False)`` always keeps
+    the first and last point of an open curve, so endpoints survive.
+
+    Mirrors the fallback commit 39b6493c used for the v7-era wrapper: a
+    centerline too short to simplify, or one that collapses to under 2 points
+    (eps too large for its extent), or a `cv2` failure on a malformed
+    centerline, all degrade to the ORIGINAL (unsimplified) curve rather than
+    dropping the microtubule from the frame.
+    """
+    if eps_px <= 0 or cl.shape[0] <= 2:
+        return cl
+    try:
+        import cv2
+
+        cv_pts = cl.astype(np.float32).reshape(-1, 1, 2)
+        simplified = cv2.approxPolyDP(cv_pts, float(eps_px), closed=False)
+        cl_simp = simplified.reshape(-1, 2).astype(np.float64)
+        if cl_simp.shape[0] >= 2:
+            return cl_simp
+        logger.warning(
+            "RDP collapsed centerline to %d pts (eps=%.2f px); keeping "
+            "original (%d pts)",
+            cl_simp.shape[0],
+            eps_px,
+            cl.shape[0],
+        )
+    except Exception as exc:  # noqa: BLE001 -- one bad centerline must not
+        # abort the whole inference and lose every other MT in the frame.
+        logger.warning(
+            "polyline simplification failed on shape=%s: %s; using unsimplified",
+            cl.shape,
+            exc,
+        )
+    return cl
+
+
 class MicrotubuleModel:
     """Semantic stage + instancer. Load once, then predict many frames.
 
@@ -234,7 +276,11 @@ class MicrotubuleModel:
             seed_threshold: Foreground cut applied to the probability map before
                 instancing. ``None`` uses the shipped params vector's
                 ``prob_thr`` (0.97), which is what the model was tuned with.
-            params: Overrides of the instancer hyperparameters.
+            params: Overrides of the instancer hyperparameters. Also accepts
+                ``polyline_eps_px`` (default from params_v5h.json), the RDP
+                tolerance applied to the OUTPUT geometry -- see
+                :func:`_simplify_polyline`. It is not read by ``instance_a``;
+                the instancer's working resolution stays ``ds``, unaffected.
 
         Returns:
             ``{
@@ -283,6 +329,18 @@ class MicrotubuleModel:
         centerlines_rc = [
             np.asarray(pl, dtype=np.float64)[:, ::-1] / UP for pl in polylines
         ]
+
+        # RDP simplification, in INPUT-px space (after the /UP rescale above,
+        # so `polyline_eps_px` means what it says: pixels of the frame that
+        # was passed in, not the 1.5x working scale). This is the ONE
+        # chokepoint both callers share -- interactive segmentation via
+        # ModelLoader.predict_microtubule() and the essays batch worker via
+        # `evaluate.py` / `infer.py` -- both consume `centerlines_rc` from
+        # this method and neither has its own copy of the geometry. See
+        # _simplify_polyline for the endpoint-preserving, fail-open contract.
+        eps_px = float(merged.get("polyline_eps_px", 0.0) or 0.0)
+        if eps_px > 0:
+            centerlines_rc = [_simplify_polyline(cl, eps_px) for cl in centerlines_rc]
 
         # Map the probability map back so callers see the frame they passed in.
         prob = zoom(prob_up, 1.0 / UP, order=1).astype(np.float32)

--- a/backend/segmentation/tests/test_microtubule_model.py
+++ b/backend/segmentation/tests/test_microtubule_model.py
@@ -21,7 +21,7 @@ for _p in (str(_PKG), str(_PKG / "vendor")):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from models.microtubule.wrapper import MicrotubuleModel  # noqa: E402
+from models.microtubule.wrapper import MicrotubuleModel, _simplify_polyline  # noqa: E402
 
 
 class _StubNet:
@@ -118,3 +118,102 @@ def test_rgb_input_is_reduced_to_grayscale():
 def test_non_2d_input_is_rejected():
     with pytest.raises(ValueError, match="expected 2D image"):
         _loaded_model().predict(np.random.rand(4, 8, 8, 2).astype(np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Post-instancer RDP simplification (polyline_eps_px).
+#
+# The instancer itself is NEVER touched by this: `ds` stays the working
+# resolution the instancer traces at (junction matching, curvature
+# enforcement, tangent windows all still see the dense grid). What changes is
+# only how densely the ALREADY-ACCEPTED geometry is stored on the way out.
+# ---------------------------------------------------------------------------
+
+
+def test_rdp_simplification_wired_into_predict_output():
+    """End-to-end through predict(), not a unit test of the helper alone.
+
+    The stub draws a near-straight horizontal band, so RDP should collapse
+    almost every interior sample, while an eps=0 override (RDP disabled)
+    must keep the instancer's full ds-spaced point count. This is the same
+    `predict()` return value both ModelLoader.predict_microtubule()
+    (interactive) and the essays batch worker (`infer.py` / `evaluate.py`)
+    consume -- there is no second copy of this geometry for either caller
+    to diverge from.
+    """
+    image = np.random.rand(256, 256).astype(np.float32)
+    model = _loaded_model()
+
+    unsimplified = model.predict(image, params={"polyline_eps_px": 0.0})["centerlines_rc"]
+    simplified = model.predict(image)["centerlines_rc"]  # shipped params_v5h.json eps (0.30)
+
+    assert unsimplified, "stub foreground produced no instance"
+    assert simplified
+    assert len(unsimplified) == len(simplified), "RDP must not change instance count"
+
+    for raw, simp in zip(unsimplified, simplified):
+        assert raw.shape[0] > 10, "fixture should have interior points to simplify"
+        assert simp.shape[0] <= 3, "a near-straight centerline must collapse to (near) its two endpoints"
+        np.testing.assert_allclose(raw[0], simp[0], atol=1e-9, err_msg="start point moved")
+        np.testing.assert_allclose(raw[-1], simp[-1], atol=1e-9, err_msg="end point moved")
+
+
+def test_vertices_count_reflects_simplified_geometry():
+    """model_loader.py stamps vertices_count = len(points) built straight from
+    centerlines_rc, so it automatically tracks whatever predict() emits --
+    guard that predict() is in fact emitting the SIMPLIFIED count."""
+    image = np.random.rand(256, 256).astype(np.float32)
+    model = _loaded_model()
+    simplified = model.predict(image)["centerlines_rc"]
+    unsimplified = model.predict(image, params={"polyline_eps_px": 0.0})["centerlines_rc"]
+    assert sum(len(c) for c in simplified) < sum(len(c) for c in unsimplified)
+
+
+def test_simplify_polyline_short_input_passthrough():
+    """<=2-point input is returned unchanged (nothing to simplify)."""
+    cl = np.array([[0.0, 0.0], [1.0, 1.0]])
+    np.testing.assert_array_equal(_simplify_polyline(cl, 0.3), cl)
+
+
+def test_simplify_polyline_zero_eps_is_noop():
+    cl = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, 2.0], [5.0, 2.0]])
+    np.testing.assert_array_equal(_simplify_polyline(cl, 0.0), cl)
+
+
+def test_simplify_polyline_preserves_endpoints_on_curved_input():
+    """cv2.approxPolyDP(..., closed=False) always keeps the first and last
+    point of an open curve; pin that guarantee directly."""
+    theta = np.linspace(0, np.pi, 40)
+    cl = np.stack([10 * np.sin(theta), theta * 5.0], axis=1)
+    simp = _simplify_polyline(cl, 0.3)
+    assert simp.shape[0] < cl.shape[0], "a curved fixture should still simplify"
+    np.testing.assert_allclose(simp[0], cl[0])
+    np.testing.assert_allclose(simp[-1], cl[-1])
+
+
+def test_simplify_polyline_falls_back_when_cv2_raises(monkeypatch):
+    """One malformed centerline must degrade to the unsimplified curve, not
+    abort the whole frame's inference (mirrors commit 39b6493c's guard)."""
+    cl = np.array([[0.0, 0.0], [1.0, 0.5], [2.0, 0.0], [3.0, 0.5], [4.0, 0.0]])
+
+    class _BoomCv2:
+        @staticmethod
+        def approxPolyDP(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setitem(sys.modules, "cv2", _BoomCv2())
+    np.testing.assert_array_equal(_simplify_polyline(cl, 0.3), cl)
+
+
+def test_simplify_polyline_falls_back_when_result_collapses(monkeypatch):
+    """eps too large for a short curve collapsing to <2 points must also
+    fall back to the original, not drop the microtubule."""
+    cl = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+
+    class _CollapseCv2:
+        @staticmethod
+        def approxPolyDP(_cv_pts, _eps, _closed):
+            return np.zeros((1, 1, 2), dtype=np.float32)
+
+    monkeypatch.setitem(sys.modules, "cv2", _CollapseCv2())
+    np.testing.assert_array_equal(_simplify_polyline(cl, 0.3), cl)


### PR DESCRIPTION
## Problem

Microtubule polylines got ~35x denser on 2026-08-17. Not a design decision: the RDP step was deleted along with the v7 wrapper in `c5484861` because its stated purpose (keeping embedding samples index-aligned with vertices) vanished when v5H stopped emitting embeddings. Nothing replaced it, so the instancer's raw 1.333 px grid now ships.

Production, by model generation:

| | median pts | p95 | max |
|---|---|---|---|
| v7 + RDP eps 1.0 (Jun-Jul) | 5 | 20 | 74 |
| v5H today (Aug) | 190 | 476 | 899 |

~21k SVG vertices and 910 kB of JSON per frame; 286 MB across the DB.

## Fix

`polyline_eps_px: 0.30` in `params_v5h.json`, applied in `wrapper.py` **after** the `/UP` rescale so the tolerance is in input-image pixels. Single chokepoint shared by interactive segmentation and the essays batch.

Measured with `cv2.approxPolyDP(closed=False)` over **3000 real production polylines** pulled from postgres:

```
   eps  median    p95    %pts   dLen_med  dLen_p95
  0.05      62    190   34.0%     0.002%    0.008%
  0.20      41    110   21.2%     0.081%    0.238%
  0.30      32     85   16.6%     0.180%    0.580%   <-- chosen
  0.50      12     42    7.4%     0.505%    0.804%
  1.00       6     19    3.4%     0.650%    1.176%
```

Sanity check that validates the harness: eps 1.0 yields median 6 against v7's actual stored median of 5.

The value was chosen to land **between** the two generations, per an explicit product decision — not back at v7 density.

## Why not just raise `ds`

`ds` is the instancer's working resolution, not an output knob: arcs are resampled at `ds` before junction matching, and `window_tangent` fits PCA tangents over the vertices inside a 28.4 px window. Raising it changes *which filaments get traced*. Untouched here.

## Risk surface

`mt_measure.rasterize_band` consumes stored points raw (no resample), so a coarser centerline cuts corners on curved filaments. Predicted sagitta displacement at eps 0.3 is ~0.05 px. **The before/after metric diff on a real frame is still outstanding and must be done before merge.**

Existing dense polylines are untouched; new segmentations only.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYYFoe8Yp1Kg1hMwYkmG7o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified microtubule centerline results to reduce unnecessary points while preserving endpoints and detected instances.
  * Added configurable control over centerline simplification tolerance.
  * Maintained original results when simplification is disabled, unsuitable, or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->