### PR TITLE
feat(projects): let annotators mark a project's annotations as verified

### DIFF
--- a/backend/prisma/migrations/20260826_add_project_verified/migration.sql
+++ b/backend/prisma/migrations/20260826_add_project_verified/migration.sql
@@ -1,0 +1,15 @@
+-- Add the project "verified" flag: the owner or an accepted-share annotator
+-- marks that all annotations in the project have been reviewed and passed.
+--
+-- verifiedAt/verifiedBy are stamped for later auditability but are NOT
+-- surfaced in the UI today. verifiedBy is a bare user id with no FK,
+-- matching how other loose per-project metadata (e.g. mtTypeLabels) is
+-- stored in this table.
+--
+-- NOTE: applied directly to production via idempotent SQL (the prod Prisma
+-- migration history has drifted, so `migrate deploy` is not run blind here —
+-- see the 20260709_add_mt_type_labels precedent).
+
+ALTER TABLE "projects" ADD COLUMN IF NOT EXISTS "verified" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "projects" ADD COLUMN IF NOT EXISTS "verifiedAt" TIMESTAMP(3);
+ALTER TABLE "projects" ADD COLUMN IF NOT EXISTS "verifiedBy" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,6 +77,15 @@ model Project {
   // Per-project microtubule type-label palette (SSOT for name + colour):
   // [{ id: string, name: string, color: string }]. Microtubule projects only.
   mtTypeLabels      Json?
+  // "All annotations reviewed and passed." Settable by the owner OR any
+  // accepted-share annotator (see SharingService.hasProjectAccess) — unlike
+  // title/description/type, which stay owner-only. verifiedAt/verifiedBy are
+  // stamped for later auditability but are NOT surfaced in the UI today.
+  // verifiedBy is a bare user id with no FK, matching mtTypeLabels-style loose
+  // metadata elsewhere in this model.
+  verified          Boolean             @default(false)
+  verifiedAt        DateTime?
+  verifiedBy        String?
   images            Image[]
   user              User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   segmentationQueue SegmentationQueue[]

--- a/backend/src/api/controllers/__tests__/projectController.gaps.test.ts
+++ b/backend/src/api/controllers/__tests__/projectController.gaps.test.ts
@@ -50,6 +50,7 @@ import {
   updateProject,
   deleteProject,
   getProjectStats,
+  setProjectVerified,
 } from '../projectController';
 
 const MockProjectService = projectService as Mocked<typeof projectService>;
@@ -93,6 +94,7 @@ function makeApp(injectUser = true) {
   app.post('/projects', mockAuth, createProject);
   app.get('/projects/:id', mockAuth, getProject);
   app.put('/projects/:id', mockAuth, updateProject);
+  app.patch('/projects/:id/verified', mockAuth, setProjectVerified);
   app.delete('/projects/:id', mockAuth, deleteProject);
   app.get('/projects/:id/stats', mockAuth, getProjectStats);
 
@@ -366,5 +368,83 @@ describe('projectController — uncovered branches', () => {
         deletedImagesCount: 7,
       });
     });
