### PR TITLE
fix(video): stop the TIFF extractor writing channel names the reader rejects

### DIFF
--- a/backend/src/api/controllers/videoController.ts
+++ b/backend/src/api/controllers/videoController.ts
@@ -28,6 +28,7 @@ import { ResponseHelper } from '../../utils/response';
 import { uploadVideoFromFile } from '../../services/videoUploadService';
 import { addChannelToFrames } from '../../services/addChannelService';
 import { isVideoFilename } from '../../services/video/videoExtractor';
+import { isSafeChannelName } from '../../services/video/types';
 
 interface ChannelDTO {
   name: string;
@@ -51,15 +52,6 @@ function isValidDisplayName(value: unknown): value is string {
   }
   // eslint-disable-next-line no-control-regex
   return !/[\x00-\x1f\x7f]/.test(value);
-}
-
-/** Allowed shape for channel names anywhere in the API surface. Filesystem-
- *  safe alnum + underscore + dash; bans dots so ``.png`` extension can't
- *  smuggle in, bans slashes so traversal is impossible. */
-const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
-
-function isSafeChannelName(name: unknown): name is string {
-  return typeof name === 'string' && CHANNEL_NAME_RE.test(name);
 }
 
 /** Assert the caller has access to ``projectId`` (owner or accepted share).

--- a/backend/src/services/__tests__/videoUploadService.test.ts
+++ b/backend/src/services/__tests__/videoUploadService.test.ts
@@ -160,6 +160,50 @@ describe('videoUploadService.uploadVideoFromFile (round-2 GAP-1)', () => {
     expect(prismaImageUpdate).toHaveBeenCalledOnce();
   });
 
+  it('rejects an unsafe channel name from the extractor instead of persisting an unreadable row (GAP-Curie)', async () => {
+    // Regression for the 2026-08-26 Institut Curie incident: a Fiji/
+    // Bio-Formats TIFF export embedded a ~140-char source filename into
+    // every channel's per-slice label. The Python extractor's
+    // `_sanitize_name` never truncated, so this long name reached
+    // `finalizeContainer` unchanged. Before the ingest-time guard, it was
+    // written straight into `Image.channels`, past `assertSafeStorageSegment`
+    // (which has no length/charset cap) — producing a row the read-side
+    // `isSafeChannelName` whitelist (64-char cap) could never serve back.
+    const longName = 'c'.repeat(140);
+    extractMock.mockResolvedValue({
+      kind: 'single',
+      result: {
+        frameCount: 3,
+        durationMs: 300,
+        channels: [
+          { name: longName, type: 'irm', isSegmentationSource: true },
+        ],
+        width: 64,
+        height: 64,
+      },
+    });
+
+    await expect(
+      uploadVideoFromFile({
+        projectId: 'proj-1',
+        originalName: 'curie_export.tif',
+        mimeType: 'image/tiff',
+        tempFilePath: '/tmp/multer/curie.tif',
+      })
+    ).rejects.toThrow(/invalid channel name/i);
+
+    // Never reached the thumbnail/frame-row/channels-persist steps.
+    expect(sharpMock).not.toHaveBeenCalled();
+    expect(prismaImageCreateMany).not.toHaveBeenCalled();
+    // Rolled back like any other extraction failure.
+    expect(prismaImageUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'container-1' },
+        data: { segmentationStatus: 'extraction_failed' },
+      })
+    );
+  });
+
   it('multi-position ND2: fans out into one container per XY position', async () => {
     // Position 0 reuses the pre-created row; positions 1..N get fresh rows.
     let nextId = 0;

--- a/backend/src/services/addChannelService.ts
+++ b/backend/src/services/addChannelService.ts
@@ -25,13 +25,16 @@ import sharp from 'sharp';
 import { prisma } from '../db/prismaClient';
 import { config } from '../utils/config';
 import { logger } from '../utils/logger';
-import { ChannelMeta, defaultColorForWavelength } from './video/types';
+import {
+  ChannelMeta,
+  CHANNEL_NAME_RE,
+  defaultColorForWavelength,
+} from './video/types';
 import { isMicrotubuleProject } from '../types/validation';
 import { detectVideoKind, extractVideoSafe } from './video/videoExtractor';
 import { alignChannelFrames, ChannelAlignJob } from './video/pythonExtractor';
 import { frameStorageKey } from './videoUploadService';
 
-const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
 const MAX_DISPLAY_NAME_LEN = 128;
 
 /**

--- a/backend/src/services/kymographService.ts
+++ b/backend/src/services/kymographService.ts
@@ -23,6 +23,7 @@ import axios from 'axios';
 import { prisma } from '../db/prismaClient';
 import { config } from '../utils/config';
 import { logger } from '../utils/logger';
+import { CHANNEL_NAME_RE } from './video/types';
 
 /** Net-velocity cut-off (µm/s): trajectories slower than this are dropped as
  *  non-processive (oscillatory / static blobs are not directed transport).
@@ -30,9 +31,6 @@ import { logger } from '../utils/logger';
  *  this µm/s threshold into px/frame. */
 const MIN_NET_VELOCITY_UM_S = 0.01;
 
