### PR TITLE
fix(ml): restore Mamba-UNet, which the transformers 5 bump silently disabled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,12 +36,19 @@ updates:
         patterns: ['*']
         update-types: [minor, patch]
     ignore:
-      # vite 6 -> 7/8 relays the whole build: manualChunks, chunk splitting and
-      # the production bundle all change shape. Failure pattern #14 in
-      # CLAUDE.md is exactly this class of break, so it is done deliberately,
-      # never as part of a routine weekly batch.
-      - dependency-name: vite
-        update-types: [version-update:semver-major]
+      # Majors are never routine here. This repo's dependency story is a set of
+      # deliberate, verified pins -- tailwindcss 3->4 restyles every surface,
+      # zod 3->4 changes the validation API the whole backend is written
+      # against, opencv 4->5 sits under the ML stack. Adding this file opened 16
+      # such PRs in one go, none of them mergeable without a project behind it.
+      #
+      # Suppressing the PR does NOT suppress the alert: if a major ever carries
+      # a security fix, it still shows up in the Dependabot alert list, where a
+      # human decides. What this removes is the weekly reminder that a major
+      # exists, which is not news.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   # ----------------------------------------------------------------- backend
   - package-ecosystem: npm
@@ -54,6 +61,20 @@ updates:
       backend-patch-minor:
         patterns: ['*']
         update-types: [minor, patch]
+    ignore:
+      # Majors are never routine here. This repo's dependency story is a set of
+      # deliberate, verified pins -- tailwindcss 3->4 restyles every surface,
+      # zod 3->4 changes the validation API the whole backend is written
+      # against, opencv 4->5 sits under the ML stack. Adding this file opened 16
+      # such PRs in one go, none of them mergeable without a project behind it.
+      #
+      # Suppressing the PR does NOT suppress the alert: if a major ever carries
+      # a security fix, it still shows up in the Dependabot alert list, where a
+      # human decides. What this removes is the weekly reminder that a major
+      # exists, which is not news.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   # -------------------------------------------------------------- ML service
   - package-ecosystem: pip
@@ -103,6 +124,9 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-major
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   # ------------------------------------------------------------ essays worker
   # Built FROM the ml image, so it inherits that validated stack and carries
@@ -124,6 +148,9 @@ updates:
       - dependency-name: transformers
         update-types:
           - version-update:semver-minor
+          - version-update:semver-major
+      - dependency-name: '*'
+        update-types:
           - version-update:semver-major
 
   # --------------------------------------------------------- GitHub Actions

--- a/backend/segmentation/models/mamba_unet.py
+++ b/backend/segmentation/models/mamba_unet.py
@@ -18,7 +18,44 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
-from mamba_ssm import Mamba
+
+# --- mamba_ssm 2.2.4 vs transformers 5.x -------------------------------------
+# `from mamba_ssm import Mamba` is not the narrow import it looks like:
+# mamba_ssm/__init__.py also pulls in MambaLMHeadModel, which pulls in
+# mamba_ssm/utils/generation.py, which does
+#
+#     from transformers.generation import (
+#         GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer)
+#
+# transformers 4.42 merged those two output dataclasses into
+# `GenerateDecoderOnlyOutput` and kept the old names as aliases; 5.x removed the
+# aliases. mamba_ssm 2.2.4 predates that, so the import raises ImportError and
+# the guard one level up quietly disables Mamba-UNet -- the service stays
+# healthy and simply reports one model fewer, which is exactly the kind of
+# regression that goes unnoticed.
+#
+# Nothing here wants that code: those dataclasses describe autoregressive TEXT
+# generation, and this file uses `Mamba` as a sequence block inside a
+# segmentation bottleneck. Aliasing the removed names to their successor lets
+# the package finish importing without touching what we actually run.
+#
+# Delete this once mamba_ssm ships a release that targets transformers 5.
+def _alias_removed_generation_outputs() -> None:
+    try:
+        import transformers.generation as _gen
+    except Exception:  # transformers absent -> mamba import will fail anyway
+        return
+    successor = getattr(_gen, "GenerateDecoderOnlyOutput", None)
+    if successor is None:
+        return
+    for removed in ("GreedySearchDecoderOnlyOutput", "SampleDecoderOnlyOutput"):
+        if not hasattr(_gen, removed):
+            setattr(_gen, removed, successor)
+
+
+_alias_removed_generation_outputs()
+
+from mamba_ssm import Mamba  # noqa: E402  -- must follow the alias shim above
 
 
 def get_norm_layer(num_features: int, use_instance_norm: bool = True) -> nn.Module:

--- a/backend/segmentation/tests/test_optional_model_imports.py
+++ b/backend/segmentation/tests/test_optional_model_imports.py
@@ -1,0 +1,98 @@
+"""Every optional model import must actually succeed.
+
+`ml/model_loader.py` wraps each optional model in `try/except ImportError` and
+logs a warning, so a broken import does not crash the service -- it quietly
+serves one model fewer while `/health` keeps saying "healthy". That is the right
+runtime behaviour and a terrible failure mode for a dependency bump: nothing
+goes red, and the only evidence is a WARNING line in a container log.
+
+It has already happened once. Bumping transformers 4.57.1 -> 5.5.4 (2026-08-27)
+broke `from mamba_ssm import Mamba`, because mamba_ssm 2.2.4's text-generation
+helper imports two output dataclasses transformers 5 removed. Mamba-UNet
+disappeared from the registry and `models_loaded` went 5 -> 4, with a green
+build and a healthy service throughout. See the shim in models/mamba_unet.py.
+
+So these tests assert the guards are NOT firing. They are the check that a
+library upgrade did not silently amputate a model.
+"""
+import importlib
+import os
+
+import pytest
+
+# models/__init__ pulls in mamba_ssm and Triton, which fail to initialise
+# without a CUDA driver ("0 active drivers"), so the whole module is GPU-only.
+torch = pytest.importorskip("torch")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="optional model imports need CUDA (mamba_ssm/Triton init)",
+)
+
+
+@pytest.fixture(scope="module")
+def loader():
+    return importlib.import_module("ml.model_loader")
+
+
+# (attribute that is None when the guard fired, error attribute, why it matters)
+OPTIONAL_MODELS = [
+    ("SpermModel", "_sperm_import_error", "sperm — live, 233 runs in 60 days"),
+    ("SegFormerModel", "_segformer_import_error", "segformer — transformers-backed"),
+]
+
+
+@pytest.mark.parametrize("attr,err_attr,why", OPTIONAL_MODELS)
+def test_optional_model_imported(loader, attr, err_attr, why):
+    err = getattr(loader, err_attr, None)
+    assert err is None, f"{attr} guard fired ({why}): {err!r}"
+    assert getattr(loader, attr, None) is not None, f"{attr} is None ({why})"
+
+
+def test_mamba_ssm_imports_under_current_transformers():
+    """The exact breakage the transformers 5 bump caused.
+
+    Asserted against `mamba_ssm` directly rather than through the loader so the
+    failure names the real culprit instead of "Mamba-UNet unavailable".
+    """
+    from models import mamba_unet  # noqa: F401  -- applies the alias shim
+
+    mamba_ssm = importlib.import_module("mamba_ssm")
+    assert hasattr(mamba_ssm, "Mamba")
+
+
+def test_generation_output_aliases_present():
+    """The shim must survive transformers dropping the old names.
+
+    If a future transformers removes `GenerateDecoderOnlyOutput` too, the shim
+    silently does nothing and we are back to a disabled model -- so check the
+    aliases actually exist after the shim has run, not merely that it ran.
+    """
+    from models import mamba_unet  # noqa: F401  -- applies the alias shim
+
+    gen = importlib.import_module("transformers.generation")
+    for name in ("GreedySearchDecoderOnlyOutput", "SampleDecoderOnlyOutput"):
+        assert hasattr(gen, name), (
+            f"transformers.generation.{name} missing after the mamba_unet shim; "
+            "mamba_ssm 2.2.4 imports it and Mamba-UNet will be disabled"
+        )
+
+
+def test_registry_advertises_only_importable_models(loader):
+    """Every entry in the registry must carry a real class, not None.
+
+    `AVAILABLE_MODELS` is what `/api/v1/models` is built from, so it is what
+    the frontend populates its picker with. An entry whose `class` is None is a
+    model a user can select and the service cannot run -- and because each
+    import is individually guarded, exactly one entry can go None without
+    anything else changing. This is the assertion that turns that from a log
+    line into a failing test.
+    """
+    registry = loader.ModelLoader.AVAILABLE_MODELS
+    assert registry, "AVAILABLE_MODELS is empty"
+
+    missing = [name for name, cfg in registry.items() if cfg.get("class") is None]
+    assert not missing, (
+        "registry advertises models whose class failed to import: "
+        + ", ".join(sorted(missing))
+    )


