### PR TITLE
fix(export): stop the microtubule export silently shipping hollow metrics

### DIFF
--- a/backend/src/services/export/exportDocs.ts
+++ b/backend/src/services/export/exportDocs.ts
@@ -199,25 +199,37 @@ The microtubule model produces **open polyline centerlines** (one polyline
 per microtubule instance), not closed polygons — so the standard
 closed-polygon report (area / perimeter) does not apply. Instead the metrics
 file is a **long-format table with one row per (frame, polyline, channel)**.
-Microtubule **length** is always present; the per-channel **intensity**
-columns are filled only when a channel was selected in the export dialog
-(otherwise they are blank and \`channel\` is empty).
+Microtubule **length** is pure geometry and never depends on a channel.
+Per-channel **intensity** is ALWAYS computed too, for **every** channel the
+video has — there is no channel picker in the export dialog any more, and no
+opt-in. The intensity columns are only blank (and \`channel\` empty) on the
+rare **geometry-only fallback**: if the original ND2/TIFF couldn't be
+re-read or the ML service failed, the export still ships microtubule length
+rather than nothing. When that happens it is stamped directly into the
+archive — see "Geometry-only fallback" below — rather than left for you to
+notice a missing column.
 
 ### Columns
 - **frameIndex** — 0-based frame index within the source video.
-- **imageId** — frame image id.
+- **imageName** — the frame's human-readable name (not its internal id).
+- **label** — the per-frame instance badge drawn on the visualisation image
+  (\`MT1\`, \`MT2\`, …); blank when the polyline has no badge.
+- **mtType** — the user-assigned tubulin type class name, when one was set;
+  blank for untyped polylines.
 - **instanceId** — unique per polyline (one MT = one instance).
 - **trackId** — stable across frames for the same MT when cross-frame
   tracking ran; blank otherwise.
-- **channel** — sampled channel machine name; blank on length-only rows.
+- **channel** — sampled channel machine name; blank only on a geometry-only
+  fallback row.
 - **lengthPx / lengthUm** — centerline arc length, Sum_i ||p_{i+1} - p_i||
   (the ${lengthUnit} column is filled when a pixel→µm scale was supplied).
 - **areaPx / areaUm2** — area of the thickness-wide sampling band around the
-  centerline (intensity exports only).
-- **pixelCount** — number of pixels in the sampling band (intensity exports
-  only).
-- **sumIntensity / meanIntensity / stdIntensity** — raw 16-bit signal
-  statistics inside the band for this channel (intensity exports only).
+  centerline (blank on a geometry-only fallback row).
+- **pixelCount** — number of pixels in the sampling band (blank on a
+  geometry-only fallback row).
+- **sumIntensity / meanIntensity / medianIntensity / stdIntensity** — raw
+  16-bit signal statistics inside the band for this channel (blank on a
+  geometry-only fallback row).
 - **medianBackground / meanBackground** — median resp. mean signal in THIS
   microtubule's own LOCAL vicinity ring: the band within
   \`thickness * margin\` of its centerline, excluding every microtubule's signal
@@ -230,6 +242,29 @@ columns are filled only when a channel was selected in the export dialog
 Intensity is derived from the **raw 16-bit** ND2/TIFF signal, not the 8-bit
 display-normalised per-channel PNGs. The sampling band width (\`thickness\`)
 and the background margin are set in the export dialog.
+
+### Channel totals (\`metrics_channel_totals.csv\` / \`.json\`, or the
+"Channel Totals" sheet in \`metrics.xlsx\`)
+
+One row per (video, channel): the sum/mean of **every** pixel of that
+channel across the whole video, independent of the microtubules — a global
+"how bright is this channel overall" measure, distinct from the per-MT band
+sums above. Present whenever intensity was computed; absent on a
+geometry-only fallback (there is no raster read to total).
+
+### Geometry-only fallback
+
+If per-channel intensity could not be computed for the video(s) in this
+export (the original ND2/TIFF was unreadable, or the ML service failed or
+timed out), the export does not fail — it re-emits this same table with
+microtubule length only, all intensity columns blank, and \`channel\` empty.
+This is rare, and it is always self-describing: a companion
+\`metrics/metrics_status.json\` is written next to \`metrics.*\` with an
+\`intensityIncluded\` boolean and a \`reason\` string, and — when
+"include documentation" was checked — \`metadata.json\`'s
+\`microtubuleIntensity\` field and a warning banner at the top of this file
+carry the same information. Check \`metrics_status.json\` first if a
+downloaded sheet's intensity columns look empty.
 
 ## JSON export
 

--- a/backend/src/services/export/imagejRoiEncoder.ts
+++ b/backend/src/services/export/imagejRoiEncoder.ts
@@ -48,6 +48,11 @@ import {
 } from './imagejColor';
 import axios from 'axios';
 import { config } from '../../utils/config';
+import { Semaphore, runGated } from '../../utils/concurrency';
+import {
+  estimateMlRequestTimeoutMs,
+  megapixelsFromFrames,
+} from './mlRequestBudget';
 
 // ---------------------------------------------------------------------------
 //  Low-level encoder
@@ -234,6 +239,10 @@ export interface RoiFrameInput {
   frameIndex?: number | null;
   isVideoContainer?: boolean;
   segmentation?: { polygons?: string | null } | null;
+  /** Frame pixel dimensions, when known. Used only to size the ML request
+   *  timeout to the actual workload (see `mlRequestBudget.ts`). */
+  width?: number | null;
+  height?: number | null;
 }
 
 export interface ImageJRoiExportResult {
@@ -672,12 +681,18 @@ interface MtBgResponse {
  * ``\`${frameIndex}:${itemIndex}\``` line up with the encoder. Returns an empty
  * map when there are no polylines; the caller treats a THROWN error as
  * "fall back to the wide stroke band".
+ *
+ * @param mlGate  Optional shared semaphore bounding how many ML-bound
+ *                requests this export job has in flight at once, across ALL
+ *                of its ML-bound stages (mt-metrics, mt-background-rois,
+ *                kymograph) — not just this one. Omitted in unit tests.
  */
 async function fetchMtBackgroundRois(
   frames: RoiFrameInput[],
   labelById: Map<string, RoiTypeLabel> | undefined,
   thicknessPx: number,
-  marginMultiplier: number
+  marginMultiplier: number,
+  mlGate?: Semaphore
 ): Promise<Map<string, Buffer>> {
   const ordered = [...frames].sort(
     (a, b) => (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
@@ -710,15 +725,31 @@ async function fetchMtBackgroundRois(
   const requested = reqFrames.reduce((n, f) => n + f.polylines.length, 0);
   if (requested === 0) return map;
 
+  // This endpoint is geometry-only (no raster read) so it's intrinsically
+  // cheap — but it runs CONCURRENTLY with mt-metrics + kymograph requests
+  // from the same export, all sharing one single-worker ML process, so its
+  // real bottleneck is queueing behind them rather than its own compute.
+  // `channels: 1` (no channel dimension applies here) still yields a
+  // generously large budget via the same workload-scaled formula
+  // mt-metrics uses — see `mlRequestBudget.ts`.
+  const megapixels = megapixelsFromFrames(frames);
+  const timeoutMs = estimateMlRequestTimeoutMs({
+    frames: reqFrames.length,
+    channels: 1,
+    megapixels,
+  });
+
   const url = `${config.SEGMENTATION_SERVICE_URL}/api/v1/mt-background-rois`;
-  const res = await axios.post<MtBgResponse>(
-    url,
-    {
-      frames: reqFrames,
-      thickness_px: thicknessPx,
-      margin_multiplier: marginMultiplier,
-    },
-    { timeout: 5 * 60 * 1000 }
+  const res = await runGated(mlGate, () =>
+    axios.post<MtBgResponse>(
+      url,
+      {
+        frames: reqFrames,
+        thickness_px: thicknessPx,
+        margin_multiplier: marginMultiplier,
+      },
+      { timeout: timeoutMs }
+    )
   );
 
   // Validate each entry before trusting it: a response-shape drift (renamed /
@@ -807,6 +838,10 @@ export async function exportImageJRoiSets(
     /** Vicinity margin multiplier (× thickness) for the background ring, matching
      *  the metrics request. Defaults to 2 when `thicknessPx` is set. */
     marginMultiplier?: number;
+    /** Shared semaphore bounding how many ML-bound requests this export job
+     *  has in flight at once, across ALL of its ML-bound stages (mt-metrics,
+     *  mt-background-rois, kymograph) — not just this one. */
+    mlGate?: Semaphore;
   } = {}
 ): Promise<ImageJRoiExportResult> {
   const baseDir = path.join(exportDir, 'annotations', 'imagej');
@@ -863,7 +898,8 @@ export async function exportImageJRoiSets(
           videoFrames,
           labelById,
           options.thicknessPx,
-          options.marginMultiplier ?? 2
+          options.marginMultiplier ?? 2,
+          options.mlGate
         );
       } catch (error) {
         logger.warn(

--- a/backend/src/services/export/mlRequestBudget.ts
+++ b/backend/src/services/export/mlRequestBudget.ts
@@ -1,0 +1,113 @@
+/**
+ * Workload-scaled axios timeout for the microtubule export's ML-bound
+ * requests (`mt-metrics`, `mt-background-rois`).
+ *
+ * Production evidence for why a fixed timeout is wrong: a 299-frame,
+ * 2-channel, ~2.08-megapixel export took **24m32s** of real ML wall-clock,
+ * against a hard-coded 5-minute axios timeout — so the backend gave up and
+ * degraded the export to a hollow, geometry-only metrics sheet, and then the
+ * ML service's real 200 OK (91,482 rows) landed 12 minutes later into
+ * nothing. Any single fixed number is wrong on the next dataset: bigger
+ * videos, more channels or higher resolution will always exist.
+ *
+ * Instead the budget scales with the actual request workload — frames x
+ * channels, adjusted for frame resolution relative to the ~2-megapixel
+ * reference size that rate was measured on — with a generous headroom
+ * multiplier on top, and a floor so a tiny request isn't cut short by
+ * request/queueing jitter.
+ *
+ * This still eventually fails a genuinely hung ML service: the computed
+ * timeout is a large but FINITE number for any given workload (see the
+ * worst-case note in the PR description), never "no timeout".
+ */
+
+/**
+ * Measured on production 2026-08-2x: 299 frames x 2 channels x ~2.08 MP took
+ * 24m32s (1472 s) of ML wall-clock => 1472 / (299*2*(2.08/2)) ≈ 2.46 s per
+ * (frame x channel) unit at the ~2 MP reference size. Rounded up slightly.
+ */
+export const SECONDS_PER_UNIT_AT_REFERENCE_MP = 2.5;
+
+/** The megapixel size the rate above was measured at. */
+export const REFERENCE_MEGAPIXELS = 2;
+
+/**
+ * Generous headroom over the measured worst case. Covers (a) a slower
+ * frame/channel mix than the one the rate was measured on, and (b) the
+ * request still having to wait its turn behind whatever else is queued on
+ * the shared per-export ML request gate (see `utils/concurrency.ts`).
+ */
+export const HEADROOM_MULTIPLIER = 3;
+
+/**
+ * Floor: never go below this even for a 1-frame, 1-channel request — at that
+ * scale request setup + queueing jitter dominates, not the compute itself.
+ */
+export const MIN_ML_TIMEOUT_MS = 60_000;
+
+export interface MlWorkload {
+  /** Number of frames covered by the request. */
+  frames: number;
+  /** Number of channels sampled per frame. Pass `1` for a channel-independent
+   *  (pure geometry) request such as `mt-background-rois`. */
+  channels: number;
+  /** Frame width x height in megapixels, when known. Falls back to the
+   *  reference size (assume "typical", not "assume tiny") when omitted or
+   *  non-finite/non-positive. */
+  megapixels?: number | null;
+}
+
+/**
+ * Compute the axios `timeout` (ms) for one ML-bound export request, scaled to
+ * its actual workload with generous headroom. Exported so both
+ * `mtMetricsExporter.ts` and `imagejRoiEncoder.ts` (and their tests) share the
+ * exact same budget — the whole point is that neither hardcodes its own
+ * fixed number again.
+ */
+export function estimateMlRequestTimeoutMs({
+  frames,
+  channels,
+  megapixels,
+}: MlWorkload): number {
+  const safeFrames = Number.isFinite(frames) && frames > 0 ? frames : 0;
+  const safeChannels =
+    Number.isFinite(channels) && channels > 0 ? channels : 1;
+  const mp =
+    typeof megapixels === 'number' &&
+    Number.isFinite(megapixels) &&
+    megapixels > 0
+      ? megapixels
+      : REFERENCE_MEGAPIXELS;
+
+  const units = safeFrames * safeChannels * (mp / REFERENCE_MEGAPIXELS);
+  const seconds = units * SECONDS_PER_UNIT_AT_REFERENCE_MP * HEADROOM_MULTIPLIER;
+  return Math.max(MIN_ML_TIMEOUT_MS, Math.ceil(seconds * 1000));
+}
+
+/**
+ * Best-effort megapixel estimate from a list of `{ width, height }` pairs
+ * (typically the frames of one video container — all frames of a video share
+ * dimensions). Returns `null` when no usable dimensions are present, letting
+ * `estimateMlRequestTimeoutMs` fall back to the reference size rather than
+ * silently under-budgeting on a size we simply don't know.
+ */
+export function megapixelsFromFrames(
+  frames: ReadonlyArray<{
+    width?: number | null;
+    height?: number | null;
+  }>
+): number | null {
+  for (const f of frames) {
+    if (
+      typeof f.width === 'number' &&
+      typeof f.height === 'number' &&
+      Number.isFinite(f.width) &&
+      Number.isFinite(f.height) &&
+      f.width > 0 &&
+      f.height > 0
+    ) {
+      return (f.width * f.height) / 1_000_000;
+    }
+  }
+  return null;
+}

--- a/backend/src/services/export/mtKymographExporter.ts
+++ b/backend/src/services/export/mtKymographExporter.ts
@@ -24,7 +24,7 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { prisma } from '../../db/prismaClient';
 import { logger } from '../../utils/logger';
-import { mapWithConcurrency } from '../../utils/concurrency';
+import { mapWithConcurrency, runGated, type Semaphore } from '../../utils/concurrency';
 import { buildKymograph } from '../kymographService';
 
 const CTX = 'MTKymographExporter';
@@ -33,8 +33,11 @@ const CTX = 'MTKymographExporter';
  *  Anything dropped is logged (never silently truncated). */
 const MAX_MT_PER_CONTAINER = 60;
 
-/** Parallel ML kymograph builds. The ML service has finite capacity, so keep
- *  this small — it bounds export wall-clock without overrunning inference. */
+/** Parallel kymograph JOB ORCHESTRATION (DB-free local prep + file writes
+ *  around each ML call) — NOT the ML request concurrency itself, which is
+ *  bounded separately by the shared `mlGate` (see `exportMicrotubuleKymographs`
+ *  below) across the whole export, not just this stage. Kept > 1 so local
+ *  I/O for one job can overlap the (gated) network call for another. */
 const KYMOGRAPH_CONCURRENCY = 3;
 
 /** Per (microtubule × channel) cap on the number of frame profiles written in
@@ -199,7 +202,15 @@ export async function exportMicrotubuleKymographs(
    * spent ~20 min here — so it is the one place where per-item reporting is
    * worth the plumbing rather than a single bump on completion.
    */
-  onProgress?: (done: number, total: number) => void
+  onProgress?: (done: number, total: number) => void,
+  /**
+   * Shared semaphore bounding how many ML-bound requests this export job has
+   * in flight at once, across ALL of its ML-bound stages (mt-metrics,
+   * mt-background-rois, kymograph) — not just this one. Every `buildKymograph`
+   * call below (the actual ML request) is routed through it. Omitted in unit
+   * tests, which mock `buildKymograph` directly.
+   */
+  mlGate?: Semaphore
 ): Promise<void> {
   // Normalise the mode: the controller casts req.body without validation, so an
   // older cached FE bundle (or a direct API caller) may omit it. Default to the
@@ -337,15 +348,17 @@ export async function exportMicrotubuleKymographs(
       };
       await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
         try {
-          const result = await buildKymograph({
-            videoContainerId: job.containerId,
-            polylineId: job.polylineId,
-            frameIndex: job.frameIndex,
-            sourceChannel: job.sourceChannel,
-            detectVelocity: false,
-            renderProfiles: true,
-            frameFilter: job.frameFilter,
-          });
+          const result = await runGated(mlGate, () =>
+            buildKymograph({
+              videoContainerId: job.containerId,
+              polylineId: job.polylineId,
+              frameIndex: job.frameIndex,
+              sourceChannel: job.sourceChannel,
+              detectVelocity: false,
+              renderProfiles: true,
+              frameFilter: job.frameFilter,
+            })
+          );
 
           const stem = `${job.safeVideo}__${safeSegment(job.polylineId)}__${safeSegment(job.sourceChannel)}`;
 
@@ -413,15 +426,17 @@ export async function exportMicrotubuleKymographs(
     };
     await mapWithConcurrency(jobs, KYMOGRAPH_CONCURRENCY, async job => {
       try {
-        const result = await buildKymograph({
-          videoContainerId: job.containerId,
-          polylineId: job.polylineId,
-          frameIndex: job.frameIndex,
-          sourceChannel: job.sourceChannel,
-          detectVelocity: true,
-          renderOverlay: options.includeSegmentedImages,
-          frameFilter: job.frameFilter,
-        });
+        const result = await runGated(mlGate, () =>
+          buildKymograph({
+            videoContainerId: job.containerId,
+            polylineId: job.polylineId,
+            frameIndex: job.frameIndex,
+            sourceChannel: job.sourceChannel,
+            detectVelocity: true,
+            renderOverlay: options.includeSegmentedImages,
+            frameFilter: job.frameFilter,
+          })
+        );
 
         // buildKymograph degrades a velocity-detection crash to empty tracks
         // (it does NOT throw), so the per-job catch below would never see it.

--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -30,6 +30,11 @@ import {
   buildInstanceLabelMap,
   MICROTUBULE_LABEL_PREFIX,
 } from '../../utils/instanceLabels';
+import { Semaphore, runGated } from '../../utils/concurrency';
+import {
+  estimateMlRequestTimeoutMs,
+  megapixelsFromFrames,
+} from './mlRequestBudget';
 
 // ----------------------------------------------------------------------------
 //  Types (mirror the Python Pydantic models — keep in sync if either changes)
@@ -198,6 +203,11 @@ interface FrameImageInput {
   frameIndex: number | null;
   isVideoContainer?: boolean;
   segmentation?: { polygons?: string | null } | null;
+  /** Frame pixel dimensions, when known. Used only to size the ML request
+   *  timeout to the actual workload (see `mlRequestBudget.ts`) — never
+   *  required, and absent entirely in most callers' minimal test fixtures. */
+  width?: number | null;
+  height?: number | null;
 }
 
 interface RawPolyline {
@@ -311,6 +321,12 @@ function resolveChannelIndices(
  * @param projectId    For logging context only.
  * @param options      User-supplied MT metric controls from the export
  *                     modal.
+ * @param mlGate       Optional shared semaphore bounding how many ML-bound
+ *                     requests this export job has in flight at once, across
+ *                     ALL of its ML-bound stages (mt-metrics,
+ *                     mt-background-rois, kymograph) — not just this one.
+ *                     Omitted in unit tests, which call this function
+ *                     directly against a mocked axios.
  * @returns Long-format rows ready to write to CSV / XLSX / JSON, plus
  *          a list of human-readable skip reasons for videos that could
  *          not be processed. The caller should surface these as job
@@ -319,7 +335,8 @@ function resolveChannelIndices(
 export async function computeMTMetrics(
   frameImages: FrameImageInput[],
   projectId: string,
-  options: MTMetricsOptions
+  options: MTMetricsOptions,
+  mlGate?: Semaphore
 ): Promise<{
   rows: MTMetricsRow[];
   skipped: string[];
@@ -581,6 +598,19 @@ export async function computeMTMetrics(
       png_channels: pngChannelNames.length ? pngChannelNames : undefined,
     };
 
+    // Scale the timeout to this request's actual workload (frames x channels,
+    // adjusted for frame resolution) rather than a fixed number — see
+    // `mlRequestBudget.ts` for the measured rate + headroom this is built
+    // from. `channels` counts every channel actually being sampled (volume +
+    // PNG-backed), matching what the ML side has to read.
+    const requestChannelCount = indices.length + pngChannelNames.length;
+    const megapixels = megapixelsFromFrames(frames);
+    const timeoutMs = estimateMlRequestTimeoutMs({
+      frames: framesPayload.length,
+      channels: requestChannelCount,
+      megapixels,
+    });
+
     logger.info(
       'MT metrics: requesting ML computation',
       'mtMetricsExporter',
@@ -591,17 +621,22 @@ export async function computeMTMetrics(
         frames: framesPayload.length,
         channels: indices.length,
         pngChannels: pngChannelNames.length,
+        megapixels,
+        timeoutMs,
       }
     );
 
     let mlResponse: MLMTMetricsResponse;
     try {
-      // 5 minutes — covers a long video × multiple channels with full
-      // ND2 / TIFF reads. Failures bubble up so the export job fails
-      // visibly rather than silently emitting an empty sheet.
-      const res = await axios.post<MLMTMetricsResponse>(mlUrl, body, {
-        timeout: 5 * 60 * 1000,
-      });
+      // Failures bubble up so the export job fails visibly rather than
+      // silently emitting an empty sheet. `mlGate` serialises this request
+      // against the export's other ML-bound stages so it never has to queue
+      // behind them AND its own timeout at once (see `Semaphore` in
+      // `utils/concurrency.ts`) — the timeout clock only starts once the
+      // request is actually sent.
+      const res = await runGated(mlGate, () =>
+        axios.post<MLMTMetricsResponse>(mlUrl, body, { timeout: timeoutMs })
+      );
       mlResponse = res.data;
     } catch (err) {
       logger.error(

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -21,7 +21,7 @@ import {
 import { WebSocketService } from './websocketService';
 import * as SharingService from './sharingService';
 import { batchProcessor } from '../utils/batchProcessor';
-import { mapWithConcurrency } from '../utils/concurrency';
+import { mapWithConcurrency, Semaphore } from '../utils/concurrency';
 import type { CancellableJobStatus } from '../types';
 import {
   generateReadme,
@@ -158,6 +158,19 @@ type ImageWithSegmentation = Prisma.ImageGetPayload<{
 
 // Define type for visualizationOptions parameter
 type VisualizationOptions = ExportOptions['visualizationOptions'];
+
+/**
+ * Outcome of the microtubule per-channel intensity computation for one
+ * export job. `generateDocumentation` stamps this into `metadata.json` /
+ * `metrics_guide.md` so a downloaded geometry-only (hollow) metrics sheet is
+ * self-describing, rather than indistinguishable from a full one once it has
+ * left the job's in-memory `warnings` list behind.
+ */
+interface MtIntensityStatus {
+  intensityIncluded: boolean;
+  /** Human-readable reason, set only when `intensityIncluded` is false. */
+  degradedReason: string | null;
+}
 
 export interface ExportJob {
   id: string;
@@ -497,6 +510,29 @@ export class ExportService {
       // crash at runtime that the type checker does not catch.
       const isMicrotubuleProject = isMicrotubuleProjectType(project.type);
 
+      // The microtubule export's ML-bound stages (mt-metrics,
+      // mt-background-rois, kymograph) are each internally bounded, but all
+      // three run CONCURRENTLY against each other via `Promise.all` below —
+      // and the ML service is a single `uvicorn --workers 1` process, so
+      // concurrent requests only queue there, they never run in parallel.
+      // Production evidence: one export produced 893 "Exceeded concurrency
+      // limit" warnings, and the `mt-metrics` request sat queued ~7 minutes
+      // behind `mt-background-rois` from the SAME export before ML even
+      // opened the file. One shared semaphore, threaded through every
+      // ML-bound call this job makes, serialises them at the source instead —
+      // there is no parallelism to give up with a single ML worker, only
+      // queueing to avoid.
+      const mlRequestGate = isMicrotubuleProject ? new Semaphore(1) : undefined;
+
+      // Resolves to the MT intensity outcome once `generateMicrotubuleMetrics`
+      // finishes (undefined for non-MT projects, or if that stage never runs).
+      // `generateDocumentation` below awaits this SAME promise before writing
+      // `metadata.json` / `metrics_guide.md`, so a downloaded hollow
+      // (geometry-only) metrics sheet is always accompanied by documentation
+      // that says so — never a race between the two concurrent stages.
+      let mtIntensityStatusPromise: Promise<MtIntensityStatus | undefined> =
+        Promise.resolve(undefined);
+
       // SSOT: the denominator lives beside `getProgressMessage` so it can be
       // unit-tested against the push sites it mirrors.
       const totalSteps = countExportSteps(
@@ -643,13 +679,15 @@ export class ExportService {
         options.metricsFormats?.length &&
         project.images?.length
       ) {
+        mtIntensityStatusPromise = this.generateMicrotubuleMetrics(
+          project.images as ImageWithSegmentation[],
+          exportDir,
+          options,
+          jobId,
+          mlRequestGate
+        );
         exportTasks.push(
-          this.generateMicrotubuleMetrics(
-            project.images as ImageWithSegmentation[],
-            exportDir,
-            options,
-            jobId
-          ).then(() => {
+          mtIntensityStatusPromise.then(() => {
             progressStep++;
             this.updateJobProgress(
               jobId,
@@ -686,7 +724,8 @@ export class ExportService {
                 'kymographs',
                 { current: done, total }
               );
-            }
+            },
+            mlRequestGate
           ).then(() => {
             progressStep++;
             this.updateJobProgress(
@@ -735,6 +774,7 @@ export class ExportService {
               // fallback band if that request fails.
               thicknessPx: mtThicknessPx,
               marginMultiplier: mtMarginMultiplier,
+              mlGate: mlRequestGate,
             }
           )
             .then(result => {
@@ -819,13 +859,23 @@ export class ExportService {
         );
       }
 
-      // Generate documentation (can run in parallel)
+      // Generate documentation (can run in parallel with everything EXCEPT MT
+      // metrics: it awaits `mtIntensityStatusPromise` first — see that
+      // variable's declaration above — so a geometry-only fallback is always
+      // reflected in metadata.json / metrics_guide.md rather than racing
+      // ahead of the (possibly very slow) metrics stage and writing "success"
+      // documentation before the outcome is even known. For non-MT projects
+      // that promise is already resolved (undefined), so this adds no delay.
       if (options.includeDocumentation) {
         exportTasks.push(
-          this.generateDocumentation(project, exportDir, options).then(() => {
-            progressStep++;
-            this.updateJobProgress(jobId, 5 + progressStep * progressIncrement);
-          })
+          mtIntensityStatusPromise
+            .then(mtStatus =>
+              this.generateDocumentation(project, exportDir, options, mtStatus)
+            )
+            .then(() => {
+              progressStep++;
+              this.updateJobProgress(jobId, 5 + progressStep * progressIncrement);
+            })
         );
       }
 
@@ -1653,8 +1703,9 @@ export class ExportService {
     images: ImageWithSegmentation[],
     exportDir: string,
     options: ExportOptions,
-    jobId?: string
-  ): Promise<void> {
+    jobId?: string,
+    mlGate?: Semaphore
+  ): Promise<MtIntensityStatus> {
     if (jobId && this.isJobCancelled(jobId)) {
       throw new Error('Export cancelled by user');
     }
@@ -1673,6 +1724,8 @@ export class ExportService {
       segmentation: i.segmentation
         ? { polygons: i.segmentation.polygons }
         : null,
+      width: i.width ?? null,
+      height: i.height ?? null,
     }));
     // Per-channel intensity (incl. the integrated sum) is ALWAYS computed for
     // MT exports — there is no opt-in. An empty channel list means "all
@@ -1696,20 +1749,36 @@ export class ExportService {
     // companion file. Empty on the geometry-only fallback.
     let channelSummaries: MTChannelSummaryRow[] = [];
     let intensityIncluded = false;
+    // Set on every path that degrades to geometry-only, so the stamp written
+    // below (and metadata.json / metrics_guide.md, via `mtIntensityStatus`)
+    // can tell the user WHY the intensity columns are empty, not just that
+    // they are.
+    let degradedReason: string | null = null;
 
     try {
-      const mtResult = await computeMTMetrics(frameInputs, projectId, {
-        thicknessPx,
-        marginMultiplier,
-        channels,
-        pixelToMicrometerScale: scale,
-      });
+      const mtResult = await computeMTMetrics(
+        frameInputs,
+        projectId,
+        {
+          thicknessPx,
+          marginMultiplier,
+          channels,
+          pixelToMicrometerScale: scale,
+        },
+        mlGate
+      );
       rows = mtResult.rows;
       channelSummaries = mtResult.channelSummaries ?? [];
       for (const reason of mtResult.skipped) {
         addWarning(`MT intensity metrics skipped: ${reason}`);
       }
       intensityIncluded = rows.length > 0;
+      if (!intensityIncluded) {
+        degradedReason =
+          mtResult.skipped.length > 0
+            ? `No per-channel intensity data was available: ${mtResult.skipped.join('; ')}`
+            : 'No per-channel intensity data was available for the selected videos.';
+      }
     } catch (err) {
       logger.error(
         'MT intensity metrics failed; falling back to length-only',
@@ -1717,9 +1786,9 @@ export class ExportService {
         'ExportService',
         { jobId, projectId }
       );
-      addWarning(
-        'Per-channel signal-intensity metrics could not be computed (the original ND2/TIFF was unreadable or the ML service failed). The metrics file contains microtubule length only.'
-      );
+      degradedReason =
+        'Per-channel signal-intensity metrics could not be computed (the original ND2/TIFF was unreadable or the ML service failed). The metrics file contains microtubule length only.';
+      addWarning(degradedReason);
       rows = [];
     }
 
@@ -1745,11 +1814,35 @@ export class ExportService {
       addWarning(
         'No microtubule annotations were found in the selected images, so no metrics file was produced.'
       );
-      return;
+      return {
+        intensityIncluded: false,
+        degradedReason:
+          'No microtubule annotations were found in the selected images.',
+      };
     }
 
     const metricsDir = path.join(exportDir, 'metrics');
     await writeMTMetrics(rows, metricsDir, formats, channelSummaries);
+
+    // ALWAYS stamp the outcome directly beside metrics.* — durable and
+    // self-describing even when the user didn't enable "include
+    // documentation" (metadata.json / metrics_guide.md below only exist when
+    // they did). This is the file a downloaded hollow sheet can be checked
+    // against without having to notice a missing toast.
+    await fs.writeFile(
+      path.join(metricsDir, 'metrics_status.json'),
+      JSON.stringify(
+        {
+          intensityIncluded,
+          reason: intensityIncluded ? null : degradedReason,
+          rows: rows.length,
+          generatedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
+    );
+
     logger.info(
       'MT metrics: wrote files',
       'ExportService',
@@ -1762,12 +1855,22 @@ export class ExportService {
         formats,
       }
     );
+    return { intensityIncluded, degradedReason: intensityIncluded ? null : degradedReason };
   }
 
   private async generateDocumentation(
     project: ProjectWithImages,
     exportDir: string,
-    options: ExportOptions
+    options: ExportOptions,
+    /**
+     * MT intensity outcome, when this export ran `generateMicrotubuleMetrics`
+     * — undefined for non-MT projects or when that stage never ran. The
+     * CALLER awaits `generateMicrotubuleMetrics`'s own promise before invoking
+     * this method (see the `mtIntensityStatusPromise` wiring above), so this
+     * is never a stale/racy read even though both stages are otherwise
+     * independent, concurrently-scheduled export tasks.
+     */
+    mtStatus?: MtIntensityStatus
   ): Promise<void> {
     const docDir = path.join(exportDir, 'documentation');
 
@@ -1778,7 +1881,11 @@ export class ExportService {
     // Generate annotation format guides
     await generateAnnotationGuides(exportDir, options);
 
-    // Generate metadata
+    // Generate metadata. `microtubuleIntensity` is present only for MT
+    // projects that ran the metrics stage, so a downloaded archive with
+    // "include documentation" checked is self-describing about a
+    // geometry-only (hollow) metrics sheet — not just a toast the user may
+    // have missed during a long export.
     const metadata = {
       projectId: project.id,
       projectName: project.title,
@@ -1786,6 +1893,14 @@ export class ExportService {
       imageCount: project.images?.length || 0,
       exportOptions: options,
       version: '1.0.0',
+      ...(mtStatus
+        ? {
+            microtubuleIntensity: {
+              included: mtStatus.intensityIncluded,
+              reason: mtStatus.degradedReason,
+            },
+          }
+        : {}),
     };
     await fs.writeFile(
       path.join(docDir, 'metadata.json'),
@@ -1795,10 +1910,21 @@ export class ExportService {
     // Generate metrics guide. Project type drives the layout: sperm gets
     // head/midpiece/tail morphology, spheroid_invasive the DI sheet,
     // wound area + time-series, spheroid the full polygon catalogue.
-    const metricsGuide = generateMetricsGuide(
+    let metricsGuide = generateMetricsGuide(
       coerceProjectType(project.type),
       options
     );
+    if (mtStatus && !mtStatus.intensityIncluded) {
+      // Loud + durable: a banner at the very top of the guide the user opens
+      // to understand the columns, not buried in job.warnings (a WebSocket
+      // toast easy to miss on a multi-hour export).
+      metricsGuide =
+        `> **⚠ Per-channel intensity is NOT included in this export.** ` +
+        `${mtStatus.degradedReason ?? 'The ML service could not compute it.'} ` +
+        `Only microtubule length (geometry) is present in metrics.* below. ` +
+        `See \`metrics/metrics_status.json\` for machine-readable detail.\n\n` +
+        metricsGuide;
+    }
     await fs.writeFile(path.join(docDir, 'metrics_guide.md'), metricsGuide);
   }
 