+  });
+});
+
+/**
+ * PATCH /projects/:id/verified — the annotator-facing verification toggle.
+ * Its 404 is load-bearing: `setVerified` returns null both when the project
+ * does not exist AND when the caller has no share on it, and the controller
+ * must not distinguish the two (doing so would let a stranger probe which
+ * project ids exist).
+ */
+describe('PATCH /projects/:id/verified', () => {
+  it('returns 401 and does not touch the service when req.user is absent', async () => {
+    const noAuthApp = makeApp(false);
+    const res = await request(noAuthApp)
+      .patch('/projects/proj-abc/verified')
+      .send({ verified: true })
+      .expect(401);
+    expect(res.body.success).toBe(false);
+    expect(MockProjectService.setVerified).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the service reports no project or no access', async () => {
+    MockProjectService.setVerified.mockResolvedValueOnce(null);
+    const res = await request(makeApp())
+      .patch('/projects/proj-abc/verified')
+      .send({ verified: true })
+      .expect(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('sets the flag and defeats the 10-minute GET cache on the way out', async () => {
+    MockProjectService.setVerified.mockResolvedValueOnce({
+      ...mockProject,
+      verified: true,
+    } as never);
+
+    const res = await request(makeApp())
+      .patch('/projects/proj-abc/verified')
+      .send({ verified: true })
+      .expect(200);
+
+    expect(MockProjectService.setVerified).toHaveBeenCalledWith(
+      'proj-abc',
+      'user-123',
+      true
+    );
+    // GET /projects/:id is served with `public, max-age=600`; without this
+    // override a browser would keep showing the pre-toggle value.
+    expect(res.headers['cache-control']).toContain('no-store');
+    expect(res.body.data.verified).toBe(true);
+  });
+
+  it('reports the un-verify case distinctly', async () => {
+    MockProjectService.setVerified.mockResolvedValueOnce({
+      ...mockProject,
+      verified: false,
+    } as never);
+
+    const res = await request(makeApp())
+      .patch('/projects/proj-abc/verified')
+      .send({ verified: false })
+      .expect(200);
+
+    expect(MockProjectService.setVerified).toHaveBeenCalledWith(
+      'proj-abc',
+      'user-123',
+      false
+    );
+    expect(res.body.message).not.toBe(undefined);
+  });
+
+  it('returns 500 when the service throws rather than reporting success', async () => {
+    MockProjectService.setVerified.mockRejectedValueOnce(new Error('db down'));
+    const res = await request(makeApp())
+      .patch('/projects/proj-abc/verified')
+      .send({ verified: true })
+      .expect(500);
+    expect(res.body.success).toBe(false);
   });
 });

--- a/backend/src/api/controllers/projectController.ts
+++ b/backend/src/api/controllers/projectController.ts
@@ -193,6 +193,14 @@ export const getProject = asyncHandler(
         return;
       }
 
+      // The route applies `cacheMiddleware` (Cache-Control: public,
+      // max-age=600) so a browser can serve a stale `verified` flag for up
+      // to 10 minutes after PATCH …/verified. Override it here, the same way
+      // getProjects() already does, rather than relying on a refetch.
+      res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.set('Pragma', 'no-cache');
+      res.set('Expires', '0');
+
       ResponseHelper.success(res, project, 'Projekt byl úspěšně načten');
     } catch (error) {
       logger.error(
@@ -350,6 +358,80 @@ export const updateProject = asyncHandler(
         res,
         error as Error,
         'Nepodařilo se aktualizovat projekt',
+        'ProjectController'
+      );
+    }
+  }
+);
+
+/**
+ * PATCH /api/projects/:id/verified — toggle the "all annotations reviewed
+ * and passed" flag. Deliberately NOT gated the same way as `updateProject`:
+ * the owner AND an accepted-share annotator may both set it (see
+ * ProjectService.setVerified), which is why this is its own dedicated
+ * endpoint rather than a widened PUT /:id.
+ */
+export const setProjectVerified = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.user) {
+      ResponseHelper.unauthorized(
+        res,
+        'Uživatel není autentizován',
+        'ProjectController'
+      );
+      return;
+    }
+
+    const projectId = req.params.id;
+    if (!projectId) {
+      ResponseHelper.badRequest(res, 'Project ID is required');
+      return;
+    }
+
+    const { verified } = req.body as { verified: boolean };
+
+    try {
+      const project = await ProjectService.setVerified(
+        projectId,
+        req.user.id,
+        verified
+      );
+
+      if (!project) {
+        ResponseHelper.notFound(
+          res,
+          'Projekt nebyl nalezen nebo k němu nemáte oprávnění',
+          'ProjectController'
+        );
+        return;
+      }
+
+      // GET /api/projects/:id is cached for 10 minutes (Cache-Control:
+      // public, max-age=600) — override here so a browser can't serve a
+      // stale `verified` right after this toggles it.
+      res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.set('Pragma', 'no-cache');
+      res.set('Expires', '0');
+
+      ResponseHelper.success(
+        res,
+        project,
+        verified
+          ? 'Projekt byl označen jako ověřený'
+          : 'Označení ověření projektu bylo zrušeno'
+      );
+    } catch (error) {
+      logger.error(
+        'Failed to set project verified flag:',
+        error as Error,
+        'ProjectController',
+        { userId: req.user.id, projectId, verified }
+      );
+
+      ResponseHelper.internalError(
+        res,
+        error as Error,
+        'Nepodařilo se aktualizovat stav ověření projektu',
         'ProjectController'
       );
     }

--- a/backend/src/api/controllers/sharingController.ts
+++ b/backend/src/api/controllers/sharingController.ts
@@ -45,6 +45,10 @@ interface ValidatedShare {
       id: string;
       email: string;
     };
