### PR TITLE
fix: clear the 93 CodeQL hygiene alerts, three of which were real bugs

### DIFF
--- a/backend/essays/module/evaluate.py
+++ b/backend/essays/module/evaluate.py
@@ -34,7 +34,6 @@ import gc
 import os
 import sys
 import time
-import traceback
 from pathlib import Path
 from typing import NamedTuple
 

--- a/backend/segmentation/api/main.py
+++ b/backend/segmentation/api/main.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 import os
-from pathlib import Path
 from datetime import datetime
 import torch
 
@@ -148,6 +147,17 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down segmentation microservice...")
     if hasattr(app.state, "model_loader"):
         delattr(app.state, "model_loader")
+
+    # `get_gpu_monitor()` auto-starts a polling thread the first time /monitoring
+    # is hit, and nothing ever stopped it -- the import of this cleanup sat
+    # unused in api/monitoring.py, which is how it was found. Shutdown is where
+    # it belongs, beside the model_loader teardown above.
+    try:
+        from monitoring.gpu_monitor import cleanup_gpu_monitor
+        cleanup_gpu_monitor()
+    except Exception as exc:  # never let teardown fail the shutdown path
+        logger.warning(f"GPU monitor cleanup skipped: {exc}")
+
     logger.info("Segmentation microservice shut down")
 
 # Create FastAPI app
@@ -287,19 +297,12 @@ async def health():
         # Determine device info
         gpu_available = cuda_available or mps_available
         
-        if cuda_available:
-            device_count = torch.cuda.device_count()
-            try:
-                device_name = torch.cuda.get_device_name(0)
-            except Exception:
-                device_name = "CUDA (unknown)"
-        elif mps_available:
-            device_count = 1
-            device_name = "Apple MPS"
-        else:
-            device_count = 0
-            device_name = "CPU"
-        
+        # HealthResponse carries only `gpu_available` and `models_loaded`, so the
+        # per-device name/count this block used to compute went straight into the
+        # bin. Removed rather than reported: `torch.cuda.get_device_name` is a
+        # driver call, and paying for one on every health poll to discard the
+        # answer is worse than not knowing.
+
         # Count loaded models
         models_loaded = 0
         if hasattr(app.state, 'model_loader') and hasattr(app.state.model_loader, 'loaded_models'):

--- a/backend/segmentation/api/metrics_endpoint.py
+++ b/backend/segmentation/api/metrics_endpoint.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import sys
 from typing import Any, Dict, List, Optional
 
 import cv2
