### PR TITLE
fix: clear the last 29 CodeQL hygiene alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,24 @@ jobs:
       # SegFormer and sperm DINOv2 checkpoints and hashing a fixed-input
       # forward. Two different pins would mean the essays worker is documented
       # against a version nobody ran that probe on.
+      # A NameError inside a function body is invisible to everything else this
+      # repo runs: the module still imports, /health still answers 200, and the
+      # failure only surfaces when that branch executes. One shipped on
+      # 2026-08-27 -- removing an `import concurrent.futures` while a
+      # `concurrent.futures.ALL_COMPLETED` reference remained, on the executor
+      # shutdown path. Ruff catches it statically in under a second.
+      #
+      # Deliberately F821 only. It is the rule with no judgement in it: an
+      # undefined name is a runtime crash, never a style opinion, so this gate
+      # cannot start arguing with the codebase. Vendored third-party code is
+      # excluded because we do not edit it.
+      - name: Python undefined names (F821)
+        run: |
+          pipx install ruff 2>/dev/null || pip install --quiet ruff
+          ruff check --isolated --select F821 --no-cache --output-format concise \
+            --exclude backend/segmentation/models/microtubule/vendor \
+            backend/segmentation backend/essays backend/src
+
       - name: ML and essays pins agree
         run: |
           set -euo pipefail

--- a/backend/essays/essays_api.py
+++ b/backend/essays/essays_api.py
@@ -470,6 +470,10 @@ def _worker() -> None:
                 _set_status(req.jobId, req.outDir, state="failed",
                             error=f"worker error: {e}")
             except Exception:
+                # Best-effort: we are already inside the handler for the failure
+                # this status write was meant to record, and the original error
+                # is on stderr above. Re-raising here would replace a useful
+                # traceback with a bookkeeping one.
                 pass
         finally:
             _work.task_done()

--- a/backend/essays/module/mt_pipeline/nd2_io.py
+++ b/backend/essays/module/mt_pipeline/nd2_io.py
@@ -88,12 +88,20 @@ def read_acquisition_time(f: "nd2.ND2File") -> str | None:
                     .isoformat()
                     .replace("+00:00", "Z"))
     except Exception:
+        # acquired_at is optional metadata: ND2 files from different NIS-Elements
+        # versions expose it in different places, or not at all. Each reader is
+        # tried in turn and the caller gets None if none of them work -- a well
+        # without a timestamp is still a well worth measuring.
         pass
     try:
         raw = (f.text_info or {}).get("date")
         if isinstance(raw, str) and raw.strip():
             return raw.strip()
     except Exception:
+        # acquired_at is optional metadata: ND2 files from different NIS-Elements
+        # versions expose it in different places, or not at all. Each reader is
+        # tried in turn and the caller gets None if none of them work -- a well
+        # without a timestamp is still a well worth measuring.
         pass
     return None
 

--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -210,11 +210,11 @@ class MTMetricsResponse(BaseModel):
 # states "unused here, used by the contract test" instead of leaving a reader to
 # infer it from an unused-global warning.
 __all__ = [
-    "_polyline_length",
-    "_imagej_median",
-    "_fill_convex_polygon",
-    "_rasterize_band",
     "_dilate",
+    "_fill_convex_polygon",
+    "_imagej_median",
+    "_polyline_length",
+    "_rasterize_band",
     "_vicinity_mask",
 ]
 

--- a/backend/segmentation/api/mt_metrics.py
+++ b/backend/segmentation/api/mt_metrics.py
@@ -205,6 +205,19 @@ class MTMetricsResponse(BaseModel):
 # keep the endpoint's own vocabulary (and its tests) while making the delegation
 # explicit: rebinding one of them here would NOT change the essays batch, which
 # is exactly the drift this arrangement exists to prevent.
+# Re-exported deliberately: `test_mt_metrics_band.py` reaches for these by name
+# to assert the endpoint's helpers ARE the shared objects, so an `__all__` entry
+# states "unused here, used by the contract test" instead of leaving a reader to
+# infer it from an unused-global warning.
+__all__ = [
+    "_polyline_length",
+    "_imagej_median",
+    "_fill_convex_polygon",
+    "_rasterize_band",
+    "_dilate",
+    "_vicinity_mask",
+]
+
 _polyline_length = mt_measure.polyline_length
 _imagej_median = mt_measure.imagej_median
 _fill_convex_polygon = mt_measure.fill_convex_polygon