+    // "All annotations reviewed and passed" — surfaced on the pre-acceptance
+    // preview too, so an invited annotator can see review status before
+    // accepting the share.
+    verified: boolean;
   };
   sharedBy: {
     id: string;
@@ -479,6 +483,10 @@ export const getSharedProjects = asyncHandler(
             image_count: share.project._count?.images || 0,
             images: share.project.images || [],
             updated_at: share.project.updatedAt,
+            // "All annotations reviewed and passed" — owner AND accepted-share
+            // annotators can both toggle it (PATCH …/verified), so it must
+            // survive this DTO for the shared-projects list to show it too.
+            verified: share.project.verified,
           },
           sharedBy: {
             id: share.sharedBy.id,
@@ -556,6 +564,7 @@ export const validateShareToken = asyncHandler(
             title: share.project.title,
             description: share.project.description,
             owner: share.project.user, // Include the project owner
+            verified: share.project.verified,
           },
           sharedBy: {
             email: share.sharedBy.email,
@@ -621,6 +630,7 @@ export const acceptShareInvitation = asyncHandler(
               title: result.share.project.title,
               description: result.share.project.description,
               owner: result.share.project.user, // Include the project owner
+              verified: result.share.project.verified,
             },
             sharedBy: {
               email: result.share.sharedBy.email,
@@ -640,6 +650,7 @@ export const acceptShareInvitation = asyncHandler(
             title: result.share.project.title,
             description: result.share.project.description,
             owner: result.share.project.user, // Include the project owner
+            verified: result.share.project.verified,
           },
           shareId: result.share.id,
           sharedWithId: result.share.sharedWithId,

--- a/backend/src/api/routes/projectRoutes.ts
+++ b/backend/src/api/routes/projectRoutes.ts
@@ -5,6 +5,7 @@ import {
   getProject,
   updateProject,
   deleteProject,
+  setProjectVerified,
   getProjectStats,
   getMtTypeLabels,
   putMtTypeLabels,
@@ -29,6 +30,7 @@ import {
   projectIdSchema,
   projectLabelParamsSchema,
   mtTypeLabelsPutSchema,
+  setProjectVerifiedSchema,
 } from '../../types/validation';
 import imageRoutes from './imageRoutes';
 
@@ -99,6 +101,25 @@ router.delete(
     `stats:user:${req.user?.id}:*`,
   ]),
   deleteProject
+);
+
+/**
+ * PATCH /api/projects/:id/verified
+ * Toggle "all annotations reviewed and passed". Dedicated endpoint (not a
+ * widened PUT /:id) so owner-only editing of title/description/type is
+ * preserved: the owner AND an accepted-share annotator may both call this
+ * one (see ProjectService.setVerified — gated on share access, not
+ * ownership).
+ */
+router.patch(
+  '/:id/verified',
+  validateParams(projectIdSchema),
+  validateBody(setProjectVerifiedSchema),
+  cacheInvalidationMiddleware(req => [
+    `project:${req.params.id}:*`,
+    `projects:user:${req.user?.id}:*`,
+  ]),
+  setProjectVerified
 );
 
 /**

--- a/backend/src/services/__tests__/projectService.test.ts
+++ b/backend/src/services/__tests__/projectService.test.ts
@@ -510,3 +510,69 @@ describe('ProjectService', () => {
     });
   });
 });
+
+/**
+ * `setVerified` is the write half of the annotator-facing verification flag.
+ * Its authorization gate is deliberately DIFFERENT from every other mutation
+ * on a project: it goes through `hasProjectAccess` (owner OR accepted share)
+ * rather than `checkProjectOwnership`, so that an annotator can mark a project
+ * reviewed without also gaining the ability to rename or retype it. That
+ * distinction is the whole feature, so it is pinned here.
+ */
+describe('ProjectService.setVerified', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasProjectAccess.mockResolvedValue({ hasAccess: true, isOwner: true });
+  });
+
+  it('returns null and writes nothing when the caller has no access', async () => {
+    mockHasProjectAccess.mockResolvedValueOnce({
+      hasAccess: false,
+      isOwner: false,
+    });
+
+    const result = await projectService.setVerified('proj-1', 'stranger', true);
+
+    expect(result).toBeNull();
+    // The important half: a denied caller must not reach the write at all.
+    expect(prismaMock.project.update).not.toHaveBeenCalled();
+  });
+
+  it('stamps verifiedAt and verifiedBy with the ACTING user when set to true', async () => {
+    // Not the owner — an accepted-share annotator. The audit columns must
+    // record who actually reviewed it, not who owns the project.
+    mockHasProjectAccess.mockResolvedValueOnce({
+      hasAccess: true,
+      isOwner: false,
+    });
+    prismaMock.project.update.mockResolvedValueOnce({ id: 'proj-1' });
+
+    await projectService.setVerified('proj-1', 'annotator-9', true);
+
+    const arg = prismaMock.project.update.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 'proj-1' });
+    expect(arg.data.verified).toBe(true);
+    expect(arg.data.verifiedBy).toBe('annotator-9');
+    expect(arg.data.verifiedAt).toBeInstanceOf(Date);
+  });
+
+  it('clears both audit columns when set to false', async () => {
+    prismaMock.project.update.mockResolvedValueOnce({ id: 'proj-1' });
+
+    await projectService.setVerified('proj-1', 'annotator-9', false);
+
+    const arg = prismaMock.project.update.mock.calls[0][0];
+    expect(arg.data.verified).toBe(false);
+    expect(arg.data.verifiedAt).toBeNull();
+    expect(arg.data.verifiedBy).toBeNull();
+  });
+
+  it('rethrows a database failure rather than reporting success', async () => {
+    const boom = new Error('db down');
+    prismaMock.project.update.mockRejectedValueOnce(boom);
+
+    await expect(
+      projectService.setVerified('proj-1', 'user-1', true)
+    ).rejects.toBe(boom);
+  });
+});

