### PR TITLE
fix(security): bump transformers to 5.5.4, whose pin rationale had gone stale

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,14 +75,20 @@ updates:
       #                       source-built against torch 2.6.0+cu124. Moving
       #                       torch means recompiling both kernels, re-pairing
       #                       torchvision, and re-verifying all 7 models.
-      #  transformers         4.57.1 backs SegFormer and the sperm Dinov2
-      #                       backbone; 4.57.6 already broke DINOv3 once.
-      #                       A 5.x bump needs its own inference verification.
+      #  transformers         pinned at 5.5.4, and only MINOR/MAJOR are
+      #                       ignored -- patches still flow. 5.16.1 renames the
+      #                       SegFormer module layout so our checkpoint stops
+      #                       loading; 5.5.4 and 5.6.0 are bit-identical to the
+      #                       old 4.57.1. Crossing a minor needs the real-
+      #                       checkpoint probe, not a green build.
       #  numpy                1.26.4 is what the pinned torch was built against.
       - dependency-name: torch
       - dependency-name: torchvision
-      - dependency-name: transformers
       - dependency-name: numpy
+      - dependency-name: transformers
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
 
   # ------------------------------------------------------------ essays worker
   # Built FROM the ml image, so it inherits that validated stack and carries
@@ -100,8 +106,11 @@ updates:
     ignore:
       - dependency-name: torch
       - dependency-name: torchvision
-      - dependency-name: transformers
       - dependency-name: numpy
+      - dependency-name: transformers
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
 
   # --------------------------------------------------------- GitHub Actions
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,8 +79,22 @@ updates:
       #                       ignored -- patches still flow. 5.16.1 renames the
       #                       SegFormer module layout so our checkpoint stops
       #                       loading; 5.5.4 and 5.6.0 are bit-identical to the
-      #                       old 4.57.1. Crossing a minor needs the real-
-      #                       checkpoint probe, not a green build.
+      #                       old 4.57.1.
+      #
+      #                       READ THIS BEFORE MERGING A TRANSFORMERS PR, patch
+      #                       included: CI cannot verify this dependency. The
+      #                       only real check loads the SegFormer and sperm
+      #                       DINOv2 checkpoints and hashes a fixed-input
+      #                       forward, and it needs weights that are not in the
+      #                       repo. A green build here proves nothing about the
+      #                       models -- run the probe by hand.
+      #
+      #                       Patch PRs are allowed to OPEN anyway because they
+      #                       cannot merge themselves: allow_auto_merge is off
+      #                       and the main-protection ruleset requires review.
+      #                       So the PR is a notification carrying a diff, not
+      #                       an applied change, and suppressing it would cost
+      #                       visibility without buying safety.
       #  numpy                1.26.4 is what the pinned torch was built against.
       - dependency-name: torch
       - dependency-name: torchvision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,44 @@ jobs:
           # instrumented full-suite run doesn't OOM.
           NODE_OPTIONS: --max-old-space-size=5120
 
+  pins:
+    name: pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # backend/essays/module/requirements.txt is NEVER pip-installed: the
+      # essays image is `FROM ${ML_IMAGE}` and inherits the ML service's stack
+      # verbatim. The file is documentation of what the module expects, so a
+      # drift between it and the ML pin is currently cosmetic -- but it stops
+      # being cosmetic the moment someone adds a `pip install -r` to
+      # docker/essays.Dockerfile, which is an entirely reasonable-looking
+      # change to make. This guard is what makes that change safe instead of
+      # silently divergent.
+      #
+      # transformers specifically: the ML pin was verified by loading the real
+      # SegFormer and sperm DINOv2 checkpoints and hashing a fixed-input
+      # forward. Two different pins would mean the essays worker is documented
+      # against a version nobody ran that probe on.
+      - name: ML and essays pins agree
+        run: |
+          set -euo pipefail
+          fail=0
+          for pkg in torch torchvision transformers numpy; do
+            ml=$(grep -iE "^${pkg}==" backend/segmentation/requirements.txt | head -1 || true)
+            es=$(grep -iE "^${pkg}==" backend/essays/module/requirements.txt | head -1 || true)
+            if [ -z "$ml" ] || [ -z "$es" ]; then
+              echo "::error::${pkg} pin missing (ml='${ml}' essays='${es}')"; fail=1; continue
+            fi
+            if [ "$ml" != "$es" ]; then
+              echo "::error::${pkg} pin drift -- ml='${ml}' essays='${es}'"; fail=1
+            else
+              echo "ok  ${ml}"
+            fi
+          done
+          exit $fail
+
   backend:
     name: backend
     runs-on: ubuntu-latest

