### PR TITLE
test(export): cover the ML request Semaphore, and finish the CHANNEL_NAME_RE dedup

### DIFF
--- a/backend/src/services/export/mtMetricsExporter.ts
+++ b/backend/src/services/export/mtMetricsExporter.ts
@@ -26,6 +26,7 @@ import { prisma } from '../../db/prismaClient';
 import { getLabels as getMtTypeLabels } from '../mtTypeLabelService';
 import { config } from '../../utils/config';
 import { logger } from '../../utils/logger';
+import { CHANNEL_NAME_RE } from '../video/types';
 import {
   buildInstanceLabelMap,
   MICROTUBULE_LABEL_PREFIX,
@@ -222,7 +223,6 @@ interface RawPolyline {
 //  Helpers
 // ----------------------------------------------------------------------------
 
-const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 function safeParsePolygons(json: string | null | undefined): RawPolyline[] {
   if (!json) return [];

--- a/backend/src/utils/__tests__/concurrency.test.ts
+++ b/backend/src/utils/__tests__/concurrency.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mapWithConcurrency } from '../concurrency';
+import { mapWithConcurrency, Semaphore, runGated } from '../concurrency';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
@@ -90,5 +90,103 @@ describe('mapWithConcurrency', () => {
       inFlight -= 1;
     });
     expect(peak).toBeLessThanOrEqual(3);
+  });
+});
+
+/**
+ * The Semaphore exists because `mapWithConcurrency` bounds concurrency WITHIN
+ * one stage, while the microtubule export runs several such stages at once
+ * through a single `Promise.all` against a one-worker ML service. A shared
+ * Semaphore makes the limit apply to the whole job. These tests pin the three
+ * properties that behaviour depends on.
+ */
+describe('Semaphore', () => {
+  it('never lets more than `concurrency` tasks run at once', async () => {
+    const gate = new Semaphore(2);
+    let inFlight = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: 12 }, () =>
+        gate.run(async () => {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await sleep(3);
+          inFlight -= 1;
+        })
+      )
+    );
+    expect(peak).toBe(2);
+    expect(inFlight).toBe(0);
+  });
+
+  it('hands a freed permit to the longest-waiting caller (FIFO)', async () => {
+    // With concurrency 1 the order tasks *finish* is the order they queued.
+    // `release()` resolves the head of the queue directly instead of bumping
+    // a counter, which is what makes this exact rather than best-effort.
+    const gate = new Semaphore(1);
+    const order: number[] = [];
+    await Promise.all(
+      [0, 1, 2, 3, 4].map(i =>
+        gate.run(async () => {
+          await sleep((5 - i) * 2); // later callers finish FASTER if unordered
+          order.push(i);
+        })
+      )
+    );
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('releases the permit when a task throws, so it cannot deadlock', async () => {
+    const gate = new Semaphore(1);
+    await expect(
+      gate.run(async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    // If the `finally` were missing, this second call would hang forever and
+    // the test would time out rather than fail an assertion.
+    await expect(gate.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('floors the limit at 1 so a bad config cannot deadlock every caller', async () => {
+    for (const bad of [0, -3, 0.4]) {
+      const gate = new Semaphore(bad);
+      await expect(gate.run(async () => 'ran')).resolves.toBe('ran');
+    }
+  });
+
+  it('propagates the task result and rejection unchanged', async () => {
+    const gate = new Semaphore(3);
+    await expect(gate.run(async () => ({ a: 1 }))).resolves.toEqual({ a: 1 });
+    const err = new Error('specific');
+    await expect(gate.run(async () => Promise.reject(err))).rejects.toBe(err);
+  });
+});
+
+describe('runGated', () => {
+  it('runs the task directly when no gate is supplied', async () => {
+    // Existing unit tests call the ML-bound helpers without a gate; that path
+    // must stay a plain call rather than requiring a Semaphore to be built.
+    await expect(runGated(undefined, async () => 'direct')).resolves.toBe(
+      'direct'
+    );
+  });
+
+  it('routes through the gate when one is supplied, honouring its limit', async () => {
+    const gate = new Semaphore(1);
+    let inFlight = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: 6 }, () =>
+        runGated(gate, async () => {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await sleep(2);
+          inFlight -= 1;
+        })
+      )
+    );
+    expect(peak).toBe(1);
   });
 });


### PR DESCRIPTION
Two loose ends from #330 / #332.

## The Semaphore shipped untested

It landed in #332 at **63% lines / 44% branches**, and that was invisible because the coverage gate is global — one untested class hides until another PR pushes the ratio over the edge. Which is exactly what happened: #331 then failed the required `backend` check with

```
ERROR: Coverage for branches (74.87%) does not meet global threshold (75%)
concurrency.ts | 67.34 | 66.66 | 44.44 | 63.63 | 46,87-121
```

The fix is not to chase the number — it is to test the class whose absence caused it. Three properties the export's behaviour actually rests on, each **mutation-verified**:

| property | mutation applied | result |
|---|---|---|
| FIFO hand-off | `queue.shift()` → `queue.pop()` | that test alone goes red |
| permit survives a throwing task | `finally { release() }` → plain sequential release | red (by timeout — the deadlock's real signature) |
| `Math.max(1, …)` floor on the limit | removed | red (by timeout) |

Restoring the file returns all 13 to green. Bounded-concurrency and result/rejection pass-through are covered too, plus `runGated(undefined, …)` staying a plain call so the existing unit tests that invoke ML-bound helpers without a gate keep working.

The two timeout-based mutations are deliberate: a leaked permit does not throw, it hangs — and a test that fails by timing out is reporting the failure exactly as production would show it.

## `CHANNEL_NAME_RE` now genuinely has one definition

#330 consolidated `videoController`, `addChannelService` and `kymographService` onto `video/types.ts`, but could not touch `mtMetricsExporter`: that file was being rewritten on the concurrent export branch, and the shared export did not exist on that branch anyway. #330's description said as much. Both are on `main` now, so the last local copy is gone.

```
$ grep -rn "CHANNEL_NAME_RE\s*=" backend/src/ | grep -v test
backend/src/services/video/types.ts:24:export const CHANNEL_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
```

Backend `tsc --noEmit` clean; 298 tests across the export and concurrency suites pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYYFoe8Yp1Kg1hMwYkmG7o