### PR TITLE
test(ml): stop the device test asserting the size of the pytest process

### DIFF
--- a/backend/segmentation/tests/unit/ml/test_inference_executor.py
+++ b/backend/segmentation/tests/unit/ml/test_inference_executor.py
@@ -302,8 +302,25 @@ class TestInferenceExecutor:
         
         input_tensor = torch.randn(1, 3, 256, 256)
         
-        # Test with CPU
-        with patch('ml.inference_executor.torch.cuda.is_available', return_value=False):
+        # Test with CPU.
+        #
+        # `_get_memory_usage` is patched alongside `cuda.is_available` on
+        # purpose. With CUDA reported absent it falls back to
+        # `psutil.Process(os.getpid()).memory_info().rss` -- the RSS of the
+        # whole pytest process, not of anything this test allocated. The
+        # fixture's limit is 2 GB, and by the time the full suite reaches here
+        # the process has loaded torch, several models and a lot of numpy, so
+        # the proactive resource check trips and the test fails with
+        # InferenceResourceError.
+        #
+        # It passes in isolation and fails in the suite, which is the signature
+        # of order dependence rather than a defect: the assertion is about
+        # device handling, and it was accidentally also asserting "this python
+        # process is under 2 GB". Pinning the reading keeps it measuring the
+        # thing it names.
+        with patch(
+            'ml.inference_executor.torch.cuda.is_available', return_value=False
+        ), patch.object(executor, '_get_memory_usage', return_value=0):
             result = executor.execute_inference(
                 model=model,
                 input_tensor=input_tensor,


### PR DESCRIPTION
`test_inference_with_different_devices` was the only red test in the ML suite — 469 tests, 468 passing, this one failing with `InferenceResourceError`. It passes in **isolation**, twice, reliably, and fails in the **full run**: order dependence, not a defect.

## The mechanism

The test patches `torch.cuda.is_available` to False to exercise the CPU path. That also changes what `_get_memory_usage` reads:

```python
if torch.cuda.is_available():
    return torch.cuda.memory_allocated()
else:
    return psutil.Process(os.getpid()).memory_info().rss   # ← the whole pytest process
```

The fixture's limit is 2 GB, and by test 468 the process has loaded torch, several models and a lot of numpy — so `_check_resources` trips before inference is ever attempted.

So the assertion was about device handling, and was accidentally *also* asserting "this python process is under 2 GB". Pinning the reading keeps it measuring the thing it names; `assert result is not None` still carries the actual check.

**Full suite is now 469 passed, 1 skipped, 0 failed.**

## A note for anyone running it

The suite needs `requirements-test.txt` (pytest-asyncio, asgi-lifespan) and `--asyncio-mode=auto`. Without those, 11 tests in `test_api_segmentation.py` error out with *"requested an async fixture … with no plugin or hook that handled it"* — which looks like breakage and is only a missing plugin. I hit exactly that before reading the recipe already documented at the top of `requirements-test.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved inference device-handling test reliability by preventing unrelated process memory usage from affecting CPU test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->