-/** Same whitelist used by VideoController. Channel names must be alnum +
- *  underscore + dash so they can't escape the storage root. */
-const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
 /** Mirrors the pattern accepted by the ML KymographRequest. Defence in
  *  depth — the controller layer also validates. */
 const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;

--- a/backend/src/services/video/pythonHelpers/extract_nd2.py
+++ b/backend/src/services/video/pythonHelpers/extract_nd2.py
@@ -26,6 +26,7 @@ result-JSON object on its own line.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -133,12 +134,39 @@ def _save_png(arr: np.ndarray, path: Path) -> None:
     )
 
 
+# Mirrors `CHANNEL_NAME_RE` in `backend/src/services/video/types.ts` (the
+# ONE canonical definition of this pattern on the TypeScript side). ND2
+# channel names come from structured NIS-Elements metadata and are
+# normally short, so this path is latent/defense-in-depth rather than a
+# fix for an observed production incident — the TIFF extractor's
+# equivalent (`extract_tiff_stack.py`) is the one that actually shipped a
+# too-long name; see the 2026-08-26 Institut Curie incident notes there.
+_CHANNEL_NAME_MAX_LEN = 64
+
+
 def _sanitize_name(name: str | None, fallback: str) -> str:
+    """Reduce to alnum + underscore + dash, then cap at
+    ``_CHANNEL_NAME_MAX_LEN`` (64) so the result ALWAYS survives the
+    backend's ``CHANNEL_NAME_RE`` whitelist (``^[A-Za-z0-9_-]{1,64}$``,
+    ``backend/src/services/video/types.ts``). A name that already fits is
+    returned unchanged; a longer one is truncated with a short
+    deterministic hash suffix (derived from the full untruncated string)
+    so two names differing only past character 64 can't collapse onto the
+    same on-disk filename. See ``extract_tiff_stack._sanitize_name`` for
+    the identical contract and rationale — kept as two copies because
+    they're single-file scripts with no shared Python module between
+    them."""
     if not name:
         return fallback
     # Filesystem-safe: alnum + underscore + dash only.
     safe = re.sub(r"[^A-Za-z0-9_-]+", "_", name).strip("_")
-    return safe or fallback
+    if not safe:
+        return fallback
+    if len(safe) <= _CHANNEL_NAME_MAX_LEN:
+        return safe
+    digest = hashlib.sha1(safe.encode("utf-8")).hexdigest()[:8]
+    keep = _CHANNEL_NAME_MAX_LEN - 1 - len(digest)
+    return f"{safe[:keep]}_{digest}"
 
 
 class UnsupportedND2(ValueError):

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -18,6 +18,7 @@ Stdout protocol:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -32,14 +33,46 @@ from channel_registration import (
     write_registration_sidecar,
 )
 
+# Mirrors `CHANNEL_NAME_RE` in `backend/src/services/video/types.ts` — the
+# ONE place that pattern is defined on the TypeScript side (every other
+# backend module imports it from there; see the 2026-08-26 Institut Curie
+# incident). `_sanitize_name` below enforces the length half of that
+# contract at the source, so an over-long metadata label can never reach
+# the DB unsanitized. Kept here only as a value the tests can assert
+# against — not a second source of truth for the shape, since Python and
+# TypeScript can't share one constant.
+_CHANNEL_NAME_MAX_LEN = 64
+
 
 def _sanitize_name(raw: str | None, fallback: str) -> str:
-    """Reduce to alnum + underscore + dash so the name is filesystem-safe
-    and survives the backend's CHANNEL_NAME_RE whitelist."""
+    """Reduce to alnum + underscore + dash, then cap at
+    ``_CHANNEL_NAME_MAX_LEN`` (64) so the result ALWAYS survives the
+    backend's ``CHANNEL_NAME_RE`` whitelist (``^[A-Za-z0-9_-]{1,64}$``,
+    ``backend/src/services/video/types.ts``) — every byte written here is
+    also a PNG filename on disk and a value round-tripped through the DB's
+    ``channels`` JSON, both of which enforce that same cap on read.
+
+    A name that already fits is returned unchanged. One that doesn't is
+    truncated and given a short deterministic hash suffix rather than a
+    bare truncation: two labels that differ only after character 64 (e.g.
+    a shared boilerplate prefix with the distinguishing part at the end)
+    would otherwise collapse into the same on-disk filename. The hash is
+    derived from the FULL untruncated sanitized string, so it stays
+    deterministic across repeated extractions of the same file — a repair
+    re-run reproduces the exact same name — while still depending on
+    every character the truncation drops.
+    """
     if not raw:
         return fallback
     safe = re.sub(r"[^A-Za-z0-9_-]+", "_", raw).strip("_")
-    return safe or fallback
+    if not safe:
+        return fallback
+    if len(safe) <= _CHANNEL_NAME_MAX_LEN:
+        return safe
+    digest = hashlib.sha1(safe.encode("utf-8")).hexdigest()[:8]
+    # 55 (kept prefix) + 1 (separator) + 8 (digest) == 64, the exact cap.
+    keep = _CHANNEL_NAME_MAX_LEN - 1 - len(digest)
+    return f"{safe[:keep]}_{digest}"
 
 
 def _imagej_channel_labels(tf, count: int) -> list[str | None]:
@@ -118,6 +151,59 @@ def _split_shared_label(labels: list[str | None], count: int) -> list[str] | Non
     return parts if len(parts) == count and _all_distinct(parts) else None
 
 