--- a/backend/segmentation/api/tracker_kymograph.py
+++ b/backend/segmentation/api/tracker_kymograph.py
@@ -1279,7 +1279,7 @@ async def kymograph(req: KymographRequest) -> KymographResponse:
             img = np.array(pil_frame, dtype=np.float32)
         else:
             img = np.array(pil_frame.convert("L"), dtype=np.float32)
-        H, W = img.shape
+        _, _ = img.shape
         pts = np.asarray(frame.polyline_rc, dtype=np.float32)
         if pts.ndim != 2 or pts.shape[1] != 2 or pts.shape[0] < 2:
             logger.warning(

--- a/backend/segmentation/ml/inference_executor.py
+++ b/backend/segmentation/ml/inference_executor.py
@@ -11,7 +11,11 @@ This module provides a production-ready inference execution system with:
 import logging
 import time
 import threading
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+    wait as futures_wait,
+)
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
@@ -550,8 +554,7 @@ class InferenceExecutor:
             
             if pending_futures:
                 # Wait for futures with timeout
-                import concurrent.futures
-                done, not_done = concurrent.futures.wait(
+                done, not_done = futures_wait(
                     pending_futures, 
                     timeout=timeout,
                     return_when=concurrent.futures.ALL_COMPLETED

--- a/backend/segmentation/ml/inference_executor.py
+++ b/backend/segmentation/ml/inference_executor.py
@@ -12,6 +12,7 @@ import logging
 import time
 import threading
 from concurrent.futures import (
+    ALL_COMPLETED,
     ThreadPoolExecutor,
     TimeoutError as FutureTimeoutError,
     wait as futures_wait,
@@ -557,7 +558,7 @@ class InferenceExecutor:
                 done, not_done = futures_wait(
                     pending_futures, 
                     timeout=timeout,
-                    return_when=concurrent.futures.ALL_COMPLETED
+                    return_when=ALL_COMPLETED
                 )
                 
                 # Cancel any remaining futures

--- a/backend/segmentation/ml/model_loader.py
+++ b/backend/segmentation/ml/model_loader.py
@@ -808,7 +808,6 @@ class ModelLoader:
             # If detect_holes is False, fill all holes in the binary mask
             if not detect_holes:
                 # Create filled mask by flood-filling from edges
-                h, w = binary_mask.shape
                 filled_mask = binary_mask.copy()
                 
                 # Find all contours

--- a/backend/segmentation/monitoring/gpu_monitor.py
+++ b/backend/segmentation/monitoring/gpu_monitor.py
@@ -122,12 +122,20 @@ class GPUMonitor:
                 try:
                     temperature = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
                 except pynvml.NVMLError:
+                    # Feature-detection, not error handling: temperature and
+                    # power draw are unsupported on some cards and in some
+                    # driver/container combinations. The reading stays at its
+                    # default and the rest of the GPU metrics are still valid.
                     pass
 
                 # Get power draw if available
                 try:
                     power_draw = pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0  # Convert to watts
                 except pynvml.NVMLError:
+                    # Feature-detection, not error handling: temperature and
+                    # power draw are unsupported on some cards and in some
+                    # driver/container combinations. The reading stays at its
+                    # default and the rest of the GPU metrics are still valid.
                     pass
                     
                 pynvml.nvmlShutdown()

--- a/backend/segmentation/sperm_final/inference/predict.py
+++ b/backend/segmentation/sperm_final/inference/predict.py
@@ -751,7 +751,7 @@ def predict_full_image_tta(
     Averages soft masks across augmentations before thresholding.
     Typically gives +1-2% IoU improvement.
     """
-    C, H, W = image_tensor.shape
+    # Shape unpacked but unused here; the other two call sites do use it.
 
     # Define augmentations: (transform_fn, inverse_fn)
     augmentations = [

--- a/backend/segmentation/sperm_final/models/mask2former.py
+++ b/backend/segmentation/sperm_final/models/mask2former.py
@@ -243,7 +243,6 @@ class TransformerDecoder(nn.Module):
         # Flatten multi-scale features for cross-attention
         memory_list = []
         for feat in multi_scale_features:
-            b, c, h, w = feat.shape
             memory_list.append(feat.flatten(2).permute(0, 2, 1))  # (B, H*W, C)
 
         aux_outputs = []

--- a/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
+++ b/backend/src/services/video/pythonHelpers/extract_tiff_stack.py
@@ -340,7 +340,6 @@ def _detect_pixel_size_um(tf) -> float | None:
     try:
         ome = getattr(tf, "ome_metadata", None)
         if isinstance(ome, str) and "<Pixels" in ome:
-            import re
             m = re.search(r'PhysicalSizeX="([0-9.eE+-]+)"', ome)
             unit_m = re.search(r'PhysicalSizeXUnit="([^"]+)"', ome)
             if m:
@@ -373,8 +372,7 @@ def _detect_pixel_size_um(tf) -> float | None:
                         return converted
             info = meta.get("info") or meta.get("Info")
             if isinstance(info, str):
-                import re
-                # Look for an inline unit on the same line as the value.
+                    # Look for an inline unit on the same line as the value.
                 for pat in (
                     r"PixelWidth\s*[:=]\s*([0-9.eE+-]+)\s*([A-Za-zµ]*)",
                     r"pixel_width\s*[:=]\s*([0-9.eE+-]+)\s*([A-Za-zµ]*)",
@@ -702,7 +700,7 @@ def _load_and_resolve(src: Path) -> tuple[np.ndarray, dict]:
         arr = arr.transpose(3, 0, 1, 2)
         T, C, H, W = arr.shape
     elif axes == "TYX" and arr.ndim == 3:
-        T, H, W = arr.shape
+        # Only C is bound; T/H/W are re-derived from arr.shape further down.
         C = 1
         arr = arr[:, None, :, :]
     elif axes == "CYX" and arr.ndim == 3:

--- a/backend/src/services/video/pythonHelpers/make_playback_proxy.py
+++ b/backend/src/services/video/pythonHelpers/make_playback_proxy.py
@@ -114,6 +114,9 @@ def existing_proxy(frame_dir: str, channel: str) -> str | None:
             if name.startswith(prefix) and name.endswith(suffix):
                 return os.path.join(frame_dir, name)
     except OSError:
+        # The frame directory may not exist yet, or may be mid-write while the
+        # extractor is still running. Either way there is no frame to return and
+        # None is the answer; the caller retries on the next poll.
         pass
     return None
 


### PR DESCRIPTION
The tail after #364's sweep. All note-level, nothing security-relevant left — but three of the five groups needed a decision rather than a deletion.

## Deliberate re-exports, now stated as such

`mt_metrics.py` binds six aliases to `models/mt_measure.py` (the shared band geometry and ImageJ statistics), and nothing in the module uses them, so `py/unused-global-variable` fired on all six.

They are not unused. They exist so `test_mt_metrics_band.py` can assert the endpoint's helpers **are** the shared objects — the check that keeps the export and the essays batch from drifting apart again, after they once disagreed on net signal by a median of +9.9%.

Deleting them deletes that contract. An `__all__` entry says *"unused here, used by the contract test"* out loud, instead of leaving the next reader to infer it from a warning they'll probably just dismiss.

## `except: pass` — kept, and explained

All six are genuine best-effort paths, and the query's own message says what's missing: *"does nothing but pass and there is no explanatory comment"*. So each gets the reason it always had:

| site | why |
|---|---|
| `essays_api` | status write inside the handler for the failure it records |
| `nd2_io` (×2) | `acquired_at` is optional and lives in different places per NIS-Elements version |
| `gpu_monitor` (×2) | feature detection — temperature/power unsupported on some cards and driver/container combinations |
| `make_playback_proxy` | the frame dir may not exist yet, or be mid-write |

Turning these into logging would be worse: they're expected paths, and the line would fire on every ND2 that simply has no timestamp.

## Shape unpacks and duplicate imports

`T, H, W = arr.shape` and friends where the names are never read — the surrounding code re-derives the shape when it needs it. Removed, except in `predict.py`, where only **one of three** identical unpacks was dead.

`import re` appeared twice inside functions of a module that already imports it at the top; `inference_executor` imported `concurrent.futures` both ways, so the local import became `wait as futures_wait` on the existing top-level line.

## Verified

- 163 python helper tests + 16 mt_metrics / model-import tests — all pass
- every touched ML module imports in the real ML image
- `ruff` clean for F401/F811/F821/F841 across the files touched
- `make ci` green

After this, CodeQL open alerts go to **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory comments clarifying optional metadata handling, GPU metric availability, retry behavior, and best-effort status updates.

* **Refactor**
  * Removed unused variables and redundant imports.
  * Clarified internal metric helper exports.
  * Improved resource checks by clearing the CUDA cache before reporting memory-limit errors and using non-blocking CPU polling.

* **Bug Fixes**
  * Improved cleanup behavior when inference resources exceed configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->