--- a/backend/essays/module/requirements.txt
+++ b/backend/essays/module/requirements.txt
@@ -5,21 +5,23 @@
 #   python3 -m venv .venv && source .venv/bin/activate
 #   pip install -r requirements.txt
 #
-# torch / transformers pins are LOAD-BEARING: transformers >= 4.57 is required
-# for the DINOv3 backbone. Pin transformers to 4.57.1 — the LAST version whose
-# DINOv3-ViT-L forward output matches the v7 checkpoint. 4.57.2 silently changed
-# the DINOv3 forward (no error, no failed load): the ViT features degrade into
-# low-frequency blobs, so the seed map fills ~50% of the frame and PySOAX emits
-# random microtubules (bisected on a reference frame: 4.57.0/.1 -> 303 MTs
-# tracing real filaments; 4.57.2-4.57.6 -> 76 scattered). 4.57.0 also worked but
-# PyPI YANKED it for a setup/install defect, so 4.57.1 is the safe floor. DO NOT
-# bump into 4.57.2+ or 5.x without re-verifying MT output against a known-good
-# frame — a green install proves nothing here.
+# torch is LOAD-BEARING and pinned at 2.6.0: mamba-ssm and causal-conv1d ship
+# CUDA kernels source-built against it, so moving torch means recompiling both
+# and re-pairing torchvision.
+#
+# transformers is NOT used by this worker at all any more. The old 4.57.1 pin
+# was for the microtubule v7 DINOv3 backbone, where 4.57.2 silently degraded the
+# ViT features. v5H (2026-08-17) replaced v7 with an nnU-Net whose checkpoint
+# carries every weight, so the MT path imports no transformers and needs no
+# HF_TOKEN. The pin is kept only to stay identical to the ml image this worker is
+# built FROM, so the two can never resolve different versions of a shared stack.
+# It tracks backend/segmentation/requirements.txt -- change both together, and
+# read the CEILING note there before crossing a transformers minor.
 
 # --- Deep learning core ---
 torch==2.6.0
 torchvision==0.21.0
-transformers==4.57.1
+transformers==5.5.4
 huggingface_hub>=0.20
 
 # --- Numerics / classical CV (PySOAX postprocessing) ---

--- a/backend/segmentation/requirements.txt
+++ b/backend/segmentation/requirements.txt
@@ -51,23 +51,36 @@ networkx>=3.0
 # encoder is architecturally unchanged) and builds the microcapsule U-Net.
 segmentation-models-pytorch==0.5.0
 