--- a/backend/src/utils/concurrency.ts
+++ b/backend/src/utils/concurrency.ts
@@ -63,3 +63,75 @@ export const mapWithConcurrency = async <T>(
     throw new Error(options.abortMessage ?? 'Operation aborted');
   }
 };
+
+/**
+ * A counting semaphore that bounds how many async tasks run at once,
+ * queueing the rest in FIFO call order (no starvation: a permit always goes
+ * to whichever caller has waited longest).
+ *
+ * Purpose: `mapWithConcurrency` only bounds concurrency WITHIN one stage. A
+ * pipeline that runs several independently-concurrency-limited stages at
+ * once (e.g. via `Promise.all`) can still fire `stageA.limit + stageB.limit +
+ * stageC.limit` requests simultaneously at a single shared downstream
+ * service — exactly what happened to the microtubule export against the
+ * ML service (single `uvicorn --workers 1`): `mt-metrics` +
+ * `mt-background-rois` + a bounded-but-still-concurrent batch of kymograph
+ * requests all landed on it at once, and one export alone produced 893
+ * "Exceeded concurrency limit" warnings.
+ *
+ * A single `Semaphore` instance shared across all of a job's ML-bound stages
+ * makes the limit apply to the WHOLE job rather than per-stage.
+ */
+export class Semaphore {
+  private available: number;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(concurrency: number) {
+    this.available = Math.max(1, Math.floor(concurrency));
+  }
+
+  /** Run `task`, waiting for a free permit first and releasing it afterwards
+   *  (success or failure) — never leaks a permit on a thrown error. */
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available -= 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      // Hand the permit straight to the next waiter rather than incrementing
+      // `available` — keeps FIFO ordering exact under contention.
+      next();
+    } else {
+      this.available += 1;
+    }
+  }
+}
+
+/**
+ * Run `task` through `gate` when one is supplied, otherwise run it directly.
+ * Lets every ML-bound call site accept an OPTIONAL shared `Semaphore` (so
+ * existing unit tests that call these functions without a gate are
+ * unaffected) while production code always threads one through.
+ */
+export async function runGated<T>(
+  gate: Semaphore | undefined,
+  task: () => Promise<T>
+): Promise<T> {
+  return gate ? gate.run(task) : task();
+}