+_BIOFORMATS_LABEL_RE = re.compile(
+    r"^c:(\d+)/\d+\s+t:\d+/\d+\s*-\s*(.*)$", re.IGNORECASE
+)
+
+
+def _strip_bioformats_scaffold(
+    labels: list[str | None], count: int
+) -> list[str] | None:
+    """Recover per-channel names from Fiji/Bio-Formats' per-slice label
+    format ``"c:N/C t:T/TT - <tail>"``.
+
+    Bio-Formats (the engine behind Fiji's "Bio-Formats Importer" — the
+    real-world path a user takes to re-export an ND2 as TIFF) stamps every
+    slice with its ``(channel, timepoint)`` position followed by the
+    ORIGINAL SOURCE FILENAME, never a per-channel name. Every channel
+    therefore shares an IDENTICAL tail, differing only in the leading
+    ``c:N/C`` index — which is enough to pass ``_all_distinct`` upstream,
+    so without this step the caller accepts the label verbatim and embeds
+    the entire (often 100+ char) filename into every channel's stored
+    name. That filename can itself contain digit runs that misparse as an
+    emission wavelength (a date like ``20260803``) or substrings that
+    misparse as a modality (``..._IRM_...``) — see ``isIrmChannel`` /
+    ``_wavelength_from_name`` downstream, and the 2026-08-26 Institut
+    Curie incident this fixes.
+
+    When every channel's tail is IDENTICAL (the normal Bio-Formats case —
+    this label format carries no real channel name), returns
+    ``["c1", "c2", ...]`` built from the parsed index: the only genuinely
+    per-channel information the label carries. When the tails differ
+    (some pipelines append a real name after the standard prefix), the
+    tails are returned instead, since they carry more than the bare index
+    — this is what lets a real ``IRM``-labelled channel still be typed
+    ``irm`` after this step runs.
+
+    Returns ``None`` when fewer than ``count`` labels match the pattern,
+    so the caller falls through to the next, more permissive strategy —
+    this never fires on an ordinary short label like ``"EGFP"``.
+    """
+    if not labels or len(labels) < count:
+        return None
+    matches = [
+        _BIOFORMATS_LABEL_RE.match(lbl) if isinstance(lbl, str) else None
+        for lbl in labels[:count]
+    ]
+    if not all(matches):
+        return None
+    indices = [m.group(1) for m in matches]  # type: ignore[union-attr]
+    tails = [m.group(2).strip() for m in matches]  # type: ignore[union-attr]
+    if _all_distinct(tails):
+        return tails
+    return [f"c{idx}" for idx in indices]
+
+
 def _resolve_channel_names(tf, count: int) -> list[str | None]:
     """Best-effort DISTINCT per-channel names, tried most-reliable first.
 
@@ -125,7 +211,11 @@ def _resolve_channel_names(tf, count: int) -> list[str | None]:
     identity, the later ones are progressively more degenerate:
       1. MetaMorph ``WaveNameN`` from the ImageJ ``Info`` block.
       2. The shared ``"… - a/b"`` per-slice label split by ``"/"``.
-      3. Genuinely distinct per-slice ``Labels`` used verbatim.
+      3. Fiji/Bio-Formats' ``"c:N/C t:T/TT - <tail>"`` scaffold: keep the
+         tail if it genuinely differs per channel, else collapse to the
+         bare index (``"c1"``/``"c2"``/…) so a shared source filename in
+         the tail never leaks into the stored name.
+      4. Genuinely distinct per-slice ``Labels`` used verbatim.
     When none yields ``count`` distinct names (e.g. an ImageJ-registered
     stack whose only label is the source filename, repeated per channel)
     we return all-``None`` so the caller falls back to ``"Channel N"`` —
@@ -145,6 +235,9 @@ def _resolve_channel_names(tf, count: int) -> list[str | None]:
         split = _split_shared_label(labels, count)
         if split:
             return split
+        scaffold = _strip_bioformats_scaffold(labels, count)
+        if scaffold:
+            return scaffold
         if _all_distinct(labels):
             return labels
     except Exception as exc:
@@ -550,28 +643,34 @@ def _detect_frame_interval_ms(tf) -> float | None:
     return None
 
 
-def main() -> int:
-    argv = sys.argv[1:]
-    # Opt-in multimodal channel registration (translation-only); the backend
-    # passes this only when the user ticked it at upload for an MT project.
-    register = "--register-channels" in argv
-    positional = [a for a in argv if not a.startswith("--")]
-    if len(positional) < 2:
-        print(
-            "usage: extract_tiff_stack.py <src.tif> <dest_dir> "
-            "[--register-channels]",
-            file=sys.stderr,
-        )
-        return 2
-    src = Path(positional[0])
-    dest = Path(positional[1])
-    dest.mkdir(parents=True, exist_ok=True)
+class UnsupportedTiffAxes(ValueError):
+    """Raised by ``_load_and_resolve`` when the TIFF's axes string doesn't
+    match any recognized ``T[Z]CYX`` / ``TYX`` / ``CYX`` layout. ``main()``
+    converts this to the historical stderr message + exit code 4;
+    ``resolve_channels_for_file`` lets it propagate — there's no
+    PNG-writing fallback to preserve there."""
 
-    try:
-        import tifffile
-    except ImportError:
-        print("tifffile not installed in this Python env", file=sys.stderr)
-        return 3
+
+def _load_and_resolve(src: Path) -> tuple[np.ndarray, dict]:
+    """Open ``src``, resolve its TIFF axes to canonical ``(T, C, Y, X)``,
+    and derive the per-channel name/displayName/wavelengthNm metadata plus
+    calibration (pixel size, frame interval).
+
+    This is the ONE place both ``main()`` (real extraction — writes PNGs)
+    and ``resolve_channels_for_file()`` (read-only repair helper, see its
+    docstring below) resolve axes and channel names, so a channel-naming
+    fix can never apply to a fresh upload and not to a repair run of the
+    same file, or vice versa — the two callers cannot drift.
+
+    Returns ``(arr, meta)``: ``arr`` is the resolved ``(T, C, H, W)``
+    ndarray; ``meta`` has keys ``channels`` (a list of
+    ``{"name", "displayName", "wavelengthNm"}`` dicts), ``pixelSizeUm``
+    and ``frameIntervalMs``.
+
+    Raises ``ImportError`` if ``tifffile`` isn't installed, or
+    ``UnsupportedTiffAxes`` if the axes can't be interpreted.
+    """
+    import tifffile
 
     with tifffile.TiffFile(str(src)) as tf:
         arr = tf.asarray()
@@ -626,12 +725,10 @@ def main() -> int:
         T, C, H, W = 1, 1, arr.shape[0], arr.shape[1]
         arr = arr[None, None, :, :]
     else:
-        print(
+        raise UnsupportedTiffAxes(
             f"Cannot interpret TIFF axes='{axes}' shape={arr.shape}; "
-            "expected T[Z]CYX / TYX",
-            file=sys.stderr,
+            "expected T[Z]CYX / TYX"
         )
-        return 4
 
     # If `_C_for_meta` was guessed before C was known, align it now.
     if len(raw_channel_labels) != C:
@@ -653,15 +750,119 @@ def main() -> int:
     # `wavelengthNm` is parsed from the resolved name (e.g. "TIRF_491"→491)
     # so fluorescence channels type correctly downstream; label-free names
     # (IRM/BF) yield None and stay IRM.
-    channel_names: list[str] = []
-    display_names: list[str] = []
-    wavelengths: list[int | None] = []
+    channels: list[dict] = []
     for i in range(C):
         raw = raw_channel_labels[i]
         display = raw if (isinstance(raw, str) and raw.strip()) else f"Channel {i + 1}"
-        display_names.append(display)
-        channel_names.append(_sanitize_name(raw, f"Channel_{i + 1}"))
-        wavelengths.append(_wavelength_from_name(raw))
+        channels.append(
+            {
+                "name": _sanitize_name(raw, f"Channel_{i + 1}"),
+                "displayName": display,
+                "wavelengthNm": _wavelength_from_name(raw),
+            }
+        )
+
+    return arr, {
+        "channels": channels,
+        "pixelSizeUm": pixel_size_um,
+        "frameIntervalMs": frame_interval_ms,
+    }
+
+
+def resolve_channels_for_file(src: str | Path) -> list[dict]:
+    """Read-only repair helper: derive the per-channel
+    name/displayName/wavelengthNm metadata this extractor would produce
+    for ``src`` WITHOUT writing any frame PNGs or touching a destination
+    directory.
+
+    Goes through the exact same ``_load_and_resolve`` path ``main()`` uses
+    for a real extraction, so the output is byte-identical to what a fresh
+    upload of the same file would store in ``Image.channels`` — which is
+    what makes it safe for repairing rows written before this module's
+    channel-naming fix (2026-08-26 Institut Curie incident: a
+    Bio-Formats-exported TIFF's per-slice label embedded the whole source
+    filename into every channel name, producing names over the backend's
+    64-char cap).
+
+    IMPORTANT: run this against the container's actual archived ORIGINAL
+    file (``original.tif`` under its upload directory), not against the
+    already-corrupted name string stored in the DB. The old, unfixed
+    ``_sanitize_name`` already destroyed the label's structure (colons and
+    slashes became underscores), so the fixed scaffold-stripping logic in
+    ``_strip_bioformats_scaffold`` can no longer recognize the Bio-Formats
+    pattern in that mangled string — only the original TIFF still carries
+    the raw ImageJ metadata this function reads.
+
+    Invoke as a CLI, one file at a time:
+
+        python3 extract_tiff_stack.py --print-channels /path/to/original.tif
+
+    which prints ``{"channels": [{"name", "displayName", "wavelengthNm"}, ...]}``
+    to stdout — nothing else: no ``PROGRESS`` lines, no directory writes,
+    no PNGs. Or import and call directly from another script:
+
+        from extract_tiff_stack import resolve_channels_for_file
+        resolve_channels_for_file("/path/to/original.tif")
+    """
+    _arr, meta = _load_and_resolve(Path(src))
+    return meta["channels"]
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+
+    # Read-only repair mode — see `resolve_channels_for_file` docstring.
+    # Takes exactly one positional arg (the source file) and never writes
+    # to a destination directory.
+    if "--print-channels" in argv:
+        positional = [a for a in argv if not a.startswith("--")]
+        if len(positional) != 1:
+            print(
+                "usage: extract_tiff_stack.py --print-channels <src.tif>",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            channels = resolve_channels_for_file(positional[0])
+        except ImportError:
+            print("tifffile not installed in this Python env", file=sys.stderr)
+            return 3
+        except UnsupportedTiffAxes as exc:
+            print(str(exc), file=sys.stderr)
+            return 4
+        print(json.dumps({"channels": channels}))
+        return 0
+
+    # Opt-in multimodal channel registration (translation-only); the backend
+    # passes this only when the user ticked it at upload for an MT project.
+    register = "--register-channels" in argv
+    positional = [a for a in argv if not a.startswith("--")]
+    if len(positional) < 2:
+        print(
+            "usage: extract_tiff_stack.py <src.tif> <dest_dir> "
+            "[--register-channels]",
+            file=sys.stderr,
+        )
+        return 2
+    src = Path(positional[0])
+    dest = Path(positional[1])
+    dest.mkdir(parents=True, exist_ok=True)
+
+    try:
+        arr, meta = _load_and_resolve(src)
+    except ImportError:
+        print("tifffile not installed in this Python env", file=sys.stderr)
+        return 3
+    except UnsupportedTiffAxes as exc:
+        print(str(exc), file=sys.stderr)
+        return 4
+
+    T, C, H, W = arr.shape
+    channel_names = [c["name"] for c in meta["channels"]]
+    display_names = [c["displayName"] for c in meta["channels"]]
+    wavelengths = [c["wavelengthNm"] for c in meta["channels"]]
+    pixel_size_um = meta["pixelSizeUm"]
+    frame_interval_ms = meta["frameIntervalMs"]
 
     # Opt-in: align each channel to channel 0 per frame (multimodal, integer
     # translation — see channel_registration). Applied to a fresh array so the

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_metadata.py
@@ -17,6 +17,7 @@ Run from repo root:
 from __future__ import annotations
 
 import os
+import re
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -39,9 +40,17 @@ from extract_tiff_stack import (  # noqa: E402
     _median_interval_ms,
     _metamorph_wave_names,
     _resolve_channel_names,
+    _sanitize_name,
     _split_shared_label,
+    _strip_bioformats_scaffold,
     _wavelength_from_name,
 )
+
+# Mirrors `CHANNEL_NAME_RE` in `backend/src/services/video/types.ts` — the
+# canonical definition on the TypeScript side. Redeclared here (rather than
+# imported, since this is a Python test) purely so the tests below can
+# assert the WIRE contract, not just "the function ran without error".
+CHANNEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -355,3 +364,138 @@ def test_resolve_channel_names_identical_labels_fall_back_to_none():
 
 def test_resolve_channel_names_no_metadata():
     assert _resolve_channel_names(_tf(), 2) == [None, None]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Institut Curie incident (2026-08-26): Fiji/Bio-Formats TIFF exports of
+# ND2 files stamp every slice with "c:N/C t:T/TT - <source filename>",
+# which is technically distinct per channel (courtesy of the index) but
+# embeds the ENTIRE filename — including digit runs that misparse as an
+# emission wavelength and substrings that misparse as IRM — into every
+# channel's stored name. Real production label measured on the affected
+# files was ~140 chars; the read-side whitelist caps at 64, so nine
+# containers (148 frames) became permanently unreadable.
+# ─────────────────────────────────────────────────────────────────────
+
+
+# A synthetic stand-in for the real ~140-char Institut Curie label: same
+# shape (index prefix + timepoint + long filename containing a date that
+# reads as a 3-digit run and an "IRM" substring + series suffix), long
+# enough on its own to blow the 64-char cap even after the scaffold strip
+# would normally shorten it — pins that the FULL label, not just a
+# shortened stand-in, is what the regex/date parsing sees.
+_CURIE_STYLE_TAIL = (
+    "20260803_HeLa_ChannelIRM_TIRF_488_561_IRM_nd2_conversion_"
+    "exported_via_bioformats_importer_really_quite_long.nd2 (series 1)"
+)
+
+
+def test_strip_bioformats_scaffold_collapses_shared_filename_tail_to_index():
+    # All three channels share the IDENTICAL tail (the normal Bio-Formats
+    # case: this label format carries no real per-channel name) — the only
+    # genuinely per-channel information is the c:N/C index.
+    labels = [f"c:{i}/3 t:26/174 - {_CURIE_STYLE_TAIL}" for i in (1, 2, 3)]
+    assert _strip_bioformats_scaffold(labels, 3) == ["c1", "c2", "c3"]
+
+
+def test_strip_bioformats_scaffold_keeps_genuinely_distinct_tail():
+    # A pipeline that DOES append a real per-channel name after the
+    # standard prefix — the tails differ, so they carry more information
+    # than the bare index and must be kept (this is what lets a real IRM
+    # channel still be typed `irm` downstream).
+    labels = [
+        "c:1/2 t:1/61 - IRM_widefield",
+        "c:2/2 t:1/61 - TIRF_491",
+    ]
+    assert _strip_bioformats_scaffold(labels, 2) == [
+        "IRM_widefield",
+        "TIRF_491",
+    ]
+
+
+@pytest.mark.parametrize(
+    "labels, count",
+    [
+        (["no bioformats prefix here"], 1),  # doesn't match the pattern
+        (["c:1/2 t:1/1 - a", "c:2/2 t:1/1 - b"], 3),  # too few labels
+        ([None, "c:2/2 t:1/1 - a"], 2),  # non-string entry
+        ([], 1),  # empty
+    ],
+)
+def test_strip_bioformats_scaffold_rejects(labels, count):
+    assert _strip_bioformats_scaffold(labels, count) is None
+
+
+def test_resolve_channel_names_curie_repro_end_to_end():
+    """The full bug repro, through `_resolve_channel_names` (the entry
+    point `main()` actually calls) rather than the helper directly — pins
+    the priority-chain wiring, not just the helper in isolation."""
+    labels = [f"c:{i}/3 t:26/174 - {_CURIE_STYLE_TAIL}" for i in (1, 2, 3)]
+    tf = _tf(ij={"Labels": labels})
+
+    resolved = _resolve_channel_names(tf, 3)
+
+    assert resolved == ["c1", "c2", "c3"]
+    # Every resolved name — and its sanitized form, which is what actually
+    # reaches the DB/filesystem — satisfies the backend's wire contract.
+    for raw in resolved:
+        sanitized = _sanitize_name(raw, "fallback")
+        assert CHANNEL_NAME_RE.match(sanitized), sanitized
+    # All three stay distinct (the whole point of the index survives).
+    assert len(set(resolved)) == 3
+    # No wavelength is parsed from the date-like digit run the OLD verbatim
+    # label would have exposed ("20260803" contains "803", 350-900 nm).
+    for raw in resolved:
+        assert _wavelength_from_name(raw) is None
+
+
+def test_resolve_channel_names_preserves_short_meaningful_label():
+    # A genuinely informative short NIS-style label with no Bio-Formats
+    # scaffolding at all must survive verbatim — the fix must not flatten
+    # every channel to "cN" indiscriminately.
+    tf = _tf(ij={"Labels": ["EGFP", "mCherry"]})
+    assert _resolve_channel_names(tf, 2) == ["EGFP", "mCherry"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _sanitize_name — length cap + collision-resistant truncation.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_sanitize_name_short_value_untouched():
+    assert _sanitize_name("TIRF_491", "fallback") == "TIRF_491"
+
+
+def test_sanitize_name_caps_at_64_chars():
+    raw = "x" * 100
+    result = _sanitize_name(raw, "fallback")
+    assert len(result) <= 64
+    assert CHANNEL_NAME_RE.match(result)
+
+
+def test_sanitize_name_truncation_is_deterministic():
+    raw = "y" * 100
+    assert _sanitize_name(raw, "fallback") == _sanitize_name(raw, "fallback")
+
+
+def test_sanitize_name_truncation_preserves_distinctness_past_the_cap():
+    # Two labels that differ ONLY after character 64 — a bare truncation
+    # would collapse them into the same on-disk filename / DB value.
+    a = "z" * 70 + "AAAA"
+    b = "z" * 70 + "BBBB"
+    sa, sb = _sanitize_name(a, "fallback"), _sanitize_name(b, "fallback")
+    assert sa != sb
+    assert CHANNEL_NAME_RE.match(sa)
+    assert CHANNEL_NAME_RE.match(sb)
+
+
+def test_sanitize_name_curie_label_fits_the_wire_contract():
+    # The actual production shape (pre-fix, this is exactly what
+    # `_resolve_channel_names` used to return verbatim before the
+    # Bio-Formats scaffold strip existed) — even in the worst case where
+    # scaffold-stripping somehow didn't apply, `_sanitize_name` alone must
+    # still guarantee the 64-char wire contract.
+    raw = f"c:1/3 t:26/174 - {_CURIE_STYLE_TAIL}"
+    result = _sanitize_name(raw, "fallback")
+    assert len(raw) > 64  # sanity: the input really does exceed the cap
+    assert CHANNEL_NAME_RE.match(result)

--- a/backend/src/services/video/types.ts
+++ b/backend/src/services/video/types.ts
@@ -8,6 +8,25 @@
  * consumes.
  */
 
+/**
+ * SINGLE canonical definition of the channel-name whitelist. Filesystem-
+ * safe alnum + underscore + dash; bans dots so a `.png` extension can't be
+ * smuggled in, bans slashes so path traversal is impossible. Every layer
+ * that reads, writes or validates a channel name — the upload pipeline
+ * (`videoUploadService`), the read/PATCH gates (`videoController`), the
+ * "add channel" flow, the MT metrics/kymograph exporters — must import
+ * this rather than redeclaring the pattern, so the write side and the
+ * read side can never drift out of sync again (see the 2026-08-26 Institut
+ * Curie incident: the TIFF extractor emitted names up to ~140 chars, the
+ * read gate enforced 64, and nine containers became permanently
+ * unreadable because the two copies of this regex disagreed).
+ */
+export const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function isSafeChannelName(name: unknown): name is string {
+  return typeof name === 'string' && CHANNEL_NAME_RE.test(name);
+}
+
 export type ChannelType = 'irm' | 'fluorescent';
 
 export interface ChannelMeta {

--- a/backend/src/services/videoUploadService.ts
+++ b/backend/src/services/videoUploadService.ts
@@ -38,6 +38,7 @@ import { config } from '../utils/config';
 import { logger } from '../utils/logger';
 import { assertSafeStorageSegment } from '../utils/storagePath';
 import { extractVideoSafe } from './video/videoExtractor';
+import { isSafeChannelName } from './video/types';
 import type {
   ChannelMeta,
   ExtractedPosition,
@@ -221,6 +222,28 @@ async function finalizeContainer(params: {
   mimeType?: string;
 }): Promise<void> {
   const { containerId, baseDir, projectId, displayName, result } = params;
+
+  // Every channel name lands in the DB's `channels` JSON — read back and
+  // whitelisted against `isSafeChannelName` by videoController's read/PATCH
+  // gates — and becomes a PNG filename on disk. `assertSafeStorageSegment`
+  // below only guards the DEFAULT channel against path traversal; it has no
+  // length or charset cap, so it happily accepts a name the read gate will
+  // later reject with 400. Validate EVERY channel here, before any of them
+  // reach a thumbnail read, a frame storage key, or the DB, and fail the
+  // upload loudly rather than persist a container the read side can never
+  // serve back (see the 2026-08-26 Institut Curie incident: a Fiji/
+  // Bio-Formats TIFF export embedded a ~140-char source filename in every
+  // channel's per-slice label; nine containers, 148 frames, went silently
+  // unreadable).
+  for (const ch of result.channels) {
+    if (!isSafeChannelName(ch.name)) {
+      throw new Error(
+        `Extractor produced an invalid channel name: "${ch.name}" — must be ` +
+          '1-64 chars of [A-Za-z0-9_-]. Refusing to persist a container the ' +
+          'read gate could never serve back.'
+      );
+    }
+  }
 
   // Channel names originate in source metadata (ND2/OME-TIFF); guard before
   // they reach the thumbnail read-path and the frame storage keys.


### PR DESCRIPTION
## Problem

A researcher at Institut Curie uploaded Fiji/Bio-Formats TIFF exports of ND2 files and got **"failed to load image channels"** on every frame. In production this affects **3 users, 9 video containers, 148 frames** (123 of which carry segmentations). The PNGs on disk were always fine — the rows were simply unreadable.

## Root cause: a write/read contract asymmetry

Bio-Formats stamps every slice with `"c:N/C t:T/TT - <source filename>"`. The slices differ only in the leading index, so `_all_distinct` passed and the whole ~140-char label was taken verbatim as the channel name. `_sanitize_name` replaced disallowed characters but **never truncated**, while its docstring claimed the result *"survives the backend's CHANNEL_NAME_RE whitelist"* — which caps at 64.

Live repro proving it is the length gate specifically, not the charset or the whitelist:

```
GET …/frame-data?channel=<138-char name>  -> 400 {"error":"Invalid channel name"}
GET …/frame-data?channel=<same, cut to 64> -> 400 {"error":"Unknown channel: …"}
```

Because the source filename ended up *inside* the channel name, it also corrupted every piece of metadata derived from that name:

- a filename containing `_IRM_` typed **all** channels `irm`
- `isSegmentationSource` landed on a 488 TIRF channel
- the date `20260803` was parsed as an **803 nm** emission wavelength

Segmenting TIRF with the IRM-only v5H model yields confident-looking polylines at ~−0.02 SD contrast, i.e. noise. `displayName` also exceeded its own 128 cap, so `PATCH /images/:id/channels` rejected these rows too — the affected users could not repair it themselves either.

## Fix — all three layers that failed independently

1. **`_strip_bioformats_scaffold`** recovers the per-channel index and collapses to `c1`/`c2`/… when the tails are identical (the normal case, where the label carries no channel name at all), while keeping genuinely distinct tails so a real `IRM` label still types correctly. Fixes length, false IRM match and false wavelength together — all three came from the filename.
2. **`_sanitize_name` caps at 64** in both extractors, with a `sha1[:8]` suffix on overflow so two labels differing only past character 64 cannot collapse onto one PNG filename. The digest covers the full sanitized string, so repeated extraction of the same file is deterministic — which is what makes the data repair reproducible.
3. **Ingest validates every channel** with `isSafeChannelName` before persisting, so an unservable row fails loudly at upload instead of silently.

`CHANNEL_NAME_RE` becomes canonical in `video/types.ts`; the copies in `videoController`, `addChannelService` and `kymographService` are gone. One copy survives in `export/mtMetricsExporter.ts`, deduped in the concurrent export-timeout branch rather than conflicting on 900 lines here.

## Not in this PR

Repair of the 9 already-broken containers — done separately against production, with a rollback snapshot.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYYFoe8Yp1Kg1hMwYkmG7o