-# Microtubule v7 dependencies (DINOv3 ViT-L/16 backbone via HuggingFace)
-# transformers 4.57+ is required to recognise the DINOv3 model config. Pinned to
-# 4.57.1 — the LAST version whose DINOv3-ViT-L forward output matches the v7
-# checkpoint. 4.57.2 silently changed the DINOv3 forward (no error, no failed
-# load): the ViT features degrade into low-frequency blobs, so the seed map
-# fills ~50% of the frame and PySOAX emits random microtubules. Verified by
-# bisection on a reference frame (4.57.0/.1 → 303 MTs tracing real filaments;
-# 4.57.2–4.57.6 → 76 scattered). 4.57.0 also worked but PyPI YANKED it for a
-# setup/install defect, so 4.57.1 is the safe floor. DO NOT bump into 4.57.2+
-# or 5.x without re-verifying MT output against a known-good frame — a green
-# build proves nothing here. The arbitrary-code-exec advisory is unfixed across
-# all of 4.57.x (only patched in the 5.0 pre-release), so this pin forfeits no
-# security fix that 4.57.6 had. DINOv3 is gated — HF_TOKEN must be set before
-# first load. tifffile is used by both the model's percentile normalisation
-# reference and the video extractor (multi-page TIFF microscopy stacks). nd2
-# reads Nikon NIS-Elements proprietary files (Apache-2.0, pure Python).
-transformers==4.57.1
+# transformers backs exactly TWO things in this repo, and neither is
+# microtubule any more:
+#
+#   models/segformer.py                 SegformerConfig / SegformerForSemanticSegmentation
+#   sperm_final/models/backbone.py      Dinov2Model.from_pretrained("facebook/dinov2-large")
+#
+# The old pin here was 4.57.1 for the microtubule v7 DINOv3 backbone, where
+# 4.57.2 silently degraded the ViT features (303 real MTs -> 76 scattered, no
+# error, no failed load). That reason is GONE: v5H (2026-08-17) replaced v7 with
+# an nnU-Net whose checkpoint carries every weight, so MT imports no transformers
+# and needs no HF_TOKEN. Only SegFormer and sperm still call `from_pretrained`.
+#
+# 5.5.4 was verified against BOTH survivors by loading their real checkpoints and
+# hashing a fixed-input forward. Output is BIT-IDENTICAL to 4.57.1:
+#
+#   segformer (segformer_b0_spheroseg.pth)  sha 3527093be5a0632e
+#   Dinov2Model facebook/dinov2-large       sha 15460fff556f45a6
+#   sperm DINOv2Backbone layer_11/layer_17  sha a463aacc545d8f6c / 8cf462a9cdbfa640
+#
+# This clears 3 advisories (2 high, 1 medium) that are unfixed across ALL of
+# 4.57.x. 5.5.4 needs only torch>=2.4, so it does NOT disturb the torch 2.6.0
+# pin the mamba-ssm / causal-conv1d CUDA kernels are built against.
+#
+# CEILING, measured, not guessed: transformers 5.16.1 BREAKS SegFormer. The
+# module layout was renamed (`segformer.encoder.block.N.M` -> `segformer.stages.
+# N.blocks.M`, `decode_head.linear_c` -> `linear_projections`), so our checkpoint
+# no longer load_state_dicts. 5.5.4 and 5.6.0 are both clean; the break is above
+# 5.6. dependabot.yml therefore allows PATCH updates here and blocks minor/major.
+# Re-run the probe against both checkpoints before crossing a minor.
+transformers==5.5.4
 tifffile>=2024.1.30
 # tifffile decodes Deflate natively but delegates LZW (and JPEG, PackBits, LZMA...)
 # to imagecodecs, which was NOT installed. LZW is the DEFAULT TIFF compression that

--- a/docker/essays.Dockerfile
+++ b/docker/essays.Dockerfile
@@ -2,13 +2,26 @@
 #
 # Wraps the essays module (a *script* tree, not a pip package) as a thin FastAPI
 # job runner. It is based on the already-built ML image, so it inherits the EXACT
-# validated model stack: torch 2.6.0+cu124 and transformers 4.57.1. This is
-# load-bearing — the module's own requirements.txt pins transformers 4.57.6,
-# which silently degrades the DINOv3 backbone into low-frequency blobs (303 real
-# MTs -> 76 garbage). Inheriting the ML image means we NEVER install that pin,
-# and every other module dependency (nd2, scikit-image, scipy, opencv, tifffile,
-# Pillow, huggingface_hub) is already present at the same version, so nothing is
+# validated model stack: torch 2.6.0+cu124 and transformers 5.5.4.
+#
+# That inheritance is the point: `backend/essays/module/requirements.txt` is
+# NEVER pip-installed here. It documents what the module expects; the versions
+# that actually run are whatever the ML image was built with. Every module
+# dependency (nd2, scikit-image, scipy, opencv, tifffile, Pillow,
+# huggingface_hub) is already present at the same version, so nothing is
 # reinstalled or recompiled.
+#
+# Because the file is documentation rather than input, a drift between it and
+# backend/segmentation/requirements.txt would be silent. The `pins` job in
+# .github/workflows/ci.yml fails the build if the two disagree on torch,
+# torchvision, transformers or numpy — which is what makes adding a
+# `pip install -r` here a safe change rather than a divergent one.
+#
+# (The warning this comment used to carry — that the module pinned a
+# transformers version which degraded the DINOv3 backbone into low-frequency
+# blobs, 303 real MTs -> 76 garbage — described microtubule v7. v5H replaced it
+# on 2026-08-17 with an nnU-Net that imports no transformers at all, so the
+# hazard is gone along with the backbone it applied to.)
 #
 # The module used to live in a separate private repo cloned at build time; it is
 # now vendored at backend/essays/module and copied in like any other first-party