### PR DESCRIPTION
## Problem

Users report that intensity metrics "don't compute" during export. They compute fine — **the ML service finishes and returns 200** — but the backend stopped listening five minutes in.

Both exports in the retained log window, same story:

| Job | sent | backend gave up | ML finished | ML wall-clock |
|---|---|---|---|---|
| 240 frames, 1 ch | 07:55:19 | 08:00:20 (+300.5 s) | 08:05:40 → 200 OK, 20 526 rows | **10m20s** |
| 299 frames, 2 ch, 1412×1474 | 12:12:20 | 12:17:23 (+302.6 s) | 12:36:53 → 200 OK, **91 482 rows** | **24m32s** |

The archive still gets a correctly-sized `metrics.json` — every intensity column `null`, `channel` empty — which is indistinguishable from a real one once downloaded. 91 482 computed rows were discarded 12 minutes before they arrived.

## Three defects

**1. A fixed 300 s budget.** `mtMetricsExporter.ts:603`, whose own comment claimed *"Failures bubble up so the export job fails visibly rather than silently emitting an empty sheet"* — the exact opposite of what happens. Replaced with a budget scaled to the actual workload (frames × channels, adjusted for resolution against the ~2 MP reference the 2.5 s/unit rate was measured on, ×3 headroom, with a floor). Still finite, so a genuinely hung ML service eventually fails rather than pinning an export forever. **The same hard-coded 300 s in `imagejRoiEncoder.ts:721` is gone too** — that one is why the ImageJ `_bg` composite ROIs quietly degraded to a plain stroke band on large exports.

