### PR TITLE
ci: gate the Python suites that can run without a GPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,39 @@ jobs:
           done
           exit $fail
 
+  python-tests:
+    name: python-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: backend/requirements-pytest-ci.txt
+
+      - name: Install
+        run: pip install -r backend/requirements-pytest-ci.txt
+
+      # 213 tests that ran nowhere before this job existed. `make ci` covers
+      # TypeScript, ESLint and i18n only, so every Python suite in the repo was
+      # unguarded -- which is how a NameError on an executor shutdown path and
+      # an order-dependent memory assertion both survived to 2026-08-27.
+      #
+      # The third suite, backend/segmentation/tests, is absent on purpose and
+      # not because it is slow: it cannot be COLLECTED without a GPU, since
+      # models/__init__ imports mamba_ssm -> Triton, which raises "0 active
+      # drivers" at import on a runner with no CUDA. It needs a real card --
+      # `make test-ml`. See backend/requirements-pytest-ci.txt for the full
+      # reasoning.
+      - name: pytest (video helpers + essays)
+        run: |
+          python -m pytest -q -p no:cacheprovider \
+            backend/src/services/video/pythonHelpers/tests \
+            backend/essays/tests
+
   backend:
     name: backend
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # backend/essays/module/requirements.txt is NEVER pip-installed: the
       # essays image is `FROM ${ML_IMAGE}` and inherits the ML service's stack
@@ -132,6 +134,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          # This job executes repository Python. Checkout would otherwise leave
+          # GITHUB_TOKEN in .git/config, readable by anything the suites run.
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -142,7 +148,7 @@ jobs:
       - name: Install
         run: pip install -r backend/requirements-pytest-ci.txt
 
-      # 213 tests that ran nowhere before this job existed. `make ci` covers
+      # 214 tests that ran nowhere before this job existed. `make ci` covers
       # TypeScript, ESLint and i18n only, so every Python suite in the repo was
       # unguarded -- which is how a NameError on an executor shutdown path and
       # an order-dependent memory assertion both survived to 2026-08-27.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down restart logs logs-f logs-fe logs-be logs-ml clean status health-status health-check shell-fe shell-be shell-ml dev-setup reset start rebuild test test-ui test-e2e test-e2e-ui test-coverage lint lint-fix type-check ci ci-test dev prod generate-ssl-cert metrics prometheus grafana alerts prometheus-config-check test-alerts monitor-health monitor-setup restart-grafana restart-prometheus monitor-errors export-metrics monitor-resources clean-monitoring download-weights check-weights weights-info
+.PHONY: help build up down restart logs logs-f logs-fe logs-be logs-ml clean status health-status health-check shell-fe shell-be shell-ml dev-setup reset start rebuild test test-py test-ml test-ui test-e2e test-e2e-ui test-coverage lint lint-fix type-check ci ci-test dev prod generate-ssl-cert metrics prometheus grafana alerts prometheus-config-check test-alerts monitor-health monitor-setup restart-grafana restart-prometheus monitor-errors export-metrics monitor-resources clean-monitoring download-weights check-weights weights-info
 
 # Detect Docker Compose version  
 DOCKER_COMPOSE := docker compose
@@ -246,6 +246,33 @@ restart-backend-utia:
 	@echo "Test connection: curl http://localhost:3001/api/test-email/test-connection"
 
 # Run unit tests with UI in Docker
+test-py:
+	@echo "🐍 Python suites CI also runs (no GPU needed)"
+	@docker run --rm -v "$$PWD":/w -w /w python:3.10-slim sh -c '\
+	  pip install -q -r backend/requirements-pytest-ci.txt && \
+	  python -m pytest -q -p no:cacheprovider \
+	    backend/src/services/video/pythonHelpers/tests \
+	    backend/essays/tests'
+
+# The ML suite cannot run in CI: models/__init__ imports mamba_ssm -> Triton,
+# which raises "0 active drivers" at import time without a CUDA driver. So it
+# needs this box, the built ml image, and --gpus. Was 469 passed / 1 skipped on
+# 2026-08-28. --asyncio-mode=auto is required; without pytest-asyncio the
+# test_api_segmentation tests error on an unhandled async fixture and look
+# broken when they are merely unplugged.
+test-ml:
+	@echo "🧠 ML suite (needs a GPU and the built ml image)"
+	@docker image inspect cell-segmentation-hub-ml:latest >/dev/null 2>&1 || \
+	  { echo "❌ build it first: make build-service SERVICE=ml"; exit 1; }
+	@docker run --rm --gpus all --entrypoint sh \
+	  -v "$$PWD/backend/segmentation":/app -w /app \
+	  -v "$$PWD/backend/segmentation/.hf-cache":/home/app/.cache/huggingface \
+	  -e HF_TOKEN="$$(grep -E '^HF_TOKEN=' .env.production | cut -d= -f2-)" \
+	  cell-segmentation-hub-ml:latest -c '\
+	    pip install -q -r requirements-test.txt && \
+	    python -m pytest tests/ -q -p no:cacheprovider --asyncio-mode=auto \
+	      --timeout=90 --timeout-method=thread'
+
 test-ui:
 	@echo "🧪 Running unit tests with UI in Docker..."
 	@$(DOCKER_COMPOSE) exec frontend npm run test:ui