--- a/backend/src/services/projectService.ts
+++ b/backend/src/services/projectService.ts
@@ -445,6 +445,59 @@ export async function updateProject(
 }
 
 /**
+ * Set the project's "verified" flag — all annotations in the project have
+ * been reviewed and passed. Deliberately gated on SHARE access
+ * (SharingService.hasProjectAccess), NOT ownership: the owner AND any
+ * accepted-share annotator may toggle it, unlike title/description/type
+ * which stay owner-only (see updateProject / checkProjectOwnership above).
+ *
+ * Stamps verifiedAt/verifiedBy for later auditability when marking verified;
+ * clears both when un-marking so they never describe a stale reviewer.
+ * Returns null when the caller has no access to the project (mapped to a
+ * 404 by the controller, matching getProjectById's convention).
+ */
+export async function setVerified(
+  projectId: string,
+  userId: string,
+  verified: boolean
+): Promise<Project | null> {
+  try {
+    const accessCheck = await SharingService.hasProjectAccess(
+      projectId,
+      userId
+    );
+    if (!accessCheck.hasAccess) {
+      return null;
+    }
+
+    const updatedProject = await prisma.project.update({
+      where: { id: projectId },
+      data: {
+        verified,
+        verifiedAt: verified ? new Date() : null,
+        verifiedBy: verified ? userId : null,
+      },
+    });
+
+    logger.info(`Project verified flag set: ${projectId}`, 'ProjectService', {
+      projectId,
+      userId,
+      verified,
+    });
+
+    return updatedProject;
+  } catch (error) {
+    logger.error(
+      'Failed to set project verified flag:',
+      error as Error,
+      'ProjectService',
+      { projectId, userId, verified }
+    );
+    throw error;
+  }
+}
+
+/**
  * Delete a project (with ownership check - only owners can delete)
  */
 export async function deleteProject(

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -286,6 +286,11 @@ export const mtTypeLabelsPutSchema = z.object({
   labels: z.array(z.unknown()).max(500),
 });
 
+// PATCH …/verified body — toggles the project "verified" flag.
+export const setProjectVerifiedSchema = z.object({
+  verified: z.boolean(),
+});
+
 // Image validation schemas
 
 /**

--- a/backend/src/utils/__tests__/logger.gaps5.test.ts
+++ b/backend/src/utils/__tests__/logger.gaps5.test.ts
@@ -209,3 +209,41 @@ describe('Logger log-injection sanitization', () => {
     spy.mockRestore();
   });
 });
+
+
+describe('Logger -- the `data` field is sanitized too', () => {
+  // `data` was the last field appended to the record without going through
+  // `sanitize`. It is attacker-shaped in practice: every controller logs
+  // request ids, project ids, filenames and channel names through it.
+  it('strips DEL, which JSON.stringify does NOT escape', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // JSON.stringify escapes C0 controls per spec, so a raw newline inside a
+    // string value cannot forge a record. It leaves DEL (\u007f) alone -- and DEL
+    // can repaint or hide part of a line in a terminal.
+    logger.error('op failed', undefined, 'Ctx', {
+      projectId: 'proj-1\u007fadmin granted',
+    });
+
+    const out = spy.mock.calls[0][0] as string;
+    expect(out).not.toContain('\u007f');
+    expect(out).toContain('proj-1admin granted');
+    spy.mockRestore();
+  });
+
+  it('keeps the pretty-printed structure, indenting continuation lines', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logger.error('op failed', undefined, 'Ctx', { a: 1, b: 2 });
+
+    const out = spy.mock.calls[0][0] as string;
+    const lines = out.split('\n');
+    // Still multi-line JSON (readability preserved), and no continuation line
+    // starts at column 0 where it could pass for a new record.
+    expect(lines.length).toBeGreaterThan(2);
+    for (const line of lines.slice(2)) {
+      expect(line.startsWith(' ')).toBe(true);
+    }
+    spy.mockRestore();
+  });
+});

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -75,7 +75,17 @@ class Logger {
     )}`;
 
     if (entry.data) {
-      message += `\nData: ${JSON.stringify(entry.data, null, 2)}`;
+      // `data` is the last field that reached the sink unsanitized. Its
+      // string values are already JSON-escaped, so a newline inside one
+      // cannot forge a record -- but the object is attacker-shaped
+      // (request ids, filenames, channel names), and JSON escaping is not a
+      // control-character filter: it leaves C1 and DEL alone, which can still
+      // repaint a terminal line. Run it through the same block sanitizer the
+      // stack trace uses, so the pretty-printed structure survives while every
+      // continuation line stays visibly a continuation.
+      message += `\nData: ${this.sanitizeBlock(
+        JSON.stringify(entry.data, null, 2)
+      )}`;
     }
 
     if (entry.error) {

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -5,7 +5,7 @@ import ProjectThumbnail from '@/components/project/ProjectThumbnail';
 import ProjectActions from '@/components/project/ProjectActions';
 import ProjectMetadata from '@/components/project/ProjectMetadata';
 import { Badge } from '@/components/ui/badge';
-import { Share2, Users, User } from 'lucide-react';
+import { Share2, Users, User, CheckCircle2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { dragSourceProps } from '@/utils/dashboardDrag';
 import { useLanguage } from '@/contexts/useLanguage';
@@ -23,6 +23,8 @@ interface ProjectCardProps {
   sharedBy?: { email: string };
   owner?: { email: string; name?: string };
   shareId?: string;
+  /** "All annotations in the project have been reviewed and passed." */
+  verified?: boolean;
   onProjectUpdate?: (projectId: string, action: string) => void;
   /** When true, opens the move-to-folder dialog for this project. */
   onRequestMove?: (projectId: string) => void;
@@ -43,6 +45,7 @@ const ProjectCard = React.memo(
     sharedBy: _sharedBy,
     owner,
     shareId,
+    verified = false,
     onProjectUpdate,
     onRequestMove,
     hasAnyFolder,
@@ -122,9 +125,18 @@ const ProjectCard = React.memo(
             <h3 className="font-medium text-lg truncate pr-2" title={title}>
               {title}
             </h3>
-            {isShared && (
-              <Share2 className="h-4 w-4 text-blue-500 flex-shrink-0" />
-            )}
+            <div className="flex items-center gap-1.5 flex-shrink-0">
+              {verified && (
+                <Badge
+                  variant="outline"
+                  className="h-5 px-1.5 text-[10px] font-medium border bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200 border-green-300 dark:border-green-700"
+                >
+                  <CheckCircle2 className="h-3 w-3 mr-0.5" />
+                  {t('projects.verified')}
+                </Badge>
+              )}
+              {isShared && <Share2 className="h-4 w-4 text-blue-500" />}
+            </div>
           </div>
 
           {/* Owner information */}

--- a/src/components/ProjectListItem.tsx
+++ b/src/components/ProjectListItem.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { ArrowRight, Share2, User } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { ArrowRight, Share2, User, CheckCircle2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useLanguage } from '@/contexts/useLanguage';
 import { dragSourceProps } from '@/utils/dashboardDrag';
 import ProjectThumbnail from '@/components/project/ProjectThumbnail';
 import ProjectActions from '@/components/project/ProjectActions';
@@ -19,6 +21,8 @@ interface ProjectListItemProps {
   isShared?: boolean;
   owner?: { email: string; name?: string };
   shareId?: string;
+  /** "All annotations in the project have been reviewed and passed." */
+  verified?: boolean;
   onProjectUpdate?: (projectId: string, action: string) => void;
   onRequestMove?: (projectId: string) => void;
   hasAnyFolder?: boolean;
@@ -36,10 +40,12 @@ const ProjectListItem = React.memo(
     isShared = false,
     owner,
     shareId,
+    verified = false,
     onProjectUpdate,
     onRequestMove,
     hasAnyFolder,
   }: ProjectListItemProps) => {
+    const { t } = useLanguage();
     const drag = dragSourceProps({ type: 'project', id });
 
     const handleCardClick = () => {
@@ -75,6 +81,15 @@ const ProjectListItem = React.memo(
               <h3 className="text-lg font-medium truncate dark:text-white">
                 {title}
               </h3>
+              {verified && (
+                <Badge
+                  variant="outline"
+                  className="h-5 px-1.5 text-[10px] font-medium border bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200 border-green-300 dark:border-green-700 flex-shrink-0"
+                >
+                  <CheckCircle2 className="h-3 w-3 mr-0.5" />
+                  {t('projects.verified')}
+                </Badge>
+              )}
               {isShared && (
                 <Share2 className="h-4 w-4 text-blue-500 flex-shrink-0" />
               )}

--- a/src/components/ProjectsList.tsx
+++ b/src/components/ProjectsList.tsx
@@ -23,6 +23,8 @@ export interface Project {
   sharedBy?: { email: string };
   owner?: { email: string; name?: string };
   shareId?: string;
+  // "All annotations in the project have been reviewed and passed."
+  verified?: boolean;
 }
 
 /**
@@ -157,6 +159,7 @@ const ProjectsList = ({
           isShared={project.isShared}
           owner={project.owner}
           shareId={project.shareId}
+          verified={project.verified}
           onProjectUpdate={onProjectUpdate}
           onRequestMove={onRequestProjectMove}
           hasAnyFolder={hasAnyFolder}
@@ -227,6 +230,7 @@ const ProjectsList = ({
         sharedBy={project.sharedBy}
         owner={project.owner}
         shareId={project.shareId}
+        verified={project.verified}
         onProjectUpdate={onProjectUpdate}
         onRequestMove={onRequestProjectMove}
         hasAnyFolder={hasAnyFolder}

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { ArrowLeft } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ArrowLeft, CheckCircle2 } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -38,6 +39,12 @@ interface ProjectHeaderProps {
   loading: boolean;
   projectType?: ProjectType;
   onTypeChange?: (type: ProjectType) => void;
+  // "All annotations in the project have been reviewed and passed." Owner OR
+  // an accepted-share annotator may toggle it — the handler is passed
+  // unconditionally by ProjectDetail (same shape as onTypeChange); the
+  // backend is the actual authorization boundary.
+  verified?: boolean;
+  onVerifiedChange?: (verified: boolean) => void;
 }
 
 const ProjectHeader = ({
@@ -46,6 +53,8 @@ const ProjectHeader = ({
   loading,
   projectType,
   onTypeChange,
+  verified,
+  onVerifiedChange,
 }: ProjectHeaderProps) => {
   const navigate = useNavigate();
   const { t } = useLanguage();
@@ -117,6 +126,42 @@ const ProjectHeader = ({
                     )}
                   >
                     {t(`projects.types.${projectType}`)}
+                  </Badge>
+                )}
+              </div>
+            )}
+            {(onVerifiedChange || verified) && (
+              <div className="hidden sm:flex items-center gap-2">
+                {onVerifiedChange ? (
+                  // Editable: owner OR an accepted-share annotator may toggle
+                  // this — the backend, not this component, is the
+                  // authorization boundary (see ProjectService.setVerified).
+                  <label
+                    className={cn(
+                      'flex items-center gap-1.5 h-8 px-3 rounded-md border text-xs font-medium cursor-pointer select-none whitespace-nowrap',
+                      verified
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200 border-green-300 dark:border-green-700'
+                        : 'bg-gray-50 text-gray-600 dark:bg-gray-800 dark:text-gray-300 border-gray-300 dark:border-gray-600'
+                    )}
+                  >
+                    <Checkbox
+                      checked={!!verified}
+                      onCheckedChange={checked =>
+                        onVerifiedChange(checked === true)
+                      }
+                      aria-label={String(t('projects.toggleVerified'))}
+                    />
+                    {t('projects.verified')}
+                  </label>
+                ) : (
+                  // Read-only: only rendered when true (same convention as
+                  // the "shared" badge elsewhere — nothing to show for false).
+                  <Badge
+                    variant="outline"
+                    className="h-8 px-3 text-xs font-medium border bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200 border-green-300 dark:border-green-700"
+                  >
+                    <CheckCircle2 className="h-3.5 w-3.5 mr-1" />
+                    {t('projects.verified')}
                   </Badge>
                 )}
               </div>

--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -20,6 +20,9 @@ export const useProjectData = (
   const [projectType, setProjectType] = useState<
     import('@/types').ProjectType | undefined
   >(undefined);
+  // "All annotations reviewed and passed." Owner OR an accepted-share
+  // annotator may toggle it (PATCH /projects/:id/verified).
+  const [projectVerified, setProjectVerified] = useState<boolean>(false);
   const [images, setImages] = useState<ProjectImage[]>([]);
   // Distinct channel names across all video containers in this project,
   // sourced from the BE response metadata. Used by the Segment-All channel
@@ -62,6 +65,7 @@ export const useProjectData = (
 
         setProjectTitle(project.name);
         setProjectType(project.type);
+        setProjectVerified(project.verified ?? false);
 
         // Fetch all images by making multiple requests if needed.
         // Backend max is 100 per request; we use lod: 'low' which
@@ -347,6 +351,8 @@ export const useProjectData = (
     projectTitle,
     projectType,
     setProjectType,
+    projectVerified,
+    setProjectVerified,
     images,
     projectChannels,
     loading,

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -669,6 +669,37 @@ describe('field mapping', () => {
       const result = await apiClient.getProject('proj-1');
       expect(result.type).toBe('spheroid');
     });
+
+    // Regression: "verified" is the #1 documented strip point in this
+    // codebase (mapProjectFields is a hand-built object literal) — an
+    // annotator-set "all annotations reviewed and passed" flag must survive
+    // the FE mapper, not just the backend response.
+    it('preserves verified=true', async () => {
+      mockAxiosInstance.get.mockResolvedValue(
+        wrap({ ...baseProject, verified: true })
+      );
+      const result = await apiClient.getProject('proj-1');
+      expect(result.verified).toBe(true);
+    });
+
+    it('preserves verified=false explicitly (not omitted as falsy)', async () => {
+      mockAxiosInstance.get.mockResolvedValue(
+        wrap({ ...baseProject, verified: false })
+      );
+      const result = await apiClient.getProject('proj-1');
+      expect(Object.prototype.hasOwnProperty.call(result, 'verified')).toBe(
+        true
+      );
+      expect(result.verified).toBe(false);
+    });
+
+    it('omits verified entirely when the backend did not send it', async () => {
+      mockAxiosInstance.get.mockResolvedValue(wrap({ ...baseProject }));
+      const result = await apiClient.getProject('proj-1');
+      expect(Object.prototype.hasOwnProperty.call(result, 'verified')).toBe(
+        false
+      );
+    });
   });
 
   // dtoToProjectImage pure mapper ─────────────────────────────────────────────

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,8 @@ export interface Project {
   updated_at: string;
   user_id: string;
   image_count?: number;
+  // "All annotations in the project have been reviewed and passed."
+  verified?: boolean;
 }
 
 /**
@@ -700,6 +702,15 @@ class ApiClient {
       result.folderId = (project.folderId as string | null) ?? null;
     }
 
+    // Annotation-review flag, set by the owner OR by any annotator the
+    // project is shared with. Same tri-state contract as `folderId` above:
+    // an explicit `false` is copied (a project deliberately un-verified),
+    // while an absent field stays absent, so a caller can tell "not
+    // verified" from "this response surface doesn't carry the field yet".
+    if (project.verified !== undefined) {
+      result.verified = project.verified as boolean;
+    }
+
     return result;
   }
 
@@ -924,6 +935,19 @@ class ApiClient {
 
   async deleteProject(id: string): Promise<void> {
     await this.instance.delete(`/projects/${id}`);
+  }
+
+  /**
+   * Toggle "all annotations reviewed and passed". Dedicated endpoint (not
+   * `updateProject`) — the owner AND an accepted-share annotator may both
+   * call this, unlike title/description/type which stay owner-only.
+   */
+  async setProjectVerified(id: string, verified: boolean): Promise<Project> {
+    const response = await this.instance.patch(`/projects/${id}/verified`, {
+      verified,
+    });
+    const project = this.extractData(response);
+    return this.mapProjectFields(project);
   }
 
   // ---- Project folders --------------------------------------------------

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -102,6 +102,8 @@ const ProjectDetail = () => {
     projectTitle,
     projectType,
     setProjectType,
+    projectVerified,
+    setProjectVerified,
     images,
     projectChannels,
     loading,
@@ -140,6 +142,32 @@ const ProjectDetail = () => {
       }
     },
     [id, setProjectType, t, images]
+  );
+
+  const handleVerifiedChange = useCallback(
+    async (verified: boolean) => {
+      if (!id) return;
+      // Optimistic: PATCH …/verified is settable by the owner AND an
+      // accepted-share annotator, and GET /projects/:id is browser-cached
+      // for 10 minutes, so we update local state directly rather than
+      // relying on a refetch.
+      try {
+        await apiClient.setProjectVerified(id, verified);
+        setProjectVerified(verified);
+        toast.success(
+          verified
+            ? t('projects.projectVerified')
+            : t('projects.projectUnverified')
+        );
+      } catch (err) {
+        logger.error('Failed to update project verified flag', err);
+        toast.error(
+          getErrorMessage(err, key => String(t(key))) ||
+            t('projects.failedToUpdateVerified')
+        );
+      }
+    },
+    [id, setProjectVerified, t]
   );
 
   // Handle cancellation events from WebSocket - define early for useSegmentationQueue
@@ -1651,6 +1679,8 @@ const ProjectDetail = () => {
         loading={loading}
         projectType={projectType}
         onTypeChange={handleProjectTypeChange}
+        verified={projectVerified}
+        onVerifiedChange={handleVerifiedChange}
       />
 
       <div className="container mx-auto px-4 py-8">

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -212,6 +212,11 @@ export default {
     changeProjectType: 'Změnit typ projektu',
     typeChangeSegmentationsWarning:
       '{{count}} existujících segmentací nemusí odpovídat exportnímu formátu "{{type}}". Re-segmentujte pro aktualizaci metrik.',
+    verified: 'Ověřeno',
+    toggleVerified: 'Přepnout ověření',
+    projectVerified: 'Projekt byl označen jako ověřený',
+    projectUnverified: 'Označení ověření projektu bylo zrušeno',
+    failedToUpdateVerified: 'Nepodařilo se aktualizovat stav ověření',
     types: {
       spheroid: 'Sféroidy (standardní)',
       spheroid_invasive: 'Rozprsknuté sféroidy',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -211,6 +211,12 @@ export default {
     changeProjectType: 'Projekttyp ändern',
     typeChangeSegmentationsWarning:
       '{{count}} bestehende Segmentierungen entsprechen möglicherweise nicht mehr dem Exportformat "{{type}}". Erneut segmentieren, um Metriken zu aktualisieren.',
+    verified: 'Verifiziert',
+    toggleVerified: 'Verifizierung umschalten',
+    projectVerified: 'Projekt als verifiziert markiert',
+    projectUnverified: 'Verifizierung des Projekts wurde entfernt',
+    failedToUpdateVerified:
+      'Verifizierungsstatus konnte nicht aktualisiert werden',
     types: {
       spheroid: 'Sphäroide (Standard)',
       spheroid_invasive: 'Zerfallene Sphäroide',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -219,6 +219,11 @@ export default {
     changeProjectType: 'Change project type',
     typeChangeSegmentationsWarning:
       '{{count}} existing segmentation(s) may no longer match the new "{{type}}" export format. Re-segment to refresh metrics.',
+    verified: 'Verified',
+    toggleVerified: 'Toggle verified',
+    projectVerified: 'Project marked as verified',
+    projectUnverified: 'Project verification removed',
+    failedToUpdateVerified: 'Failed to update verification status',
     types: {
       spheroid: 'Spheroids (standard)',
       spheroid_invasive: 'Disintegrated spheroids',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -211,6 +211,11 @@ export default {
     changeProjectType: 'Cambiar tipo de proyecto',
     typeChangeSegmentationsWarning:
       '{{count}} segmentaciones existentes pueden no coincidir con el formato de exportación "{{type}}". Vuelva a segmentar para actualizar las métricas.',
+    verified: 'Verificado',
+    toggleVerified: 'Alternar verificación',
+    projectVerified: 'Proyecto marcado como verificado',
+    projectUnverified: 'Se ha eliminado la verificación del proyecto',
+    failedToUpdateVerified: 'Error al actualizar el estado de verificación',
     types: {
       spheroid: 'Esferoides (estándar)',
       spheroid_invasive: 'Esferoides desintegrados',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -211,6 +211,12 @@ export default {
     changeProjectType: 'Changer le type de projet',
     typeChangeSegmentationsWarning:
       '{{count}} segmentations existantes peuvent ne plus correspondre au format d\'export "{{type}}". Re-segmentez pour mettre à jour les métriques.',
+    verified: 'Vérifié',
+    toggleVerified: 'Basculer la vérification',
+    projectVerified: 'Projet marqué comme vérifié',
+    projectUnverified: 'La vérification du projet a été supprimée',
+    failedToUpdateVerified:
+      'Impossible de mettre à jour le statut de vérification',
     types: {
       spheroid: 'Sphéroïdes (standard)',
       spheroid_invasive: 'Sphéroïdes désintégrés',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -198,6 +198,11 @@ export default {
     changeProjectType: '更改项目类型',
     typeChangeSegmentationsWarning:
       '{{count}} 个现有分割可能不再符合 "{{type}}" 导出格式。重新分割以更新指标。',
+    verified: '已验证',
+    toggleVerified: '切换验证状态',
+    projectVerified: '项目已标记为已验证',
+    projectUnverified: '已取消项目验证标记',
+    failedToUpdateVerified: '无法更新验证状态',
     types: {
       spheroid: '球体（标准）',
       spheroid_invasive: '分解球体',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -407,6 +407,10 @@ export interface Project {
   // the caller's root level. Two users can see different folderId values for
   // the same shared project — see backend ProjectFolderItem model.
   folderId?: string | null;
+  // "All annotations in the project have been reviewed and passed." Settable
+  // by the owner OR an accepted-share annotator via PATCH /projects/:id/verified
+  // — unlike title/description/type, which stay owner-only.
+  verified?: boolean;
 }
 
 export interface ProjectFolder {


### PR DESCRIPTION
## What

A `verified` flag on every project, so an annotator can record that all annotations in it have been reviewed and passed.

## The substance is authorization, not the checkbox

Project metadata was strictly owner-only — a shared user hitting `PUT /api/projects/:id` gets a 404. But the people doing the reviewing are exactly the ones the project is shared *with*.

Rather than widening `PUT` (which would also hand over title/description/type), this adds a dedicated **`PATCH /api/projects/:id/verified`** gated on `SharingService.hasProjectAccess`. That mirrors the existing `mtTypeLabels` endpoints, which already let accepted-share users write project-scoped metadata. `updateProject` and `checkProjectOwnership` stay untouched and owner-only.

## Five allow-list bottlenecks, three of which silently strip

| Bottleneck | Before |
|---|---|
| `projectService.ts:254` (`...project` spread) | passes through |
| `sharingController.ts` `/shared/projects` DTO | **stripped** |
| `api.ts` `mapProjectFields` | **stripped** |
| `ProjectsList.tsx` (separate grid + list branches) | **stripped** |
| `useProjectData.tsx` | **stripped** |

`sharingController` matters most: `useDashboardProjects` merges shared projects **over** owned ones, so missing it there would blank the flag on precisely the annotators' projects. Both accept-invitation DTOs are patched too.

`mapProjectFields` is the codebase's documented #1 strip point — and it *was* missed on the first pass here. The regression tests were written before the mapper change and confirmed red (`expected false to be true`) before the fix landed. Copied with the same tri-state contract as `folderId`: an explicit `false` survives, an absent field stays absent.

## Migration

Hand-authored and idempotent (`ADD COLUMN IF NOT EXISTS`) rather than generated. Production's Prisma history has drifted from the repo — 13 recorded rows vs 17 migration dirs, and three of the unrecorded ones are **not** idempotent — so `migrate deploy` would fail with `42P07` and poison `_prisma_migrations` for every future migration. Same approach as `20260709_add_mt_type_labels`. Already applied to production and verified:

```
 verified   | boolean                        | not null | false
 verifiedAt | timestamp(3) without time zone |          |
 verifiedBy | text                           |          |
```

`verifiedAt`/`verifiedBy` are stored for later auditability but deliberately not surfaced in the UI yet.

i18n complete in all 6 languages. **Browser verification still outstanding before merge.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYYFoe8Yp1Kg1hMwYkmG7o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project verification status with a visible badge across project lists and cards.
  * Project owners and accepted collaborators can mark projects as verified or unverified from the project details page.
  * Verification status is displayed for shared projects and invitations.
  * Added localized labels and success/error messages in supported languages.

* **Bug Fixes**
  * Prevented stale project verification status from being displayed.
  * Improved log sanitization for safer, clearer error output.

* **Tests**
  * Added coverage for verification data handling and sanitized log formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->