@@ -172,7 +170,12 @@ async def batch_calculate_metrics(polygons: List[MetricsRequest]) -> List[Metric
             metrics = await calculate_metrics(polygon_request)
             results.append(metrics)
         except Exception as e:
-            # Return default values on error
+            # Returning zeros keeps one bad polygon from failing the whole batch,
+            # but doing it silently meant a caller could not tell "area is 0"
+            # from "this one blew up". Log which, and why.
+            logger.warning(
+                "Metrics failed for one polygon in batch; returning zeros: %s", e
+            )
             results.append(MetricsResponse(
                 Area=0,
                 Perimeter=0,

--- a/backend/segmentation/api/models.py
+++ b/backend/segmentation/api/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for API requests and responses"""
 
 from pydantic import BaseModel, Field
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from enum import Enum
 
 class ModelType(str, Enum):

--- a/backend/segmentation/api/monitoring.py
+++ b/backend/segmentation/api/monitoring.py
@@ -3,7 +3,7 @@ GPU Monitoring API Endpoints
 Provides REST endpoints for GPU metrics and monitoring data
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from typing import Dict, Any, Optional
 import logging
 import sys
@@ -14,7 +14,7 @@ from api._errors import internal_error
 # Add monitoring module to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 try:
-    from monitoring.gpu_monitor import get_gpu_monitor, cleanup_gpu_monitor
+    from monitoring.gpu_monitor import get_gpu_monitor
     gpu_monitor_available = True
 except ImportError:
     gpu_monitor_available = False

--- a/backend/segmentation/api/routes.py
+++ b/backend/segmentation/api/routes.py
@@ -4,16 +4,10 @@ import time
 import logging
 import threading
 from datetime import datetime
-from typing import Optional
-from fastapi import APIRouter, HTTPException, UploadFile, File, Depends, Query, Form
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException, UploadFile, File, Depends, Form
 import torch
 
 from ._errors import internal_error
-from .models import (
-    SegmentationResponse, ModelsResponse, HealthResponse, 
-    ErrorResponse, ModelType, ModelInfo
-)
 from PIL import Image
 import io
 

--- a/backend/segmentation/ml/inference_executor.py
+++ b/backend/segmentation/ml/inference_executor.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Callable, List
+from typing import Any, Dict, Optional, List
 import torch
 import psutil
 import os

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -5,17 +5,15 @@ Loads pretrained models and provides inference functionality with batch processi
 import os
 import json
 import torch
-import torch.nn.functional as F
 import torchvision.transforms as transforms
 from PIL import Image
 import numpy as np
 import cv2
-from typing import Dict, List, Tuple, Any, Optional, Union
+from typing import Dict, List, Tuple, Any, Optional
 import logging
 import threading
 from pathlib import Path
 import time
-import uuid
 import sys
 
 # Add monitoring module to path
@@ -1649,7 +1647,11 @@ class ModelLoader:
                             f"GPU out of memory even with batch size 1 for {model_name}: {str(e)}"
                         ) from e
                     
-                except InferenceTimeoutError as e:
+                # No `as e` and no `from e`: this sits inside the OOM
+                # batch-shrinking retry loop, and a chained exception keeps the
+                # failed forward pass's frames alive, which pins the CUDA memory
+                # the retry is trying to free.
+                except InferenceTimeoutError:
                     self.is_processing = False
                     self.current_model = None
                     raise InferenceTimeoutError(

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -1612,6 +1612,7 @@ class ModelLoader:
                         _dropped_sizes = []
                 
                 # Perform batch inference with GPU OOM handling
+                timeout_error: Optional[InferenceTimeoutError] = None
                 try:
                     batch_output = executor.execute_inference(
                         model=model,
@@ -1647,14 +1648,19 @@ class ModelLoader:
                             f"GPU out of memory even with batch size 1 for {model_name}: {str(e)}"
                         ) from e
                     
-                # No `as e` and no `from e`: this sits inside the OOM
-                # batch-shrinking retry loop, and a chained exception keeps the
-                # failed forward pass's frames alive, which pins the CUDA memory
-                # the retry is trying to free.
+                # Built here, raised BELOW, outside the handler. Dropping `as e`
+                # and `from e` is not enough on its own: raising inside an
+                # `except` block makes Python attach the active exception as
+                # `__context__` implicitly, and that keeps the failed
+                # `execute_inference` frame -- and its `input_tensor` local --
+                # reachable. On CUDA that pins the very allocation this loop is
+                # shrinking the batch to free. Once the handler exits the
+                # exception is no longer active, so the raise below carries no
+                # context and the frame is collectable.
                 except InferenceTimeoutError:
                     self.is_processing = False
                     self.current_model = None
-                    raise InferenceTimeoutError(
+                    timeout_error = InferenceTimeoutError(
                         model_name=model_name,
                         timeout=timeout,
                         image_size=f"batch_{current_batch_size}_images"
@@ -1664,7 +1670,11 @@ class ModelLoader:
                     self.is_processing = False
                     self.current_model = None
                     raise InferenceError(f"Batch inference failed for {model_name}: {str(e)}") from e
-                
+
+                # Outside every handler -- see the InferenceTimeoutError branch.
+                if timeout_error is not None:
+                    raise timeout_error
+
                 # Check memory after inference and record metrics
                 if self.device.type == 'cuda':
                     memory_after = torch.cuda.memory_allocated()

--- a/backend/segmentation/monitoring/gpu_monitor.py
+++ b/backend/segmentation/monitoring/gpu_monitor.py
@@ -7,11 +7,10 @@ import torch
 import time
 import threading
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 from dataclasses import dataclass, asdict
 from datetime import datetime
 import json
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/backend/segmentation/scripts/download_weights.py
+++ b/backend/segmentation/scripts/download_weights.py
@@ -3,12 +3,11 @@
 Model Weight Download Script for SpheroSeg
 Downloads model weights from Google Drive with resume capability and integrity verification
 """
-import os
 import sys
 import hashlib
 import argparse
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 import urllib.request
 import urllib.error
 import re
@@ -134,9 +133,6 @@ def download_from_gdrive(file_id: str, dest: Path, expected_size: int, model_nam
 
         print(f"  📥 {model_name}: Starting download from Google Drive...")
 
-        # Session for cookies
-        session_cookies = {}
-
         # First request to get confirmation token
         request = urllib.request.Request(url)
 
@@ -231,7 +227,6 @@ def download_file(url: str, dest: Path, expected_size: int, model_name: str) -> 
             mode = 'ab' if start_pos > 0 else 'wb'
 
             # Create progress reporter
-            remaining_size = expected_size - start_pos
             progress = ProgressReporter(expected_size, model_name)
             progress.downloaded = start_pos
 

--- a/backend/segmentation/services/postprocessing.py
+++ b/backend/segmentation/services/postprocessing.py
@@ -3,9 +3,8 @@
 import logging
 import cv2
 import numpy as np
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Tuple
 from skimage import measure
-from scipy import ndimage
 
 logger = logging.getLogger(__name__)
 

--- a/backend/segmentation/sperm_final/config.py
+++ b/backend/segmentation/sperm_final/config.py
@@ -1,7 +1,7 @@
 """Central configuration for the DINOv2 + Mask2Former training pipeline."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 
 # Class mapping (same as existing codebase)

--- a/backend/segmentation/sperm_final/inference/group_sperm.py
+++ b/backend/segmentation/sperm_final/inference/group_sperm.py
@@ -6,7 +6,7 @@ Adapted from:
 """
 
 import math
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 

--- a/backend/segmentation/sperm_final/inference/postprocess.py
+++ b/backend/segmentation/sperm_final/inference/postprocess.py
@@ -11,7 +11,6 @@ import numpy as np
 from scipy.interpolate import splprep, splev
 from skimage.morphology import skeletonize
 
-from sperm_final.config import TARGET_POINTS
 
 
 def mask_to_skeleton(mask01: np.ndarray) -> np.ndarray:

--- a/backend/segmentation/sperm_final/inference/predict.py
+++ b/backend/segmentation/sperm_final/inference/predict.py
@@ -11,8 +11,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from sperm_final.config import ID_TO_CLASS, NUM_CLASSES
-from sperm_final.data.dataset import IMAGENET_MEAN, IMAGENET_STD
+from sperm_final.config import NUM_CLASSES
 
 logger = logging.getLogger(__name__)
 

--- a/backend/segmentation/sperm_final/models/simple_fpn.py
+++ b/backend/segmentation/sperm_final/models/simple_fpn.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class SimpleFPN(nn.Module):

--- a/backend/segmentation/sperm_final/run_pipeline.py
+++ b/backend/segmentation/sperm_final/run_pipeline.py
@@ -23,7 +23,7 @@ import cv2
 import numpy as np
 import torch
 
-from sperm_final.config import ModelConfig, GraphAssemblyConfig, ID_TO_CLASS
+from sperm_final.config import ModelConfig, GraphAssemblyConfig
 from sperm_final.data.dataset import IMAGENET_MEAN, IMAGENET_STD
 from sperm_final.models.mask2former import Mask2FormerModel
 from sperm_final.inference.predict import predict_full_image_for_graph

--- a/backend/src/api/routes/authRoutes.ts
+++ b/backend/src/api/routes/authRoutes.ts
@@ -11,7 +11,6 @@ import {
 import {
   loginSchema,
   registerSchema,
-  resetPasswordRequestSchema,
   resetPasswordConfirmSchema,
   changePasswordSchema,
   resendVerificationSchema,

--- a/backend/src/services/exportService.ts
+++ b/backend/src/services/exportService.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import fs from 'fs/promises';
-import archiver from 'archiver';
 import sharp from 'sharp';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../db';
@@ -38,7 +37,6 @@ import {
 } from '../utils/instanceLabels';
 import { polylineSemanticsForProjectType } from '../utils/polylineSemantics';
 import {
-  sanitizeFilename,
   getProgressMessage,
   createZipArchive,
   countExportSteps,

--- a/backend/src/services/sharingService.ts
+++ b/backend/src/services/sharingService.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { prisma } from '../db';
 import { logger } from '../utils/logger';
 import * as EmailService from './emailService';
-import { User, ProjectShare, Project, Profile } from '@prisma/client';
+import { User, ProjectShare, Project } from '@prisma/client';
 import { ShareByEmailData, ShareByLinkData } from '../types/validation';
 import {
   generateShareInvitationSimpleHTML,

--- a/backend/src/services/video/ffmpegExtractor.ts
+++ b/backend/src/services/video/ffmpegExtractor.ts
@@ -111,7 +111,6 @@ export async function extractWithFfmpeg(
   const channelName = options.channelName ?? 'video';
 
   const probed = await probeFrameCount(sourcePath);
-  const totalFrames = probed?.frameCount ?? -1;
 
   // ffmpeg can't easily write into per-frame subdirectories in one pass,
   // so we extract flat first then move into the per-frame layout.

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -713,16 +712,19 @@ def _load_and_resolve(src: Path) -> tuple[np.ndarray, dict]:
         # C separate time frames — destroying the channel split and turning
         # a still into a bogus "video" the browser can't display.
         C, H, W = arr.shape
-        T = 1
         arr = arr[None, :, :, :]
     elif arr.ndim == 3 and arr.shape[0] > 1 and arr.shape[-1] not in (3, 4):
-        # Heuristic: leading axis is time, single channel.
-        T, H, W = arr.shape
+        # Heuristic: leading axis is time, single channel. Only C is bound: it is
+        # read below to reconcile `raw_channel_labels`, whereas naming T/H/W here
+        # just to discard them read as an assertion that never asserted --
+        # `arr.ndim == 3` in this branch's own guard already fixes the shape.
         C = 1
         arr = arr[:, None, :, :]
     elif arr.ndim == 2:
-        # Single image masquerading as a stack — treat as one frame.
-        T, C, H, W = 1, 1, arr.shape[0], arr.shape[1]
+        # Single image masquerading as a stack — treat as one frame. Same as the
+        # branch above: only C is bound, because T/H/W are re-derived from
+        # `arr.shape` further down before anything reads them.
+        C = 1
         arr = arr[None, None, :, :]
     else:
         raise UnsupportedTiffAxes(

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_axes.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_axes.py
@@ -84,8 +84,7 @@ def test_channel_count_survives_every_branch(
     out, info = _load_and_resolve(src)
 
     assert out.shape[1] == expected_channels
-    channels = info.get("channels") or []
-    if channels:
-        assert len(channels) == expected_channels, (
-            f"{name}: {len(channels)} channel labels for {expected_channels} channels"
-        )
+    channels = info["channels"]
+    assert len(channels) == expected_channels, (
+        f"{name}: {len(channels)} channel labels for {expected_channels} channels"
+    )

--- a/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_axes.py
+++ b/backend/src/services/video/pythonHelpers/tests/test_extract_tiff_stack_axes.py
@@ -1,0 +1,91 @@
+"""Every branch of `_load_and_resolve`'s axis chain must produce a usable T,C,H,W.
+
+The chain is easy to break in a way no linter and no type checker will notice.
+Its branches bind names inconsistently -- some unpack all four of T/C/H/W from
+`arr.shape`, some bind only what they need -- and everything downstream then
+RE-DERIVES `T, C, H, W = arr.shape` before use. All except `C`, which is read
+earlier, to reconcile `raw_channel_labels`.
+
+So `T`/`H`/`W` in a branch are genuinely dead, `C` is load-bearing, and the two
+look identical. Removing the wrong one is a `NameError` on a real upload of that
+one TIFF layout, and only that layout -- exactly the shape of bug that reaches
+production because the other four branches still pass.
+
+That is not hypothetical: it happened while clearing the `py/unused-local-variable`
+alerts on 2026-08-27, and this file is what caught it. Mutation-checked -- dropping
+`C = 1` from a branch turns that branch red and leaves the rest green.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+tifffile = pytest.importorskip("tifffile")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from extract_tiff_stack import _load_and_resolve  # noqa: E402
+
+
+def _write(tmp_path: Path, name: str, arr: np.ndarray, **kw) -> Path:
+    p = tmp_path / name
+    tifffile.imwrite(str(p), arr, photometric="minisblack", **kw)
+    return p
+
+
+@pytest.mark.parametrize(
+    "name,shape,meta,expected",
+    [
+        # explicit axes metadata
+        ("tcyx.tif", (5, 2, 16, 20), {"axes": "TCYX"}, (5, 2, 16, 20)),
+        ("tyx.tif", (7, 16, 20), {"axes": "TYX"}, (7, 1, 16, 20)),
+        ("cyx.tif", (3, 16, 20), {"axes": "CYX"}, (1, 3, 16, 20)),
+        # no metadata: leading axis > 1 and trailing axis not 3/4 -> time heuristic
+        ("heuristic.tif", (6, 16, 20), None, (6, 1, 16, 20)),
+        # a plain 2-D image that arrived through the stack path
+        ("single.tif", (16, 20), None, (1, 1, 16, 20)),
+    ],
+)
+def test_axis_branch_resolves_to_tcyx(tmp_path, name, shape, meta, expected):
+    rng = np.random.default_rng(0)
+    arr = rng.integers(0, 4096, shape, dtype=np.uint16)
+    kw = {"metadata": meta} if meta else {}
+    src = _write(tmp_path, name, arr, **kw)
+
+    out, _ = _load_and_resolve(src)
+
+    assert out.shape == expected, f"{name}: got {out.shape}, expected {expected}"
+    assert out.ndim == 4, "downstream code indexes arr as (T, C, H, W)"
+
+
+@pytest.mark.parametrize(
+    "name,shape,meta,expected_channels",
+    [
+        ("tcyx.tif", (5, 2, 16, 20), {"axes": "TCYX"}, 2),
+        ("cyx.tif", (3, 16, 20), {"axes": "CYX"}, 3),
+        ("heuristic.tif", (6, 16, 20), None, 1),
+        ("single.tif", (16, 20), None, 1),
+    ],
+)
+def test_channel_count_survives_every_branch(
+    tmp_path, name, shape, meta, expected_channels
+):
+    """`C` is the one name read before the re-derivation, via raw_channel_labels.
+
+    A branch that forgets to bind it raises NameError; a branch that binds it
+    wrongly silently mislabels the channels, which is worse. Assert the count
+    that actually reaches the caller.
+    """
+    rng = np.random.default_rng(1)
+    arr = rng.integers(0, 4096, shape, dtype=np.uint16)
+    kw = {"metadata": meta} if meta else {}
+    src = _write(tmp_path, name, arr, **kw)
+
+    out, info = _load_and_resolve(src)
+
+    assert out.shape[1] == expected_channels
+    channels = info.get("channels") or []
+    if channels:
+        assert len(channels) == expected_channels, (
+            f"{name}: {len(channels)} channel labels for {expected_channels} channels"
+        )

--- a/src/components/StatsOverview.tsx
+++ b/src/components/StatsOverview.tsx
@@ -192,7 +192,7 @@ const StatsOverview = () => {
           if (signal.aborted) return;
 
           // Format storage used based on size
-          let formattedStorage = '0 MB';
+          let formattedStorage: string;
           if (storageStats.totalStorageGB >= 1) {
             formattedStorage = `${storageStats.totalStorageGB} GB`;
           } else {

--- a/src/hooks/useProjectData.tsx
+++ b/src/hooks/useProjectData.tsx
@@ -120,7 +120,7 @@ export const useProjectData = (
           }
         }
 
-        const formattedImages: ProjectImage[] = (allImages || []).map(img => {
+        const formattedImages: ProjectImage[] = allImages.map(img => {
           // Normalize segmentation status from different backend field names
           let segmentationStatus =
             img.segmentationStatus || img.segmentation_status;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2032,7 +2032,6 @@ class ApiClient {
                         (point: unknown) =>
                           point &&
                           typeof point === 'object' &&
-                          point !== null &&
                           typeof (point as Record<string, unknown>).x ===
                             'number' &&
                           typeof (point as Record<string, unknown>).y ===

--- a/src/lib/coordinateUtils.ts
+++ b/src/lib/coordinateUtils.ts
@@ -192,10 +192,6 @@ export const constrainTransform = (
   const scaledWidth = imageWidth * zoom;
   const scaledHeight = imageHeight * zoom;
 
-  // With the new coordinate system (transformOrigin at 0 0 and centering)
-  let translateX = transform.translateX;
-  let translateY = transform.translateY;
-
   // When zoomed in (>= 1x), allow unlimited panning
   // so the user can freely navigate to any part of the image
   if (zoom >= 1.0) {
@@ -206,35 +202,10 @@ export const constrainTransform = (
     };
   }
 
-  // For zoom levels 1x to 2x, apply very generous constraints
-  if (zoom >= 1.0) {
-    const veryGenerousMargin = Math.max(canvasWidth, canvasHeight) * 3.0;
-    const minVisibleSize = 10; // Very small minimum visibility requirement
-
-    // For X axis - allow very generous panning
-    const maxTranslateX = veryGenerousMargin - scaledWidth / 2;
-    const minTranslateX =
-      -scaledWidth / 2 - veryGenerousMargin + minVisibleSize;
-    translateX = Math.max(
-      minTranslateX,
-      Math.min(maxTranslateX, transform.translateX)
-    );
-
-    // For Y axis - allow very generous panning
-    const maxTranslateY = veryGenerousMargin - scaledHeight / 2;
-    const minTranslateY =
-      -scaledHeight / 2 - veryGenerousMargin + minVisibleSize;
-    translateY = Math.max(
-      minTranslateY,
-      Math.min(maxTranslateY, transform.translateY)
-    );
-
-    return {
-      zoom,
-      translateX,
-      translateY,
-    };
-  }
+  // Everything below is the zoom < 1 path. The `zoom >= 1.0` branch that
+  // used to sit here was unreachable -- the early return above already
+  // took every zoom >= 1 case -- so its "very generous" constraints never
+  // ran and the panning they described was simply unbounded.
 
   // For zoom levels < 1x (zoomed out), apply moderate constraints to prevent complete loss
   const moderateMargin = Math.max(canvasWidth, canvasHeight) * 0.8;
@@ -243,7 +214,7 @@ export const constrainTransform = (
   // For X axis - moderate constraints for zoomed out images
   const maxTranslateX = moderateMargin - scaledWidth / 2;
   const minTranslateX = -scaledWidth / 2 - moderateMargin + minVisibleSize;
-  translateX = Math.max(
+  const translateX = Math.max(
     minTranslateX,
     Math.min(maxTranslateX, transform.translateX)
   );
@@ -251,7 +222,7 @@ export const constrainTransform = (
   // For Y axis - moderate constraints for zoomed out images
   const maxTranslateY = moderateMargin - scaledHeight / 2;
   const minTranslateY = -scaledHeight / 2 - moderateMargin + minVisibleSize;
-  translateY = Math.max(
+  const translateY = Math.max(
     minTranslateY,
     Math.min(maxTranslateY, transform.translateY)
   );

--- a/src/lib/retryUtils.ts
+++ b/src/lib/retryUtils.ts
@@ -336,7 +336,7 @@ export function isRetryableError(error: unknown): boolean {
   }
 
   // Timeout errors
-  if (error && typeof error === 'object' && 'name' in error) {
+  if (typeof error === 'object' && 'name' in error) {
     const errorName = (error as { name?: string }).name;
     if (errorName === 'TimeoutError' || errorName === 'NetworkError') {
       return true;
@@ -344,7 +344,7 @@ export function isRetryableError(error: unknown): boolean {
   }
 
   // HTTP errors that are retryable
-  if (error && typeof error === 'object' && 'status' in error) {
+  if (typeof error === 'object' && 'status' in error) {
     const status = (error as { status?: number }).status;
     // Retry on rate limit, bad gateway, service unavailable, gateway timeout
     if (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -120,7 +120,6 @@ const Profile = () => {
             const projects = allProjectsResponse.projects || [];
 
             if (projects.length === 0) {
-              hasMoreProjects = false;
               break;
             }
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -246,7 +246,7 @@ const ProjectDetail = () => {
             }
 
             const existingById = new Map(images.map(i => [i.id, i]));
-            const formattedImages = (allImages || []).map(img => {
+            const formattedImages = allImages.map(img => {
               let segmentationStatus =
                 img.segmentationStatus || img.segmentation_status;
               if (segmentationStatus === 'segmented') {
@@ -329,7 +329,7 @@ const ProjectDetail = () => {
       }
 
       const existingById = new Map(images.map(i => [i.id, i]));
-      const formattedImages = (allImages || []).map(img => {
+      const formattedImages = allImages.map(img => {
         let segmentationStatus =
           img.segmentationStatus || img.segmentation_status;
         if (segmentationStatus === 'segmented') {
@@ -533,7 +533,7 @@ const ProjectDetail = () => {
       }
 
       const existingById = new Map(images.map(i => [i.id, i]));
-      const formattedImages = (allImages || []).map(img => {
+      const formattedImages = allImages.map(img => {
         let segmentationStatus =
           img.segmentationStatus || img.segmentation_status;
         if (segmentationStatus === 'segmented') {

--- a/src/pages/export/AdvancedExportDialog.tsx
+++ b/src/pages/export/AdvancedExportDialog.tsx
@@ -962,7 +962,14 @@ export const AdvancedExportDialog: React.FC<AdvancedExportDialogProps> =
               )}
 
               {/* Completed Export - Manual Download */}
-              {completedJobId && !isExporting && !isDownloading && (
+              {/* `!isDownloading` used to be part of this guard, which made the
+                  isDownloading branches on the button below unreachable: the
+                  whole panel unmounted the moment a download started, so the
+                  "Downloading..." spinner it renders could never appear and the
+                  user just watched the box vanish. Both the guard and the
+                  spinner arrived in the same commit, so the spinner is the
+                  intent and the guard was the slip. */}
+              {completedJobId && !isExporting && (
                 <div className="flex items-center gap-2 p-3 bg-green-50 border border-green-200 rounded-lg relative">
                   <AlertCircle className="h-4 w-4 flex-shrink-0 text-green-600" />
                   <div className="min-w-0 flex-1">

--- a/src/pages/segmentation/components/ChannelOverlayList.tsx
+++ b/src/pages/segmentation/components/ChannelOverlayList.tsx
@@ -277,7 +277,7 @@ export function ChannelOverlayList({
 
       {editingColor && (
         <ChannelColorDialog
-          open={editingColor !== null}
+          open
           channelName={
             channels.find(c => c.name === editingColor)?.displayName ??
             editingColor

--- a/src/pages/segmentation/hooks/view/useImageCentering.tsx
+++ b/src/pages/segmentation/hooks/view/useImageCentering.tsx
@@ -32,7 +32,7 @@ export const useImageCentering = (
       const containerRatio = containerWidth / containerHeight;
 
       // Výpočet nové velikosti s ohledem na zachování poměru stran
-      let newZoom = 1;
+      let newZoom: number;
 
       // Vždy fit to container, aby se celý obrázek vešel do plátna
       if (imgRatio > containerRatio) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,7 +67,10 @@ export function getErrorMessage(
   if (typeof error === 'object' && error !== null) {
     const apiError = error as ApiError & { config?: { url?: string } };
     statusCode = apiError.response?.status || apiError.status;
-    message = apiError.response?.data?.message || apiError.message;
+    // `|| message` matters: an Error is also `typeof 'object'`, so this branch
+    // runs for one too and used to overwrite the `error.message` captured above
+    // -- with undefined, whenever the response carried no message of its own.
+    message = apiError.response?.data?.message || apiError.message || message;
     url = apiError.config?.url;
 
     // Special handling for authentication endpoints


### PR DESCRIPTION
These sat as note/warning-level noise long enough that nobody read them. Two thirds are exactly what they look like — unused imports, initialisers nothing reads. The rest are not.

## Actual bugs, found by reading the "noise"

**Unreachable panning constraints.** `constrainTransform` returns early for `zoom >= 1.0`, then tests `if (zoom >= 1.0)` a *second* time and builds a whole block of "very generous" pan limits behind it. That block has never run — its own comment says "For zoom levels 1x to 2x", a range the early return already took. Deleted; panning at zoom ≥ 1 is unbounded, as it has been all along.

**`getErrorMessage` threw away the message it had just extracted.**
```ts
if (error instanceof Error) message = error.message;
// ...
message = apiError.response?.data?.message || apiError.message;  // ← unconditional
```
An `Error` is also `typeof 'object'`, so the second branch runs for one too and overwrites the first — with `undefined` whenever the response carries no message of its own. Now falls back to the captured value.

**The export dialog's "Downloading…" spinner could never render.** Its panel is guarded `completedJobId && !isExporting && !isDownloading`, and *inside* it the button branches on `isDownloading` for a spinner and a tooltip. The guard unmounts the panel the instant a download starts, so the user watches the box vanish instead. Guard and spinner arrived in the **same commit**, so the spinner is the intent — dropped `!isDownloading` from the guard. This is the one behaviour change in the PR.

## Two mistakes I made doing this, both caught before commit

Worth recording, because both are the kind that survive a green build.

**Ruff's autofix looked safe and was not.** In `extract_tiff_stack.py` I removed `T, H, W = arr.shape` **and** the `C = 1` beside it. `T`/`H`/`W` really are dead — everything downstream re-derives `T, C, H, W = arr.shape` — but `C` is read *before* that, to reconcile `raw_channel_labels`. Dropping it is a `NameError` on one TIFF layout and only that layout, which is how it reaches production.

`tests/test_extract_tiff_stack_axes.py` now covers all five axis branches with real TIFF files. Mutation-checked: removing a `C` binding turns that branch red and leaves the other four green — the exact signature of the bug.

**A blanket replace would have introduced a null dereference.** `retryUtils.ts` has four `if (error && typeof error === 'object' …)` lines; CodeQL flagged two. Only the two inside `isRetryableError` are redundant, because that function opens with `if (!error) return false`. The other two have no such guard, and `typeof null === 'object'` — removing their `error &&` is a null deref. Patched by line number instead.

## Two things that were missing rather than surplus

**A monitoring thread nothing stopped.** `api/monitoring.py` imported `cleanup_gpu_monitor` and never called it — that unused import is how this was found. `get_gpu_monitor()` auto-starts a polling thread on first use, so the thread outlived every shutdown. Now called from the lifespan teardown, beside the existing `model_loader` cleanup.

**A silently swallowed batch error.** `metrics_endpoint.py` catches per-polygon failures and returns zeros so one bad polygon cannot fail the batch. Correct — but silent, so a caller could not tell "area is 0" from "this one blew up". Now logs which, and why.

## Deliberately left alone

- `model_loader.py`'s timeout handler drops `as e` rather than gaining `from e`. It sits inside the OOM batch-shrinking retry loop, where a chained exception keeps the failed forward pass's frames — and the CUDA memory the retry is trying to free — alive.
- The six `except: pass` blocks are genuine best-effort paths (optional ND2 metadata, GPU temperature feature-detection, an optional file lookup).

## Verified

- `make ci` green: TypeScript gate, ESLint 0 warnings, i18n complete across 6 locales
- **163** python helper tests (9 new), **128 + 127** frontend, **140** backend — all pass
- all **18** touched Python modules import in the real ML image
- `ruff` clean for F401/F811/F821/F841 across every file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export downloads now remain visible while in progress, with a clear downloading indicator.
  * Error messages are preserved more reliably when detailed API information is unavailable.
  * Improved cleanup during application shutdown and clearer warnings for failed metric calculations.

* **Refactor**
  * Simplified internal processing and removed unused code across segmentation, video, export, sharing, and project workflows.
  * Added coverage for TIFF image-axis handling and channel preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->