--- a/Makefile
+++ b/Makefile
@@ -264,10 +264,14 @@ test-ml:
 	@echo "🧠 ML suite (needs a GPU and the built ml image)"
 	@docker image inspect cell-segmentation-hub-ml:latest >/dev/null 2>&1 || \
 	  { echo "❌ build it first: make build-service SERVICE=ml"; exit 1; }
-	@docker run --rm --gpus all --entrypoint sh \
+	@# HF_TOKEN is exported into the command's environment and passed by NAME.
+	@# Writing `-e HF_TOKEN="$$(grep ...)"` would expand the secret into the
+	@# docker argument list, where any user on the box can read it out of ps.
+	@HF_TOKEN="$$(grep -E '^HF_TOKEN=' .env.production | cut -d= -f2-)" \
+	docker run --rm --gpus all --entrypoint sh \
 	  -v "$$PWD/backend/segmentation":/app -w /app \
 	  -v "$$PWD/backend/segmentation/.hf-cache":/home/app/.cache/huggingface \
-	  -e HF_TOKEN="$$(grep -E '^HF_TOKEN=' .env.production | cut -d= -f2-)" \
+	  -e HF_TOKEN \
 	  cell-segmentation-hub-ml:latest -c '\
 	    pip install -q -r requirements-test.txt && \
 	    python -m pytest tests/ -q -p no:cacheprovider --asyncio-mode=auto \
@@ -317,14 +321,16 @@ type-check:
 # legacy editor tests). Including it here would render `make ci` unusable
 # until the suite is healed. Use `make ci-test` to run vitest separately.
 ci:
-	@echo "🔍 [1/4] TypeScript (frontend — baseline gate)"
+	@echo "🔍 [1/5] TypeScript (frontend — baseline gate)"
 	@npm run type-check
-	@echo "🔍 [2/4] TypeScript (backend)"
+	@echo "🔍 [2/5] TypeScript (backend)"
 	@cd backend && npm run type-check
-	@echo "🔍 [3/4] ESLint (strict — 0 warnings)"
+	@echo "🔍 [3/5] ESLint (strict — 0 warnings)"
 	@npx eslint --max-warnings=0 src/
-	@echo "🔍 [4/4] i18n completeness (6 locales)"
+	@echo "🔍 [4/5] i18n completeness (6 locales)"
 	@node scripts/check-i18n.cjs
+	@echo "🔍 [5/5] Python suites (same 214 tests CI runs)"
+	@$(MAKE) --no-print-directory test-py
 	@echo "✅ All local CI checks passed"
 
 # Optional: run the Vitest suite. Currently has known pre-existing

--- a/backend/essays/tests/test_gpu_budget.py
+++ b/backend/essays/tests/test_gpu_budget.py
@@ -120,6 +120,36 @@ def test_cap_leaves_room_for_interactive_segmentation():
     assert float(essays_api.GPU_MEM_FRACTION) < 0.8
 
 