### PR DESCRIPTION
The `transformers==4.57.1` pin carried a long, careful comment about the **microtubule v7 DINOv3 backbone**: 4.57.2 silently degraded the ViT features, 303 real filaments became 76 scattered ones, no error and no failed load. All of it true — and all of it irrelevant since 2026-08-17, when **v5H replaced v7** with an nnU-Net whose checkpoint carries every weight. The MT path imports no transformers at all any more.

What still imports it is exactly two things:

| file | API |
|---|---|
| `models/segformer.py` | `SegformerConfig` / `SegformerForSemanticSegmentation` |
| `sperm_final/models/backbone.py` | `Dinov2Model.from_pretrained("facebook/dinov2-large")` |

`sperm` is live — **233 segmentations in the last 60 days** — so this was never a dead pin. It just had the wrong reason attached.

## Verified bit-identical, not merely "tests pass"

Each model was built the way the service builds it, loaded with its **real checkpoint**, and a fixed-input forward was hashed:

| check | 4.57.1 | 5.5.4 |
|---|---|---|
| segformer (`segformer_b0_spheroseg.pth`) | `3527093be5a0632e` | **same** |
| `Dinov2Model` facebook/dinov2-large | `15460fff556f45a6` | **same** |
| sperm `DINOv2Backbone` layer_11 / layer_17 | `a463aacc545d8f6c` / `8cf462a9cdbfa640` | **same** |

Random-init forwards were discarded as worthless here — the init RNG differs between library versions, so only loaded weights can prove equivalence. (My first attempt made exactly that mistake and showed a bogus delta.)

This clears **3 advisories (2 high, 1 medium)** that are unfixed across *all* of 4.57.x. 5.5.4 needs only `torch>=2.4`, so the torch 2.6.0 pin that mamba-ssm and causal-conv1d are built against is untouched; `pip check` reports the same two pre-existing ninja warnings and no new conflicts.

## The ceiling is measured, and it is real

**transformers 5.16.1 breaks SegFormer.** The module layout was renamed — `segformer.encoder.block.N.M` → `segformer.stages.N.blocks.M`, `decode_head.linear_c` → `decode_head.linear_projections` — so `load_state_dict` rejects our checkpoint with ~200 missing keys. 5.5.4 and 5.6.0 are both clean, so the break is somewhere above 5.6.

`dependabot.yml` therefore stops ignoring transformers outright and instead ignores only **semver-minor and semver-major**: patches keep flowing, minors need a human running the real-checkpoint probe first.

## torch: 10 alerts dismissed as unreachable, not fixed

Every torch advisory names one function, and every one requires **local access**. None are called anywhere in `backend/segmentation` or `backend/essays`:

`mkldnn_max_pool2d` · `ctc_loss` · `ops.profiler._call_end_callbacks_on_jit_fut` · `pad_packed_sequence` · `unpack_sequence` · `lstm_cell` · `jit.script` · `nnq_Sigmoid`

The 11 `torch.jit` references in the tree are `torch.jit.Final` annotations, `@torch.jit.ignore` decorators and `is_scripting()` guards — **none call `jit.script()`**. One advisory reports `<= 2.6.0` with *no patched version in existence*, so these could not be fixed by upgrading even if the CUDA kernels allowed it.

Dismissed as `not_used` with the specific function named on each alert, so the reasoning is checkable rather than a blanket wave-through.

## Net effect

Dependabot **82 → 4 → 0** once this merges (the 4 remaining are the transformers advisories this PR fixes). CodeQL security alerts already at **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated machine-learning components to a newer compatible release.
  * Cleared three known security advisories affecting the previous component version.
  * Maintained compatibility with existing segmentation and image-processing workflows.
  * Added safeguards to prevent unsupported version upgrades that could disrupt model operation.
  * Updated dependency maintenance rules to allow safe patch-level improvements while preserving validated versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->