**2. The export DoSes its own ML service.** Up to 9 tasks run through one `Promise.all` against a single `uvicorn --workers 1`, so `mt-metrics`, `mt-background-rois` and the kymograph fan-out all land at once: **893** `Exceeded concurrency limit` warnings, `/health` 503s. In job 1 `mt-metrics` sat queued **~7 minutes** behind a request from its *own* export before ML even opened the ND2 — with the axios clock already running, so most of the budget went on queueing. A per-export `Semaphore` now bounds ML-bound work across *all* stages rather than per-stage, and the timeout starts only once the request holds a permit.

**3. The degradation was invisible.** `intensityIncluded` was tracked but only surfaced as a WebSocket toast, easy to miss during a multi-hour export. Documentation generation now awaits the metrics outcome and records it in `metadata.json` / `metrics_guide.md`, so a hollow sheet is self-describing.

## Also

`exportDocs.ts` still told users intensity columns *"are filled only when a channel was selected in the export dialog"*. That picker was removed; intensity is **always** computed for every channel, read from the raw 16-bit ND2/TIFF rather than the percentile-clipped display PNGs. That stale sentence is what prompted the original question.

**A real end-to-end export producing populated intensity columns is still outstanding and must be run before merge.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYYFoe8Yp1Kg1hMwYkmG7o