+def test_sitecustomize_default_matches_the_module_default():
+    """The file that APPLIES the cap must default to the one the tests police.
+
+    There are three copies of this number: essays_api.GPU_MEM_FRACTION (which
+    every assertion above is written against), the compose default (checked
+    below), and a third in sitecustomize.py -- which is the one that actually
+    calls `set_per_process_memory_fraction` on the evaluate.py subprocess.
+
+    In normal operation essays_api passes ESSAYS_GPU_MEM_FRACTION down in the
+    subprocess env, so sitecustomize's literal never fires. It fires when
+    evaluate.py is run directly, which is exactly the debugging path where a
+    silently different cap is hardest to notice -- the run simply behaves
+    unlike production and nothing says why.
+
+    Found by mutating sitecustomize's literal from 0.12 to 0.02 and watching
+    the whole suite stay green.
+    """
+    src = (Path(__file__).resolve().parents[1] / "sitecustomize.py").read_text()
+    m = re.search(
+        r'os\.environ\.get\(\s*["\']ESSAYS_GPU_MEM_FRACTION["\']\s*,\s*["\']([^"\']+)["\']',
+        src,
+    )
+    assert m, "sitecustomize.py no longer reads ESSAYS_GPU_MEM_FRACTION with a default"
+    assert float(m.group(1)) == float(essays_api.GPU_MEM_FRACTION), (
+        f"sitecustomize defaults to {m.group(1)} but essays_api uses "
+        f"{essays_api.GPU_MEM_FRACTION}; a direct evaluate.py run would cap "
+        "differently from production"
+    )
+
+
 @pytest.mark.skipif(COMPOSE is None, reason="compose file not in this tree")
 @pytest.mark.parametrize(
     "var, attr, cast",

--- a/backend/requirements-pytest-ci.txt
+++ b/backend/requirements-pytest-ci.txt
@@ -1,0 +1,45 @@
+# Dependencies for the Python test suites that CI can actually run.
+#
+# WHICH SUITES, AND WHY NOT THE THIRD
+# -----------------------------------
+# Three pytest suites live in this repo:
+#
+#   backend/src/services/video/pythonHelpers/tests   163 tests   <- CI runs it
+#   backend/essays/tests                              50 tests   <- CI runs it
+#   backend/segmentation/tests                       469 tests   <- CI cannot
+#
+# The segmentation suite is not excluded for being slow or flaky. It cannot be
+# collected at all without a GPU: `models/__init__` imports mamba_ssm, which
+# imports Triton, which raises at import time on a machine with no CUDA driver:
+#
+#     triton/runtime/driver.py:8
+#       RuntimeError: 0 active drivers ([]). There should only be one.
+#
+# GitHub-hosted runners have no GPU, so that suite needs a real card. Run it
+# with `make test-ml`, which uses the recipe in
+# backend/segmentation/requirements-test.txt. It was 469 passed / 1 skipped as
+# of 2026-08-28.
+#
+# WHY THESE VERSIONS
+# ------------------
+# fastapi/starlette/pydantic are pinned to the same versions the ML image ships
+# (see backend/segmentation/requirements.txt). The essays tests import the real
+# `essays_api` module, so a mismatch here would test a stack nothing runs.
+#
+# Everything else is left unpinned: these are the imaging libraries the helper
+# modules use, and the tests assert on behaviour that is stable across their
+# versions. If one of them ever breaks a test, pin it here with the reason.
+pytest>=7.4
+
+# essays_api is a FastAPI app; its tests import it directly.
+fastapi==0.141.1
+starlette==1.6.0
+pydantic==2.13.4
+
+# The video helpers: TIFF/ND2 decoding, PNG writing, the resampling and
+# morphology used by channel registration and the playback proxy.
+numpy
+pillow
+tifffile
+scipy
+scikit-image

--- a/backend/requirements-pytest-ci.txt
+++ b/backend/requirements-pytest-ci.txt
@@ -5,7 +5,7 @@
 # Three pytest suites live in this repo:
 #
 #   backend/src/services/video/pythonHelpers/tests   163 tests   <- CI runs it
-#   backend/essays/tests                              50 tests   <- CI runs it
+#   backend/essays/tests                              51 tests   <- CI runs it
 #   backend/segmentation/tests                       469 tests   <- CI cannot
 #
 # The segmentation suite is not excluded for being slow or flaky. It cannot be


### PR DESCRIPTION
`make ci` covers TypeScript, ESLint and i18n. It has **never run a single Python test** — which is how a `NameError` on an executor shutdown path and an order-dependent memory assertion both reached 2026-08-27 unnoticed. This puts **214** of them behind the gate.

| suite | tests |
|---|---|
| `backend/src/services/video/pythonHelpers/tests` | 163 |
| `backend/essays/tests` | 51 |

## Why the third suite is not here

`backend/segmentation/tests` is excluded for a reason that is not "slow" or "flaky" — it cannot be **collected** without a GPU. `models/__init__` imports mamba_ssm → Triton, which raises at *import time* with no CUDA driver:

```
triton/runtime/driver.py:8
  RuntimeError: 0 active drivers ([]). There should only be one.
```

GitHub-hosted runners have no card, so that suite needs the box. **`make test-ml`** now runs it with the recipe its own `requirements-test.txt` documents — including `--asyncio-mode=auto`, without which 11 tests error on an unhandled async fixture and *look* broken when they are merely unplugged. It was 469 passed / 1 skipped on 2026-08-28.

**`make test-py`** runs exactly what CI runs, so the gate is reproducible locally.

## Mutation-checked — and the second mutation found something

Reinstating the `C = 1` bug from #364 turns the gate red, so it catches the class of thing it exists for.

The second mutation did **not**: changing `sitecustomize.py`'s `ESSAYS_GPU_MEM_FRACTION` default from `0.12` to `0.02` left all 213 green.

That number has **three** copies:

1. `essays_api.GPU_MEM_FRACTION` — what every assertion in `test_gpu_budget.py` is written against
2. the compose default — already checked
3. `sitecustomize.py` — **the one that actually calls `set_per_process_memory_fraction`** on the `evaluate.py` subprocess

In normal operation `essays_api` passes the value down in the subprocess env, so sitecustomize's literal never fires. It fires when `evaluate.py` is run **directly** — exactly the debugging path where a silently different cap is hardest to notice, because the run just behaves unlike production and nothing says why.

Given this is the setting that once cost **255 wells in a single run**, the third copy now has a test. 214 with it, and re-running that mutation turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zcPGDLtwXKVhUQZXU57i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated Python test coverage for video helpers and essays.
  - Added a validation test to ensure GPU memory defaults remain consistent.
  - Added a dedicated dependency set for running Python tests.

- **Chores**
  - Added CI execution for Python test suites.
  - Added Makefile commands for Python and machine-learning tests, including required environment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->