### PR DESCRIPTION
Self-inflicted by #358, caught in post-deploy verification rather than by anything that went red. `/health` reported `models_loaded` **5 → 4**, and the only other evidence was one WARNING line in the container log:

```
Could not import UMamba (Mamba-UNet): cannot import name
'GreedySearchDecoderOnlyOutput' from 'transformers.generation'
```

## What I missed

Before bumping I grepped for transformers imports, found exactly two — `models/segformer.py` and `sperm_final/models/backbone.py` — verified both against their real checkpoints, and treated that as the complete surface. It was the complete surface of **our** code. `mamba_ssm` is a third consumer, transitively:

```
from mamba_ssm import Mamba
  → mamba_ssm/__init__.py also imports MambaLMHeadModel
  → mamba_ssm/utils/generation.py
  → from transformers.generation import
        GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer
```

transformers 4.42 merged those two output dataclasses into `GenerateDecoderOnlyOutput` and kept the old names as aliases; 5.x removed the aliases. mamba_ssm 2.2.4 predates that.

Nothing in this repo wants that code — those dataclasses describe autoregressive **text** generation, while `mamba_unet.py` uses `Mamba` as a sequence block in a segmentation bottleneck. So the shim aliases the removed names to their successor before importing mamba_ssm, and touches nothing else. It carries a delete-me condition: when mamba_ssm ships a release targeting transformers 5.

## Why nothing caught it

`ml/model_loader.py` wraps each optional model in `try/except ImportError` and logs a warning, so one broken import serves **one model fewer while the service stays healthy and the build stays green**. Correct at runtime; awful for a dependency bump.

`tests/test_optional_model_imports.py` asserts the guards are *not* firing:

- every entry in `ModelLoader.AVAILABLE_MODELS` carries a real class (this is the one that would have caught it)
- `mamba_ssm` imports under the current transformers
- the aliases exist **after** the shim has run — so a future transformers dropping `GenerateDecoderOnlyOutput` fails loudly instead of letting the shim silently no-op

Mutation-checked: commenting out the shim turns **3 of 5** red.

## Verified in production, not just in a container

Re-run against the same real images used for the pre-bump baselines:

| model | result |
|---|---|
| sperm | 21 polylines — identical point counts and first coordinates |
| segformer | 5 polygons — identical point counts and first coordinates |
| mamba_unet | segments again (was unavailable) |
| registry | 10 models, 0 broken |

## Also: 16 Dependabot PRs that can never be merged

Adding `dependabot.yml` opened 21 PRs, 16 of them **majors** — tailwindcss 3→4, zod 3→4, opencv 4→5 and similar. Majors are not routine here; this repo's dependency story is a set of deliberate, verified pins, and a major is a project rather than a weekly chore. Every ecosystem except github-actions now ignores `*` at semver-major.

That suppresses the **PR**, not the **alert** — a major carrying a security fix still appears in the Dependabot alert list for a human to act on. What's gone is the weekly reminder that a major exists, which is not news. The vite-specific major ignore is removed as dead config, subsumed by the wildcard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for Mamba-based segmentation models with newer transformer versions.
  - Prevented optional model loading from failing due to missing generation-output aliases.
  - Ensured supported models are correctly recognized and available when their dependencies are installed.

- **Chores**
  - Deferred major dependency upgrades to help preserve application stability while compatibility is validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->